### PR TITLE
dispatch close only when open

### DIFF
--- a/src/components/datePicker/DatePickerDropdown.tsx
+++ b/src/components/datePicker/DatePickerDropdown.tsx
@@ -77,7 +77,7 @@ export class DatePickerDropdown extends React.Component<IDatePickerDropdownProps
 
   private handleDocumentClick = (e: MouseEvent) => {
     let dropdown: HTMLDivElement = ReactDOM.findDOMNode<HTMLDivElement>(this.dropdown);
-    if (!dropdown.contains(e.target as Node)) {
+    if (!dropdown.contains(e.target as Node) && this.props.isOpened) {
       this.props.onDocumentClick();
       this.handleCancel();
     }

--- a/src/components/datePicker/tests/DatePickerDropdown.spec.tsx
+++ b/src/components/datePicker/tests/DatePickerDropdown.spec.tsx
@@ -186,9 +186,9 @@ describe('Date picker', () => {
       expect(onClickSpy).toHaveBeenCalled();
     });
 
-    it('should add a listener on document on mount and remove it on unmount if prop onDocumentClick is set', () => {
+    it('should trigger onDocumentClick dispatch on mount and remove it on unmount if prop onDocumentClick is set and isOpened is true', () => {
       let onDocumentClickSpy = jasmine.createSpy('onDocumentClick');
-      let newDropdownProps = _.extend({}, DATE_PICKER_DROPDOWN_BASIC_PROPS, { onDocumentClick: onDocumentClickSpy });
+      let newDropdownProps = _.extend({}, DATE_PICKER_DROPDOWN_BASIC_PROPS, { onDocumentClick: onDocumentClickSpy, isOpened: true });
 
       datePickerDropdown.mount();
       document.getElementById('App').click();
@@ -205,9 +205,28 @@ describe('Date picker', () => {
       expect(onDocumentClickSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('should not trigger onDocumentClick dispatch on mount if prop onDocumentClick is set and isOpened is false', () => {
+      let onDocumentClickSpy = jasmine.createSpy('onDocumentClick');
+      let newDropdownProps = _.extend({}, DATE_PICKER_DROPDOWN_BASIC_PROPS, { onDocumentClick: onDocumentClickSpy, isOpened: false });
+
+      datePickerDropdown.mount();
+      document.getElementById('App').click();
+      expect(onDocumentClickSpy).not.toHaveBeenCalled();
+
+      datePickerDropdown.unmount();
+      datePickerDropdown.setProps(newDropdownProps);
+      datePickerDropdown.mount();
+      document.getElementById('App').click();
+      expect(onDocumentClickSpy).not.toHaveBeenCalled();
+
+      datePickerDropdown.unmount();
+      document.getElementById('App').click();
+      expect(onDocumentClickSpy).not.toHaveBeenCalled();
+    });
+
     it('should not call onDocumentClick when prop is set and clicking on the dropdown', () => {
       let onDocumentClickSpy = jasmine.createSpy('onDocumentClick');
-      let newDropdownProps = _.extend({}, DATE_PICKER_DROPDOWN_BASIC_PROPS, { onDocumentClick: onDocumentClickSpy });
+      let newDropdownProps = _.extend({}, DATE_PICKER_DROPDOWN_BASIC_PROPS, { onDocumentClick: onDocumentClickSpy, isOpened: true });
 
       datePickerDropdown = mount(
         <DatePickerDropdown {...newDropdownProps} />,


### PR DESCRIPTION
if you have many date pickers in a view, it triggers many CLOSE actions which cause the UI to be very very slow, we want to dispatch the action only if the datepicker is open