### PR TITLE
Fix date picker end date manual input

### DIFF
--- a/src/components/calendar/CalendarConnected.tsx
+++ b/src/components/calendar/CalendarConnected.tsx
@@ -11,7 +11,6 @@ import {
   changeDatePickerLowerLimit,
   changeDatePickerUpperLimit,
   DateLimits,
-  resetDatePickers,
   selectDate
 } from '../datePicker/DatePickerActions';
 import { changeOptionPicker } from '../optionPicker/OptionPickerActions';
@@ -40,9 +39,7 @@ const mapDispatchToProps = (dispatch: (action: IReduxAction<IReduxActionsPayload
     onClick: (pickerId: string, isUpperLimit: boolean, value: Date) => {
       dispatch(selectDate(pickerId, ''));
       dispatch(changeOptionPicker(pickerId, '', ''));
-      if (!value) {
-        dispatch(resetDatePickers(pickerId));
-      } else {
+      if (value) {
         if (isUpperLimit) {
           dispatch(changeDatePickerUpperLimit(pickerId, moment(value).endOf('day').toDate()));
         } else {

--- a/src/components/calendar/tests/CalendarConnected.spec.tsx
+++ b/src/components/calendar/tests/CalendarConnected.spec.tsx
@@ -145,11 +145,13 @@ describe('Calendar', () => {
         expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).selected).toBe(DateLimits.upper);
       });
 
-    it('should reset the date picker if on click is called without a value', () => {
+    it('should keep the current value set if on click is called without a value', () => {
       store.dispatch(addDatePicker(PICKER_ID, false, 'any', CALENDAR_ID));
       store.dispatch(selectDate(PICKER_ID, DateLimits.lower));
 
-      calendar.props().onClick(PICKER_ID, false, new Date());
+      const newDate: Date = new Date();
+
+      calendar.props().onClick(PICKER_ID, false, newDate);
 
       expect(_.findWhere(store.getState().datePickers, { id: PICKER_ID }).lowerLimit).toBeDefined();
 
@@ -157,7 +159,7 @@ describe('Calendar', () => {
 
       const datePicker: IDatePickerState = _.findWhere(store.getState().datePickers, { id: PICKER_ID });
 
-      expect(datePicker.lowerLimit).toBe(datePicker.appliedLowerLimit);
+      expect(datePicker.lowerLimit).toBe(newDate);
       expect(datePicker.selected).toBe('');
     });
 

--- a/src/components/datePicker/DatePickerBox.tsx
+++ b/src/components/datePicker/DatePickerBox.tsx
@@ -100,7 +100,7 @@ export class DatePickerBox extends React.Component<IDatePickerBoxProps, any> {
       <div className='date-picker-box flex flex-column'>
         <div className='split-layout'>
           {calendar}
-          <div className='date-selection column p2'>
+          <div className='date-selection column mod-small-content p2'>
             {datesSelectionBoxes}
           </div>
         </div>

--- a/src/components/datePicker/DatePickerReducers.ts
+++ b/src/components/datePicker/DatePickerReducers.ts
@@ -62,11 +62,13 @@ const selectDate = (state: IDatePickerState, action: IReduxAction<IReduxActionsP
 };
 
 const applyDates = (state: IDatePickerState, action: IReduxAction<IReduxActionsPayload>): IDatePickerState => {
+  const lowerLimit: Date = state.lowerLimit || state.appliedLowerLimit;
+
   return state.id.indexOf(action.payload.id) !== 0
     ? state
     : _.extend({}, state, {
-      appliedLowerLimit: state.lowerLimit || state.appliedLowerLimit,
-      appliedUpperLimit: (state.upperLimit >= state.lowerLimit ? state.upperLimit : state.lowerLimit) || state.appliedUpperLimit
+      appliedLowerLimit: lowerLimit,
+      appliedUpperLimit: (state.upperLimit >= lowerLimit ? state.upperLimit : state.lowerLimit) || state.appliedUpperLimit,
     });
 };
 

--- a/src/components/datePicker/tests/DatePickerReducers.spec.ts
+++ b/src/components/datePicker/tests/DatePickerReducers.spec.ts
@@ -490,7 +490,7 @@ describe('Date picker', () => {
       expect(expectedState).toEqual(datePickerInitialState);
     });
 
-    describe('reducers for the action "APPLY_DATE"', () => {
+    describe('reducer for the action "APPLY_DATE"', () => {
 
       let action: IReduxAction<IDatePickerPayload>;
       let oldState: IDatePickerState;

--- a/src/components/datePicker/tests/DatePickerReducers.spec.ts
+++ b/src/components/datePicker/tests/DatePickerReducers.spec.ts
@@ -505,78 +505,64 @@ describe('Date picker', () => {
       expect(datePickerState.appliedLowerLimit).toBe(oldState.appliedLowerLimit);
     });
 
-    it('should return the lowerLimit if the lowerLimit is defined', () => {
-      let oldState: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE);
-      let action: IReduxAction<IDatePickerPayload> = {
-        type: DatePickerActions.apply,
-        payload: {
-          id: 'some-date-picker',
-        },
-      };
-      let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
+    describe('reducers for the action "APPLY_DATE"', () => {
 
-      expect(datePickerState.lowerLimit).toBe(oldState.lowerLimit);
-    });
+      let action: IReduxAction<IDatePickerPayload>;
+      let oldState: IDatePickerState;
+      let datePickerState: IDatePickerState;
 
-    it('should return the appliedUpperLimit if the upperLimit and the lowerLimit is not defined', () => {
-      let oldState: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE, {
-        upperLimit: undefined,
-        lowerLimit: undefined,
+      beforeEach(() => {
+        action = {
+          type: DatePickerActions.apply,
+          payload: {
+            id: 'some-date-picker',
+          },
+        };
       });
-      let action: IReduxAction<IDatePickerPayload> = {
-        type: DatePickerActions.apply,
-        payload: {
-          id: 'some-date-picker',
-        },
-      };
-      let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
-      expect(datePickerState.appliedUpperLimit).toBe(oldState.appliedUpperLimit);
-    });
+      it('should return the lowerLimit if the lowerLimit is defined', () => {
+        oldState = _.extend({}, BASE_DATE_PICKER_STATE);
+        datePickerState = datePickerReducer(oldState, action);
 
-    it('should return the upperLimit if its greater than the lowerLimit', () => {
-      let oldState: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE);
-      let action: IReduxAction<IDatePickerPayload> = {
-        type: DatePickerActions.apply,
-        payload: {
-          id: 'some-date-picker',
-        },
-      };
-      let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
-
-      expect(datePickerState.appliedUpperLimit).toBe(oldState.upperLimit);
-    });
-
-    it('should return the lowerLimit if the upperLimit is smaller than the lowerLimit', () => {
-      let oldState: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE, {
-        lowerLimit: new Date().setHours(2, 1, 2, 1),
-        upperLimit: new Date().setHours(1, 1, 2, 1),
+        expect(datePickerState.lowerLimit).toBe(oldState.lowerLimit);
       });
-      let action: IReduxAction<IDatePickerPayload> = {
-        type: DatePickerActions.apply,
-        payload: {
-          id: 'some-date-picker',
-        },
-      };
-      let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
-      expect(datePickerState.appliedUpperLimit).toBe(oldState.lowerLimit);
-    });
+      it('should return the appliedUpperLimit if the upperLimit and the lowerLimit are not defined', () => {
+        oldState = _.extend({}, BASE_DATE_PICKER_STATE, {
+          upperLimit: undefined,
+          lowerLimit: undefined,
+        });
+        datePickerState = datePickerReducer(oldState, action);
 
-    it('should return the lowerLimit if the upperLimit is equal than the lowerLimit', () => {
-      let oldState: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE, {
-        lowerLimit: new Date().setHours(1, 1, 2, 1),
-        upperLimit: new Date().setHours(1, 1, 2, 1),
+        expect(datePickerState.appliedUpperLimit).toBe(oldState.appliedUpperLimit);
       });
-      let action: IReduxAction<IDatePickerPayload> = {
-        type: DatePickerActions.apply,
-        payload: {
-          id: 'some-date-picker',
-        },
-      };
-      let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
-      expect(datePickerState.appliedUpperLimit).toBe(oldState.lowerLimit);
+      it('should return the upperLimit if its greater than the lowerLimit', () => {
+        oldState = _.extend({}, BASE_DATE_PICKER_STATE);
+        datePickerState = datePickerReducer(oldState, action);
+
+        expect(datePickerState.appliedUpperLimit).toBe(oldState.upperLimit);
+      });
+
+      it('should return the lowerLimit if the upperLimit is smaller than the lowerLimit', () => {
+        oldState = _.extend({}, BASE_DATE_PICKER_STATE, {
+          lowerLimit: new Date().setHours(2, 1, 2, 1),
+          upperLimit: new Date().setHours(1, 1, 2, 1),
+        });
+        datePickerState = datePickerReducer(oldState, action);
+
+        expect(datePickerState.appliedUpperLimit).toBe(oldState.lowerLimit);
+      });
+
+      it('should return the lowerLimit if the upperLimit is equal than the lowerLimit', () => {
+        oldState = _.extend({}, BASE_DATE_PICKER_STATE, {
+          lowerLimit: new Date().setHours(1, 1, 2, 1),
+          upperLimit: new Date().setHours(1, 1, 2, 1),
+        });
+        datePickerState = datePickerReducer(oldState, action);
+
+        expect(datePickerState.appliedUpperLimit).toBe(oldState.lowerLimit);
+      });
     });
   });
 });

--- a/src/components/datePicker/tests/DatePickerReducers.spec.ts
+++ b/src/components/datePicker/tests/DatePickerReducers.spec.ts
@@ -5,14 +5,14 @@ import {
   DatePickerActions,
   IChangeDatePickerPayload,
   DateLimits,
-  ISelectDatePickerPayload
+  ISelectDatePickerPayload,
 } from '../DatePickerActions';
 import {
   IDatePickerState,
   datePickersReducer,
   datePickersInitialState,
   datePickerInitialState,
-  datePickerReducer
+  datePickerReducer,
 } from '../DatePickerReducers';
 import * as _ from 'underscore';
 
@@ -21,8 +21,8 @@ describe('Date picker', () => {
   const GENERIC_ACTION: IReduxAction<IDatePickerPayload> = {
     type: 'DO_SOMETHING',
     payload: {
-      id: 'some-date-picker'
-    }
+      id: 'some-date-picker',
+    },
   };
 
   const BASE_DATE_PICKER_STATE: IDatePickerState = {
@@ -34,7 +34,7 @@ describe('Date picker', () => {
     upperLimit: new Date(new Date().setHours(3, 2, 1, 2)),
     selected: '',
     appliedLowerLimit: new Date(new Date().setHours(0, 0, 0, 0)),
-    appliedUpperLimit: new Date(new Date().setHours(23, 59, 59, 999))
+    appliedUpperLimit: new Date(new Date().setHours(23, 59, 59, 999)),
   };
 
   describe('datePickersReducer', () => {
@@ -60,8 +60,8 @@ describe('Date picker', () => {
           id: 'some-date-picker',
           isRange: true,
           calendarId: 'calendar-321',
-          color: 'magenta'
-        }
+          color: 'magenta',
+        },
       };
       let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
 
@@ -82,13 +82,13 @@ describe('Date picker', () => {
       let oldState: IDatePickerState[] = [
         _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
         _.extend({}, BASE_DATE_PICKER_STATE),
-        _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' })
+        _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' }),
       ];
       let action: IReduxAction<IDatePickerPayload> = {
         type: DatePickerActions.remove,
         payload: {
-          id: 'some-date-picker'
-        }
+          id: 'some-date-picker',
+        },
       };
       let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
 
@@ -110,13 +110,13 @@ describe('Date picker', () => {
         let oldState: IDatePickerState[] = [
           _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
           _.extend({}, BASE_DATE_PICKER_STATE),
-          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' })
+          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' }),
         ];
         let action: IReduxAction<IDatePickerPayload> = {
           type: DatePickerActions.remove,
           payload: {
-            id: 'some-date-picker4'
-          }
+            id: 'some-date-picker4',
+          },
         };
         let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
 
@@ -129,13 +129,13 @@ describe('Date picker', () => {
       let oldState: IDatePickerState[] = [
         _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
         _.extend({}, BASE_DATE_PICKER_STATE),
-        _.extend({}, BASE_DATE_PICKER_STATE, { id: 'other-id' })
+        _.extend({}, BASE_DATE_PICKER_STATE, { id: 'other-id' }),
       ];
       let action: IReduxAction<IDatePickerPayload> = {
         type: DatePickerActions.reset,
         payload: {
-          id: 'some-date-picker'
-        }
+          id: 'some-date-picker',
+        },
       };
       let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
 
@@ -156,13 +156,13 @@ describe('Date picker', () => {
       let oldState: IDatePickerState[] = [
         _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
         _.extend({}, BASE_DATE_PICKER_STATE),
-        _.extend({}, BASE_DATE_PICKER_STATE, { id: 'other-id' })
+        _.extend({}, BASE_DATE_PICKER_STATE, { id: 'other-id' }),
       ];
       let action: IReduxAction<IDatePickerPayload> = {
         type: DatePickerActions.reset,
         payload: {
-          id: 'some-date-picker'
-        }
+          id: 'some-date-picker',
+        },
       };
       let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
 
@@ -184,14 +184,14 @@ describe('Date picker', () => {
         let oldState: IDatePickerState[] = [
           _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
           _.extend({}, BASE_DATE_PICKER_STATE),
-          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' })
+          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' }),
         ];
         let action: IReduxAction<IChangeDatePickerPayload> = {
           type: DatePickerActions.changeLowerLimit,
           payload: {
             id: 'some-date-picker',
-            date: new Date(new Date().setHours(4, 4, 4, 4))
-          }
+            date: new Date(new Date().setHours(4, 4, 4, 4)),
+          },
         };
         let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
         expect(_.findWhere(datePickersState, { id: action.payload.id }).lowerLimit).toBe(action.payload.date);
@@ -202,14 +202,14 @@ describe('Date picker', () => {
         let oldState: IDatePickerState[] = [
           _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
           _.extend({}, BASE_DATE_PICKER_STATE),
-          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' })
+          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' }),
         ];
         let action: IReduxAction<IChangeDatePickerPayload> = {
           type: DatePickerActions.changeUpperLimit,
           payload: {
             id: 'some-date-picker',
-            date: new Date(new Date().setHours(4, 4, 4, 4))
-          }
+            date: new Date(new Date().setHours(4, 4, 4, 4)),
+          },
         };
         let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
         expect(_.findWhere(datePickersState, { id: action.payload.id }).upperLimit).toBe(action.payload.date);
@@ -220,14 +220,14 @@ describe('Date picker', () => {
         let oldState: IDatePickerState[] = [
           _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
           _.extend({}, BASE_DATE_PICKER_STATE),
-          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' })
+          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' }),
         ];
         let action: IReduxAction<ISelectDatePickerPayload> = {
           type: DatePickerActions.select,
           payload: {
             id: 'some-date-picker',
-            limit: DateLimits.upper
-          }
+            limit: DateLimits.upper,
+          },
         };
         let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
         expect(_.findWhere(datePickersState, { id: action.payload.id }).selected).toBe(action.payload.limit);
@@ -239,8 +239,8 @@ describe('Date picker', () => {
       let action: IReduxAction<IDatePickerPayload> = {
         type: DatePickerActions.add,
         payload: {
-          id: 'some-date-picker'
-        }
+          id: 'some-date-picker',
+        },
       };
       datePickersReducer(datePickersInitialState, action);
 
@@ -271,8 +271,8 @@ describe('Date picker', () => {
           id: 'some-date-picker',
           isRange: true,
           color: 'rainbow',
-          calendarId: 'radnelac'
-        }
+          calendarId: 'radnelac',
+        },
       };
       let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -289,8 +289,8 @@ describe('Date picker', () => {
           type: DatePickerActions.changeLowerLimit,
           payload: {
             id: 'some-date-picker5',
-            date: new Date(new Date().setHours(3, 3, 3, 3))
-          }
+            date: new Date(new Date().setHours(3, 3, 3, 3)),
+          },
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -304,8 +304,8 @@ describe('Date picker', () => {
           type: DatePickerActions.changeUpperLimit,
           payload: {
             id: 'some-date-picker5',
-            date: new Date(new Date().setHours(3, 3, 3, 3))
-          }
+            date: new Date(new Date().setHours(3, 3, 3, 3)),
+          },
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -319,8 +319,8 @@ describe('Date picker', () => {
           type: DatePickerActions.changeLowerLimit,
           payload: {
             id: 'some-date-picker',
-            date: new Date(new Date().setHours(3, 3, 3, 3))
-          }
+            date: new Date(new Date().setHours(3, 3, 3, 3)),
+          },
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -334,8 +334,8 @@ describe('Date picker', () => {
           type: DatePickerActions.changeUpperLimit,
           payload: {
             id: 'some-date-picker',
-            date: new Date(new Date().setHours(3, 3, 3, 3))
-          }
+            date: new Date(new Date().setHours(3, 3, 3, 3)),
+          },
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -348,8 +348,8 @@ describe('Date picker', () => {
         let action: IReduxAction<IDatePickerPayload> = {
           type: DatePickerActions.reset,
           payload: {
-            id: 'date-picker'
-          }
+            id: 'date-picker',
+          },
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -363,8 +363,8 @@ describe('Date picker', () => {
         let action: IReduxAction<IDatePickerPayload> = {
           type: DatePickerActions.reset,
           payload: {
-            id: 'some-date'
-          }
+            id: 'some-date',
+          },
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -380,8 +380,8 @@ describe('Date picker', () => {
         let action: IReduxAction<IDatePickerPayload> = {
           type: DatePickerActions.apply,
           payload: {
-            id: 'date-picker'
-          }
+            id: 'date-picker',
+          },
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -395,8 +395,8 @@ describe('Date picker', () => {
         let action: IReduxAction<IDatePickerPayload> = {
           type: DatePickerActions.apply,
           payload: {
-            id: 'some-date'
-          }
+            id: 'some-date',
+          },
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -413,8 +413,8 @@ describe('Date picker', () => {
         let action: IReduxAction<IDatePickerPayload> = {
           type: DatePickerActions.apply,
           payload: {
-            id: 'some-date'
-          }
+            id: 'some-date',
+          },
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -430,13 +430,13 @@ describe('Date picker', () => {
           upperLimit: undefined,
           lowerLimit: undefined,
           appliedUpperLimit: new Date(new Date().setHours(2, 0, 1, 1)),
-          appliedLowerLimit: new Date(new Date().setHours(0, 0, 1, 1))
+          appliedLowerLimit: new Date(new Date().setHours(0, 0, 1, 1)),
         });
       let action: IReduxAction<IDatePickerPayload> = {
         type: DatePickerActions.apply,
         payload: {
-          id: 'some-date'
-        }
+          id: 'some-date',
+        },
       };
       let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -451,8 +451,8 @@ describe('Date picker', () => {
           type: DatePickerActions.select,
           payload: {
             id: 'some-date-picker5',
-            limit: DateLimits.upper
-          }
+            limit: DateLimits.upper,
+          },
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -467,8 +467,8 @@ describe('Date picker', () => {
           type: DatePickerActions.select,
           payload: {
             id: 'some-date-picker',
-            limit: DateLimits.upper
-          }
+            limit: DateLimits.upper,
+          },
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -482,12 +482,101 @@ describe('Date picker', () => {
         type: DatePickerActions.changeUpperLimit,
         payload: {
           id: 'some-date-picker',
-          date: new Date(new Date().setHours(3, 3, 3, 3))
-        }
+          date: new Date(new Date().setHours(3, 3, 3, 3)),
+        },
       };
       datePickerReducer(datePickerInitialState, action);
 
       expect(expectedState).toEqual(datePickerInitialState);
+    });
+
+    it('should return the appliedLowerLimit if the lowerLimit is not defined', () => {
+      let oldState: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE, {
+        lowerLimit: undefined,
+      });
+      let action: IReduxAction<IDatePickerPayload> = {
+        type: DatePickerActions.apply,
+        payload: {
+          id: 'some-date-picker',
+        },
+      };
+      let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
+
+      expect(datePickerState.appliedLowerLimit).toBe(oldState.appliedLowerLimit);
+    });
+
+    it('should return the lowerLimit if the lowerLimit is defined', () => {
+      let oldState: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE);
+      let action: IReduxAction<IDatePickerPayload> = {
+        type: DatePickerActions.apply,
+        payload: {
+          id: 'some-date-picker',
+        },
+      };
+      let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
+
+      expect(datePickerState.lowerLimit).toBe(oldState.lowerLimit);
+    });
+
+    it('should return the appliedUpperLimit if the upperLimit and the lowerLimit is not defined', () => {
+      let oldState: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE, {
+        upperLimit: undefined,
+        lowerLimit: undefined,
+      });
+      let action: IReduxAction<IDatePickerPayload> = {
+        type: DatePickerActions.apply,
+        payload: {
+          id: 'some-date-picker',
+        },
+      };
+      let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
+
+      expect(datePickerState.appliedUpperLimit).toBe(oldState.appliedUpperLimit);
+    });
+
+    it('should return the upperLimit if its greater than the lowerLimit', () => {
+      let oldState: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE);
+      let action: IReduxAction<IDatePickerPayload> = {
+        type: DatePickerActions.apply,
+        payload: {
+          id: 'some-date-picker',
+        },
+      };
+      let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
+
+      expect(datePickerState.appliedUpperLimit).toBe(oldState.upperLimit);
+    });
+
+    it('should return the lowerLimit if the upperLimit is smaller than the lowerLimit', () => {
+      let oldState: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE, {
+        lowerLimit: new Date().setHours(2, 1, 2, 1),
+        upperLimit: new Date().setHours(1, 1, 2, 1),
+      });
+      let action: IReduxAction<IDatePickerPayload> = {
+        type: DatePickerActions.apply,
+        payload: {
+          id: 'some-date-picker',
+        },
+      };
+      let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
+
+      expect(datePickerState.appliedUpperLimit).toBe(oldState.lowerLimit);
+    });
+
+    it('should return the lowerLimit if the upperLimit is equal than the lowerLimit', () => {
+      let oldState: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE, {
+        lowerLimit: new Date().setHours(1, 1, 2, 1),
+        upperLimit: new Date().setHours(1, 1, 2, 1),
+      });
+      let action: IReduxAction<IDatePickerPayload> = {
+        type: DatePickerActions.apply,
+        payload: {
+          id: 'some-date-picker',
+        },
+      };
+      let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
+
+      expect(datePickerState.appliedUpperLimit).toBe(oldState.upperLimit);
     });
   });
 });

--- a/src/components/datePicker/tests/DatePickerReducers.spec.ts
+++ b/src/components/datePicker/tests/DatePickerReducers.spec.ts
@@ -5,14 +5,14 @@ import {
   DatePickerActions,
   IChangeDatePickerPayload,
   DateLimits,
-  ISelectDatePickerPayload,
+  ISelectDatePickerPayload
 } from '../DatePickerActions';
 import {
   IDatePickerState,
   datePickersReducer,
   datePickersInitialState,
   datePickerInitialState,
-  datePickerReducer,
+  datePickerReducer
 } from '../DatePickerReducers';
 import * as _ from 'underscore';
 
@@ -21,8 +21,8 @@ describe('Date picker', () => {
   const GENERIC_ACTION: IReduxAction<IDatePickerPayload> = {
     type: 'DO_SOMETHING',
     payload: {
-      id: 'some-date-picker',
-    },
+      id: 'some-date-picker'
+    }
   };
 
   const BASE_DATE_PICKER_STATE: IDatePickerState = {
@@ -34,7 +34,7 @@ describe('Date picker', () => {
     upperLimit: new Date(new Date().setHours(3, 2, 1, 2)),
     selected: '',
     appliedLowerLimit: new Date(new Date().setHours(0, 0, 0, 0)),
-    appliedUpperLimit: new Date(new Date().setHours(23, 59, 59, 999)),
+    appliedUpperLimit: new Date(new Date().setHours(23, 59, 59, 999))
   };
 
   describe('datePickersReducer', () => {
@@ -60,8 +60,8 @@ describe('Date picker', () => {
           id: 'some-date-picker',
           isRange: true,
           calendarId: 'calendar-321',
-          color: 'magenta',
-        },
+          color: 'magenta'
+        }
       };
       let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
 
@@ -82,13 +82,13 @@ describe('Date picker', () => {
       let oldState: IDatePickerState[] = [
         _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
         _.extend({}, BASE_DATE_PICKER_STATE),
-        _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' }),
+        _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' })
       ];
       let action: IReduxAction<IDatePickerPayload> = {
         type: DatePickerActions.remove,
         payload: {
-          id: 'some-date-picker',
-        },
+          id: 'some-date-picker'
+        }
       };
       let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
 
@@ -110,13 +110,13 @@ describe('Date picker', () => {
         let oldState: IDatePickerState[] = [
           _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
           _.extend({}, BASE_DATE_PICKER_STATE),
-          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' }),
+          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' })
         ];
         let action: IReduxAction<IDatePickerPayload> = {
           type: DatePickerActions.remove,
           payload: {
-            id: 'some-date-picker4',
-          },
+            id: 'some-date-picker4'
+          }
         };
         let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
 
@@ -129,13 +129,13 @@ describe('Date picker', () => {
       let oldState: IDatePickerState[] = [
         _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
         _.extend({}, BASE_DATE_PICKER_STATE),
-        _.extend({}, BASE_DATE_PICKER_STATE, { id: 'other-id' }),
+        _.extend({}, BASE_DATE_PICKER_STATE, { id: 'other-id' })
       ];
       let action: IReduxAction<IDatePickerPayload> = {
         type: DatePickerActions.reset,
         payload: {
-          id: 'some-date-picker',
-        },
+          id: 'some-date-picker'
+        }
       };
       let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
 
@@ -156,13 +156,13 @@ describe('Date picker', () => {
       let oldState: IDatePickerState[] = [
         _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
         _.extend({}, BASE_DATE_PICKER_STATE),
-        _.extend({}, BASE_DATE_PICKER_STATE, { id: 'other-id' }),
+        _.extend({}, BASE_DATE_PICKER_STATE, { id: 'other-id' })
       ];
       let action: IReduxAction<IDatePickerPayload> = {
         type: DatePickerActions.reset,
         payload: {
-          id: 'some-date-picker',
-        },
+          id: 'some-date-picker'
+        }
       };
       let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
 
@@ -184,14 +184,14 @@ describe('Date picker', () => {
         let oldState: IDatePickerState[] = [
           _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
           _.extend({}, BASE_DATE_PICKER_STATE),
-          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' }),
+          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' })
         ];
         let action: IReduxAction<IChangeDatePickerPayload> = {
           type: DatePickerActions.changeLowerLimit,
           payload: {
             id: 'some-date-picker',
-            date: new Date(new Date().setHours(4, 4, 4, 4)),
-          },
+            date: new Date(new Date().setHours(4, 4, 4, 4))
+          }
         };
         let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
         expect(_.findWhere(datePickersState, { id: action.payload.id }).lowerLimit).toBe(action.payload.date);
@@ -202,14 +202,14 @@ describe('Date picker', () => {
         let oldState: IDatePickerState[] = [
           _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
           _.extend({}, BASE_DATE_PICKER_STATE),
-          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' }),
+          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' })
         ];
         let action: IReduxAction<IChangeDatePickerPayload> = {
           type: DatePickerActions.changeUpperLimit,
           payload: {
             id: 'some-date-picker',
-            date: new Date(new Date().setHours(4, 4, 4, 4)),
-          },
+            date: new Date(new Date().setHours(4, 4, 4, 4))
+          }
         };
         let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
         expect(_.findWhere(datePickersState, { id: action.payload.id }).upperLimit).toBe(action.payload.date);
@@ -220,14 +220,14 @@ describe('Date picker', () => {
         let oldState: IDatePickerState[] = [
           _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker2' }),
           _.extend({}, BASE_DATE_PICKER_STATE),
-          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' }),
+          _.extend({}, BASE_DATE_PICKER_STATE, { id: 'some-date-picker3' })
         ];
         let action: IReduxAction<ISelectDatePickerPayload> = {
           type: DatePickerActions.select,
           payload: {
             id: 'some-date-picker',
-            limit: DateLimits.upper,
-          },
+            limit: DateLimits.upper
+          }
         };
         let datePickersState: IDatePickerState[] = datePickersReducer(oldState, action);
         expect(_.findWhere(datePickersState, { id: action.payload.id }).selected).toBe(action.payload.limit);
@@ -239,8 +239,8 @@ describe('Date picker', () => {
       let action: IReduxAction<IDatePickerPayload> = {
         type: DatePickerActions.add,
         payload: {
-          id: 'some-date-picker',
-        },
+          id: 'some-date-picker'
+        }
       };
       datePickersReducer(datePickersInitialState, action);
 
@@ -271,8 +271,8 @@ describe('Date picker', () => {
           id: 'some-date-picker',
           isRange: true,
           color: 'rainbow',
-          calendarId: 'radnelac',
-        },
+          calendarId: 'radnelac'
+        }
       };
       let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -289,8 +289,8 @@ describe('Date picker', () => {
           type: DatePickerActions.changeLowerLimit,
           payload: {
             id: 'some-date-picker5',
-            date: new Date(new Date().setHours(3, 3, 3, 3)),
-          },
+            date: new Date(new Date().setHours(3, 3, 3, 3))
+          }
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -304,8 +304,8 @@ describe('Date picker', () => {
           type: DatePickerActions.changeUpperLimit,
           payload: {
             id: 'some-date-picker5',
-            date: new Date(new Date().setHours(3, 3, 3, 3)),
-          },
+            date: new Date(new Date().setHours(3, 3, 3, 3))
+          }
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -319,8 +319,8 @@ describe('Date picker', () => {
           type: DatePickerActions.changeLowerLimit,
           payload: {
             id: 'some-date-picker',
-            date: new Date(new Date().setHours(3, 3, 3, 3)),
-          },
+            date: new Date(new Date().setHours(3, 3, 3, 3))
+          }
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -334,8 +334,8 @@ describe('Date picker', () => {
           type: DatePickerActions.changeUpperLimit,
           payload: {
             id: 'some-date-picker',
-            date: new Date(new Date().setHours(3, 3, 3, 3)),
-          },
+            date: new Date(new Date().setHours(3, 3, 3, 3))
+          }
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -348,8 +348,8 @@ describe('Date picker', () => {
         let action: IReduxAction<IDatePickerPayload> = {
           type: DatePickerActions.reset,
           payload: {
-            id: 'date-picker',
-          },
+            id: 'date-picker'
+          }
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -363,8 +363,8 @@ describe('Date picker', () => {
         let action: IReduxAction<IDatePickerPayload> = {
           type: DatePickerActions.reset,
           payload: {
-            id: 'some-date',
-          },
+            id: 'some-date'
+          }
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -380,8 +380,8 @@ describe('Date picker', () => {
         let action: IReduxAction<IDatePickerPayload> = {
           type: DatePickerActions.apply,
           payload: {
-            id: 'date-picker',
-          },
+            id: 'date-picker'
+          }
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -395,8 +395,8 @@ describe('Date picker', () => {
         let action: IReduxAction<IDatePickerPayload> = {
           type: DatePickerActions.apply,
           payload: {
-            id: 'some-date',
-          },
+            id: 'some-date'
+          }
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -413,8 +413,8 @@ describe('Date picker', () => {
         let action: IReduxAction<IDatePickerPayload> = {
           type: DatePickerActions.apply,
           payload: {
-            id: 'some-date',
-          },
+            id: 'some-date'
+          }
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -430,13 +430,13 @@ describe('Date picker', () => {
           upperLimit: undefined,
           lowerLimit: undefined,
           appliedUpperLimit: new Date(new Date().setHours(2, 0, 1, 1)),
-          appliedLowerLimit: new Date(new Date().setHours(0, 0, 1, 1)),
+          appliedLowerLimit: new Date(new Date().setHours(0, 0, 1, 1))
         });
       let action: IReduxAction<IDatePickerPayload> = {
         type: DatePickerActions.apply,
         payload: {
-          id: 'some-date',
-        },
+          id: 'some-date'
+        }
       };
       let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -451,8 +451,8 @@ describe('Date picker', () => {
           type: DatePickerActions.select,
           payload: {
             id: 'some-date-picker5',
-            limit: DateLimits.upper,
-          },
+            limit: DateLimits.upper
+          }
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -467,8 +467,8 @@ describe('Date picker', () => {
           type: DatePickerActions.select,
           payload: {
             id: 'some-date-picker',
-            limit: DateLimits.upper,
-          },
+            limit: DateLimits.upper
+          }
         };
         let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
@@ -482,8 +482,8 @@ describe('Date picker', () => {
         type: DatePickerActions.changeUpperLimit,
         payload: {
           id: 'some-date-picker',
-          date: new Date(new Date().setHours(3, 3, 3, 3)),
-        },
+          date: new Date(new Date().setHours(3, 3, 3, 3))
+        }
       };
       datePickerReducer(datePickerInitialState, action);
 
@@ -576,7 +576,7 @@ describe('Date picker', () => {
       };
       let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
 
-      expect(datePickerState.appliedUpperLimit).toBe(oldState.upperLimit);
+      expect(datePickerState.appliedUpperLimit).toBe(oldState.lowerLimit);
     });
   });
 });

--- a/src/components/datePicker/tests/DatePickerReducers.spec.ts
+++ b/src/components/datePicker/tests/DatePickerReducers.spec.ts
@@ -490,21 +490,6 @@ describe('Date picker', () => {
       expect(expectedState).toEqual(datePickerInitialState);
     });
 
-    it('should return the appliedLowerLimit if the lowerLimit is not defined', () => {
-      let oldState: IDatePickerState = _.extend({}, BASE_DATE_PICKER_STATE, {
-        lowerLimit: undefined,
-      });
-      let action: IReduxAction<IDatePickerPayload> = {
-        type: DatePickerActions.apply,
-        payload: {
-          id: 'some-date-picker',
-        },
-      };
-      let datePickerState: IDatePickerState = datePickerReducer(oldState, action);
-
-      expect(datePickerState.appliedLowerLimit).toBe(oldState.appliedLowerLimit);
-    });
-
     describe('reducers for the action "APPLY_DATE"', () => {
 
       let action: IReduxAction<IDatePickerPayload>;
@@ -518,6 +503,15 @@ describe('Date picker', () => {
             id: 'some-date-picker',
           },
         };
+      });
+
+      it('should return the appliedLowerLimit if the lowerLimit is not defined', () => {
+        oldState = _.extend({}, BASE_DATE_PICKER_STATE, {
+          lowerLimit: undefined,
+        });
+        datePickerState = datePickerReducer(oldState, action);
+
+        expect(datePickerState.appliedLowerLimit).toBe(oldState.appliedLowerLimit);
       });
 
       it('should return the lowerLimit if the lowerLimit is defined', () => {


### PR DESCRIPTION
Remove the reset after a click without value for the DateSelected
Use the appliedLowerLimit or the lowerLimit to validate the upperLimit to avoid a undefined value.
Add uts to cover this changes
https://drive.google.com/file/d/1CKAt7T-C56mxw34_8IYR_nyBxmEVAniC/view