### PR TITLE
Added missing class

### DIFF
--- a/src/components/datePicker/DatePickerDropdown.tsx
+++ b/src/components/datePicker/DatePickerDropdown.tsx
@@ -153,7 +153,7 @@ export class DatePickerDropdown extends React.Component<IDatePickerDropdownProps
       ? <DatePickerBox withReduxState id={this.props.id} {...datePickerBoxProps} />
       : <DatePickerBox {...datePickerBoxProps} />;
 
-    let dropdownClasses: string[] = ['dropdown-wrapper'];
+    let dropdownClasses: string[] = ['dropdown-wrapper', 'dropdown'];
     if (this.props.isOpened) {
       dropdownClasses.push('open');
     }


### PR DESCRIPTION
There was a change in the css for the dropdown class that made the datepicker dropdown unable to open. Since the change in vapor was legitimate, I simply added the class here to make it work again.