### PR TITLE
Cleaned up code for the date picker and the per page navigation

### DIFF
--- a/src/ReactVapor.ts
+++ b/src/ReactVapor.ts
@@ -47,8 +47,9 @@ export interface IReduxActionsPayload {
   color?: string;
   date?: Date;
   calendarId?: string;
-  value?: () => string | string;
+  value?: string;
   isRange?: boolean;
   limit?: string;
   item?: string;
+  label?: string;
 }

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -165,7 +165,7 @@ export class Calendar extends React.Component<ICalendarProps, any> {
       ? <OptionsCycleConnected id={this.props.id + YEAR_PICKER_ID} {...yearPickerProps} />
       : <OptionsCycle {...yearPickerProps} />;
 
-    let sectedYearOption = this.props.selectedYear ? this.props.selectedYear : startingYear;
+    let sectedYearOption = !_.isUndefined(this.props.selectedYear) ? this.props.selectedYear : startingYear;
     let year = parseInt(years[sectedYearOption]);
     let selectedMonth = !_.isUndefined(this.props.selectedMonth) ? this.props.selectedMonth : startingMonth;
 

--- a/src/components/calendar/CalendarConnected.tsx
+++ b/src/components/calendar/CalendarConnected.tsx
@@ -7,7 +7,10 @@ import {
   ICalendarOwnProps,
   ICalendarDispatchProps
 } from './Calendar';
-import { changeDatePickerUpperLimit, changeDatePickerLowerLimit, selectDate } from '../datePicker/DatePickerActions';
+import {
+  changeDatePickerUpperLimit, changeDatePickerLowerLimit, selectDate,
+  DateLimits
+} from '../datePicker/DatePickerActions';
 import { changeOptionPicker } from '../optionPicker/OptionPickerActions';
 import { IReactVaporState, IReduxActionsPayload } from '../../ReactVapor';
 import { ReduxUtils, IReduxAction } from '../../utils/ReduxUtils';
@@ -37,6 +40,7 @@ const mapDispatchToProps = (dispatch: (action: IReduxAction<IReduxActionsPayload
         dispatch(changeDatePickerUpperLimit(pickerId, value));
       } else {
         dispatch(changeDatePickerLowerLimit(pickerId, value));
+        dispatch(selectDate(pickerId, DateLimits.upper));
       }
     },
     onDateChange: (pickerId: string, newValue: number) => dispatch(changeOptionsCycle(pickerId, newValue))

--- a/src/components/calendar/CalendarConnected.tsx
+++ b/src/components/calendar/CalendarConnected.tsx
@@ -32,7 +32,7 @@ const mapDispatchToProps = (dispatch: (action: IReduxAction<IReduxActionsPayload
   ownProps: ICalendarOwnProps): ICalendarDispatchProps => ({
     onClick: (pickerId: string, isUpperLimit: boolean, value: Date) => {
       dispatch(selectDate(pickerId, ''));
-      dispatch(changeOptionPicker(pickerId, () => ''));
+      dispatch(changeOptionPicker(pickerId, '', ''));
       if (isUpperLimit) {
         dispatch(changeDatePickerUpperLimit(pickerId, value));
       } else {

--- a/src/components/calendar/CalendarConnected.tsx
+++ b/src/components/calendar/CalendarConnected.tsx
@@ -12,12 +12,13 @@ import {
   DateLimits
 } from '../datePicker/DatePickerActions';
 import { changeOptionPicker } from '../optionPicker/OptionPickerActions';
+import { changeOptionsCycle } from '../optionsCycle/OptionsCycleActions';
 import { IReactVaporState, IReduxActionsPayload } from '../../ReactVapor';
 import { ReduxUtils, IReduxAction } from '../../utils/ReduxUtils';
 import { connect } from 'react-redux';
 import * as React from 'react';
 import * as _ from 'underscore';
-import { changeOptionsCycle } from '../optionsCycle/OptionsCycleActions';
+import * as moment from 'moment';
 
 const mapStateToProps = (state: IReactVaporState, ownProps: ICalendarOwnProps): ICalendarStateProps => {
   let selectedMonth = _.findWhere(state.optionsCycles, { id: ownProps.id + MONTH_PICKER_ID });
@@ -37,7 +38,7 @@ const mapDispatchToProps = (dispatch: (action: IReduxAction<IReduxActionsPayload
       dispatch(selectDate(pickerId, ''));
       dispatch(changeOptionPicker(pickerId, '', ''));
       if (isUpperLimit) {
-        dispatch(changeDatePickerUpperLimit(pickerId, value));
+        dispatch(changeDatePickerUpperLimit(pickerId, moment(value).endOf('day').toDate()));
       } else {
         dispatch(changeDatePickerLowerLimit(pickerId, value));
         dispatch(selectDate(pickerId, DateLimits.upper));

--- a/src/components/calendar/tests/CalendarConnected.spec.tsx
+++ b/src/components/calendar/tests/CalendarConnected.spec.tsx
@@ -16,11 +16,9 @@ import {
 } from '../../datePicker/DatePickerActions';
 import { addOptionPicker, changeOptionPicker } from '../../optionPicker/OptionPickerActions';
 import * as _ from 'underscore';
-import * as moment from 'moment';
+import moment = require('moment');
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
-import { IDatePickerState } from '../../datePicker/DatePickerReducers';
-import moment = require('moment');
 
 describe('Calendar', () => {
   const CALENDAR_ID: string = 'calendar';
@@ -127,16 +125,19 @@ describe('Calendar', () => {
     });
 
     it('should unselected any option from the option picker when calling onClick', () => {
-      let pickerSelected: () => string = () => 'something-selected';
+      let pickerSelected: string = 'something-selected';
+      let pickerLabelSelected: string = 'the label';
 
       store.dispatch(addOptionPicker(PICKER_ID));
-      store.dispatch(changeOptionPicker(PICKER_ID, pickerSelected));
+      store.dispatch(changeOptionPicker(PICKER_ID, pickerLabelSelected, pickerSelected));
 
-      expect(_.findWhere(store.getState().optionPickers, { id: PICKER_ID }).selectedValue()).toBe(pickerSelected());
+      expect(_.findWhere(store.getState().optionPickers, { id: PICKER_ID }).selectedValue).toBe(pickerSelected);
+      expect(_.findWhere(store.getState().optionPickers, { id: PICKER_ID }).selectedLabel).toBe(pickerLabelSelected);
 
       calendar.props().onClick(PICKER_ID, false, new Date());
 
-      expect(_.findWhere(store.getState().optionPickers, { id: PICKER_ID }).selectedValue()).toBe('');
+      expect(_.findWhere(store.getState().optionPickers, { id: PICKER_ID }).selectedValue).toBe('');
+      expect(_.findWhere(store.getState().optionPickers, { id: PICKER_ID }).selectedLabel).toBe('');
     });
 
     it('should change the upper limit if the onClick was called on an upper limit', () => {

--- a/src/components/calendar/tests/CalendarConnected.spec.tsx
+++ b/src/components/calendar/tests/CalendarConnected.spec.tsx
@@ -12,7 +12,7 @@ import {
   addDatePicker,
   selectDate,
   changeDatePickerUpperLimit,
-  changeDatePickerLowerLimit
+  changeDatePickerLowerLimit, DateLimits
 } from '../../datePicker/DatePickerActions';
 import { addOptionPicker, changeOptionPicker } from '../../optionPicker/OptionPickerActions';
 import * as _ from 'underscore';
@@ -111,8 +111,23 @@ describe('Calendar', () => {
       expect(calendar.find(OptionsCycleConnected).length).toBe(2);
     });
 
-    it('should set the selected value of the picker to an empty string when calling onClick', () => {
-      let pickerSelected: string = 'soemthing-selected';
+    it('should set the selected value of the picker to an empty string when calling onClick and the limit selected ' +
+      'is the upper one', () => {
+      let pickerSelected: string = DateLimits.upper;
+
+      store.dispatch(addDatePicker(PICKER_ID, false, 'any', CALENDAR_ID));
+      store.dispatch(selectDate(PICKER_ID, pickerSelected));
+
+      expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).selected).toBe(pickerSelected);
+
+      calendar.props().onClick(PICKER_ID, true, new Date());
+
+      expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).selected).toBe('');
+    });
+
+    it('should set the selected value of the picker to the upper limit when calling onClick and the limit selected ' +
+      'is the lower one', () => {
+      let pickerSelected: string = DateLimits.lower;
 
       store.dispatch(addDatePicker(PICKER_ID, false, 'any', CALENDAR_ID));
       store.dispatch(selectDate(PICKER_ID, pickerSelected));
@@ -121,7 +136,7 @@ describe('Calendar', () => {
 
       calendar.props().onClick(PICKER_ID, false, new Date());
 
-      expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).selected).toBe('');
+      expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).selected).toBe(DateLimits.upper);
     });
 
     it('should unselected any option from the option picker when calling onClick', () => {
@@ -156,7 +171,7 @@ describe('Calendar', () => {
 
     it('should change the lower limit if the onClick was called on a lower limit', () => {
       let currentLowerLimit: Date = moment(new Date()).add(10, 'day').toDate();
-      let newLimit: Date = moment(new Date()).add(5, 'day').toDate();
+      let newLimit: Date = moment(new Date()).subtract(5, 'day').toDate();
 
       store.dispatch(addDatePicker(PICKER_ID, true, 'any', CALENDAR_ID));
       store.dispatch(changeDatePickerLowerLimit(PICKER_ID, currentLowerLimit));
@@ -169,27 +184,27 @@ describe('Calendar', () => {
     });
 
     it('should change the selected month and year if one of the calendar selection changed a limit', () => {
-      let ridiculousYear: number = 500;
+      let secondYear: number = 1;
       let monthId: string = CALENDAR_ID + MONTH_PICKER_ID;
       let yearId: string = CALENDAR_ID + YEAR_PICKER_ID;
 
       store.dispatch(changeOptionsCycle(monthId, 13));
-      store.dispatch(changeOptionsCycle(yearId, ridiculousYear));
+      store.dispatch(changeOptionsCycle(yearId, secondYear));
 
       store.dispatch(addDatePicker(PICKER_ID, true, 'any', CALENDAR_ID));
       store.dispatch(changeDatePickerLowerLimit(PICKER_ID, moment().endOf('hour').toDate()));
 
       expect(_.findWhere(store.getState().optionsCycles, { id: monthId }).currentOption).toBe(DateUtils.currentMonth);
-      expect(_.findWhere(store.getState().optionsCycles, { id: yearId }).currentOption).not.toBe(ridiculousYear);
+      expect(_.findWhere(store.getState().optionsCycles, { id: yearId }).currentOption).not.toBe(secondYear);
 
       store.dispatch(changeOptionsCycle(monthId, 13));
-      store.dispatch(changeOptionsCycle(yearId, ridiculousYear));
+      store.dispatch(changeOptionsCycle(yearId, secondYear));
 
       store.dispatch(addDatePicker(PICKER_ID, true, 'any', CALENDAR_ID));
       store.dispatch(changeDatePickerUpperLimit(PICKER_ID, moment().endOf('year').toDate()));
 
       expect(_.findWhere(store.getState().optionsCycles, { id: monthId }).currentOption).toBe(11);
-      expect(_.findWhere(store.getState().optionsCycles, { id: yearId }).currentOption).not.toBe(ridiculousYear);
+      expect(_.findWhere(store.getState().optionsCycles, { id: yearId }).currentOption).not.toBe(secondYear);
     });
   });
 });

--- a/src/components/calendar/tests/CalendarConnected.spec.tsx
+++ b/src/components/calendar/tests/CalendarConnected.spec.tsx
@@ -113,31 +113,31 @@ describe('Calendar', () => {
 
     it('should set the selected value of the picker to an empty string when calling onClick and the limit selected ' +
       'is the upper one', () => {
-      let pickerSelected: string = DateLimits.upper;
+        let pickerSelected: string = DateLimits.upper;
 
-      store.dispatch(addDatePicker(PICKER_ID, false, 'any', CALENDAR_ID));
-      store.dispatch(selectDate(PICKER_ID, pickerSelected));
+        store.dispatch(addDatePicker(PICKER_ID, false, 'any', CALENDAR_ID));
+        store.dispatch(selectDate(PICKER_ID, pickerSelected));
 
-      expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).selected).toBe(pickerSelected);
+        expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).selected).toBe(pickerSelected);
 
-      calendar.props().onClick(PICKER_ID, true, new Date());
+        calendar.props().onClick(PICKER_ID, true, new Date());
 
-      expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).selected).toBe('');
-    });
+        expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).selected).toBe('');
+      });
 
     it('should set the selected value of the picker to the upper limit when calling onClick and the limit selected ' +
       'is the lower one', () => {
-      let pickerSelected: string = DateLimits.lower;
+        let pickerSelected: string = DateLimits.lower;
 
-      store.dispatch(addDatePicker(PICKER_ID, false, 'any', CALENDAR_ID));
-      store.dispatch(selectDate(PICKER_ID, pickerSelected));
+        store.dispatch(addDatePicker(PICKER_ID, false, 'any', CALENDAR_ID));
+        store.dispatch(selectDate(PICKER_ID, pickerSelected));
 
-      expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).selected).toBe(pickerSelected);
+        expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).selected).toBe(pickerSelected);
 
-      calendar.props().onClick(PICKER_ID, false, new Date());
+        calendar.props().onClick(PICKER_ID, false, new Date());
 
-      expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).selected).toBe(DateLimits.upper);
-    });
+        expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).selected).toBe(DateLimits.upper);
+      });
 
     it('should unselected any option from the option picker when calling onClick', () => {
       let pickerSelected: string = 'something-selected';
@@ -155,7 +155,8 @@ describe('Calendar', () => {
       expect(_.findWhere(store.getState().optionPickers, { id: PICKER_ID }).selectedLabel).toBe('');
     });
 
-    it('should change the upper limit if the onClick was called on an upper limit', () => {
+    it('should change the upper limit to the end of the day selected if the onClick was called on an upper limit',
+      () => {
       let currentUpperLimit: Date = moment(new Date()).add(10, 'day').toDate();
       let newLimit: Date = moment(new Date()).add(5, 'day').toDate();
 
@@ -166,7 +167,8 @@ describe('Calendar', () => {
 
       calendar.props().onClick(PICKER_ID, true, newLimit);
 
-      expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).upperLimit).toBe(newLimit);
+      expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).upperLimit)
+        .toEqual(moment(newLimit).endOf('day').toDate());
     });
 
     it('should change the lower limit if the onClick was called on a lower limit', () => {

--- a/src/components/calendar/tests/CalendarConnected.spec.tsx
+++ b/src/components/calendar/tests/CalendarConnected.spec.tsx
@@ -157,19 +157,19 @@ describe('Calendar', () => {
 
     it('should change the upper limit to the end of the day selected if the onClick was called on an upper limit',
       () => {
-      let currentUpperLimit: Date = moment(new Date()).add(10, 'day').toDate();
-      let newLimit: Date = moment(new Date()).add(5, 'day').toDate();
+        let currentUpperLimit: Date = moment(new Date()).add(10, 'day').toDate();
+        let newLimit: Date = moment(new Date()).add(5, 'day').toDate();
 
-      store.dispatch(addDatePicker(PICKER_ID, true, 'any', CALENDAR_ID));
-      store.dispatch(changeDatePickerUpperLimit(PICKER_ID, currentUpperLimit));
+        store.dispatch(addDatePicker(PICKER_ID, true, 'any', CALENDAR_ID));
+        store.dispatch(changeDatePickerUpperLimit(PICKER_ID, currentUpperLimit));
 
-      expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).upperLimit).toBe(currentUpperLimit);
+        expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).upperLimit).toBe(currentUpperLimit);
 
-      calendar.props().onClick(PICKER_ID, true, newLimit);
+        calendar.props().onClick(PICKER_ID, true, newLimit);
 
-      expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).upperLimit)
-        .toEqual(moment(newLimit).endOf('day').toDate());
-    });
+        expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).upperLimit)
+          .toEqual(moment(newLimit).endOf('day').toDate());
+      });
 
     it('should change the lower limit if the onClick was called on a lower limit', () => {
       let currentLowerLimit: Date = moment(new Date()).add(10, 'day').toDate();

--- a/src/components/datePicker/DatePickerDropdown.tsx
+++ b/src/components/datePicker/DatePickerDropdown.tsx
@@ -34,7 +34,7 @@ export interface IDatePickerDropdownStateProps extends IReduxStatePossibleProps 
 
 export interface IDatePickerDropdownDispatchProps {
   onApply?: () => void;
-  onCancel?: (currentMonth: number, currentYear: number) => void;
+  onCancel?: (currentMonth: number, currentYear: number, isOpened: boolean) => void;
   onRender?: () => void;
   onDestroy?: () => void;
   onClick?: () => void;
@@ -106,7 +106,7 @@ export class DatePickerDropdown extends React.Component<IDatePickerDropdownProps
       let currentYear: number = this.props.datePicker
         ? this.props.datePicker.appliedLowerLimit.getFullYear()
         : DateUtils.currentYear;
-      this.props.onCancel(currentMonth, years.indexOf(currentYear.toString()));
+      this.props.onCancel(currentMonth, years.indexOf(currentYear.toString()), this.props.isOpened);
     }
   }
 

--- a/src/components/datePicker/DatePickerDropdown.tsx
+++ b/src/components/datePicker/DatePickerDropdown.tsx
@@ -37,7 +37,7 @@ export interface IDatePickerDropdownDispatchProps {
   onCancel?: (currentMonth: number, currentYear: number, isOpened: boolean) => void;
   onRender?: () => void;
   onDestroy?: () => void;
-  onClick?: () => void;
+  onClick?: (datePicker: IDatePickerState) => void;
   onDocumentClick?: () => void;
 }
 
@@ -54,7 +54,7 @@ export class DatePickerDropdown extends React.Component<IDatePickerDropdownProps
 
   private handleClick = () => {
     if (this.props.onClick) {
-      this.props.onClick();
+      this.props.onClick(this.props.datePicker);
     }
   };
 

--- a/src/components/datePicker/DatePickerDropdownConnected.tsx
+++ b/src/components/datePicker/DatePickerDropdownConnected.tsx
@@ -43,12 +43,14 @@ const mapDispatchToProps = (dispatch: (action: IReduxAction<IReduxActionsPayload
     dispatch(applyDatePicker(ownProps.id));
     dispatch(resetDatePickers(ownProps.id));
   },
-  onCancel: (currentMonth: number, currentYear: number) => {
-    dispatch(changeOptionsCycle(`calendar-${ownProps.id}${MONTH_PICKER_ID}`, currentMonth));
-    dispatch(changeOptionsCycle(`calendar-${ownProps.id}${YEAR_PICKER_ID}`, currentYear));
-    dispatch(resetDatePickers(ownProps.id));
-    dispatch(resetOptionPickers(ownProps.id));
-    dispatch(closeDropdown(ownProps.id));
+  onCancel: (currentMonth: number, currentYear: number, isOpened: boolean) => {
+    if (isOpened) {
+      dispatch(changeOptionsCycle(`calendar-${ownProps.id}${MONTH_PICKER_ID}`, currentMonth));
+      dispatch(changeOptionsCycle(`calendar-${ownProps.id}${YEAR_PICKER_ID}`, currentYear));
+      dispatch(resetDatePickers(ownProps.id));
+      dispatch(resetOptionPickers(ownProps.id));
+      dispatch(closeDropdown(ownProps.id));
+    }
   }
 });
 

--- a/src/components/datePicker/DatePickerDropdownConnected.tsx
+++ b/src/components/datePicker/DatePickerDropdownConnected.tsx
@@ -7,7 +7,7 @@ import {
 } from './DatePickerDropdown';
 import { addDropdown, removeDropdown, toggleDropdown, closeDropdown } from '../dropdown/DropdownActions';
 import { IDropdownState } from '../dropdown/DropdownReducers';
-import { applyDatePicker, resetDatePickers } from './DatePickerActions';
+import { applyDatePicker, resetDatePickers, selectDate, DateLimits } from './DatePickerActions';
 import { resetOptionPickers } from '../optionPicker/OptionPickerActions';
 import { IDatePickerState } from './DatePickerReducers';
 import { changeOptionsCycle } from '../optionsCycle/OptionsCycleActions';
@@ -36,7 +36,12 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IDatePickerDropdownO
 const mapDispatchToProps = (dispatch: (action: IReduxAction<IReduxActionsPayload>) => void, ownProps: IDatePickerDropdownOwnProps): IDatePickerDropdownDispatchProps => ({
   onRender: () => dispatch(addDropdown(ownProps.id)),
   onDestroy: () => dispatch(removeDropdown(ownProps.id)),
-  onClick: () => dispatch(toggleDropdown(ownProps.id)),
+  onClick: (datePicker: IDatePickerState) => {
+    dispatch(toggleDropdown(ownProps.id));
+    if (datePicker) {
+      dispatch(selectDate(datePicker.id, DateLimits.lower));
+    }
+  },
   onDocumentClick: () => dispatch(closeDropdown(ownProps.id)),
   onApply: () => {
     dispatch(closeDropdown(ownProps.id));

--- a/src/components/datePicker/DatePickerReducers.ts
+++ b/src/components/datePicker/DatePickerReducers.ts
@@ -29,47 +29,72 @@ export const datePickerInitialState: IDatePickerState = {
 };
 export const datePickersInitialState: IDatePickerState[] = [];
 
+const addDatePicker = (state: IDatePickerState = datePickerInitialState,
+  action: IReduxAction<IReduxActionsPayload>): IDatePickerState => {
+  return {
+    id: action.payload.id,
+    calendarId: action.payload.calendarId,
+    color: action.payload.color,
+    isRange: action.payload.isRange,
+    lowerLimit: state.lowerLimit,
+    upperLimit: state.upperLimit,
+    selected: state.selected,
+    appliedLowerLimit: state.appliedLowerLimit,
+    appliedUpperLimit: state.appliedUpperLimit
+  };
+};
+
+const changeLowerLimit = (state: IDatePickerState = datePickerInitialState,
+  action: IReduxAction<IReduxActionsPayload>): IDatePickerState => {
+  return state.id !== action.payload.id ? state : _.extend({}, state, { lowerLimit: action.payload.date });
+};
+
+const changeUpperLimit = (state: IDatePickerState = datePickerInitialState,
+  action: IReduxAction<IReduxActionsPayload>): IDatePickerState => {
+  return state.id !== action.payload.id ? state : _.extend({}, state, { upperLimit: action.payload.date });
+};
+
+const selectDate = (state: IDatePickerState = datePickerInitialState,
+  action: IReduxAction<IReduxActionsPayload>): IDatePickerState => {
+  return state.id !== action.payload.id ? state : _.extend({}, state, { selected: action.payload.limit });
+};
+
+const applyDates = (state: IDatePickerState = datePickerInitialState,
+  action: IReduxAction<IReduxActionsPayload>): IDatePickerState => {
+  return state.id.indexOf(action.payload.id) !== 0
+    ? state
+    : _.extend({}, state, {
+      appliedLowerLimit: state.lowerLimit,
+      appliedUpperLimit: state.upperLimit >= state.lowerLimit ? state.upperLimit : state.lowerLimit
+    });
+};
+
+const resetDates = (state: IDatePickerState = datePickerInitialState,
+  action: IReduxAction<IReduxActionsPayload>): IDatePickerState => {
+  return state.id.indexOf(action.payload.id) !== 0
+    ? state
+    : _.extend({}, state, {
+      selected: '',
+      lowerLimit: state.appliedLowerLimit,
+      upperLimit: state.appliedUpperLimit
+    });
+};
+
 export const datePickerReducer = (state: IDatePickerState = datePickerInitialState,
   action: IReduxAction<IReduxActionsPayload>): IDatePickerState => {
   switch (action.type) {
     case DatePickerActions.add:
-      return {
-        id: action.payload.id,
-        calendarId: action.payload.calendarId,
-        color: action.payload.color,
-        isRange: action.payload.isRange,
-        lowerLimit: state.lowerLimit,
-        upperLimit: state.upperLimit,
-        selected: state.selected,
-        appliedLowerLimit: state.appliedLowerLimit,
-        appliedUpperLimit: state.appliedUpperLimit
-      };
+      return addDatePicker(state, action);
     case DatePickerActions.changeLowerLimit:
-      if (state.id !== action.payload.id) {
-        return state;
-      }
-      return _.extend({}, state, {
-        lowerLimit: action.payload.date
-      });
+      return changeLowerLimit(state, action);
     case DatePickerActions.changeUpperLimit:
-      return state.id !== action.payload.id ? state : _.extend({}, state, { upperLimit: action.payload.date });
+      return changeUpperLimit(state, action);
     case DatePickerActions.select:
-      return state.id !== action.payload.id ? state : _.extend({}, state, { selected: action.payload.limit });
+      return selectDate(state, action);
     case DatePickerActions.apply:
-      return state.id.indexOf(action.payload.id) !== 0
-        ? state
-        : _.extend({}, state, {
-          appliedLowerLimit: state.lowerLimit,
-          appliedUpperLimit: state.upperLimit >= state.lowerLimit ? state.upperLimit : state.lowerLimit
-        });
+      return applyDates(state, action);
     case DatePickerActions.reset:
-      return state.id.indexOf(action.payload.id) !== 0
-        ? state
-        : _.extend({}, state, {
-          selected: '',
-          lowerLimit: state.appliedLowerLimit,
-          upperLimit: state.appliedUpperLimit
-        });
+      return resetDates(state, action);
     default:
       return state;
   }

--- a/src/components/datePicker/DatesSelectionConnected.tsx
+++ b/src/components/datePicker/DatesSelectionConnected.tsx
@@ -27,7 +27,7 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IDatesSelectionOwnPr
   return {
     lowerLimit: item ? item.lowerLimit : new Date(),
     upperLimit: item ? item.upperLimit : new Date(),
-    quickOption: optionPicker && optionPicker.selectedValue ? optionPicker.selectedValue() : '',
+    quickOption: optionPicker && optionPicker.selectedValue ? optionPicker.selectedValue : '',
     isSelecting: item ? item.selected : ''
   };
 };
@@ -44,7 +44,7 @@ const mapDispatchToProps = (dispatch: (action: IReduxAction<IReduxActionsPayload
       }
 
       if (!optionPicker) {
-        dispatch(changeOptionPicker(ownProps.id, () => ''));
+        dispatch(changeOptionPicker(ownProps.id, '', ''));
       }
     },
     onClick: (isUpperLimit: boolean) => dispatch(selectDate(ownProps.id, (isUpperLimit ? DateLimits.upper : DateLimits.lower)))

--- a/src/components/datePicker/tests/DatePickerDropdownConnected.spec.tsx
+++ b/src/components/datePicker/tests/DatePickerDropdownConnected.spec.tsx
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux';
 import { DatePickerDropdownConnected } from '../DatePickerDropdownConnected';
 import { IDatePickerDropdownProps, DatePickerDropdown } from '../DatePickerDropdown';
 import { toggleDropdown, closeDropdown } from '../../dropdown/DropdownActions';
-import { addDatePicker, changeDatePickerLowerLimit, applyDatePicker } from '../DatePickerActions';
+import {addDatePicker, changeDatePickerLowerLimit, applyDatePicker, DateLimits} from '../DatePickerActions';
 import { IDatePickerState } from '../DatePickerReducers';
 import { addOptionPicker, changeOptionPicker } from '../../optionPicker/OptionPickerActions';
 import { DatePickerBox } from '../DatePickerBox';
@@ -149,8 +149,20 @@ describe('Date picker', () => {
     it('should toggle the open property of the dropdown when calling the onClick prop', () => {
       expect(_.findWhere(store.getState().dropdowns, { id: DATE_PICKER_DROPDOWN_BASIC_PROPS.id }).opened).toBe(false);
 
-      datePickerDropdown.props().onClick();
+      datePickerDropdown.props().onClick(datePickerDropdown.props().datePicker);
       expect(_.findWhere(store.getState().dropdowns, { id: DATE_PICKER_DROPDOWN_BASIC_PROPS.id }).opened).toBe(true);
+    });
+
+    it('should select the date picker\'s lower limit when calling the onClick prop', () => {
+      let pickerId: string = DATE_PICKER_DROPDOWN_BASIC_PROPS.id + '6868';
+
+      store.dispatch(addDatePicker(pickerId, false));
+
+      expect(_.findWhere(store.getState().datePickers, { id: pickerId }).selected).toBe('');
+
+      datePickerDropdown.props().onClick(datePickerDropdown.props().datePicker);
+
+      expect(_.findWhere(store.getState().datePickers, { id: pickerId }).selected).toBe(DateLimits.lower);
     });
 
     it('should close the dropdown menu when calling onDocumentClick prop', () => {

--- a/src/components/datePicker/tests/DatePickerDropdownConnected.spec.tsx
+++ b/src/components/datePicker/tests/DatePickerDropdownConnected.spec.tsx
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux';
 import { DatePickerDropdownConnected } from '../DatePickerDropdownConnected';
 import { IDatePickerDropdownProps, DatePickerDropdown } from '../DatePickerDropdown';
 import { toggleDropdown, closeDropdown } from '../../dropdown/DropdownActions';
-import {addDatePicker, changeDatePickerLowerLimit, applyDatePicker, DateLimits} from '../DatePickerActions';
+import { addDatePicker, changeDatePickerLowerLimit, applyDatePicker, DateLimits } from '../DatePickerActions';
 import { IDatePickerState } from '../DatePickerReducers';
 import { addOptionPicker, changeOptionPicker } from '../../optionPicker/OptionPickerActions';
 import { DatePickerBox } from '../DatePickerBox';

--- a/src/components/datePicker/tests/DatesSelectionConnected.spec.tsx
+++ b/src/components/datePicker/tests/DatesSelectionConnected.spec.tsx
@@ -144,12 +144,12 @@ describe('Date picker', () => {
     });
 
     it('should return the selected value if the option picker exists in the state', () => {
-      let expectedValue: () => string = () => 'this option';
+      let expectedValue: string = 'this option';
 
       store.dispatch(addOptionPicker(DATES_SELECTION_ID));
-      store.dispatch(changeOptionPicker(DATES_SELECTION_ID, expectedValue));
+      store.dispatch(changeOptionPicker(DATES_SELECTION_ID, 'this label', expectedValue));
 
-      expect(datesSelection.props().quickOption).toBe(expectedValue());
+      expect(datesSelection.props().quickOption).toBe(expectedValue);
     });
 
     it('should call onRender prop when mounted', () => {
@@ -201,17 +201,20 @@ describe('Date picker', () => {
 
     it('should deselect the quick option when calling onChange prop if the call does not come from the option picker',
       () => {
-        let expectedValue: () => string = () => 'anything';
+        let expectedValue: string = 'anything';
+        let expectedLabel: string = 'something';
 
         store.dispatch(addOptionPicker(DATES_SELECTION_ID));
-        store.dispatch(changeOptionPicker(DATES_SELECTION_ID, expectedValue));
+        store.dispatch(changeOptionPicker(DATES_SELECTION_ID, expectedLabel, expectedValue));
 
         datesSelection.props().onChange(new Date(), true, true);
 
-        expect(_.findWhere(store.getState().optionPickers, { id: DATES_SELECTION_ID }).selectedValue()).toBe(expectedValue());
+        expect(_.findWhere(store.getState().optionPickers, { id: DATES_SELECTION_ID }).selectedValue).toBe(expectedValue);
+        expect(_.findWhere(store.getState().optionPickers, { id: DATES_SELECTION_ID }).selectedLabel).toBe(expectedLabel);
 
         datesSelection.props().onChange(new Date(), true, false);
-        expect(_.findWhere(store.getState().optionPickers, { id: DATES_SELECTION_ID }).selectedValue()).toBe('');
+        expect(_.findWhere(store.getState().optionPickers, { id: DATES_SELECTION_ID }).selectedValue).toBe('');
+        expect(_.findWhere(store.getState().optionPickers, { id: DATES_SELECTION_ID }).selectedLabel).toBe('');
       });
   });
 });

--- a/src/components/facets/FacetReducers.ts
+++ b/src/components/facets/FacetReducers.ts
@@ -13,62 +13,86 @@ export interface IFacetState {
 export const facetInitialState: IFacetState = { facet: undefined, opened: false, selected: [] };
 export const facetsInitialState: IFacetState[] = [];
 
+const toggleMore = (state: IFacetState = facetInitialState,
+  action: (IReduxAction<IReduxActionsPayload>)): IFacetState => {
+  if (state.facet !== action.payload.facet) {
+    return state;
+  }
+
+  return {
+    facet: state.facet,
+    opened: !state.opened,
+    selected: state.selected
+  };
+};
+
+const closeMore = (state: IFacetState = facetInitialState): IFacetState => {
+  return {
+    facet: state.facet,
+    opened: false,
+    selected: state.selected
+  };
+};
+
+const addFacet = (state: IFacetState = facetInitialState,
+  action: (IReduxAction<IReduxActionsPayload>)): IFacetState => {
+  return {
+    facet: action.payload.facet,
+    opened: false,
+    selected: []
+  };
+};
+
+const changeFacet = (state: IFacetState = facetInitialState,
+  action: (IReduxAction<IReduxActionsPayload>)): IFacetState => {
+  if (state.facet !== action.payload.facet) {
+    return state;
+  }
+
+  let selected = state.selected;
+  if (_.some(state.selected, (facetRow: IFacet) => { return facetRow.name === action.payload.facetRow.name; })) {
+    selected = _.reject(state.selected, (facetRow: IFacet) => {
+      return facetRow.name === action.payload.facetRow.name;
+    });
+  } else {
+    selected = [
+      action.payload.facetRow,
+      ...state.selected
+    ];
+  }
+  return {
+    facet: state.facet,
+    opened: state.opened,
+    selected: selected
+  };
+};
+
+const emptyFacet = (state: IFacetState = facetInitialState,
+  action: (IReduxAction<IReduxActionsPayload>)): IFacetState => {
+  if (state.facet !== action.payload.facet) {
+    return state;
+  }
+
+  return {
+    facet: state.facet,
+    opened: state.opened,
+    selected: []
+  };
+};
+
 export const facetReducer = (state: IFacetState = facetInitialState,
   action: (IReduxAction<IReduxActionsPayload>)): IFacetState => {
   switch (action.type) {
     case FacetActions.toggleMoreFacetRows:
-      if (state.facet !== action.payload.facet) {
-        return state;
-      }
-
-      return {
-        facet: state.facet,
-        opened: !state.opened,
-        selected: state.selected
-      };
+      return toggleMore(state, action);
     case FacetActions.closeMoreFacetRows:
-      return {
-        facet: state.facet,
-        opened: false,
-        selected: state.selected
-      };
+      return closeMore(state);
     case FacetActions.addFacet:
-      return {
-        facet: action.payload.facet,
-        opened: false,
-        selected: []
-      };
+      return addFacet(state, action);
     case FacetActions.changeFacet:
-      if (state.facet !== action.payload.facet) {
-        return state;
-      }
-
-      let selected = state.selected;
-      if (_.some(state.selected, (facetRow: IFacet) => { return facetRow.name === action.payload.facetRow.name; })) {
-        selected = _.reject(state.selected, (facetRow: IFacet) => {
-          return facetRow.name === action.payload.facetRow.name;
-        });
-      } else {
-        selected = [
-          action.payload.facetRow,
-          ...state.selected
-        ];
-      }
-      return {
-        facet: state.facet,
-        opened: state.opened,
-        selected: selected
-      };
+      return changeFacet(state, action);
     case FacetActions.emptyFacet:
-      if (state.facet !== action.payload.facet) {
-        return state;
-      }
-
-      return {
-        facet: state.facet,
-        opened: state.opened,
-        selected: []
-      };
+      return emptyFacet(state, action);
     default:
       return state;
   }

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -18,13 +18,13 @@ export interface INavigationChildrenProps {
   numberOfPagesToShow?: number;
   previousLabel?: string;
   nextLabel?: string;
-  currentPage?: number;
-  currentPerPage?: number;
   onPageClick?: (pageNb: number) => void;
   perPageLabel?: string;
   perPageNumbers?: number[];
   onPerPageClick?: () => void;
   hidePages?: boolean;
+  currentPerPage?: number;
+  currentPage?: number;
 }
 
 export interface INavigationStateProps extends IReduxStatePossibleProps {
@@ -56,10 +56,11 @@ export class Navigation extends React.Component<INavigationProps, any> {
       let perPageProps: INavigationPerPageProps = {
         label: this.props.perPageLabel,
         perPageNumbers: this.props.perPageNumbers,
-        totalEntries: this.props.totalEntries,
-        currentPerPage: this.props.currentPerPage,
-        currentPage: this.props.currentPage
+        totalEntries: this.props.totalEntries
       };
+      if (this.props.currentPerPage) {
+        perPageProps.currentPerPage = this.props.currentPerPage;
+      }
       perPage = this.props.withReduxState ?
         <NavigationPerPageConnected id={this.props.id} loadingIds={this.props.loadingIds} {...perPageProps} /> :
         <NavigationPerPage onPerPageClick={this.props.onPerPageClick} {...perPageProps} />;

--- a/src/components/navigation/perPage/NavigationPerPage.tsx
+++ b/src/components/navigation/perPage/NavigationPerPage.tsx
@@ -6,20 +6,19 @@ export interface INavigationPerPageOwnProps extends React.ClassAttributes<Naviga
   id?: string;
   totalEntries: number;
   label?: string;
-  currentPage?: number;
-  currentPerPage?: number;
   perPageNumbers?: number[];
   loadingIds?: string[];
 }
 
 export interface INavigationPerPageStateProps {
   currentPerPage?: number;
+  currentPage?: number;
 }
 
 export interface INavigationPerPageDispatchProps {
   onRender?: (perPageNb: number) => void;
   onDestroy?: () => void;
-  onPerPageClick?: (perPageNb: number) => void;
+  onPerPageClick?: (perPageNb: number, oldPerPageNb: number, currentPage: number) => void;
 }
 
 export interface INavigationPerPageProps extends INavigationPerPageOwnProps, INavigationPerPageStateProps,
@@ -30,6 +29,12 @@ export const PER_PAGE_LABEL: string = 'Results per page';
 
 export class NavigationPerPage extends React.Component<INavigationPerPageProps, any> {
   private perPageNumbers: number[];
+
+  private handleClick(newPerPage: number) {
+    if (this.props.onPerPageClick) {
+      this.props.onPerPageClick(newPerPage, this.props.currentPerPage, this.props.currentPage);
+    }
+  }
 
   componentWillMount() {
     this.perPageNumbers = this.props.perPageNumbers || PER_PAGE_NUMBERS;
@@ -60,7 +65,7 @@ export class NavigationPerPage extends React.Component<INavigationPerPageProps, 
         let isSelected: boolean = currentPerPage === number;
         return (
           <NavigationPerPageSelect
-            onPerPageClick={this.props.onPerPageClick}
+            onPerPageClick={(newPerPageNb: number) => this.handleClick(newPerPageNb)}
             perPageNb={number}
             key={selectId}
             selected={isSelected}

--- a/src/components/navigation/perPage/NavigationPerPageConnected.tsx
+++ b/src/components/navigation/perPage/NavigationPerPageConnected.tsx
@@ -5,7 +5,7 @@ import {
   INavigationPerPageStateProps,
   NavigationPerPage,
   INavigationPerPageDispatchProps,
-  INavigationPerPageOwnProps
+  INavigationPerPageOwnProps, PER_PAGE_NUMBERS
 } from './NavigationPerPage';
 import { IPerPageState } from './NavigationPerPageReducers';
 import { addPerPage, removePerPage, changePerPage } from './NavigationPerPageActions';
@@ -14,12 +14,16 @@ import { turnOnLoading } from '../../loading/LoadingActions';
 import { connect } from 'react-redux';
 import * as React from 'react';
 import * as _ from 'underscore';
+import { IPaginationState } from '../pagination/NavigationPaginationReducers';
 
 const mapStateToProps = (state: IReactVaporState, ownProps: INavigationPerPageOwnProps): INavigationPerPageStateProps => {
   let item: IPerPageState = _.findWhere(state.perPageComposite, { id: ownProps.id });
+  let pagination: IPaginationState = _.findWhere(state.paginationComposite, { id: 'pagination-' + ownProps.id });
+  let firstPerPage: number = ownProps.perPageNumbers ? ownProps.perPageNumbers[0] : PER_PAGE_NUMBERS[0];
 
   return {
-    currentPerPage: item ? item.perPage : null
+    currentPerPage: item ? item.perPage : firstPerPage,
+    currentPage: pagination ? pagination.pageNb : 0
   };
 };
 
@@ -27,13 +31,10 @@ const mapDispatchToProps = (dispatch: (action: IReduxAction<IReduxActionsPayload
   ownProps: INavigationPerPageOwnProps): INavigationPerPageDispatchProps => ({
     onRender: (perPageNb: number) => dispatch(addPerPage(ownProps.id, perPageNb)),
     onDestroy: () => dispatch(removePerPage(ownProps.id)),
-    onPerPageClick: (perPageNb: number) => {
-      let newCurrentPage = ownProps.currentPage && ownProps.currentPerPage ?
-        Math.floor(ownProps.currentPage * ownProps.currentPerPage / perPageNb) : 0;
-
+    onPerPageClick: (perPageNb: number, oldPerPageNb: number, currentPage: number) => {
       dispatch(turnOnLoading(ownProps.loadingIds));
       dispatch(changePerPage(ownProps.id, perPageNb));
-      dispatch(changePage(`pagination-${ownProps.id}`, newCurrentPage));
+      dispatch(changePage(`pagination-${ownProps.id}`, Math.floor(currentPage * oldPerPageNb / perPageNb)));
     }
   });
 

--- a/src/components/navigation/perPage/tests/NavigationPerPage.spec.tsx
+++ b/src/components/navigation/perPage/tests/NavigationPerPage.spec.tsx
@@ -6,7 +6,7 @@ import * as _ from 'underscore';
 import * as React from 'react';
 
 describe('NavigationPerPage', () => {
-  let basicNavigationPerPageProps: INavigationPerPageProps = {
+  const NAVIGATION_PER_PAGE_BASIC_PROPS: INavigationPerPageProps = {
     totalEntries: 50
   };
 
@@ -14,19 +14,19 @@ describe('NavigationPerPage', () => {
     it('should render without errors', () => {
       expect(() => {
         shallow(
-          <NavigationPerPage {...basicNavigationPerPageProps} />
+          <NavigationPerPage {...NAVIGATION_PER_PAGE_BASIC_PROPS} />
         );
       }).not.toThrow();
     });
   });
 
-  describe('NavigationPerPageView', () => {
+  describe('<NavigationPerPage />', () => {
     let navigationPerPage: ReactWrapper<INavigationPerPageProps, any>;
     let navigationPerPageInstance: NavigationPerPage;
 
     beforeEach(() => {
       navigationPerPage = mount(
-        <NavigationPerPage {...basicNavigationPerPageProps} />,
+        <NavigationPerPage {...NAVIGATION_PER_PAGE_BASIC_PROPS} />,
         { attachTo: document.getElementById('App') }
       );
       navigationPerPageInstance = navigationPerPage.instance() as NavigationPerPage;
@@ -41,7 +41,7 @@ describe('NavigationPerPage', () => {
       let totalEntriesProp = navigationPerPage.props().totalEntries;
 
       expect(totalEntriesProp).toBeDefined();
-      expect(totalEntriesProp).toBe(basicNavigationPerPageProps.totalEntries);
+      expect(totalEntriesProp).toBe(NAVIGATION_PER_PAGE_BASIC_PROPS.totalEntries);
     });
 
     it('should render zero <NavigationPerPageSelect /> if the total entries are equal to zero', () => {
@@ -96,7 +96,7 @@ describe('NavigationPerPage', () => {
       expect(() => { navigationPerPageInstance.componentWillMount(); }).not.toThrow();
 
       navigationPerPage = mount(
-        <NavigationPerPage {...basicNavigationPerPageProps} onRender={onRenderSpy} />,
+        <NavigationPerPage {...NAVIGATION_PER_PAGE_BASIC_PROPS} onRender={onRenderSpy} />,
         { attachTo: document.getElementById('App') }
       );
       expect(onRenderSpy).toHaveBeenCalled();
@@ -108,7 +108,7 @@ describe('NavigationPerPage', () => {
       expect(() => { navigationPerPageInstance.componentWillMount(); }).not.toThrow();
 
       navigationPerPage = mount(
-        <NavigationPerPage {...basicNavigationPerPageProps} onDestroy={onDestroySpy} />,
+        <NavigationPerPage {...NAVIGATION_PER_PAGE_BASIC_PROPS} onDestroy={onDestroySpy} />,
         { attachTo: document.getElementById('App') }
       );
       navigationPerPage.unmount();
@@ -117,7 +117,7 @@ describe('NavigationPerPage', () => {
 
     it('should display the per page label if prop is set else it should show the default one', () => {
       let expectedLabel = 'Show this many items per page';
-      let newNavigationPerPageProps = _.extend({}, basicNavigationPerPageProps, { label: expectedLabel });
+      let newNavigationPerPageProps = _.extend({}, NAVIGATION_PER_PAGE_BASIC_PROPS, { label: expectedLabel });
 
       expect(navigationPerPage.html()).toContain(PER_PAGE_LABEL);
 
@@ -128,12 +128,25 @@ describe('NavigationPerPage', () => {
 
     it('should show the custom per page numbers if set as a prop or show the default ones', () => {
       let expectedPerPageNumbers = [2, 3, 4, 5, 10, 30];
-      let newNavigationPerPageProps = _.extend({}, basicNavigationPerPageProps, { perPageNumbers: expectedPerPageNumbers });
+      let newNavigationPerPageProps = _.extend({}, NAVIGATION_PER_PAGE_BASIC_PROPS, { perPageNumbers: expectedPerPageNumbers });
 
       expect(navigationPerPage.find('NavigationPerPageSelect').length).toBe(PER_PAGE_NUMBERS.length);
 
       navigationPerPage.setProps(newNavigationPerPageProps);
       expect(navigationPerPage.find('NavigationPerPageSelect').length).toBe(expectedPerPageNumbers.length);
+    });
+
+    it('should call onPerPageClick prop if it is set when calling handleClick', () => {
+      let newProps: INavigationPerPageProps = _.extend({}, NAVIGATION_PER_PAGE_BASIC_PROPS,
+        { onPerPageClick: jasmine.createSpy('onPerPageClick') });
+      let expectedPerPage: number = 22;
+
+      expect(() => navigationPerPageInstance['handleClick'].call(navigationPerPageInstance, expectedPerPage)).not.toThrow();
+
+      navigationPerPage.setProps(newProps);
+      navigationPerPageInstance['handleClick'].call(navigationPerPageInstance, expectedPerPage);
+
+      expect(newProps.onPerPageClick).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/navigation/perPage/tests/NavigationPerPageConnected.spec.tsx
+++ b/src/components/navigation/perPage/tests/NavigationPerPageConnected.spec.tsx
@@ -5,14 +5,16 @@ import { clearState } from '../../../../utils/ReduxUtils';
 import { IReactVaporState } from '../../../../ReactVapor';
 import { NavigationPerPageConnected } from '../NavigationPerPageConnected';
 import { TestUtils } from '../../../../utils/TestUtils';
-import { NavigationPerPage, INavigationPerPageProps } from '../NavigationPerPage';
+import { NavigationPerPage, INavigationPerPageProps, PER_PAGE_NUMBERS } from '../NavigationPerPage';
 import { addLoading, turnOffLoading } from '../../../loading/LoadingActions';
 import { changePerPage } from '../NavigationPerPageActions';
+import { addPagination, changePage } from '../../pagination/NavigationPaginationActions';
+import { INavigationPerPageSelectProps, NavigationPerPageSelect } from '../NavigationPerPageSelect';
 import * as _ from 'underscore';
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
 
-describe('NavigationPerPageView', () => {
+describe('<NavigationPerPageConnected />', () => {
   let wrapper: ReactWrapper<any, any>;
   let navigationPerPage: ReactWrapper<INavigationPerPageProps, any>;
   let store: Store<IReactVaporState>;
@@ -55,6 +57,26 @@ describe('NavigationPerPageView', () => {
 
     currentPerPageProp = navigationPerPage.props().currentPerPage;
     expect(currentPerPageProp).toBe(20);
+
+    store.dispatch(clearState());
+
+    currentPerPageProp = navigationPerPage.props().currentPerPage;
+    expect(currentPerPageProp).toBe(PER_PAGE_NUMBERS[0]);
+
+    let perPageNumber: number[] = [11, 22, 33];
+    wrapper = mount(
+      <Provider store={store}>
+        <div>
+          <NavigationPerPageConnected {...basicNavigationPerPageProps} perPageNumbers={perPageNumber} />
+        </div>
+      </Provider>,
+      { attachTo: document.getElementById('App') }
+    );
+    navigationPerPage = wrapper.find(NavigationPerPage).first();
+    store.dispatch(clearState());
+
+    currentPerPageProp = navigationPerPage.props().currentPerPage;
+    expect(currentPerPageProp).toBe(perPageNumber[0]);
   });
 
   it('should get what to do onRender as a prop', () => {
@@ -93,4 +115,44 @@ describe('NavigationPerPageView', () => {
     expect(_.findWhere(store.getState().perPageComposite, { id: basicNavigationPerPageProps.id }).perPage.toString()).toBe(perPageSelected.find('span').text());
     expect(_.findWhere(store.getState().loadings, { id: basicNavigationPerPageProps.loadingIds[0] }).isOn).toBe(true);
   });
+
+  it('should not update the currentPerPage prop if a selected <NavigationPerPageSelect /> is clicked', () => {
+    let perPageSelected = navigationPerPage.find('NavigationPerPageSelect').first();
+
+    expect(_.findWhere(store.getState().perPageComposite, { id: basicNavigationPerPageProps.id }).perPage).toBe(10);
+
+    perPageSelected.find('a').simulate('click');
+
+    expect(_.findWhere(store.getState().perPageComposite, { id: basicNavigationPerPageProps.id }).perPage).toBe(10);
+  });
+
+  it('should update the currentPerPage prop if an unselected <NavigationPerPageSelect /> is clicked', () => {
+    let perPageUnSelected = navigationPerPage.find('NavigationPerPageSelect').at(1);
+
+    expect(_.findWhere(store.getState().perPageComposite, { id: basicNavigationPerPageProps.id }).perPage).toBe(10);
+
+    perPageUnSelected.find('a').simulate('click');
+
+    expect(_.findWhere(store.getState().perPageComposite, { id: basicNavigationPerPageProps.id }).perPage).toBe(20);
+  });
+
+  it('should change the page to the one starting with the same item as the previous per page when a new per page is' +
+    'selected', () => {
+      let paginationId: string = 'pagination-' + basicNavigationPerPageProps.id;
+      let firstPerPage: ReactWrapper<INavigationPerPageSelectProps, any> =
+        navigationPerPage.find(NavigationPerPageSelect).first() as ReactWrapper<INavigationPerPageSelectProps, any>;
+      let secondPerPage: ReactWrapper<INavigationPerPageSelectProps, any> =
+        navigationPerPage.find(NavigationPerPageSelect).at(1) as ReactWrapper<INavigationPerPageSelectProps, any>;
+      let startingPage: number = 4;
+      let expectedPage: number = Math.floor(startingPage * firstPerPage.props().perPageNb / secondPerPage.props().perPageNb);
+
+      store.dispatch(addPagination(paginationId));
+      store.dispatch(changePage(paginationId, 4));
+
+      secondPerPage.find('a').simulate('click');
+      expect(_.findWhere(store.getState().paginationComposite, { id: paginationId }).pageNb).toBe(expectedPage);
+
+      firstPerPage.find('a').simulate('click');
+      expect(_.findWhere(store.getState().paginationComposite, { id: paginationId }).pageNb).toBe(startingPage);
+    });
 });

--- a/src/components/navigation/tests/Navigation.spec.tsx
+++ b/src/components/navigation/tests/Navigation.spec.tsx
@@ -2,7 +2,7 @@ import { shallow, mount, ReactWrapper } from 'enzyme';
 import { Navigation, INavigationProps } from '../Navigation';
 import { Loading } from '../../loading/Loading';
 import { NavigationPagination } from '../pagination/NavigationPagination';
-import { NavigationPerPage, PER_PAGE_NUMBERS } from '../perPage/NavigationPerPage';
+import { NavigationPerPage, PER_PAGE_NUMBERS, INavigationPerPageProps } from '../perPage/NavigationPerPage';
 import * as _ from 'underscore';
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
@@ -72,6 +72,17 @@ describe(' navigation', () => {
 
       navigation.setProps(newNavigationProps);
       expect(navigation.find(NavigationPerPage).length).toBe(0);
+    });
+
+    it('should pass on the currentPerPage prop if it is set (used without Redux)', () => {
+      let perPageNav: ReactWrapper<INavigationPerPageProps, any> = navigation.find(NavigationPerPage);
+      let expectedPerPage: number = 33;
+      let newNavigationProps: INavigationProps = _.extend({}, basicNavigationProps, { currentPerPage: expectedPerPage });
+
+      expect(perPageNav.props().currentPerPage).toBeUndefined();
+
+      navigation.setProps(newNavigationProps);
+      expect(perPageNav.props().currentPerPage).toBe(expectedPerPage);
     });
   });
 });

--- a/src/components/navigation/tests/NavigationConnected.spec.tsx
+++ b/src/components/navigation/tests/NavigationConnected.spec.tsx
@@ -9,8 +9,6 @@ import { Provider } from 'react-redux';
 import { LoadingConnected } from '../../loading/LoadingConnected';
 import { NavigationPaginationConnected } from '../pagination/NavigationPaginationConnected';
 import { NavigationPerPageConnected } from '../perPage/NavigationPerPageConnected';
-import { NavigationPerPageSelect } from '../perPage/NavigationPerPageSelect';
-import { NavigationPaginationSelect } from '../pagination/NavigationPaginationSelect';
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
 
@@ -68,34 +66,5 @@ describe('<NavigationConnected />', () => {
 
   it('should render a <NavigationPerPageConnected /> component if totalEntries is higher than the first perPageNumber', () => {
     expect(navigation.find(NavigationPerPageConnected).length).toBe(1);
-  });
-
-  it('should not update the currentPerPage prop if a selected <NavigationPerPageSelect /> is clicked', () => {
-    expect(store.getState().perPageComposite[0].perPage).toBe(10);
-    let secondNavPerPageSelect = navigation.find(NavigationPerPageSelect).at(0);
-    secondNavPerPageSelect.find('a').simulate('click');
-    expect(store.getState().perPageComposite[0].perPage).toBe(10);
-  });
-
-  it('should update the currentPerPage prop if an unselected <NavigationPerPageSelect /> is clicked', () => {
-    expect(store.getState().perPageComposite[0].perPage).toBe(10);
-    let firstNavPerPageSelect = navigation.find(NavigationPerPageSelect).at(1);
-    firstNavPerPageSelect.find('a').simulate('click');
-    expect(store.getState().perPageComposite[0].perPage).toBe(20);
-  });
-
-  it('should reset selected page to 0 when a <NavigationPerPageSelect/> is clicked and currentPerPage and currentPage are not passed as props', () => {
-    let fourthPage = navigation.find(NavigationPaginationSelect).at(3);
-    fourthPage.find('a').simulate('click');
-    expect(store.getState().paginationComposite[0].pageNb).toBe(3);
-
-    let secondNavPerPageSelect = navigation.find(NavigationPerPageSelect).at(1);
-    secondNavPerPageSelect.find('a').simulate('click');
-    expect(store.getState().paginationComposite[0].pageNb).toBe(0);
-
-    fourthPage.find('a').simulate('click');
-    let firstNavPerPageSelect = navigation.find(NavigationPerPageSelect).at(0);
-    firstNavPerPageSelect.find('a').simulate('click');
-    expect(store.getState().paginationComposite[0].pageNb).toBe(0);
   });
 });

--- a/src/components/optionPicker/Option.tsx
+++ b/src/components/optionPicker/Option.tsx
@@ -8,7 +8,7 @@ export interface IOption {
 export interface IOptionProps extends React.ClassAttributes<Option> {
   option: IOption;
   isActive: boolean;
-  onClick: (value: () => string) => void;
+  onClick: (value: string, label: string) => void;
 }
 
 export class Option extends React.Component<IOptionProps, any> {
@@ -17,7 +17,7 @@ export class Option extends React.Component<IOptionProps, any> {
     let buttonClass = this.props.isActive ? 'active' : '';
 
     return (
-      <button className={buttonClass} onClick={() => this.props.onClick(this.props.option.value)}>
+      <button className={buttonClass} onClick={() => this.props.onClick(this.props.option.value(), this.props.option.label)}>
         {this.props.option.label}
       </button>
     );

--- a/src/components/optionPicker/OptionPicker.tsx
+++ b/src/components/optionPicker/OptionPicker.tsx
@@ -8,22 +8,22 @@ export interface IOptionPickerOwnProps extends React.ClassAttributes<OptionPicke
 }
 
 export interface IOptionPickerStateProps {
-  activeValue?: () => string;
+  activeLabel?: string;
 }
 
 export interface IOptionPickerDispatchProps {
   onRender?: () => void;
   onDestroy?: () => void;
-  onClick?: (value: () => string) => void;
+  onClick?: (value: string, label: string) => void;
 }
 
 export interface IOptionPickerProps extends IOptionPickerOwnProps, IOptionPickerStateProps, IOptionPickerDispatchProps { }
 
 export class OptionPicker extends React.Component<IOptionPickerProps, any> {
 
-  private handleClick(value: () => string) {
+  private handleClick(value: string, label: string) {
     if (this.props.onClick) {
-      this.props.onClick(value);
+      this.props.onClick(value, label);
     }
   }
 
@@ -45,8 +45,8 @@ export class OptionPicker extends React.Component<IOptionPickerProps, any> {
       return <li key={`option-${this.props.id}-${index}`}>
         <Option
           option={option}
-          onClick={(value) => this.handleClick(value)}
-          isActive={this.props.activeValue && option.value() === this.props.activeValue()}
+          onClick={(value: string, label: string) => this.handleClick(value, label)}
+          isActive={this.props.activeLabel && option.label === this.props.activeLabel}
           />
       </li>;
     });

--- a/src/components/optionPicker/OptionPickerActions.ts
+++ b/src/components/optionPicker/OptionPickerActions.ts
@@ -12,7 +12,8 @@ export interface IOptionPickerPayload {
 }
 
 export interface IChangeOptionPayload extends IOptionPickerPayload {
-  value: () => string;
+  label: string;
+  value: string;
 }
 
 export const addOptionPicker = (id: string): IReduxAction<IOptionPickerPayload> => ({
@@ -29,10 +30,11 @@ export const removeOptionPicker = (id: string): IReduxAction<IOptionPickerPayloa
   }
 });
 
-export const changeOptionPicker = (id: string, value: () => string): IReduxAction<IChangeOptionPayload> => ({
+export const changeOptionPicker = (id: string, label: string, value: string): IReduxAction<IChangeOptionPayload> => ({
   type: OptionPickerActions.change,
   payload: {
     id,
+    label,
     value
   }
 });

--- a/src/components/optionPicker/OptionPickerConnected.tsx
+++ b/src/components/optionPicker/OptionPickerConnected.tsx
@@ -17,7 +17,7 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IOptionPickerOwnProp
   let item: IOptionPickerState = _.findWhere(state.optionPickers, { id: ownProps.id });
 
   return {
-    activeValue: item && item.selectedValue ? item.selectedValue : () => '',
+    activeLabel: item ? item.selectedLabel : ''
   };
 };
 
@@ -25,7 +25,7 @@ const mapDispatchToProps = (dispatch: (action: IReduxAction<IReduxActionsPayload
   ownProps: IOptionPickerOwnProps): IOptionPickerDispatchProps => ({
     onRender: () => dispatch(addOptionPicker(ownProps.id)),
     onDestroy: () => dispatch(removeOptionPicker(ownProps.id)),
-    onClick: (value: () => string) => dispatch(changeOptionPicker(ownProps.id, value))
+    onClick: (value: string, label: string) => dispatch(changeOptionPicker(ownProps.id, label, value))
   });
 
 export const OptionPickerConnected: React.ComponentClass<IOptionPickerProps> =

--- a/src/components/optionPicker/OptionPickerReducers.ts
+++ b/src/components/optionPicker/OptionPickerReducers.ts
@@ -5,12 +5,14 @@ import * as _ from 'underscore';
 
 export interface IOptionPickerState {
   id: string;
-  selectedValue: () => string;
+  selectedLabel: string;
+  selectedValue: string;
 }
 
 export const optionPickerInitialState: IOptionPickerState = {
   id: undefined,
-  selectedValue: undefined
+  selectedLabel: '',
+  selectedValue: ''
 };
 export const optionPickersInitialState: IOptionPickerState[] = [];
 
@@ -20,6 +22,7 @@ export const optionPickerReducer = (state: IOptionPickerState = optionPickerInit
     case OptionPickerActions.add:
       return {
         id: action.payload.id,
+        selectedLabel: state.selectedLabel,
         selectedValue: state.selectedValue
       };
     case OptionPickerActions.change:
@@ -27,6 +30,7 @@ export const optionPickerReducer = (state: IOptionPickerState = optionPickerInit
         return state;
       }
       return _.extend({}, state, {
+        selectedLabel: action.payload.label,
         selectedValue: action.payload.value
       });
     case OptionPickerActions.reset:

--- a/src/components/optionPicker/tests/Option.spec.tsx
+++ b/src/components/optionPicker/tests/Option.spec.tsx
@@ -76,7 +76,10 @@ describe('Option picker', () => {
     it('should call the onClick prop with the result of the option value when clicking the button', () => {
       option.find('button').simulate('click');
 
-      expect(OPTION_BASIC_PROPS.onClick).toHaveBeenCalledWith(OPTION_BASIC_PROPS.option.value);
+      expect(OPTION_BASIC_PROPS.onClick).toHaveBeenCalledWith(
+        OPTION_BASIC_PROPS.option.value(),
+        OPTION_BASIC_PROPS.option.label
+      );
     });
   });
 });

--- a/src/components/optionPicker/tests/OptionPicker.spec.tsx
+++ b/src/components/optionPicker/tests/OptionPicker.spec.tsx
@@ -101,15 +101,16 @@ describe('Option picker', () => {
     it('should call prop onClick on mounting if set when calling handleClick', () => {
       let onClickSpy: jasmine.Spy = jasmine.createSpy('onClick');
       let expectedValue: string = 'value';
+      let expectedLabel: string = 'label';
       let withOnClickProps: IOptionPickerProps = _.extend({}, OPTION_PICKER_BASIC_PROPS, { onClick: onClickSpy });
 
-      expect(() => optionPickerInstance['handleClick'].call(optionPickerInstance, expectedValue)).not.toThrow();
+      expect(() => optionPickerInstance['handleClick'].call(optionPickerInstance, expectedValue, expectedLabel)).not.toThrow();
       expect(onClickSpy).not.toHaveBeenCalled();
 
       optionPicker.setProps(withOnClickProps);
-      optionPickerInstance['handleClick'].call(optionPickerInstance, expectedValue);
+      optionPickerInstance['handleClick'].call(optionPickerInstance, expectedValue, expectedLabel);
 
-      expect(onClickSpy).toHaveBeenCalledWith(expectedValue);
+      expect(onClickSpy).toHaveBeenCalledWith(expectedValue, expectedLabel);
     });
 
     it('should call handleClick when clicking an option', () => {
@@ -117,7 +118,10 @@ describe('Option picker', () => {
 
       optionPicker.find('Option').first().find('button').simulate('click');
 
-      expect(handleClickSpy).toHaveBeenCalledWith(OPTION_PICKER_BASIC_PROPS.options[0].value);
+      expect(handleClickSpy).toHaveBeenCalledWith(
+        OPTION_PICKER_BASIC_PROPS.options[0].value(),
+        OPTION_PICKER_BASIC_PROPS.options[0].label
+      );
     });
   });
 });

--- a/src/components/optionPicker/tests/OptionPickerActions.spec.ts
+++ b/src/components/optionPicker/tests/OptionPickerActions.spec.ts
@@ -37,16 +37,18 @@ describe('Option picker', () => {
     });
 
     it('should create an action to change the option picker value', () => {
-      let expectedValue: () => string = () => 'any value we want';
+      let expectedValue: string = 'any value we want';
+      let expectedLabel: string = 'any label';
       let expectedAction: IReduxAction<IReduxActionsPayload> = {
         type: OptionPickerActions.change,
         payload: {
           id: OPTION_PICKER_ID,
-          value: expectedValue
+          value: expectedValue,
+          label: expectedLabel
         }
       };
 
-      expect(changeOptionPicker(OPTION_PICKER_ID, expectedValue)).toEqual(expectedAction);
+      expect(changeOptionPicker(OPTION_PICKER_ID, expectedLabel, expectedValue)).toEqual(expectedAction);
     });
 
     it('should create an action to reset the option pickers', () => {

--- a/src/components/optionPicker/tests/OptionPickerReducers.spec.ts
+++ b/src/components/optionPicker/tests/OptionPickerReducers.spec.ts
@@ -27,7 +27,7 @@ describe('Option picker', () => {
     });
 
     it('should return the old state when the action is not defined', () => {
-      let oldState: IOptionPickerState[] = [{ id: 'some-option-picker', selectedValue: () => 'anything' }];
+      let oldState: IOptionPickerState[] = [{ id: 'some-option-picker', selectedValue: 'anything', selectedLabel: 'the label' }];
       let optionPickersState: IOptionPickerState[] = optionPickersReducer(oldState, genericAction);
 
       expect(optionPickersState).toBe(oldState);
@@ -58,13 +58,16 @@ describe('Option picker', () => {
       let oldState: IOptionPickerState[] = [
         {
           id: 'some-option-picker2',
-          selectedValue: () => ''
+          selectedValue: '',
+          selectedLabel: ''
         }, {
           id: 'some-option-picker',
-          selectedValue: () => 'something'
+          selectedValue: 'something',
+          selectedLabel: 'something'
         }, {
           id: 'some-option-picker3',
-          selectedValue: () => 'nothing'
+          selectedValue: 'nothing',
+          selectedLabel: 'nothing'
         }
       ];
       let action: IReduxAction<IOptionPickerPayload> = {
@@ -86,69 +89,85 @@ describe('Option picker', () => {
       expect(optionPickersState.filter((optionPicker: IOptionPickerState) => optionPicker.id === action.payload.id).length).toBe(0);
     });
 
-    it('should return the old state when the action is "REMOVE_OPTION_PICKER" and the options cycle id does not exist', () => {
-      let oldState: IOptionPickerState[] = [
-        {
-          id: 'some-option-picker2',
-          selectedValue: () => ''
-        }, {
-          id: 'some-option-picker',
-          selectedValue: () => 'something'
-        }, {
-          id: 'some-option-picker3',
-          selectedValue: () => 'nothing'
-        }
-      ];
-      let action: IReduxAction<IOptionPickerPayload> = {
-        type: OptionPickerActions.remove,
-        payload: {
-          id: 'some-option-picker4'
-        }
-      };
-      let optionPickersState: IOptionPickerState[] = optionPickersReducer(oldState, action);
+    it('should return the old state when the action is "REMOVE_OPTION_PICKER" and the options cycle id does not exist',
+      () => {
+        let oldState: IOptionPickerState[] = [
+          {
+            id: 'some-option-picker2',
+            selectedValue: '',
+            selectedLabel: ''
+          }, {
+            id: 'some-option-picker',
+            selectedValue: 'something',
+            selectedLabel: 'something'
+          }, {
+            id: 'some-option-picker3',
+            selectedValue: 'nothing',
+            selectedLabel: 'nothing'
+          }
+        ];
+        let action: IReduxAction<IOptionPickerPayload> = {
+          type: OptionPickerActions.remove,
+          payload: {
+            id: 'some-option-picker4'
+          }
+        };
+        let optionPickersState: IOptionPickerState[] = optionPickersReducer(oldState, action);
 
-      expect(optionPickersState.length).toBe(oldState.length);
-      expect(optionPickersState.filter((optionPicker: IOptionPickerState) => optionPicker.id === action.payload.id).length).toBe(0);
-    });
+        expect(optionPickersState.length).toBe(oldState.length);
+        expect(optionPickersState
+          .filter((optionPicker: IOptionPickerState) => optionPicker.id === action.payload.id).length).toBe(0);
+      });
 
-    it('should return the state with the new selected value for the option picker with the action id when the action is "CHANGE_OPTION"', () => {
-      let oldState: IOptionPickerState[] = [
-        {
-          id: 'some-option-picker2',
-          selectedValue: () => ''
-        }, {
-          id: 'some-option-picker',
-          selectedValue: () => 'something'
-        }, {
-          id: 'some-option-picker3',
-          selectedValue: () => 'nothing'
-        }
-      ];
-      let action: IReduxAction<IChangeOptionPayload> = {
-        type: OptionPickerActions.change,
-        payload: {
-          id: 'some-option-picker',
-          value: () => 'new value'
-        }
-      };
-      let optionPickersState: IOptionPickerState[] = optionPickersReducer(oldState, action);
-      expect(_.findWhere(optionPickersState, { id: action.payload.id }).selectedValue()).toBe(action.payload.value());
-    });
+    it('should return the state with the new selected value and label for the option picker with the action id when' +
+      'the action is "CHANGE_OPTION"', () => {
+        let oldState: IOptionPickerState[] = [
+          {
+            id: 'some-option-picker2',
+            selectedValue: '',
+            selectedLabel: ''
+          }, {
+            id: 'some-option-picker',
+            selectedValue: 'something',
+            selectedLabel: 'something'
+          }, {
+            id: 'some-option-picker3',
+            selectedValue: 'nothing',
+            selectedLabel: 'nothing'
+          }
+        ];
+        let action: IReduxAction<IChangeOptionPayload> = {
+          type: OptionPickerActions.change,
+          payload: {
+            id: 'some-option-picker',
+            value: 'new value',
+            label: 'new label'
+          }
+        };
+        let optionPickersState: IOptionPickerState[] = optionPickersReducer(oldState, action);
+
+        expect(_.findWhere(optionPickersState, { id: action.payload.id }).selectedValue).toBe(action.payload.value);
+        expect(_.findWhere(optionPickersState, { id: action.payload.id }).selectedLabel).toBe(action.payload.label);
+      });
 
     it('should reset all option pickers starting with the action id if the action is "RESET_OPTION_PICKERS"', () => {
       let oldState: IOptionPickerState[] = [
         {
           id: 'some-option-picker2',
-          selectedValue: () => ''
+          selectedValue: '',
+          selectedLabel: ''
         }, {
           id: 'some-option-picker',
-          selectedValue: () => 'something'
+          selectedValue: 'something',
+          selectedLabel: 'something'
         }, {
           id: 'some-option-picker3',
-          selectedValue: () => 'nothing'
+          selectedValue: 'nothing',
+          selectedLabel: 'nothing'
         }, {
           id: 'other-id',
-          selectedValue: () => 'this will not be reset'
+          selectedValue: 'this will not be reset',
+          selectedLabel: 'this wont be rest either'
         }
       ];
       let action: IReduxAction<IOptionPickerPayload> = {
@@ -158,10 +177,18 @@ describe('Option picker', () => {
         }
       };
       let optionPickersState: IOptionPickerState[] = optionPickersReducer(oldState, action);
-      expect(_.findWhere(optionPickersState, { id: 'some-option-picker2' }).selectedValue).toBeUndefined();
-      expect(_.findWhere(optionPickersState, { id: 'some-option-picker' }).selectedValue).toBeUndefined();
-      expect(_.findWhere(optionPickersState, { id: 'some-option-picker3' }).selectedValue).toBeUndefined();
-      expect(_.findWhere(optionPickersState, { id: 'other-id' }).selectedValue).toBeDefined();
+
+      expect(_.findWhere(optionPickersState, { id: 'some-option-picker2' }).selectedValue).toBe('');
+      expect(_.findWhere(optionPickersState, { id: 'some-option-picker2' }).selectedLabel).toBe('');
+
+      expect(_.findWhere(optionPickersState, { id: 'some-option-picker' }).selectedValue).toBe('');
+      expect(_.findWhere(optionPickersState, { id: 'some-option-picker' }).selectedLabel).toBe('');
+
+      expect(_.findWhere(optionPickersState, { id: 'some-option-picker3' }).selectedValue).toBe('');
+      expect(_.findWhere(optionPickersState, { id: 'some-option-picker3' }).selectedLabel).toBe('');
+
+      expect(_.findWhere(optionPickersState, { id: 'other-id' }).selectedValue).not.toBe('');
+      expect(_.findWhere(optionPickersState, { id: 'other-id' }).selectedLabel).not.toBe('');
     });
 
     it('should not change the original state', () => {
@@ -187,7 +214,7 @@ describe('Option picker', () => {
     });
 
     it('should return the old state when the action is not defined', () => {
-      let oldState: IOptionPickerState = { id: 'some-option-picker', selectedValue: () => 'anything' };
+      let oldState: IOptionPickerState = { id: 'some-option-picker', selectedValue: 'anything', selectedLabel: 'aaa' };
       let optionPickerState: IOptionPickerState = optionPickerReducer(oldState, genericAction);
 
       expect(optionPickerState).toBe(oldState);
@@ -204,47 +231,55 @@ describe('Option picker', () => {
       let optionPickerState: IOptionPickerState = optionPickerReducer(oldState, action);
 
       expect(optionPickerState.id).toBe(action.payload.id);
-      expect(optionPickerState.selectedValue).toBeUndefined();
+      expect(optionPickerState.selectedValue).toBe('');
+      expect(optionPickerState.selectedValue).toBe('');
     });
 
     it('should return the original state if the action is "CHANGE_OPTION" and the id is not the one specified in the action', () => {
       let oldState: IOptionPickerState = {
         id: 'some-option-picker',
-        selectedValue: () => 'anything'
+        selectedValue: 'anything',
+        selectedLabel: 'aaa'
       };
       let action: IReduxAction<IChangeOptionPayload> = {
         type: OptionPickerActions.change,
         payload: {
           id: 'some-option-picker5',
-          value: () => 'nothing'
+          value: 'nothing',
+          label: 'bbb'
         }
       };
       let optionPickerState: IOptionPickerState = optionPickerReducer(oldState, action);
 
-      expect(optionPickerState.selectedValue()).toBe(oldState.selectedValue());
+      expect(optionPickerState.selectedValue).toBe(oldState.selectedValue);
+      expect(optionPickerState.selectedLabel).toBe(oldState.selectedLabel);
     });
 
-    it('should return the option picker with a new selected value when the action is "CHANGE_OPTION" and the id is the one specified', () => {
+    it('should return the option picker with a new selected value and label when the action is "CHANGE_OPTION" and the id is the one specified', () => {
       let oldState: IOptionPickerState = {
         id: 'some-option-picker',
-        selectedValue: () => 'anything'
+        selectedValue: 'anything',
+        selectedLabel: 'aaa'
       };
       let action: IReduxAction<IChangeOptionPayload> = {
         type: OptionPickerActions.change,
         payload: {
           id: 'some-option-picker',
-          value: () => 'nothing'
+          value: 'nothing',
+          label: 'bbb'
         }
       };
       let optionPickerState: IOptionPickerState = optionPickerReducer(oldState, action);
 
-      expect(optionPickerState.selectedValue()).toBe(action.payload.value());
+      expect(optionPickerState.selectedValue).toBe(action.payload.value);
+      expect(optionPickerState.selectedLabel).toBe(action.payload.label);
     });
 
     it('should return the option picker as is if the action is "RESET_OPTION_PICKERS" and the id does not start with the one from the action', () => {
       let oldState: IOptionPickerState = {
         id: 'some-option-picker',
-        selectedValue: () => 'anything'
+        selectedValue: 'anything',
+        selectedLabel: 'aaa'
       };
       let action: IReduxAction<IOptionPickerPayload> = {
         type: OptionPickerActions.reset,
@@ -254,13 +289,15 @@ describe('Option picker', () => {
       };
       let optionPickerState: IOptionPickerState = optionPickerReducer(oldState, action);
 
-      expect(optionPickerState.selectedValue()).toBe(oldState.selectedValue());
+      expect(optionPickerState.selectedValue).toBe(oldState.selectedValue);
+      expect(optionPickerState.selectedLabel).toBe(oldState.selectedLabel);
     });
 
     it('should return the option picker without a selected value if the action is "RESET_OPTION_PICKERS" and the id starts with the one from the action', () => {
       let oldState: IOptionPickerState = {
         id: 'some-option-picker',
-        selectedValue: () => 'anything'
+        selectedValue: 'anything',
+        selectedLabel: 'aaa'
       };
       let action: IReduxAction<IOptionPickerPayload> = {
         type: OptionPickerActions.reset,
@@ -270,7 +307,8 @@ describe('Option picker', () => {
       };
       let optionPickerState: IOptionPickerState = optionPickerReducer(oldState, action);
 
-      expect(optionPickerState.selectedValue).toBeUndefined();
+      expect(optionPickerState.selectedValue).toBe('');
+      expect(optionPickerState.selectedLabel).toBe('');
     });
 
     it('should not change the original state', () => {
@@ -279,7 +317,8 @@ describe('Option picker', () => {
         type: OptionPickerActions.change,
         payload: {
           id: 'some-option-picker',
-          value: () => 'a value'
+          value: 'a value',
+          label: 'a label'
         }
       };
       optionPickerReducer(optionPickerInitialState, action);

--- a/src/components/optionPicker/tests/OptionsPickerConnected.spec.tsx
+++ b/src/components/optionPicker/tests/OptionsPickerConnected.spec.tsx
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import { IOptionPickerProps, OptionPicker } from '../OptionPicker';
 import { OptionPickerConnected } from '../OptionPickerConnected';
 import { changeOptionPicker } from '../OptionPickerActions';
+import { IOptionPickerState } from '../OptionPickerReducers';
 import * as _ from 'underscore';
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
@@ -56,11 +57,11 @@ describe('Option picker', () => {
       expect(idProp).toBe(OPTION_PICKER_BASIC_PROPS.id);
     });
 
-    it('should get the active value as a prop', () => {
-      let activeValueProp = optionPicker.props().activeValue;
+    it('should get the active label as a prop', () => {
+      let activeLabelProp = optionPicker.props().activeLabel;
 
-      expect(activeValueProp).toBeDefined();
-      expect(activeValueProp()).toBe('');
+      expect(activeLabelProp).toBeDefined();
+      expect(activeLabelProp).toBe('');
     });
 
     it('should get what to do on render as a prop', () => {
@@ -81,19 +82,20 @@ describe('Option picker', () => {
       expect(onChangeProp).toBeDefined();
     });
 
-    it('should return an empty string for the activeValue when the option picker does not exist in the state', () => {
+    it('should return an empty string for the activeLabel when the option picker does not exist in the state', () => {
       store.dispatch(clearState());
 
       expect(_.findWhere(store.getState().optionPickers, { id: OPTION_PICKER_BASIC_PROPS.id })).toBeUndefined();
-      expect(optionPicker.props().activeValue()).toBe('');
+      expect(optionPicker.props().activeLabel).toBe('');
     });
 
-    it('should return the selectedValue from the state when the option picker exists in the state', () => {
-      let expectedSelectedValue: () => string = () => 'our value';
+    it('should return the activeLabel from the state when the option picker exists in the state', () => {
+      let expectedSelectedValue: string = 'our value';
+      let expectedSelectedLabel: string = 'our label';
 
-      store.dispatch(changeOptionPicker(OPTION_PICKER_BASIC_PROPS.id, expectedSelectedValue));
+      store.dispatch(changeOptionPicker(OPTION_PICKER_BASIC_PROPS.id, expectedSelectedLabel, expectedSelectedValue));
 
-      expect(optionPicker.props().activeValue()).toBe(expectedSelectedValue());
+      expect(optionPicker.props().activeLabel).toBe(expectedSelectedLabel);
     });
 
     it('should call onRender prop when mounted', () => {
@@ -114,19 +116,24 @@ describe('Option picker', () => {
     });
 
     it('should set the selected value to the one sent when calling the onClick prop', () => {
-      let expectedSelectedValue: () => string = () => 'our value';
+      let expectedSelectedValue: string = 'our value';
+      let expectedSelectedLabel: string = 'our label';
+      let optionPickerState: IOptionPickerState;
 
-      optionPicker.props().onClick(expectedSelectedValue);
+      optionPicker.props().onClick(expectedSelectedValue, expectedSelectedLabel);
 
-      expect(_.findWhere(store.getState().optionPickers, { id: OPTION_PICKER_BASIC_PROPS.id }).selectedValue())
-        .toBe(expectedSelectedValue());
+      optionPickerState = _.findWhere(store.getState().optionPickers, { id: OPTION_PICKER_BASIC_PROPS.id });
+      expect(optionPickerState.selectedValue).toBe(expectedSelectedValue);
+      expect(optionPickerState.selectedLabel).toBe(expectedSelectedLabel);
 
-      expectedSelectedValue = () => 'new value';
+      expectedSelectedValue = 'new value';
+      expectedSelectedLabel = 'new label';
 
-      optionPicker.props().onClick(expectedSelectedValue);
+      optionPicker.props().onClick(expectedSelectedValue, expectedSelectedLabel);
 
-      expect(_.findWhere(store.getState().optionPickers, { id: OPTION_PICKER_BASIC_PROPS.id }).selectedValue())
-        .toBe(expectedSelectedValue());
+      optionPickerState = _.findWhere(store.getState().optionPickers, { id: OPTION_PICKER_BASIC_PROPS.id });
+      expect(optionPickerState.selectedValue).toBe(expectedSelectedValue);
+      expect(optionPickerState.selectedLabel).toBe(expectedSelectedLabel);
     });
   });
 });


### PR DESCRIPTION
What changed: 

1. Value of the option picker is calculated on option click and not re-evaluated each time the state changes. I added the label in the state also to compare the options between them instead of using the value which can sometimes be different because of when it was calculated.

2. The per page navigation gets it's current per page and the page number from the state and not from its parent (currentPerPage was there twice and there were often conflicts were the selected per page number was not the right one).

3. Auto-selections of inputs on the date picker. We select the first one when opening the date picker and the second one when the first one have been selected.

4. Select the end of the day when clicking and selecting the upper limit. Feels more natural this way and fixes the problem of the lower and upper limit being the same when clicking on the same date.