### PR TITLE
display clear icon on filter through dispatch

### DIFF
--- a/src/components/filterBox/FilterBox.tsx
+++ b/src/components/filterBox/FilterBox.tsx
@@ -83,6 +83,7 @@ export class FilterBox extends React.Component<IFilterBoxProps, any> {
     const filterPlaceholder = this.props.filterPlaceholder || FILTER_PLACEHOLDER;
     const filterBoxContainerClasses = classNames('filter-container', this.props.containerClasses);
     const filterInputClasses = classNames('filter-box', { 'truncate': this.props.truncate });
+    const svgClearClasses = classNames({ 'hidden': !(this.filterInput && this.filterInput.value) });
 
     return (
       <div
@@ -104,7 +105,7 @@ export class FilterBox extends React.Component<IFilterBoxProps, any> {
 
           autoFocus={this.props.isAutoFocus}
         />
-        <Svg svgName='clear' className='hidden' svgClass='icon mod-lg fill-medium-grey' onClick={() => this.clearValue()} />
+        <Svg svgName='clear' className={svgClearClasses} svgClass='icon mod-lg fill-medium-grey' onClick={() => this.clearValue()} />
         <Svg svgName='filter' className='filter-icon' svgClass='icon fill-medium-grey mod-lg' />
       </div>
     );

--- a/src/components/filterBox/tests/FilterBox.spec.tsx
+++ b/src/components/filterBox/tests/FilterBox.spec.tsx
@@ -98,6 +98,26 @@ describe('FilterBox', () => {
       expect(clearIcon.hasClass('hidden')).toBe(true);
     });
 
+    it('should remove the hidden class of the clear icon if there is a value in the input without a change event', () => {
+      const clearIcon = filterBox.find('span').first();
+
+      expect(clearIcon.hasClass('hidden')).toBe(true);
+
+      filterBoxInstance.filterInput.value = 'non empty';
+      filterBox.update();
+
+      expect(clearIcon.hasClass('hidden')).toBe(false);
+    });
+
+    it('should leave the hidden class of the clear icon if there is an empty value in the input without a change event', () => {
+      const clearIcon = filterBox.find('span').first();
+
+      filterBoxInstance.filterInput.value = '';
+      filterBox.update();
+
+      expect(clearIcon.hasClass('hidden')).toBe(true);
+    });
+
     it('should clear the filter input when clicking the clear icon', () => {
       let clearIcon = filterBox.find('span').first();
 


### PR DESCRIPTION
https://drive.google.com/file/d/1wdlVYHWqAJFvMsYnW-O4Xsl2cBwzzbGz/view  

see demo, if you dispatch a `filterThrough` action from outside the filter with a non empty value (like in the video), you still want the clear icon to pop up, this was not the case previously. This does not break the FilterBox unconnected