### PR TITLE
Add update to the dropdown search options on mount 

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/tether": "1.4.3",
     "@types/underscore": "1.8.3",
     "@types/underscore.string": "0.0.31",
-    "@types/webpack": "3.0.10",
+    "@types/webpack": "3.0.12",
     "@types/webpack-env": "1.13.1",
     "autoprefixer": "7.1.4",
     "bithound": "1.7.0",
@@ -118,11 +118,11 @@
     "ts-loader": "2.3.7",
     "tslint": "4.5.1",
     "tslint-loader": "3.5.3",
-    "typescript": "2.5.2",
+    "typescript": "2.5.3",
     "underscore": "1.8.3",
     "underscore.string": "3.3.4",
-    "webpack": "3.5.6",
-    "webpack-dev-server": "2.6.0"
+    "webpack": "3.6.0",
+    "webpack-dev-server": "2.9.1"
   },
   "files": [
     "dist",

--- a/src/components/dropdownSearch/DropdownSearchConnected.tsx
+++ b/src/components/dropdownSearch/DropdownSearchConnected.tsx
@@ -9,7 +9,7 @@ import {
   removeDropdownSearch,
   selectOptionDropdownSearch,
   toggleDropdownSearch,
-  updateActiveOptionDropdownSearch,
+  updateActiveOptionDropdownSearch, updateOptionsDropdownSearch,
 } from './DropdownSearchActions';
 import { IDropdownSearchState } from './DropdownSearchReducers';
 
@@ -35,7 +35,14 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IDropdownSearchProps
 
 const mapDispatchToProps = (dispatch: (action: IReduxAction<IReduxActionsPayload>) => void,
   ownProps: IDropdownSearchOwnProps) => ({
-    onMount: () => { dispatch(addDropdownSearch(ownProps.id, ownProps.defaultOptions, ownProps.defaultSelectedOption, ownProps.supportSingleCustomOption)); },
+    onMount: () => {
+      dispatch(addDropdownSearch(ownProps.id, ownProps.defaultOptions, ownProps.defaultSelectedOption, ownProps.supportSingleCustomOption));
+
+      // TODO: remove this once the component is refactored and the DropdownSearchReducer is not overwriting the defaultSelectedOption passed above anymore.
+      if (ownProps.defaultSelectedOption) {
+        dispatch(updateOptionsDropdownSearch(ownProps.id, ownProps.defaultOptions, ownProps.defaultSelectedOption));
+      }
+    },
     onDestroy: () => dispatch(removeDropdownSearch(ownProps.id)),
     onToggleDropdown: () => dispatch(toggleDropdownSearch(ownProps.id)),
     onBlur: () => dispatch(toggleDropdownSearch(ownProps.id)),

--- a/src/components/dropdownSearch/tests/DropdownSearchConnected.spec.tsx
+++ b/src/components/dropdownSearch/tests/DropdownSearchConnected.spec.tsx
@@ -2,14 +2,16 @@
 import { mount, ReactWrapper } from 'enzyme';
 import { Provider, Store } from 'react-redux';
 import { clearState } from '../../../utils/ReduxUtils';
-import { IReactVaporState } from '../../../ReactVapor';
-import { TestUtils } from '../../../utils/TestUtils';
+import { IReactVaporTestState, TestUtils } from '../../../utils/TestUtils';
 import * as React from 'react';
 import { DropdownSearchConnected } from '../DropdownSearchConnected';
 import { UUID } from '../../../utils/UUID';
 import { DropdownSearch, IDropdownSearchProps } from '../DropdownSearch';
 import { defaultSelectedOptionPlaceholder } from '../DropdownSearchReducers';
-import { toggleDropdownSearch, updateActiveOptionDropdownSearch, updateOptionsDropdownSearch } from '../DropdownSearchActions';
+import {
+  DropdownSearchActions, toggleDropdownSearch, updateActiveOptionDropdownSearch,
+  updateOptionsDropdownSearch
+} from '../DropdownSearchActions';
 import { keyCode } from '../../../utils/InputUtils';
 import * as _ from 'underscore';
 
@@ -19,7 +21,7 @@ describe('DropdownSearch', () => {
   describe('<DropdownSearchConnected />', () => {
     let wrapper: ReactWrapper<any, any>;
     let dropdownSearch: ReactWrapper<IDropdownSearchProps, any>;
-    let store: Store<IReactVaporState>;
+    let store: Store<IReactVaporTestState>;
 
     const defaultOptions = [{ value: 'a' }, { value: 'b' }];
 
@@ -57,6 +59,22 @@ describe('DropdownSearch', () => {
         wrapper.mount();
         expect(store.getState().dropdownSearch.length).toBe(1);
       });
+
+      it('should also dispatch a updateOptionsDropdownSearch onMount if there is a defaultSelectedOption', () => {
+        expect(store.getState().lastAction.type).not.toBe(DropdownSearchActions.update);
+
+        wrapper.unmount();
+
+        wrapper = mount(
+          <Provider store={store}>
+            <DropdownSearchConnected id={id} defaultOptions={defaultOptions} defaultSelectedOption={defaultSelectedOptionPlaceholder} />
+          </Provider>,
+          { attachTo: document.getElementById('App') },
+        );
+
+        expect(store.getState().lastAction.type).toBe(DropdownSearchActions.update);
+      });
+
 
       it('should call onDestroy prop when will unmount', () => {
         wrapper.unmount();

--- a/src/utils/TestUtils.ts
+++ b/src/utils/TestUtils.ts
@@ -21,9 +21,18 @@ import * as Redux from 'redux';
 import { dropdownsSearchReducer } from '../components/dropdownSearch/DropdownSearchReducers';
 import { toastsContainerReducer } from '../components/toast/ToastReducers';
 
+export interface IReactVaporTestState extends IReactVaporState {
+  lastAction?: Redux.Action;
+}
+
 export class TestUtils {
   static buildStore() {
-    let reactVaporReducers = Redux.combineReducers({
+    const lastActionReducer = (state: IReactVaporTestState = null, action: Redux.Action): Redux.Action => {
+      return action;
+    };
+
+    const reactVaporReducers = Redux.combineReducers({
+      lastAction: lastActionReducer,
       lastUpdatedComposite: lastUpdatedCompositeReducer,
       filters: filterBoxesReducer,
       facets: facetsReducer,
@@ -45,7 +54,7 @@ export class TestUtils {
       toastContainers: toastsContainerReducer,
     });
 
-    let reactVapor = (state: IReactVaporState, action: Redux.Action) => {
+    const reactVapor = (state: IReactVaporTestState, action: Redux.Action) => {
       state = action.type === CommonActions.clearState ? undefined : state;
       return reactVaporReducers(state, action as any);
     };

--- a/webpack.config.test.js
+++ b/webpack.config.test.js
@@ -29,7 +29,7 @@ module.exports = {
         use: {
           loader: 'ts-loader',
           options: {
-            configFileName: 'tsconfig.test.json',
+            configFile: 'tsconfig.test.json',
           },
         },
       },


### PR DESCRIPTION
If there is a default selected option since it is currently being overwritten by the reducer, with the update on mount, we are now showing the custom option. This is a quick fix until the dropdown search is being refactored. The reducer should not initialized itself with options that should be customizable.