### PR TITLE
Cleaned up dts for projects using a typescript version below 2.1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,6 +109,7 @@ gulp.task('internalDefs', false, () =>
 
 gulp.task('cleanDefs', false, () =>
   gulp.src('dist/react-vapor.d.ts')
+    .pipe(replace(/: Partial<[A-Za-z]+>/gm, ''))
     .pipe(replace(/import.*$/gm, ''))
     .pipe(replace(/export =.+;$/gm, ''))
     .pipe(replace(/export default.+;$/gm, ''))


### PR DESCRIPTION
It simply removes the offending "Partial<>" types from the d.ts which isn't all that useful in the definition file either way.