### PR TITLE
print the demo url in travis logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,10 @@ cache:
     - node_modules
 
 script:
- - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then npm run docs && node create-live-demo.js; fi' # run this line on pull request builds only
  - npm run test
 
 after_success:
  - npm run report-coverage
+
+after_script:
+ - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then npm run docs && node create-live-demo.js; fi' # run this line on pull request builds only

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ cache:
 
 script:
  - npm run test
- - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then echo "Your live demo url, if everything went well, should be https://coveo.github.io/react-vapor/$(TRAVIS_PULL_REQUEST_BRANCH)/"; fi' # run this line on pull request builds only
+ - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then echo "Your live demo url, if everything went well, should be https://coveo.github.io/react-vapor/$TRAVIS_PULL_REQUEST_BRANCH/"; fi' # run this line on pull request builds only
 
 after_success:
  - npm run report-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ cache:
 
 script:
  - npm run test
+ - echo "Your live demo url, if everything went well, should be https://coveo.github.io/react-vapor/$(TRAVIS_PULL_REQUEST_BRANCH)/"
 
 after_success:
  - npm run report-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ cache:
 
 script:
  - npm run test
- - echo "Your live demo url, if everything went well, should be https://coveo.github.io/react-vapor/$(TRAVIS_PULL_REQUEST_BRANCH)/"
+ - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then echo "Your live demo url, if everything went well, should be https://coveo.github.io/react-vapor/$(TRAVIS_PULL_REQUEST_BRANCH)/"; fi' # run this line on pull request builds only
 
 after_success:
  - npm run report-coverage

--- a/create-live-demo.js
+++ b/create-live-demo.js
@@ -16,6 +16,4 @@ console.log(`Pushing live demo to gh-pages for branch: ${branchName}`);
 const currentCommit = sh.exec('git show --oneline -s').stdout.trim().split(' ')[0];
 sh.exec(`git push ${originWithAuthentication} ${currentCommit}:gh-pages`);
 
-console.log(`Live demo creation completed.
-If it succeeded, the demo url should be https://coveo.github.io/react-vapor/${branchName}/`);
 process.exit();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vapor",
-  "version": "1.11.8",
+  "version": "1.11.9",
   "description": "Vapor CSS components implemented with React!",
   "keywords": [
     "coveo",


### PR DESCRIPTION
Since the live demo script is nom in a `after_script` the demo url doesn't show in the build logs. We need to echo it at the `script` level to be able to retrieve it in the logs. I added something to retrieve it in the commits seeable in the gh-pages branch https://github.com/coveo/react-vapor/tree/gh-pages (see besides the `print-live-demo` folder)