### PR TITLE
add dblclick fix for actions

### DIFF
--- a/src/components/tables/Table.tsx
+++ b/src/components/tables/Table.tsx
@@ -201,7 +201,7 @@ export class Table extends React.Component<ITableProps, {}> {
           tableId={this.props.id}
           rowData={currentRowData}
           isLoading={this.props.tableCompositeState.isLoading}
-          getActions={(rowData?: IData) => this.props.getActions && this.props.getActions(rowData)}
+          getActions={(rowData?: IData) => (this.props.getActions && this.props.getActions(rowData)) || []}
           headingAttributes={this.props.headingAttributes}
           collapsibleFormatter={this.props.collapsibleFormatter}
           onRowClick={(actions: IActionOptions[]) => this.props.onRowClick(actions)}

--- a/src/components/tables/table-children/TableChildBody.tsx
+++ b/src/components/tables/table-children/TableChildBody.tsx
@@ -70,14 +70,10 @@ export const TableChildBody = (props: ITableChildBodyProps): JSX.Element => {
             props.onRowClick(props.getActions(props.rowData));
           }
         }}
-        onDoubleClick={() => {
-          const actions = props.getActions
-            ? props.getActions(props.rowData)
-            : [];
-          actions
+        onDoubleClick={() => props.getActions(props.rowData)
             .filter((action) => action.callOnDoubleClick)
-            .forEach((action) => action.trigger());
-        }}>
+            .forEach((action) => action.trigger())
+        }>
         {tableHeadingRowContent}
       </TableHeadingRowConnected>
       {collapsibleRow}

--- a/src/components/tables/tests/TableChildBody.spec.tsx
+++ b/src/components/tables/tests/TableChildBody.spec.tsx
@@ -90,14 +90,6 @@ describe('<TableChildBody />', () => {
       expect(tableChildBodyProps.getActions).toHaveBeenCalledWith(tableChildBodyProps.rowData);
     });
 
-    it('should not throw on row double click and getAction prop is undefined', () => {
-      const propsWithoutGetActions: ITableChildBodyProps = _.extend({}, tableChildBodyProps, { getActions: undefined });
-
-      const row = mountComponentWithProps(propsWithoutGetActions).find(TableHeadingRow);
-
-      expect(() => row.simulate('dblclick')).not.toThrow();
-    });
-
     it('should call getActions results with option callOnDoubleClick true on row double click', () => {
       const actionSpy: jasmine.Spy = jasmine.createSpy('actionSpy');
       const twoActions: IActionOptions[] = [{


### PR DESCRIPTION
since getActions is always defined and could have returned undefined it could have thrown at `actions.filter...bla bla`