### PR TITLE
Extract and export a TableCompositeState "builder"

### DIFF
--- a/src/Index.ts
+++ b/src/Index.ts
@@ -115,7 +115,7 @@ export { TableCollapsibleRowConnected } from './components/tables/TableCollapsib
 export { TableEmptyRow } from './components/tables/TableEmptyRow';
 export { tableRowsReducer } from './components/tables/TableRowReducers';
 export { TableRowActions, selectRow, unselectAllRows } from './components/tables/TableRowActions';
-export { TableConnected } from './components/tables/TableConnected';
+export { TableConnected, getTableCompositeState } from './components/tables/TableConnected';
 export { tablesReducer } from './components/tables/TableReducers';
 export { addTable, modifyState, removeTable, setIsInError, TableActions } from './components/tables/TableActions';
 export { defaultTableStateModifierThunk, dispatchPreTableStateModification, dispatchPostTableStateModification } from './components/tables/TableDataModifier';

--- a/src/components/tables/TableConnected.tsx
+++ b/src/components/tables/TableConnected.tsx
@@ -22,40 +22,48 @@ import { ITableHeaderCellState } from './TableHeaderCellReducers';
 import { ITableCompositeState, ITableState } from './TableReducers';
 import { getTableChildComponentId } from './TableUtils';
 
-const mapStateToProps = (state: IReactVaporState, ownProps: ITableOwnProps): ITableCompositeStateProps => {
-  const tableState: ITableState = state.tables[ownProps.id] || {} as ITableState;
-  const filterState: IFilterState = tableState && _.findWhere(state.filters, { id: tableState.filterId });
-  const paginationState: IPaginationState = tableState && _.findWhere(state.paginationComposite, { id: tableState.paginationId });
-  const perPageState: IPerPageState = tableState && _.findWhere(state.perPageComposite, { id: tableState.perPageId });
+export interface IReactVaporStateExtended extends IReactVaporState {
+  [additionalState: string]: any;
+}
+
+export const getTableCompositeState = (state: IReactVaporStateExtended, id: string): ITableCompositeState => {
+  const tableState: ITableState = state.tables[id] || {} as ITableState;
+  const filterState: IFilterState = tableState && _.findWhere(state.filters, {id: tableState.filterId});
+  const paginationState: IPaginationState = tableState && _.findWhere(state.paginationComposite, {id: tableState.paginationId});
+  const perPageState: IPerPageState = tableState && _.findWhere(state.perPageComposite, {id: tableState.perPageId});
   const tableHeaderCellState: ITableHeaderCellState = tableState && state.tableHeaderCells[tableState.tableHeaderCellId];
-  const predicateStates: IDropdownSearchState[] = tableState && _.reject(state.dropdownSearch, (dropdownSearch: IDropdownSearchState) => !contains(dropdownSearch.id, ownProps.id)) || [];
-  const datePickerState: IDatePickerState = tableState && _.findWhere(state.datePickers, { id: tableState.datePickerRangeId });
+  const predicateStates: IDropdownSearchState[] = tableState && _.reject(state.dropdownSearch, (dropdownSearch: IDropdownSearchState) => !contains(dropdownSearch.id, id)) || [];
+  const datePickerState: IDatePickerState = tableState && _.findWhere(state.datePickers, {id: tableState.datePickerRangeId});
 
   return {
-    tableCompositeState: {
-      id: tableState.id,
-      data: tableState.data,
-      isInError: tableState.isInError,
-      isLoading: tableState.isLoading,
-      filter: filterState && filterState.filterText,
-      page: paginationState && paginationState.pageNb,
-      perPage: perPageState && perPageState.perPage,
-      sortState: {
-        attribute: tableHeaderCellState && tableHeaderCellState.attributeToSort,
-        order: tableHeaderCellState && tableHeaderCellState.sorted,
-      },
-      predicates: predicateStates.reduce((currentPredicates, nextPredicate: IDropdownSearchState) => {
-        // the attribute name is stored in the id of the dropdownSearch
-        const attributeName = nextPredicate.id.split(getTableChildComponentId(ownProps.id, TableChildComponent.PREDICATE))[1];
-        const selectedOption = _.findWhere(nextPredicate.options, { selected: true });
-        return {
-          ...currentPredicates,
-          [attributeName]: selectedOption && selectedOption.value || TABLE_PREDICATE_DEFAULT_VALUE,
-        };
-      }, {}),
-      from: datePickerState && datePickerState.appliedLowerLimit,
-      to: datePickerState && datePickerState.appliedUpperLimit,
-    } as ITableCompositeState,
+    id: tableState.id,
+    data: tableState.data,
+    isInError: tableState.isInError,
+    isLoading: tableState.isLoading,
+    filter: filterState && filterState.filterText,
+    page: paginationState && paginationState.pageNb,
+    perPage: perPageState && perPageState.perPage,
+    sortState: {
+      attribute: tableHeaderCellState && tableHeaderCellState.attributeToSort,
+      order: tableHeaderCellState && tableHeaderCellState.sorted,
+    },
+    predicates: predicateStates.reduce((currentPredicates, nextPredicate: IDropdownSearchState) => {
+      // the attribute name is stored in the id of the dropdownSearch
+      const attributeName = nextPredicate.id.split(getTableChildComponentId(id, TableChildComponent.PREDICATE))[1];
+      const selectedOption = _.findWhere(nextPredicate.options, { selected: true });
+      return {
+        ...currentPredicates,
+        [attributeName]: selectedOption && selectedOption.value || TABLE_PREDICATE_DEFAULT_VALUE,
+      };
+    }, {}),
+    from: datePickerState && datePickerState.appliedLowerLimit,
+    to: datePickerState && datePickerState.appliedUpperLimit,
+  } as ITableCompositeState;
+};
+
+const mapStateToProps = (state: IReactVaporState, ownProps: ITableOwnProps): ITableCompositeStateProps => {
+  return {
+    tableCompositeState: getTableCompositeState(state, ownProps.id),
   };
 };
 

--- a/src/components/tables/TableConnected.tsx
+++ b/src/components/tables/TableConnected.tsx
@@ -22,11 +22,7 @@ import { ITableHeaderCellState } from './TableHeaderCellReducers';
 import { ITableCompositeState, ITableState } from './TableReducers';
 import { getTableChildComponentId } from './TableUtils';
 
-export interface IReactVaporStateExtended extends IReactVaporState {
-  [additionalState: string]: any;
-}
-
-export const getTableCompositeState = (state: IReactVaporStateExtended, id: string): ITableCompositeState => {
+export const getTableCompositeState = (state: IReactVaporState, id: string): ITableCompositeState => {
   const tableState: ITableState = state.tables[id] || {} as ITableState;
   const filterState: IFilterState = tableState && _.findWhere(state.filters, {id: tableState.filterId});
   const paginationState: IPaginationState = tableState && _.findWhere(state.paginationComposite, {id: tableState.paginationId});

--- a/src/components/tables/TableDataModifier.ts
+++ b/src/components/tables/TableDataModifier.ts
@@ -13,20 +13,20 @@ import { ITableCompositeState, ITableState } from './TableReducers';
 import { unselectAllRows } from './TableRowActions';
 import { getTableChildComponentId, getTableLoadingIds } from './TableUtils';
 
-export const dispatchPreTableStateModification = (id: string, dispatch: IDispatch) => {
-  dispatch(unselectAllRows(id));
+export const dispatchPreTableStateModification = (tableId: string, dispatch: IDispatch) => {
+  dispatch(unselectAllRows(tableId));
   dispatch(
     addActionsToActionBar(
-      getTableChildComponentId(id, TableChildComponent.ACTION_BAR),
+      getTableChildComponentId(tableId, TableChildComponent.ACTION_BAR),
       [],
     ),
   );
-  dispatch(turnOnLoading(getTableLoadingIds(id)));
+  dispatch(turnOnLoading(getTableLoadingIds(tableId)));
 };
 
-export const dispatchPostTableStateModification = (id: string, dispatch: IDispatch) => {
-  dispatch(turnOffLoading(getTableLoadingIds(id)));
-  dispatch(changeLastUpdated(getTableChildComponentId(id, TableChildComponent.LAST_UPDATED)));
+export const dispatchPostTableStateModification = (tableId: string, dispatch: IDispatch) => {
+  dispatch(turnOffLoading(getTableLoadingIds(tableId)));
+  dispatch(changeLastUpdated(getTableChildComponentId(tableId, TableChildComponent.LAST_UPDATED)));
 };
 
 export const applyPredicatesOnDisplayedIds = (

--- a/src/components/tables/TableDataModifier.ts
+++ b/src/components/tables/TableDataModifier.ts
@@ -13,20 +13,20 @@ import { ITableCompositeState, ITableState } from './TableReducers';
 import { unselectAllRows } from './TableRowActions';
 import { getTableChildComponentId, getTableLoadingIds } from './TableUtils';
 
-export const dispatchPreTableStateModification = (tableOwnProps: ITableOwnProps, dispatch: IDispatch) => {
-  dispatch(unselectAllRows(tableOwnProps.id));
+export const dispatchPreTableStateModification = (id: string, dispatch: IDispatch) => {
+  dispatch(unselectAllRows(id));
   dispatch(
     addActionsToActionBar(
-      getTableChildComponentId(tableOwnProps.id, TableChildComponent.ACTION_BAR),
+      getTableChildComponentId(id, TableChildComponent.ACTION_BAR),
       [],
     ),
   );
-  dispatch(turnOnLoading(getTableLoadingIds(tableOwnProps.id)));
+  dispatch(turnOnLoading(getTableLoadingIds(id)));
 };
 
-export const dispatchPostTableStateModification = (tableOwnProps: ITableOwnProps, dispatch: IDispatch) => {
-  dispatch(turnOffLoading(getTableLoadingIds(tableOwnProps.id)));
-  dispatch(changeLastUpdated(getTableChildComponentId(tableOwnProps.id, TableChildComponent.LAST_UPDATED)));
+export const dispatchPostTableStateModification = (id: string, dispatch: IDispatch) => {
+  dispatch(turnOffLoading(getTableLoadingIds(id)));
+  dispatch(changeLastUpdated(getTableChildComponentId(id, TableChildComponent.LAST_UPDATED)));
 };
 
 export const applyPredicatesOnDisplayedIds = (

--- a/src/components/tables/examples/TableExamples.tsx
+++ b/src/components/tables/examples/TableExamples.tsx
@@ -69,21 +69,21 @@ const tableData: ITableData = {
 };
 
 const buildNewTableStateManually = (data: any, currentState: ITableState, tableCompositeState: ITableCompositeState, tableOwnProps: ITableOwnProps): ITableState => {
-  const totalEntries = JSON.parse(data).count;
+  const totalEntries = data.count;
   const totalPages = Math.ceil(totalEntries / perPageNumbers[0]);
-  const newTableData = JSON.parse(data).entries.reduce((finalTableData: ITableData, entry: any, arr: any[]) => {
+  const newTableData = data.reduce((finalTableData: ITableData, comment: any, arr: any[]) => {
     return {
       byId: {
         ...(finalTableData.byId || {}),
-        [entry.API]: {
-          id: entry.API,
-          attribute1: entry.API,
-          attribute3: entry.Category,
-          attribute4: entry.Description,
+        [comment.id]: {
+          id: comment.id,
+          attribute1: comment.email,
+          attribute2: comment.name,
+          attribute3: comment.body,
         },
       },
-      allIds: [...finalTableData.allIds, entry.API],
-      displayedIds: [...finalTableData.displayedIds, entry.API],
+      allIds: [...finalTableData.allIds, comment.id],
+      displayedIds: [...finalTableData.displayedIds, comment.id],
       totalEntries: totalEntries,
       totalPages: totalPages,
     };
@@ -94,8 +94,8 @@ const buildNewTableStateManually = (data: any, currentState: ITableState, tableC
 const manualModeThunk = (tableOwnProps: ITableOwnProps, shouldResetPage: boolean, tableCompositeState: ITableCompositeState): IThunkAction => {
   return (dispatch: IDispatch, getState: () => { [globalStateProp: string]: any; tables: ITablesState; }) => {
     const currentTableState = getState().tables[tableOwnProps.id];
-    dispatchPreTableStateModification(tableOwnProps, dispatch);
-    $.get('https://raw.githubusercontent.com/toddmotto/public-apis/master/json/entries.json')
+    dispatchPreTableStateModification(tableOwnProps.id, dispatch);
+    $.get('https://jsonplaceholder.typicode.com/comments')
       .done((data) => {
         dispatch(
           modifyState(
@@ -114,7 +114,7 @@ const manualModeThunk = (tableOwnProps: ITableOwnProps, shouldResetPage: boolean
         ));
       })
       .always(() => {
-        dispatchPostTableStateModification(tableOwnProps, dispatch);
+        dispatchPostTableStateModification(tableOwnProps.id, dispatch);
       });
   };
 };
@@ -138,7 +138,7 @@ export class TableExamples extends React.Component<any, any> {
                 attributeFormatter: _.identity,
               },
               {
-                attributeName: 'attribute4',
+                attributeName: 'attribute2',
                 titleFormatter: _.identity,
                 sort: true,
                 attributeFormatter: _.identity,

--- a/src/components/tables/tests/TableDataModifier.spec.ts
+++ b/src/components/tables/tests/TableDataModifier.spec.ts
@@ -32,7 +32,7 @@ describe('TableDataModifier', () => {
         turnOnLoading(getTableLoadingIds(tableOwnPropsMock.id)),
       ];
 
-      dispatchPreTableStateModification(tableOwnPropsMock, dispatchSpy);
+      dispatchPreTableStateModification(tableOwnPropsMock.id, dispatchSpy);
 
       actions.forEach((action) => {
         expect(dispatchSpy).toHaveBeenCalledWith(action);
@@ -50,7 +50,7 @@ describe('TableDataModifier', () => {
         changeLastUpdated(getTableChildComponentId(tableOwnPropsMock.id, TableChildComponent.LAST_UPDATED)),
       ];
 
-      dispatchPostTableStateModification(tableOwnPropsMock, dispatchSpy);
+      dispatchPostTableStateModification(tableOwnPropsMock.id, dispatchSpy);
 
       actions.forEach((action) => {
         expect(dispatchSpy).toHaveBeenCalledWith(action);


### PR DESCRIPTION
I needed to be able to build the Table composite state from outside of ReactVapor to use the manual version of the Table in more complex ways (fetch from outside for example). We decided to extract the function from `mapStateToProps`.  

I changed the API endpoint for the TableExamples because it was broken.

**POSSIBLE BREAKING CHANGE** the `dispatchPreTableStateModification ` and `dispatchPostTableStateModification` are called with the table ID directly instead of the whole `ownProps`