### PR TITLE
implement visible disabled actions

### DIFF
--- a/src/animations/SlideY.spec.tsx
+++ b/src/animations/SlideY.spec.tsx
@@ -1,7 +1,6 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 import {TransitionProps} from 'react-transition-group/Transition';
-import {IDropdownProps} from '../components/dropdown/Dropdown';
 import {SlideY} from './SlideY';
 
 describe('SlideY', () => {

--- a/src/components/actions/Action.tsx
+++ b/src/components/actions/Action.tsx
@@ -20,6 +20,7 @@ export interface IBaseActionOptions {
   primary?: boolean;
   tooltip?: string;
   tooltipPlacement?: string;
+  hideDisabled?: boolean;
   onClick?: () => void;
 }
 
@@ -45,6 +46,9 @@ export interface IBasicActionProps {
 export interface IActionProps extends React.ClassAttributes<Action>, IBasicActionProps { }
 
 export class Action extends React.Component<IActionProps, any> {
+  static defaultProps: Partial<IActionOptions> = {
+    hideDisabled: true,
+  };
 
   render() {
     const actionIcon: JSX.Element = this.props.action.icon

--- a/src/components/actions/ActionBarConnected.tsx
+++ b/src/components/actions/ActionBarConnected.tsx
@@ -25,7 +25,7 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IActionBarOwnProps):
 
   return {
     withReduxState: true,
-    actions: actionBar && actionBar.actions ? _.filter(actionBar.actions, (action: IActionOptions) => _.result(action, 'enabled')) : [],
+    actions: actionBar && actionBar.actions ? _.filter(actionBar.actions, (action: IActionOptions) => action.enabled || action.hideDisabled === false) : [],
     isLoading: actionBar && actionBar.isLoading,
     prompt: prompt && prompt.options ?
       <div className='prompt'>

--- a/src/components/actions/LinkAction.tsx
+++ b/src/components/actions/LinkAction.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
 import { Action, IBasicActionProps } from './Action';
 
@@ -6,17 +7,22 @@ export interface ILinkActionProps extends React.ClassAttributes<LinkAction>, IBa
 export class LinkAction extends React.Component<ILinkActionProps> {
 
   render() {
-    const actionClasses: string = 'enabled' + (this.props.simple ? '' : ' inline-flex flex-center');
+    const actionClasses: string = classNames({
+      'enabled': this.props.action.enabled,
+      'state-disabled': !this.props.action.enabled && !this.props.action.hideDisabled,
+      'inline-flex flex-center': !this.props.simple,
+    });
     const opts: React.AllHTMLAttributes<HTMLAnchorElement> = {
       children: <Action action={this.props.action} simple={this.props.simple} />,
     };
+    const href = this.props.action.enabled ? this.props.action.link : undefined;
     if (this.props.action.target) {
-      opts.target = this.props.action.target;
+      opts.target = this.props.action.enabled ? this.props.action.target : undefined;
       opts.rel = 'noopener noreferrer';
     }
 
     return (
-      <a className={actionClasses} href={this.props.action.link} title={this.props.action.name} {...opts} />
+      <a className={actionClasses} href={href} title={this.props.action.name} {...opts} />
     );
   }
 }

--- a/src/components/actions/TriggerAction.tsx
+++ b/src/components/actions/TriggerAction.tsx
@@ -1,6 +1,7 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
-import { IUserChoice } from '../inlinePrompt/InlinePrompt';
-import { Action, IBasicActionProps, IConfirmData } from './Action';
+import {IUserChoice} from '../inlinePrompt/InlinePrompt';
+import {Action, IBasicActionProps, IConfirmData} from './Action';
 
 export interface ITriggerActionOwnProps extends React.ClassAttributes<TriggerAction>, IBasicActionProps {
   confirmLabel?: string;
@@ -13,7 +14,7 @@ export interface ITriggerActionDispatchProps {
   onCloseDropdown?: () => void;
 }
 
-export interface ITriggerActionProps extends ITriggerActionOwnProps, ITriggerActionDispatchProps { }
+export interface ITriggerActionProps extends ITriggerActionOwnProps, ITriggerActionDispatchProps {}
 
 export const CONFIRM_LABEL: string = 'Are you sure?';
 
@@ -54,10 +55,14 @@ export class TriggerAction extends React.Component<ITriggerActionProps, any> {
   }
 
   render() {
-    const actionClasses: string = this.props.action.enabled ? 'enabled' : (this.props.simple ? 'state-disabled' : 'disabled');
+    const actionClasses: string = classNames({
+      'enabled': this.props.action.enabled,
+      'state-disabled': !this.props.action.enabled && (this.props.simple || !this.props.action.hideDisabled),
+      'disabled': !this.props.action.enabled && !this.props.simple,
+    });
 
     return (
-      <span onClick={() => this.onTriggerAction()} className={actionClasses} title={this.props.action.name}>
+      <span onClick={() => this.props.action.enabled && this.onTriggerAction()} className={actionClasses} title={this.props.action.name}>
         <Action action={this.props.action} simple={this.props.simple} />
       </span>
     );

--- a/src/components/actions/examples/ActionBarConnectedExamples.tsx
+++ b/src/components/actions/examples/ActionBarConnectedExamples.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { ReactVaporStore } from '../../../../docs/ReactVaporStore';
-import { IActionOptions } from '../Action';
-import { addActionsToActionBar } from '../ActionBarActions';
-import { ActionBarConnected } from '../ActionBarConnected';
+import {ReactVaporStore} from '../../../../docs/ReactVaporStore';
+import {IActionOptions} from '../Action';
+import {addActionsToActionBar} from '../ActionBarActions';
+import {ActionBarConnected} from '../ActionBarConnected';
 
 const actionBarId = 'action-bar-connected';
 
@@ -17,7 +17,8 @@ export class ActionBarConnectedExamples extends React.Component<any, any> {
         icon: 'edit',
         primary: true,
         enabled: true,
-      }, {
+      },
+      {
         name: 'Action 1',
         trigger: () => alert('Action 1 was triggered'),
         enabled: true,
@@ -28,10 +29,12 @@ export class ActionBarConnectedExamples extends React.Component<any, any> {
             cancel: 'Cancel',
           },
         },
-      }, {
+      },
+      {
         separator: true,
         enabled: true,
-      }, {
+      },
+      {
         name: 'Action 2',
         trigger: () => alert('Action 2 was triggered'),
         enabled: true,
@@ -42,7 +45,25 @@ export class ActionBarConnectedExamples extends React.Component<any, any> {
             cancel: 'Cancel',
           },
         },
-      }];
+      },
+      {
+        name: 'Link to Coveo (disabled)',
+        link: 'http://coveo.com',
+        target: '_blank',
+        icon: 'edit',
+        primary: true,
+        enabled: false,
+        hideDisabled: false,
+      },
+      {
+        name: 'Action 3',
+        trigger: () => alert('You cannot trigger me'),
+        icon: 'edit',
+        primary: true,
+        enabled: false,
+        hideDisabled: false,
+      },
+    ];
     setTimeout(() => {
       ReactVaporStore.dispatch(addActionsToActionBar(actionBarId, actions));
     }, 4000);

--- a/src/components/actions/examples/ActionBarExamples.tsx
+++ b/src/components/actions/examples/ActionBarExamples.tsx
@@ -57,7 +57,7 @@ export class ActionBarExamples extends React.Component<any, any> {
           <ActionBar />
         </div>
         <div className='form-group'>
-          <label className='form-control-label'>Action bar without actions</label>
+          <label className='form-control-label'>Action bar with actions</label>
           <ActionBar actions={actions} />
         </div>
         <div className='form-group'>

--- a/src/components/actions/examples/ActionBarExamples.tsx
+++ b/src/components/actions/examples/ActionBarExamples.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { IActionOptions } from '../Action';
-import { ActionBar } from '../ActionBar';
+import {IActionOptions} from '../Action';
+import {ActionBar} from '../ActionBar';
 
 export class ActionBarExamples extends React.Component<any, any> {
 
@@ -20,11 +20,35 @@ export class ActionBarExamples extends React.Component<any, any> {
       }, {
         separator: true,
         enabled: true,
-      }, {
+      },
+      {
         name: 'action2',
         trigger: () => alert('Action 2 was triggered'),
         enabled: true,
-      }];
+      },
+      {
+        name: 'Link to Coveo (disabled)',
+        link: 'http://coveo.com',
+        target: '_blank',
+        icon: 'exit',
+        primary: true,
+        enabled: false,
+        hideDisabled: false,
+        tooltip: 'You cannot access Coveo\'s website at the moment.',
+        tooltipPlacement: 'bottom',
+      },
+      {
+        name: 'visibly disabled',
+        trigger: () => alert('I will never be triggered'),
+        target: '_blank',
+        icon: 'open',
+        primary: true,
+        enabled: false,
+        hideDisabled: false,
+        tooltip: 'You cannot trigger me.',
+        tooltipPlacement: 'bottom',
+      },
+    ];
 
     return (
       <div className='mt2'>

--- a/src/components/actions/tests/Action.spec.tsx
+++ b/src/components/actions/tests/Action.spec.tsx
@@ -19,6 +19,10 @@ describe('Actions', () => {
         );
       }).not.toThrow();
     });
+
+    it('should have a defaultProp hideDisabled set to true by default', () => {
+      expect(Action.defaultProps.hideDisabled).toBe(true);
+    });
   });
 
   describe('<Action />', () => {

--- a/src/components/actions/tests/Action.spec.tsx
+++ b/src/components/actions/tests/Action.spec.tsx
@@ -20,7 +20,7 @@ describe('Actions', () => {
       }).not.toThrow();
     });
 
-    it('should have a defaultProp hideDisabled set to true by default', () => {
+    it('should have a defaultProp hideDisabled set to true', () => {
       expect(Action.defaultProps.hideDisabled).toBe(true);
     });
   });

--- a/src/components/actions/tests/ActionBarConnected.spec.tsx
+++ b/src/components/actions/tests/ActionBarConnected.spec.tsx
@@ -1,21 +1,21 @@
-import { mount, ReactWrapper } from 'enzyme';
+import {mount, ReactWrapper} from 'enzyme';
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
-import { Provider } from 'react-redux';
-import { Store } from 'react-redux';
+import {Provider} from 'react-redux';
+import {Store} from 'react-redux';
 import * as _ from 'underscore';
-import { IReactVaporState } from '../../../ReactVapor';
-import { clearState } from '../../../utils/ReduxUtils';
-import { TestUtils } from '../../../utils/TestUtils';
-import { IInlinePromptOptions } from '../../inlinePrompt/InlinePrompt';
-import { addPrompt } from '../../inlinePrompt/InlinePromptActions';
-import { IActionOptions } from '../Action';
-import { ActionBar, IActionBarProps } from '../ActionBar';
-import { addActionsToActionBar } from '../ActionBarActions';
-import { ActionBarConnected } from '../ActionBarConnected';
-import { filterItems } from '../filters/ItemFilterActions';
-import { PrimaryActionConnected } from '../PrimaryActionConnected';
-import { SecondaryActionsConnected } from '../SecondaryActionsConnected';
+import {IReactVaporState} from '../../../ReactVapor';
+import {clearState} from '../../../utils/ReduxUtils';
+import {TestUtils} from '../../../utils/TestUtils';
+import {IInlinePromptOptions} from '../../inlinePrompt/InlinePrompt';
+import {addPrompt} from '../../inlinePrompt/InlinePromptActions';
+import {IActionOptions} from '../Action';
+import {ActionBar, IActionBarProps} from '../ActionBar';
+import {addActionsToActionBar} from '../ActionBarActions';
+import {ActionBarConnected} from '../ActionBarConnected';
+import {filterItems} from '../filters/ItemFilterActions';
+import {PrimaryActionConnected} from '../PrimaryActionConnected';
+import {SecondaryActionsConnected} from '../SecondaryActionsConnected';
 
 describe('Actions', () => {
   const id: string = 'secondary-actions';
@@ -29,6 +29,17 @@ describe('Actions', () => {
     name: 'action2',
     trigger: jasmine.createSpy('triggerMethod'),
     enabled: true,
+  },
+  {
+    name: 'action3',
+    trigger: jasmine.createSpy('triggerMethod'),
+    enabled: false,
+  },
+  {
+    name: 'action4',
+    trigger: jasmine.createSpy('triggerMethod'),
+    enabled: false,
+    hideDisabled: false,
   }];
   const itemFilter: string = 'the item';
   const itemFilterLabel: string = 'Item filter';
@@ -45,7 +56,7 @@ describe('Actions', () => {
         <Provider store={store}>
           <ActionBarConnected id={id} itemFilterLabel={itemFilterLabel} />
         </Provider>,
-        { attachTo: document.getElementById('App') },
+        {attachTo: document.getElementById('App')},
       );
       actionBar = wrapper.find(ActionBar).first();
 
@@ -66,11 +77,11 @@ describe('Actions', () => {
       expect(idProp).toBe(id);
     });
 
-    it('should get the actions as a prop', () => {
+    it('should get the enabled actions and unhidden disabled actions as a prop', () => {
       const actionsProp = actionBar.props().actions;
 
       expect(actionsProp).toBeDefined();
-      expect(actionsProp.length).toBe(actions.length);
+      expect(actionsProp.length).toBe(actions.filter((action) => action.enabled || action.hideDisabled === false).length);
       expect(actionsProp[0]).toEqual(jasmine.objectContaining(actions[0]));
     });
 
@@ -128,7 +139,7 @@ describe('Actions', () => {
         <Provider store={store}>
           <ActionBarConnected id={id} />
         </Provider>,
-        { attachTo: document.getElementById('App') },
+        {attachTo: document.getElementById('App')},
       );
       actionBar = wrapper.find(ActionBar).first();
 
@@ -170,7 +181,7 @@ describe('Actions', () => {
         <Provider store={store}>
           <ActionBarConnected id={id} itemFilterLabel={itemFilterLabel} onClearItemFilter={onClearItemFilterSpy} />
         </Provider>,
-        { attachTo: document.getElementById('App') },
+        {attachTo: document.getElementById('App')},
       );
       actionBar = wrapper.find(ActionBar).first();
 
@@ -186,11 +197,11 @@ describe('Actions', () => {
     });
 
     it('should clear the item filter when calling clearItemFilter', () => {
-      expect(_.findWhere(store.getState().itemFilters, { id: id }).item).toBe(itemFilter);
+      expect(_.findWhere(store.getState().itemFilters, {id: id}).item).toBe(itemFilter);
 
       actionBar.props().clearItemFilter();
 
-      expect(_.findWhere(store.getState().itemFilters, { id: id }).item).toBe('');
+      expect(_.findWhere(store.getState().itemFilters, {id: id}).item).toBe('');
     });
   });
 });

--- a/src/components/actions/tests/ActionBarConnected.spec.tsx
+++ b/src/components/actions/tests/ActionBarConnected.spec.tsx
@@ -19,28 +19,31 @@ import {SecondaryActionsConnected} from '../SecondaryActionsConnected';
 
 describe('Actions', () => {
   const id: string = 'secondary-actions';
-  const actions: IActionOptions[] = [{
-    name: 'action',
-    link: 'http://coveo.com',
-    target: '_blank',
-    primary: true,
-    enabled: true,
-  }, {
-    name: 'action2',
-    trigger: jasmine.createSpy('triggerMethod'),
-    enabled: true,
-  },
-  {
-    name: 'action3',
-    trigger: jasmine.createSpy('triggerMethod'),
-    enabled: false,
-  },
-  {
-    name: 'action4',
-    trigger: jasmine.createSpy('triggerMethod'),
-    enabled: false,
-    hideDisabled: false,
-  }];
+  const actions: IActionOptions[] = [
+    {
+      name: 'action',
+      link: 'http://coveo.com',
+      target: '_blank',
+      primary: true,
+      enabled: true,
+    },
+    {
+      name: 'action2',
+      trigger: jasmine.createSpy('triggerMethod'),
+      enabled: true,
+    },
+    {
+      name: 'action3',
+      trigger: jasmine.createSpy('triggerMethod'),
+      enabled: false,
+    },
+    {
+      name: 'action4',
+      trigger: jasmine.createSpy('triggerMethod'),
+      enabled: false,
+      hideDisabled: false,
+    },
+  ];
   const itemFilter: string = 'the item';
   const itemFilterLabel: string = 'Item filter';
 

--- a/src/components/actions/tests/LinkAction.spec.tsx
+++ b/src/components/actions/tests/LinkAction.spec.tsx
@@ -117,11 +117,11 @@ describe('Actions', () => {
         expect(linkAction.find('a').hasClass('state-disabled')).toBe(true);
       });
 
-      it('should have no target provided if the action is not enabled', () => {
+      it('should have no target provided', () => {
         expect(linkAction.find('a').prop('target')).toBeUndefined();
       });
 
-      it('should have no href provided if the action is not enabled', () => {
+      it('should have no href provided', () => {
         expect(linkAction.find('a').prop('href')).toBeUndefined();
       });
     });

--- a/src/components/actions/tests/LinkAction.spec.tsx
+++ b/src/components/actions/tests/LinkAction.spec.tsx
@@ -1,9 +1,9 @@
-import { mount, ReactWrapper, shallow } from 'enzyme';
+import {mount, ReactWrapper, shallow} from 'enzyme';
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
 import * as _ from 'underscore';
-import { IActionOptions } from '../Action';
-import { ILinkActionProps, LinkAction } from '../LinkAction';
+import {IActionOptions} from '../Action';
+import {ILinkActionProps, LinkAction} from '../LinkAction';
 
 describe('Actions', () => {
   const action: IActionOptions = {
@@ -33,7 +33,7 @@ describe('Actions', () => {
           action={action}
           simple={simple}
         />,
-        { attachTo: document.getElementById('App') },
+        {attachTo: document.getElementById('App')},
       );
     });
 
@@ -66,7 +66,7 @@ describe('Actions', () => {
 
       const newAction = _.extend({}, action);
       newAction.target = undefined;
-      linkAction.setProps({ action: newAction, simple: simple });
+      linkAction.setProps({action: newAction, simple: simple});
 
       expect(linkAction.html()).not.toContain(expectedTarget);
     });
@@ -77,7 +77,7 @@ describe('Actions', () => {
 
       const newAction = _.extend({}, action);
       newAction.target = undefined;
-      linkAction.setProps({ action: newAction, simple: simple });
+      linkAction.setProps({action: newAction, simple: simple});
 
       expect(linkAction.html()).not.toContain(expectedRel);
     });
@@ -89,10 +89,41 @@ describe('Actions', () => {
       expect(linkAction.find('a').hasClass(expectedFlexClass)).toBe(true);
       expect(linkAction.find('a').hasClass(expectedCenterFlexClass)).toBe(true);
 
-      linkAction.setProps({ action: action, simple: true });
+      linkAction.setProps({action: action, simple: true});
 
       expect(linkAction.find('a').hasClass(expectedFlexClass)).toBe(false);
       expect(linkAction.find('a').hasClass(expectedCenterFlexClass)).toBe(false);
+    });
+
+    it('shoud have the enabled class if the action is enabled', () => {
+      expect(linkAction.find('a').hasClass('enabled')).toBe(true);
+    });
+
+    it('shoud not have the state-disabled class if the action is enabled', () => {
+      expect(linkAction.find('a').hasClass('state-disabled')).toBe(false);
+    });
+
+    describe('disabled action', () => {
+      beforeEach(() => {
+        linkAction.setProps({action: {...action, enabled: false}});
+      });
+
+      it('shoud not have the enabled class', () => {
+        expect(linkAction.find('a').hasClass('enabled')).toBe(false);
+      });
+
+      it('shoud have the state-disabled class if hideDisabled set to false is passed as prop', () => {
+        linkAction.setProps({action: {...action, enabled: false, hideDisabled: false}});
+        expect(linkAction.find('a').hasClass('state-disabled')).toBe(true);
+      });
+
+      it('should have no target provided if the action is not enabled', () => {
+        expect(linkAction.find('a').prop('target')).toBeUndefined();
+      });
+
+      it('should have no href provided if the action is not enabled', () => {
+        expect(linkAction.find('a').prop('href')).toBeUndefined();
+      });
     });
   });
 });

--- a/src/components/actions/tests/TriggerAction.spec.tsx
+++ b/src/components/actions/tests/TriggerAction.spec.tsx
@@ -72,13 +72,26 @@ describe('Actions', () => {
 
       expect(triggerAction.find('.enabled').length).toBe(0);
       expect(triggerAction.find('.state-disabled').length).toBe(1);
+
+      triggerAction.setProps({ action: {...newAction, hideDisabled: false}, simple: false });
+
+      expect(triggerAction.find('.enabled').length).toBe(0);
+      expect(triggerAction.find('.state-disabled').length).toBe(1);
     });
 
-    it('should call onTriggerAction when clicked', () => {
+    it('should call onTriggerAction when clicked if action is enabled', () => {
       const onTriggerActionSpy = spyOn<any>(triggerActionInstance, 'onTriggerAction');
 
       triggerAction.find('.enabled').simulate('click');
       expect(onTriggerActionSpy.calls.count()).toBe(1);
+    });
+
+    it('should not call onTriggerAction when clicked if action is not enabled and not hideDisabled', () => {
+      triggerAction.setProps({ action: {...action, enabled: false, hideDisabled: false}});
+      const onTriggerActionSpy = spyOn<any>(triggerActionInstance, 'onTriggerAction');
+
+      triggerAction.find('.state-disabled').simulate('click');
+      expect(onTriggerActionSpy.calls.count()).toBe(0);
     });
 
     it('should call the trigger of the action when clicked and no confirmation is required', () => {

--- a/src/components/actions/tests/TriggerAction.spec.tsx
+++ b/src/components/actions/tests/TriggerAction.spec.tsx
@@ -86,7 +86,7 @@ describe('Actions', () => {
       expect(onTriggerActionSpy.calls.count()).toBe(1);
     });
 
-    it('should not call onTriggerAction when clicked if action is not enabled and not hideDisabled', () => {
+    it('should not call onTriggerAction when clicked if action is not enabled and visible', () => {
       triggerAction.setProps({ action: {...action, enabled: false, hideDisabled: false}});
       const onTriggerActionSpy = spyOn<any>(triggerActionInstance, 'onTriggerAction');
 


### PR DESCRIPTION
we need this for a use case in ML, where offline models won't have access to an action, and we want to give context to the user through a tooltip on the action ("You can not open this model because it is currently inactive") . 

demo: https://coveo.github.io/react-vapor/unhidden-disabled-actions/  

search for `Action bar with actions`