### PR TITLE
Use ReactVapor's Checkbox in facets instead of input

### DIFF
--- a/src/components/facets/FacetRow.tsx
+++ b/src/components/facets/FacetRow.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { Checkbox } from '../checkbox/Checkbox';
+import { Label } from '../input/Label';
 import { Tooltip } from '../tooltip/Tooltip';
 import { IFacet } from './Facet';
 
@@ -20,17 +22,13 @@ export class FacetRow extends React.Component<IFacetRowProps, any> {
 
     return (
       <li className='facet-value facet-selectable'>
-        <label className='coveo-checkbox-label facet-value-label'>
-          <input
-            type='checkbox'
-            name={this.props.facetRow.name}
-            className='coveo-checkbox facet-checkbox-input'
-            checked={this.props.isChecked}
-            onChange={() => this.props.onToggleFacet(this.props.facetRow)}
-          />
-          <button type='button'></button>
-          <span className='label'>{label}</span>
-        </label>
+        <Checkbox
+          name={this.props.facetRow.name}
+          classes={['facet-value-label']}
+          checked={this.props.isChecked}
+          onClick={() => this.props.onToggleFacet(this.props.facetRow)}>
+          <Label classes={['label']}>{label}</Label>
+        </Checkbox>
       </li>
     );
   }

--- a/src/components/facets/tests/FacetConnected.spec.tsx
+++ b/src/components/facets/tests/FacetConnected.spec.tsx
@@ -203,7 +203,7 @@ describe('Facets', () => {
       expect(onToggleFacet).not.toHaveBeenCalled();
 
       expect(facetRowInput.length).toBe(1);
-      facetRowInput.simulate('change');
+      facetRowInput.simulate('click');
 
       expect(onToggleFacet).toHaveBeenCalled();
     });

--- a/src/components/facets/tests/FacetRow.spec.tsx
+++ b/src/components/facets/tests/FacetRow.spec.tsx
@@ -73,10 +73,10 @@ describe('Facets', () => {
       expect(facetRowView.html()).toContain(FACET_ROW_PROPS.facetRow.formattedName);
     });
 
-    it('should should call onToggleFacet on change', () => {
+    it('should should call onToggleFacet on click', () => {
       expect(FACET_ROW_PROPS.onToggleFacet).not.toHaveBeenCalled();
 
-      facetRowView.find('input').simulate('change');
+      facetRowView.find('input').simulate('click');
 
       expect(FACET_ROW_PROPS.onToggleFacet).toHaveBeenCalled();
     });


### PR DESCRIPTION
Reuse one of ReactVapor's own component.
Before, clicking on the checkbox didn't toggle the change in the facets, only clicking the label worked.
Looks like this change will not be breaking behaviour outside of ReactVapor, but I'm still curious.

To test, go checkout connected facets in the demo and click on the checkbox.

DEMO https://coveo.github.io/react-vapor/update-facets-checkboxes/