### PR TITLE
FIX: Add feature-export-version to prod script also

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -48,6 +48,7 @@ const config = {
   },
   plugins: [
     new webpack.DefinePlugin({
+      WEBPACK_DEFINED_VERSION: JSON.stringify(require('./package.json').version),
       'process.env.NODE_ENV': JSON.stringify('production'),
     }),
   ],


### PR DESCRIPTION
I needed to add the plugin to the prod webpack script also because it's the only one that runs when building.