### PR TITLE
handle padding depending on context and add padding top

### DIFF
--- a/src/components/headers/HeaderWrapper.tsx
+++ b/src/components/headers/HeaderWrapper.tsx
@@ -13,12 +13,19 @@ export interface IHeaderWrapperProps extends ITabsHeaderProps, React.ClassAttrib
 export class HeaderWrapper extends React.Component<IHeaderWrapperProps, {}> {
 
   private getClasses(): string {
-    return classNames('flex',
-      'flex-center space-between',
+    return classNames(
+      'flex',
+      'flex-center',
+      'space-between',
       'mod-header-padding',
       'header-height',
-      'pb2',
-      this.props.classes);
+      {
+        'pt1': !!this.props.tabs,
+        'pb2': !!this.props.tabs,
+        'p1': !this.props.tabs,
+      },
+      this.props.classes,
+    );
   }
 
   private getActions(): JSX.Element[] {

--- a/src/components/headers/HeaderWrapper.tsx
+++ b/src/components/headers/HeaderWrapper.tsx
@@ -19,10 +19,10 @@ export class HeaderWrapper extends React.Component<IHeaderWrapperProps, {}> {
       'space-between',
       'mod-header-padding',
       'header-height',
+      'pt1',
       {
-        'pt1': !!this.props.tabs,
         'pb2': !!this.props.tabs,
-        'p1': !this.props.tabs,
+        'pb1': !this.props.tabs,
       },
       this.props.classes,
     );


### PR DESCRIPTION

![screen shot 2017-12-22 at 3 26 07 pm](https://user-images.githubusercontent.com/9539763/34311613-8b16da9a-e72c-11e7-9fe7-1a1abc0c4df9.png)
![screen shot 2017-12-22 at 3 25 50 pm](https://user-images.githubusercontent.com/9539763/34311612-8b0bb8c2-e72c-11e7-87e4-0fcbf62e6b09.png)
![screen shot 2017-12-22 at 3 26 17 pm](https://user-images.githubusercontent.com/9539763/34311614-8b228340-e72c-11e7-94fe-cbb8991fa97e.png)

tough to see in the image, but the first one does not have enough padding on top and is different compare to other headers