### PR TITLE
force push to gh-pages for live demos

### DIFF
--- a/create-live-demo.js
+++ b/create-live-demo.js
@@ -14,6 +14,6 @@ sh.exec(`git merge --no-edit --strategy-option ours ${originWithAuthentication}/
 
 console.log(`Pushing live demo to gh-pages for branch: ${branchName}`);
 const currentCommit = sh.exec('git show --oneline -s').stdout.trim().split(' ')[0];
-sh.exec(`git push ${originWithAuthentication} ${currentCommit}:gh-pages`);
+sh.exec(`git push -f ${originWithAuthentication} ${currentCommit}:gh-pages`);
 
 process.exit();


### PR DESCRIPTION
otherwise we sometimes get `Updates were rejected because a pushed branch tip is behind its remote`

see `after_script` logs for details here https://travis-ci.org/coveo/react-vapor/builds/329518230