### PR TITLE
fix default selected option in DropdownSearch

### DIFF
--- a/src/components/dropdownSearch/DropdownSearchActions.tsx
+++ b/src/components/dropdownSearch/DropdownSearchActions.tsx
@@ -13,7 +13,7 @@ export interface IOptionsDropdownSearchPayload extends IDefaultDropdownSearchPay
   dropdownOptions?: IDropdownOption[];
   filterText?: string;
   selectedOptions?: IDropdownOption[];
-  selectedOption?: IDropdownOption;
+  defaultSelectedOption?: IDropdownOption;
   selectedOptionValue?: string;
   addedSelectedOption?: IDropdownOption;
   isOpened?: boolean;
@@ -74,11 +74,12 @@ export const closeDropdownSearch = (id: string): IReduxAction<IDefaultDropdownSe
   },
 });
 
-export const addDropdownSearch = (id: string, dropdownOptions: IDropdownOption[]): IReduxAction<IOptionsDropdownSearchPayload> => ({
+export const addDropdownSearch = (id: string, dropdownOptions: IDropdownOption[], defaultSelectedOption?: IDropdownOption): IReduxAction<IOptionsDropdownSearchPayload> => ({
   type: DropdownSearchActions.add,
   payload: {
     id,
     dropdownOptions,
+    defaultSelectedOption,
   },
 });
 

--- a/src/components/dropdownSearch/DropdownSearchActions.tsx
+++ b/src/components/dropdownSearch/DropdownSearchActions.tsx
@@ -45,11 +45,12 @@ export const applyFilterDropdownSearch = (id: string, filterText: string): IRedu
   },
 });
 
-export const updateOptionsDropdownSearch = (id: string, dropdownOptions: IDropdownOption[]): IReduxAction<IOptionsDropdownSearchPayload> => ({
+export const updateOptionsDropdownSearch = (id: string, dropdownOptions: IDropdownOption[], defaultSelectedOption?: IDropdownOption): IReduxAction<IOptionsDropdownSearchPayload> => ({
   type: DropdownSearchActions.update,
   payload: {
     id,
     dropdownOptions,
+    defaultSelectedOption,
   },
 });
 

--- a/src/components/dropdownSearch/DropdownSearchConnected.tsx
+++ b/src/components/dropdownSearch/DropdownSearchConnected.tsx
@@ -35,7 +35,7 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IDropdownSearchProps
 
 const mapDispatchToProps = (dispatch: (action: IReduxAction<IReduxActionsPayload>) => void,
   ownProps: IDropdownSearchOwnProps) => ({
-    onMount: () => dispatch(addDropdownSearch(ownProps.id, ownProps.defaultOptions)),
+    onMount: () => dispatch(addDropdownSearch(ownProps.id, ownProps.defaultOptions, ownProps.defaultSelectedOption)),
     onDestroy: () => dispatch(removeDropdownSearch(ownProps.id)),
     onToggleDropdown: () => dispatch(toggleDropdownSearch(ownProps.id)),
     onBlur: () => dispatch(toggleDropdownSearch(ownProps.id)),

--- a/src/components/dropdownSearch/DropdownSearchReducers.tsx
+++ b/src/components/dropdownSearch/DropdownSearchReducers.tsx
@@ -17,7 +17,7 @@ export interface IDropdownSearchState {
   setFocusOnDropdownButton?: boolean;
 }
 
-export const defaultSelectedOption: IDropdownOption = {
+export const defaultSelectedOptionPlaceholder: IDropdownOption = {
   value: 'Select an option',
   selected: true,
   custom: true,
@@ -125,6 +125,22 @@ export const multiSelectOption = (options: IDropdownOption[], selectedOption: ID
   });
 };
 
+export const updateOptions = (options: IDropdownOption[], selectedOption?: IDropdownOption): IDropdownOption[] => {
+  let updatedOptions: IDropdownOption[] = options
+    ? deepClone(options)
+    : [];
+
+  const defaultSelectedOption = selectedOption
+    ? { ...selectedOption, selected: true, custom: true }
+    : defaultSelectedOptionPlaceholder;
+
+  updatedOptions = _.find(updatedOptions, (option) => option.value === defaultSelectedOption.value)
+    ? selectSingleOption(updatedOptions, defaultSelectedOption)
+    : [...updatedOptions, defaultSelectedOption];
+
+  return updatedOptions;
+};
+
 export const dropdownSearchReducer = (state: IDropdownSearchState = dropdownSearchInitialState,
   action: IReduxAction<IOptionsDropdownSearchPayload>): IDropdownSearchState => {
 
@@ -157,7 +173,8 @@ export const dropdownSearchReducer = (state: IDropdownSearchState = dropdownSear
       return {
         ...state,
         id: action.payload.id,
-        options: action.payload.dropdownOptions,
+        options: updateOptions(action.payload.dropdownOptions, action.payload.defaultSelectedOption),
+        filterText: '',
         setFocusOnDropdownButton: false,
       };
     case DropdownSearchActions.filter:
@@ -178,13 +195,9 @@ export const dropdownSearchReducer = (state: IDropdownSearchState = dropdownSear
         setFocusOnDropdownButton: false,
       };
     case DropdownSearchActions.add:
-      const options = action.payload.dropdownOptions || [];
-      const defaultOption = action.payload.defaultSelectedOption
-        ? { ...action.payload.defaultSelectedOption, selected: true, custom: true }
-        : defaultSelectedOption;
       return {
         ...state,
-        options: [...options, defaultOption],
+        options: updateOptions(action.payload.dropdownOptions, action.payload.defaultSelectedOption),
         id: action.payload.id,
         filterText: '',
         isOpened: false,

--- a/src/components/dropdownSearch/DropdownSearchReducers.tsx
+++ b/src/components/dropdownSearch/DropdownSearchReducers.tsx
@@ -178,10 +178,14 @@ export const dropdownSearchReducer = (state: IDropdownSearchState = dropdownSear
         setFocusOnDropdownButton: false,
       };
     case DropdownSearchActions.add:
+      const options = action.payload.dropdownOptions || [];
+      const defaultOption = action.payload.defaultSelectedOption
+        ? {...action.payload.defaultSelectedOption, selected: true, custom: true}
+        : defaultSelectedOption;
       return {
         ...state,
+        options: [...options, defaultOption],
         id: action.payload.id,
-        options: action.payload.dropdownOptions ? action.payload.dropdownOptions.concat(defaultSelectedOption) : [defaultSelectedOption],
         filterText: '',
         isOpened: false,
       };

--- a/src/components/dropdownSearch/DropdownSearchReducers.tsx
+++ b/src/components/dropdownSearch/DropdownSearchReducers.tsx
@@ -180,7 +180,7 @@ export const dropdownSearchReducer = (state: IDropdownSearchState = dropdownSear
     case DropdownSearchActions.add:
       const options = action.payload.dropdownOptions || [];
       const defaultOption = action.payload.defaultSelectedOption
-        ? {...action.payload.defaultSelectedOption, selected: true, custom: true}
+        ? { ...action.payload.defaultSelectedOption, selected: true, custom: true }
         : defaultSelectedOption;
       return {
         ...state,

--- a/src/components/dropdownSearch/MultiSelectDropdownSearch/tests/MultiSelectDropdownSearchConnected.spec.tsx
+++ b/src/components/dropdownSearch/MultiSelectDropdownSearch/tests/MultiSelectDropdownSearchConnected.spec.tsx
@@ -8,7 +8,7 @@ import { MultiSelectDropdownSearchConnected } from '../MultiSelectDropdownSearch
 import { MultiSelectDropdownSearch } from '../MultiSelectDropdownSearch';
 import { TestUtils } from '../../../../utils/TestUtils';
 import { clearState } from '../../../../utils/ReduxUtils';
-import { defaultSelectedOption } from '../../DropdownSearchReducers';
+import { defaultSelectedOptionPlaceholder } from '../../DropdownSearchReducers';
 import {
   addCustomSelectedOption,
   applyFilterDropdownSearch,
@@ -163,7 +163,7 @@ describe('MultiSelectDropdownSearch', () => {
         wrapper.find('li span').first().simulate('mouseDown');
 
         const selectedOption = store.getState().dropdownSearch[0].options[0];
-        expect(selectedOption).not.toBe(defaultSelectedOption);
+        expect(selectedOption).not.toBe(defaultSelectedOptionPlaceholder);
         expect(selectedOption.value).toBe('test 1');
       });
 

--- a/src/components/dropdownSearch/examples/DropdownSearchExamples.tsx
+++ b/src/components/dropdownSearch/examples/DropdownSearchExamples.tsx
@@ -53,7 +53,7 @@ export class DropdownSearchExamples extends React.Component<any, any> {
         <div className='form-group'>
           <label className='form-control-label'>Default Dropdown</label>
           <div className='form-control'>
-            <DropdownSearchConnected {..._.extend({}, defaultOptions, { id: UUID.generate() }) } />
+            <DropdownSearchConnected {..._.extend({}, defaultOptions, { id: UUID.generate(), defaultSelectedOption: {value: 'default', displayValue: 'Default Option'} }) } />
           </div>
         </div>
         <div className='form-group'>

--- a/src/components/dropdownSearch/examples/DropdownSearchExamples.tsx
+++ b/src/components/dropdownSearch/examples/DropdownSearchExamples.tsx
@@ -53,19 +53,25 @@ export class DropdownSearchExamples extends React.Component<any, any> {
         <div className='form-group'>
           <label className='form-control-label'>Default Dropdown</label>
           <div className='form-control'>
-            <DropdownSearchConnected {..._.extend({}, defaultOptions, { id: UUID.generate(), defaultSelectedOption: { value: 'default', displayValue: 'Default Option' } }) } />
+            <DropdownSearchConnected {..._.extend({}, defaultOptions, { id: UUID.generate() }) } />
+          </div>
+        </div>
+        <div className='form-group'>
+          <label className='form-control-label'>Dropdown with default selected option</label>
+          <div className='form-control'>
+            <DropdownSearchConnected {..._.extend({}, defaultOptions, { id: UUID.generate(), defaultSelectedOption: { value: 'Option 1' } }) } />
+          </div>
+        </div>
+        <div className='form-group'>
+          <label className='form-control-label'>Dropdown with custom default selected option</label>
+          <div className='form-control'>
+            <DropdownSearchConnected {..._.extend({}, defaultOptions, { id: UUID.generate(), defaultSelectedOption: { value: 'Custom default selected option' } }) } />
           </div>
         </div>
         <div className='form-group'>
           <label className='form-control-label'>Dropdown with 5 000 options</label>
           <div className='form-control'>
             <DropdownSearchConnected {..._.extend({}, manyOptions, { id: UUID.generate() }) } />
-          </div>
-        </div>
-        <div className='form-group'>
-          <label className='form-control-label'>Dropdown with selected option</label>
-          <div className='form-control'>
-            <DropdownSearchConnected {..._.extend({}, { id: UUID.generate() }) } />
           </div>
         </div>
         <div className='form-group'>

--- a/src/components/dropdownSearch/examples/DropdownSearchExamples.tsx
+++ b/src/components/dropdownSearch/examples/DropdownSearchExamples.tsx
@@ -53,7 +53,7 @@ export class DropdownSearchExamples extends React.Component<any, any> {
         <div className='form-group'>
           <label className='form-control-label'>Default Dropdown</label>
           <div className='form-control'>
-            <DropdownSearchConnected {..._.extend({}, defaultOptions, { id: UUID.generate(), defaultSelectedOption: {value: 'default', displayValue: 'Default Option'} }) } />
+            <DropdownSearchConnected {..._.extend({}, defaultOptions, { id: UUID.generate(), defaultSelectedOption: { value: 'default', displayValue: 'Default Option' } }) } />
           </div>
         </div>
         <div className='form-group'>

--- a/src/components/dropdownSearch/tests/DropdownSearch.spec.tsx
+++ b/src/components/dropdownSearch/tests/DropdownSearch.spec.tsx
@@ -6,7 +6,7 @@ import { DropdownSearch, IDropdownOption, IDropdownSearchProps } from '../Dropdo
 import * as _ from 'underscore';
 import { FilterBox } from '../../filterBox/FilterBox';
 import { keyCode } from '../../../utils/InputUtils';
-import { defaultSelectedOption } from '../DropdownSearchReducers';
+import { defaultSelectedOptionPlaceholder } from '../DropdownSearchReducers';
 
 describe('DropdownSearch', () => {
   const id: string = UUID.generate();
@@ -217,7 +217,7 @@ describe('DropdownSearch', () => {
 
     describe('Props functionality', () => {
 
-      let selectedOption: IDropdownOption = defaultSelectedOption;
+      let selectedOption: IDropdownOption = defaultSelectedOptionPlaceholder;
 
       beforeEach(() => {
         selectedOption = {

--- a/src/components/dropdownSearch/tests/DropdownSearchConnected.spec.tsx
+++ b/src/components/dropdownSearch/tests/DropdownSearchConnected.spec.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { DropdownSearchConnected } from '../DropdownSearchConnected';
 import { UUID } from '../../../utils/UUID';
 import { DropdownSearch, IDropdownSearchProps } from '../DropdownSearch';
-import { defaultSelectedOption } from '../DropdownSearchReducers';
+import { defaultSelectedOptionPlaceholder } from '../DropdownSearchReducers';
 import { toggleDropdownSearch, updateActiveOptionDropdownSearch, updateOptionsDropdownSearch } from '../DropdownSearchActions';
 import { keyCode } from '../../../utils/InputUtils';
 import * as _ from 'underscore';
@@ -87,8 +87,6 @@ describe('DropdownSearch', () => {
       it('should get the options as a prop', () => {
         const optionsProp = dropdownSearch.props().options;
 
-        console.log(optionsProp);
-
         expect(optionsProp).toBeDefined();
         expect(optionsProp.length).toBe(3);
       });
@@ -97,7 +95,7 @@ describe('DropdownSearch', () => {
         const defaultSelectedOptionProp = _.findWhere(dropdownSearch.props().options, { selected: true });
 
         expect(defaultSelectedOptionProp).toBeDefined();
-        expect(defaultSelectedOptionProp).toBe(defaultSelectedOption);
+        expect(defaultSelectedOptionProp).toBe(defaultSelectedOptionPlaceholder);
       });
 
       it('should get the filterText as a prop', () => {
@@ -200,7 +198,7 @@ describe('DropdownSearch', () => {
         wrapper.find('li span').first().simulate('mouseDown');
 
         const selectedOption = store.getState().dropdownSearch[0].options[0];
-        expect(selectedOption).not.toBe(defaultSelectedOption);
+        expect(selectedOption).not.toBe(defaultSelectedOptionPlaceholder);
         expect(selectedOption.value).toBe('test 1');
       });
 

--- a/src/components/dropdownSearch/tests/DropdownSearchReducer.spec.tsx
+++ b/src/components/dropdownSearch/tests/DropdownSearchReducer.spec.tsx
@@ -100,12 +100,12 @@ describe('DropdownSearch', () => {
       expect(dropdownSearchState.filter((dropdownSearch: IDropdownSearchState) => dropdownSearch.id === action.payload.id).length).toBe(1);
     });
 
-    it('should return a state with a default selected option when defaultSelectedOption is given', () =>{
+    it('should return a state with a default selected option when defaultSelectedOption is given', () => {
       let oldState: IDropdownSearchState[] = dropdownsSearchInitialState;
       const defaultSelectedOption: IDropdownOption = { value: 'Default option' };
       const action: IReduxAction<IOptionsDropdownSearchPayload> = {
         type: DropdownSearchActions.add,
-        payload: _.extend({}, {...defaultPayload, defaultSelectedOption, dropdownOptions: options}),
+        payload: _.extend({}, { ...defaultPayload, defaultSelectedOption, dropdownOptions: options }),
       };
       let dropdownSearchState: IDropdownSearchState[] = dropdownsSearchReducer(oldState, action);
 

--- a/src/components/dropdownSearch/tests/DropdownSearchReducer.spec.tsx
+++ b/src/components/dropdownSearch/tests/DropdownSearchReducer.spec.tsx
@@ -100,6 +100,20 @@ describe('DropdownSearch', () => {
       expect(dropdownSearchState.filter((dropdownSearch: IDropdownSearchState) => dropdownSearch.id === action.payload.id).length).toBe(1);
     });
 
+    it('should return a state with a default selected option when defaultSelectedOption is given', () =>{
+      let oldState: IDropdownSearchState[] = dropdownsSearchInitialState;
+      const defaultSelectedOption: IDropdownOption = { value: 'Default option' };
+      const action: IReduxAction<IOptionsDropdownSearchPayload> = {
+        type: DropdownSearchActions.add,
+        payload: _.extend({}, {...defaultPayload, defaultSelectedOption, dropdownOptions: options}),
+      };
+      let dropdownSearchState: IDropdownSearchState[] = dropdownsSearchReducer(oldState, action);
+
+      const dropdownSearch = _.find(dropdownSearchState, (dropdownSearch: IDropdownSearchState) => dropdownSearch.id === action.payload.id);
+
+      expect(_.find(dropdownSearch.options, (option) => option.value === defaultSelectedOption.value).selected).toBe(true);
+    });
+
     it('should return the old state without the dropdownSearch with the payload id when the action is "REMOVE_DROPDOWN_SEARCH"', () => {
       let oldState: IDropdownSearchState[] = defaultState.slice();
       const action: IReduxAction<IOptionsDropdownSearchPayload> = {

--- a/src/components/dropdownSearch/tests/DropdownSearchReducer.spec.tsx
+++ b/src/components/dropdownSearch/tests/DropdownSearchReducer.spec.tsx
@@ -6,7 +6,7 @@ import {
   dropdownSearchReducer,
   dropdownsSearchInitialState,
   dropdownsSearchReducer, getDisplayedOptions,
-  IDropdownSearchState, deselectLastSelectedOption, deselectAllOptions, deselectOption, defaultSelectedOption,
+  IDropdownSearchState, deselectLastSelectedOption, deselectAllOptions, deselectOption, defaultSelectedOptionPlaceholder,
 } from '../DropdownSearchReducers';
 import { DropdownSearchActions, IOptionsDropdownSearchPayload } from '../DropdownSearchActions';
 import * as _ from 'underscore';
@@ -124,7 +124,21 @@ describe('DropdownSearch', () => {
 
       const dropdownSearch = _.find(dropdownSearchState, (dropdownSearch: IDropdownSearchState) => dropdownSearch.id === action.payload.id);
 
-      expect(_.find(dropdownSearch.options, (option) => option.value === defaultSelectedOption.value)).toBeDefined();
+      expect(_.find(dropdownSearch.options, (option) => option.value === defaultSelectedOptionPlaceholder.value)).toBeDefined();
+    });
+
+    it('should return a state with a selectedOption if the defaultSelectedOption is equal to one option already present "ADD_DROPDOWN_SEARCH"', () => {
+      let oldState: IDropdownSearchState[] = dropdownsSearchInitialState;
+      const defaultSelectedOption: IDropdownOption = { value: 'Default option', selected: false };
+      const action: IReduxAction<IOptionsDropdownSearchPayload> = {
+        type: DropdownSearchActions.add,
+        payload: _.extend({}, { ...defaultPayload, options: [defaultSelectedOption], defaultSelectedOption }),
+      };
+      let dropdownSearchState: IDropdownSearchState[] = dropdownsSearchReducer(oldState, action);
+
+      const dropdownSearch = _.find(dropdownSearchState, (dropdownSearch: IDropdownSearchState) => dropdownSearch.id === action.payload.id);
+
+      expect(_.find(dropdownSearch.options, (option) => option.value === defaultSelectedOption.value).selected).toBe(true);
     });
 
     it('should return the old state without the dropdownSearch with the payload id when the action is "REMOVE_DROPDOWN_SEARCH"', () => {
@@ -173,7 +187,7 @@ describe('DropdownSearch', () => {
 
     it('should return the new state with the isOpened toggle and the filterText reset to empty string on "UPDATE_DROPDOWN_SEARCH"', () => {
       const dropdownOption = [{ value: 'test' }, { value: 'test 1' }, { value: 'test 2' }];
-      const newDropdownOption = [{ value: 'test 4' }];
+      const newDropdownOption = [{ value: 'test 4', selected: true }];
       const oldState: IDropdownSearchState[] = [
         {
           id: 'new-dropdown-search',
@@ -184,13 +198,14 @@ describe('DropdownSearch', () => {
 
       const action: IReduxAction<IOptionsDropdownSearchPayload> = {
         type: DropdownSearchActions.update,
-        payload: _.extend({}, defaultPayload, { dropdownOptions: newDropdownOption }),
+        payload: _.extend({}, defaultPayload, { dropdownOptions: newDropdownOption, defaultSelectedOption: newDropdownOption[0] }),
       };
+
       const dropdownSearchState: IDropdownSearchState[] = dropdownsSearchReducer(oldState, action);
 
       expect(dropdownSearchState.length).toBe(oldState.length);
       expect(dropdownSearchState.filter((dropdownSearch: IDropdownSearchState) =>
-        dropdownSearch.id === action.payload.id && dropdownSearch.options === newDropdownOption).length).toBe(1);
+        dropdownSearch.id === action.payload.id)[0].options).toEqual(newDropdownOption);
     });
 
     it('should return the new state with the isOpened toggle and the filterText reset to empty string on "FILTER_DROPDOWN_SEARCH"', () => {

--- a/src/components/dropdownSearch/tests/DropdownSearchReducer.spec.tsx
+++ b/src/components/dropdownSearch/tests/DropdownSearchReducer.spec.tsx
@@ -6,7 +6,7 @@ import {
   dropdownSearchReducer,
   dropdownsSearchInitialState,
   dropdownsSearchReducer, getDisplayedOptions,
-  IDropdownSearchState, deselectLastSelectedOption, deselectAllOptions, deselectOption,
+  IDropdownSearchState, deselectLastSelectedOption, deselectAllOptions, deselectOption, defaultSelectedOption,
 } from '../DropdownSearchReducers';
 import { DropdownSearchActions, IOptionsDropdownSearchPayload } from '../DropdownSearchActions';
 import * as _ from 'underscore';
@@ -80,7 +80,7 @@ describe('DropdownSearch', () => {
       expect(actionBarState).toBe(oldState);
     });
 
-    it('should return a new state with actions payload has parameter on "ADD_DROPDOWN_SEARCH', () => {
+    it('should return a new state with actions payload has parameter on "ADD_DROPDOWN_SEARCH"', () => {
       let oldState: IDropdownSearchState[] = dropdownsSearchInitialState;
       const action: IReduxAction<IOptionsDropdownSearchPayload> = {
         type: DropdownSearchActions.add,
@@ -100,7 +100,7 @@ describe('DropdownSearch', () => {
       expect(dropdownSearchState.filter((dropdownSearch: IDropdownSearchState) => dropdownSearch.id === action.payload.id).length).toBe(1);
     });
 
-    it('should return a state with a default selected option when defaultSelectedOption is given', () => {
+    it('should return a state with a default selected option when defaultSelectedOption is given on "ADD_DROPDOWN_SEARCH"', () => {
       let oldState: IDropdownSearchState[] = dropdownsSearchInitialState;
       const defaultSelectedOption: IDropdownOption = { value: 'Default option' };
       const action: IReduxAction<IOptionsDropdownSearchPayload> = {
@@ -112,6 +112,19 @@ describe('DropdownSearch', () => {
       const dropdownSearch = _.find(dropdownSearchState, (dropdownSearch: IDropdownSearchState) => dropdownSearch.id === action.payload.id);
 
       expect(_.find(dropdownSearch.options, (option) => option.value === defaultSelectedOption.value).selected).toBe(true);
+    });
+
+    it('should return a state with a default selected option when no options are given on "ADD_DROPDOWN_SEARCH"', () => {
+      let oldState: IDropdownSearchState[] = dropdownsSearchInitialState;
+      const action: IReduxAction<IOptionsDropdownSearchPayload> = {
+        type: DropdownSearchActions.add,
+        payload: _.extend({}, { ...defaultPayload }),
+      };
+      let dropdownSearchState: IDropdownSearchState[] = dropdownsSearchReducer(oldState, action);
+
+      const dropdownSearch = _.find(dropdownSearchState, (dropdownSearch: IDropdownSearchState) => dropdownSearch.id === action.payload.id);
+
+      expect(_.find(dropdownSearch.options, (option) => option.value === defaultSelectedOption.value)).toBeDefined();
     });
 
     it('should return the old state without the dropdownSearch with the payload id when the action is "REMOVE_DROPDOWN_SEARCH"', () => {


### PR DESCRIPTION
L'org picker était pété à cause que j'ai joué un peu dans les props du dropdown search. Maintenant ça devrait être beau! On peut entrer une option par défaut à la création du dropdown.