### PR TITLE
Types and Gulpfile cleanup!

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -117,7 +117,7 @@ gulp.task('internalDefs', false, () => {
     project: './',
     baseDir: './src/',
     out: 'dist/react-vapor.d.ts',
-    exclude: ['lib/**/*.d.ts', 'node_modules/**/*.d.ts', 'types/**/*.d.ts', 'src/Index.ts']
+    exclude: ['node_modules/**/*.d.ts', 'types/**/*.d.ts', 'src/Index.ts']
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vapor",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Vapor CSS components implemented with React!",
   "keywords": [
     "coveo",

--- a/tests/components/PopoverComponent.spec.tsx
+++ b/tests/components/PopoverComponent.spec.tsx
@@ -1,5 +1,3 @@
-///<reference path="../../node_modules/@types/jasmine/index.d.ts"/>
-
 import { shallow, mount, ReactWrapper } from 'enzyme';
 import * as $ from 'jquery';
 import { PopoverComponent, IPopoverComponentProps } from '../../src/components/PopoverComponent';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,10 +10,16 @@
     "outDir": "./dist/split/",
     "removeComments": true,
     "sourceMap": true,
-    "target": "ES5"
+    "target": "ES5",
+    "typeRoots": [
+      "types"
+    ],
+    // Required for WebPack since typeRoots does not look to be supported, works fine without it when using tsc..
+    "types": [
+      "react-tether"
+    ]
   },
   "include": [
-    "types/**/*.d.ts",
     "src/**/*.tsx",
     "src/**/*.ts"
   ]

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -9,11 +9,16 @@
     "experimentalDecorators": true,
     "sourceMap": false,
     "inlineSourceMap": true,
-    "jsx": "react"
+    "jsx": "react",
+    "typeRoots": [
+      "types"
+    ],
+    "types": [
+      "react-tether",
+      "jasmine"
+    ]
   },
   "include": [
-    "node_modules/@types/**/*.d.ts",
-    "types/**/*.d.ts",
     "src/**/*.tsx",
     "src/**/*.ts"
   ]


### PR DESCRIPTION
* Clean the gulpfile
* Leverage typeRoots for types resolution, make it work with webpack
- Remove the now useless jasmine types reference