### PR TITLE
Make the PopoverComponent handle it's own state instead of passing a toggle method in props

### DIFF
--- a/docs/Index.tsx
+++ b/docs/Index.tsx
@@ -9,7 +9,7 @@ import { render as ReactDOMRender } from 'react-dom';
 import { createStore } from 'redux';
 import { connect, Provider } from 'react-redux';
 
-import * as ReduxUtils from '../src/utils/ReduxUtils';
+import { ReduxUtils } from '../src/utils/ReduxUtils';
 import { PopoverComponent } from '../src/components/PopoverComponent';
 
 import './style.scss';
@@ -204,47 +204,36 @@ class MemberEditView extends React.Component<IMemberEditViewProps, IMemberEditVi
         constraints={[{
           to: 'scrollParent',
           pin: true
-        }]}
-        >
-        <button className='btn'>
+        }]}>
+        <button type='button' className='btn'>
           {this.props.memberModel.isNew() ? 'Add member' : this.props.memberModel.email}
         </button>
-        {
-          this.getPopoverContent()
-        }
+        <div className='popover'>
+          <div className='popover-body coveo-form p2'>
+            <fieldset className='form-group input-field'>
+              <input type='text' required name='email' ref='email' value={this.props.email}
+                onChange={(event: FormEvent<HTMLInputElement>) => this.props.onChangeEmail((event.target as HTMLInputElement).value)} />
+              <label>Email</label>
+            </fieldset>
+            <fieldset className='form-group'>
+              <label className='form-control-label'>Send invite</label>
+              <div className='form-control'>
+                <label className='coveo-checkbox-label'>
+                  <input type='checkbox' className='coveo-checkbox' name='sendEmail' ref='sendEmail' checked={this.props.sendEmail}
+                    onChange={(event: FormEvent<HTMLInputElement>) => this.props.onChangeSendEmail((event.target as HTMLInputElement).checked)} />
+                  <button type='button' onClick={(jQueryEventObject) => { $(jQueryEventObject.currentTarget).prev().click(); } } />
+                </label>
+              </div>
+            </fieldset>
+          </div>
+          <div className='popover-footer'>
+            <button type='button' className='btn mod-primary mod-small' onClick={() => this.onSaveMember()}>
+              {this.props.memberModel.isNew() ? 'Add' : 'Save'}
+            </button>
+            <button type='button' className='btn mod-small' onClick={() => this.onCancelEdition()}>Cancel</button>
+          </div>
+        </div>
       </PopoverComponent>
-    );
-  }
-
-  private getPopoverContent() {
-    return (
-      <div className='popover'>
-        <div className='popover-body coveo-form p2'>
-          <fieldset className='form-group input-field'>
-            <input type='text' required name='email' ref='email' value={this.props.email}
-              onChange={(event: FormEvent<HTMLInputElement>) => this.props.onChangeEmail((event.target as HTMLInputElement).value)} />
-            <label>Email</label>
-          </fieldset>
-          <fieldset className='form-group'>
-            <label className='form-control-label'>Send invite</label>
-            <div className='form-control'>
-              <label className='coveo-checkbox-label'>
-                <input type='checkbox' className='coveo-checkbox' name='sendEmail' ref='sendEmail' checked={this.props.sendEmail}
-                  onChange={(event: FormEvent<HTMLInputElement>) => this.props.onChangeSendEmail((event.target as HTMLInputElement).checked)} />
-                <button type='button' onClick={(jQueryEventObject) => {
-                  $(jQueryEventObject.currentTarget).prev().click();
-                } } />
-              </label>
-            </div>
-          </fieldset>
-        </div>
-        <div className='popover-footer'>
-          <button type='button' className='btn mod-primary mod-small' onClick={() => this.onSaveMember()}>
-            {this.props.memberModel.isNew() ? 'Add' : 'Save'}
-          </button>
-          <button type='button' className='btn mod-small' onClick={() => this.onCancelEdition()}>Cancel</button>
-        </div>
-      </div>
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "peerDependencies": {
     "tether": "^1.3.7",
     "react": "^15.3.2",
-    "react-dom": "^15.3.2"
+    "react-dom": "^15.3.2",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "@types/backbone": "1.3.33",
@@ -100,7 +101,6 @@
     "tslint": "3.15.1",
     "tslint-loader": "2.1.5",
     "typescript": "2.0.3",
-    "underscore": "1.8.3",
     "webpack": "1.13.2",
     "webpack-dev-server": "1.16.1"
   },

--- a/src/Index.ts
+++ b/src/Index.ts
@@ -1,4 +1,4 @@
-import * as ReduxUtils from './utils/ReduxUtils';
+import { ReduxUtils } from './utils/ReduxUtils';
 import { PopoverComponent } from './components/PopoverComponent';
 
 export {

--- a/src/Index.ts
+++ b/src/Index.ts
@@ -1,3 +1,7 @@
+import * as ReduxUtils from './utils/ReduxUtils';
 import { PopoverComponent } from './components/PopoverComponent';
 
-export { PopoverComponent };
+export {
+  ReduxUtils,
+  PopoverComponent
+};

--- a/src/components/PopoverComponent.tsx
+++ b/src/components/PopoverComponent.tsx
@@ -5,9 +5,11 @@ import * as _ from 'underscore';
 
 /*
  The children property should be mandatory, but waiting for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/10641 and/or
- https://github.com/Microsoft/TypeScript/issues/8588. After that, we will be allowed to build using the strictNullChecks flag
+ https://github.com/Microsoft/TypeScript/issues/8588. After that, we will be allowed to build using the strictNullChecks flag.
+
+ Extending React.ClassAttributes<PopoverComponent> is required to be compatible with Typescript 1.7.
  */
-export interface IPopoverComponentProps extends TetherComponent.ITetherComponentProps {
+export interface IPopoverComponentProps extends TetherComponent.ITetherComponentProps, React.ClassAttributes<PopoverComponent> {
   isOpen?: boolean;
   children?: [React.ReactNode, React.ReactNode];
 }

--- a/src/components/PopoverComponent.tsx
+++ b/src/components/PopoverComponent.tsx
@@ -3,11 +3,20 @@ import * as ReactDOM from 'react-dom';
 import * as TetherComponent from 'react-tether';
 import * as _ from 'underscore';
 
+/*
+ The children property should be mandatory, but waiting for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/10641 and/or
+ https://github.com/Microsoft/TypeScript/issues/8588. After that, we will be allowed to build using the strictNullChecks flag
+ */
 export interface IPopoverComponentProps extends TetherComponent.ITetherComponentProps {
-  toggleOpenedTetherElement: Function;
+  isOpen?: boolean;
+  children?: [React.ReactNode, React.ReactNode];
 }
 
-export class PopoverComponent extends React.Component<IPopoverComponentProps, any> {
+export interface IPopoverComponentState {
+  isOpen: boolean;
+}
+
+export class PopoverComponent extends React.Component<IPopoverComponentProps, IPopoverComponentState> {
   static propTypes = _.extend(TetherComponent.propTypes, {
     children: ({children}: IPopoverComponentProps, propName: string, componentName: string) => {
       if (_.isUndefined(children) || React.Children.count(children) != 2) {
@@ -19,23 +28,17 @@ export class PopoverComponent extends React.Component<IPopoverComponentProps, an
 
   refs: {
     [key: string]: (Element);
-    tetherToggle?: HTMLElement;
-    tetherElement?: HTMLElement;
-  } = {};
-
-  // Using a fat arrow function instead of a methot here to bind it to context and to make sure we have the same listener for both
-  // addEventListener and removeEventListener and therefore prevent leaking listeners.
-  private handleDocumentClick: EventListener = (event: Event) => {
-    const tetherToggle = ReactDOM.findDOMNode<HTMLElement>(this.refs.tetherToggle);
-    const tetherElement = ReactDOM.findDOMNode<HTMLElement>(this.refs.tetherElement);
-
-    let outsideTetherToggle = !tetherToggle.contains(event.target as Node);
-    let outsideTetherElement = tetherElement ? !tetherElement.contains(event.target as Node) : true;
-
-    if (outsideTetherElement && outsideTetherToggle) {
-      this.props.toggleOpenedTetherElement(false);
-    }
+    tetherToggle: HTMLElement;
+    tetherElement: HTMLElement;
   };
+
+  constructor(props: IPopoverComponentProps, state: IPopoverComponentState) {
+    super(props, state);
+
+    this.state = {
+      isOpen: !!this.props.isOpen
+    };
+  }
 
   componentDidMount() {
     document.addEventListener('click', this.handleDocumentClick, true);
@@ -51,11 +54,11 @@ export class PopoverComponent extends React.Component<IPopoverComponentProps, an
 
     return (
       <TetherComponent {..._.omit(this.props, 'children') } >
-        <div ref='tetherToggle'>
+        <div ref='tetherToggle' onClick={() => this.toggleOpened(!this.state.isOpen)}>
           {tetherToggle}
         </div>
         {
-          tetherElement &&
+          this.state.isOpen &&
           <div ref='tetherElement'>
             {tetherElement}
           </div>
@@ -63,4 +66,24 @@ export class PopoverComponent extends React.Component<IPopoverComponentProps, an
       </TetherComponent>
     );
   }
+
+  toggleOpened(isOpen: boolean) {
+    this.setState({
+      isOpen: isOpen
+    });
+  }
+
+  // Using a fat arrow function instead of a methot here to bind it to context and to make sure we have the same listener for both
+  // addEventListener and removeEventListener and therefore prevent leaking listeners.
+  private handleDocumentClick: EventListener = (event: Event) => {
+    const tetherToggle = ReactDOM.findDOMNode<HTMLElement>(this.refs.tetherToggle);
+    const tetherElement = ReactDOM.findDOMNode<HTMLElement>(this.refs.tetherElement);
+
+    let outsideTetherToggle = !tetherToggle.contains(event.target as Node);
+    let outsideTetherElement = tetherElement ? !tetherElement.contains(event.target as Node) : true;
+
+    if (outsideTetherElement && outsideTetherToggle) {
+      this.toggleOpened(false);
+    }
+  };
 }

--- a/src/utils/ReduxUtils.ts
+++ b/src/utils/ReduxUtils.ts
@@ -1,5 +1,7 @@
 import * as _ from 'underscore';
 
-export const mergeProps = (stateProps: any, dispatchProps: any, ownProps: any) => {
-  return _.extend({}, stateProps, dispatchProps, ownProps);
-};
+export class ReduxUtils {
+  static mergeProps(stateProps: any, dispatchProps: any, ownProps: any) {
+    return _.extend({}, stateProps, dispatchProps, ownProps);
+  }
+}

--- a/src/utils/ReduxUtils.ts
+++ b/src/utils/ReduxUtils.ts
@@ -1,0 +1,5 @@
+import * as _ from 'underscore';
+
+export const mergeProps = (stateProps: any, dispatchProps: any, ownProps: any) => {
+  return _.extend({}, stateProps, dispatchProps, ownProps);
+};

--- a/tests/components/PopoverComponent.spec.tsx
+++ b/tests/components/PopoverComponent.spec.tsx
@@ -1,4 +1,4 @@
-import * as Enzyme from 'enzyme';
+import { shallow, mount, ReactWrapper } from 'enzyme';
 import * as $ from 'jquery';
 import * as _ from 'underscore';
 import { PopoverComponent, IPopoverComponentProps } from '../../src/components/PopoverComponent';
@@ -9,7 +9,7 @@ import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 
 describe('<PopoverComponent>', () => {
-  let popoverComponentWrapper: Enzyme.ReactWrapper<IPopoverComponentProps, any>;
+  let popoverComponentWrapper: ReactWrapper<IPopoverComponentProps, any>;
 
   let popoverComponentProps: IPopoverComponentProps;
 
@@ -21,7 +21,7 @@ describe('<PopoverComponent>', () => {
 
   it('should render without error', () => {
     expect(() => {
-      Enzyme.shallow(
+      shallow(
         <PopoverComponent {...popoverComponentProps}>
           <span>Toggle</span>
           <span>Tether element</span>
@@ -32,7 +32,7 @@ describe('<PopoverComponent>', () => {
 
   it('should mount and unmount/detach without error', () => {
     expect(() => {
-      popoverComponentWrapper = Enzyme.mount(
+      popoverComponentWrapper = mount(
         <PopoverComponent {...popoverComponentProps}>
           <span>Toggle</span>
           <span>Tether element</span>
@@ -50,7 +50,7 @@ describe('<PopoverComponent>', () => {
   describe('Children propTypes', () => {
     it('should not throw when redering a PopoverComponent with only one children', () => {
       expect(() => {
-        Enzyme.shallow(
+        shallow(
           <PopoverComponent {...popoverComponentProps}>
             <span>Toggle</span>
           </PopoverComponent>
@@ -60,7 +60,7 @@ describe('<PopoverComponent>', () => {
 
     it('should not throw when redering a PopoverComponent without childrens', () => {
       expect(() => {
-        Enzyme.shallow(
+        shallow(
           <PopoverComponent {...popoverComponentProps} />
         );
       }).not.toThrow();
@@ -69,7 +69,7 @@ describe('<PopoverComponent>', () => {
 
   describe('Tether toggle click handler', () => {
     beforeEach(() => {
-      popoverComponentWrapper = Enzyme.mount(
+      popoverComponentWrapper = mount(
         <PopoverComponent {...popoverComponentProps} >
           <span id='PopoverToggle'>Toggle</span>
           <span id='PopoverElement'>Tether element</span>
@@ -108,7 +108,7 @@ describe('<PopoverComponent>', () => {
         isOpen: true
       });
 
-      popoverComponentWrapper = Enzyme.mount(
+      popoverComponentWrapper = mount(
         <PopoverComponent {...popoverComponentProps} >
           <span id='PopoverToggle'>Toggle</span>
           <span id='PopoverElement'>Tether element</span>
@@ -145,7 +145,7 @@ describe('<PopoverComponent>', () => {
         isOpen: false
       });
 
-      popoverComponentWrapper = Enzyme.mount(
+      popoverComponentWrapper = mount(
         <PopoverComponent {...popoverComponentProps}>
           <span id='PopoverToggle'>Toggle</span>
           <span id='PopoverElement'>Tether element</span>


### PR DESCRIPTION
+ Add the mergeProps ReduxUtils method
* Make the PopoverComponent handle it's own state instead of passing a toggle method in props
* Adjust unit test
* Adjust the demo
+ Add the missing underscore peer dependency