### PR TITLE
Fix svg names

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "chosen-js": "1.8.2",
     "classnames": "2.2.5",
     "codecov": "3.0.0",
-    "coveo-styleguide": "2.10.x",
+    "coveo-styleguide": "2.13.x",
     "css-loader": "0.28.10",
     "del": "3.0.0",
     "dts-generator": "2.1.0",

--- a/src/components/logoCard/LogoCard.tsx
+++ b/src/components/logoCard/LogoCard.tsx
@@ -1,12 +1,14 @@
 import * as classNames from 'classnames';
+import * as VaporSVG from 'coveo-styleguide';
 import * as React from 'react';
-import * as  s from 'underscore.string';
+import * as s from 'underscore.string';
+
 import {Badge, IBadgeProps} from '../badge/Badge';
 import {CornerRibbon, DEFAULT_CORNER_RIBBON_CONTAINER_CLASSNAME, ICornerRibbonProps} from '../cornerRibbon/CornerRibbon';
 import {Svg} from '../svg/Svg';
 
 export const DEFAULT_LOGO_CARD_CLASSNAME: string = 'logo-card';
-export const DEFAULT_LOGO_ICON: string = 'source-custom';
+export const DEFAULT_LOGO_ICON: string = VaporSVG.svg.sourceCustom.name;
 export const DEFAULT_LOGO_ICON_CLASSNAME: string = 'icon';
 export const DEFAULT_LOGO_ICON_SIZE: string = 'mod-4x';
 export const DEFAULT_DISABLED_RIBBON_LABEL: string = 'Unavailable';

--- a/src/components/logoCard/LogoCard.tsx
+++ b/src/components/logoCard/LogoCard.tsx
@@ -1,7 +1,7 @@
 import * as classNames from 'classnames';
 import * as VaporSVG from 'coveo-styleguide';
 import * as React from 'react';
-import * as s from 'underscore.string';
+import {slugify} from 'underscore.string';
 
 import {Badge, IBadgeProps} from '../badge/Badge';
 import {CornerRibbon, DEFAULT_CORNER_RIBBON_CONTAINER_CLASSNAME, ICornerRibbonProps} from '../cornerRibbon/CornerRibbon';
@@ -60,7 +60,7 @@ export class LogoCard extends React.Component<ILogoCardProps> {
         const badges = this.props.badges.map((badgeProps) =>
             <Badge
                 {...badgeProps}
-                key={s.slugify(badgeProps.label)}
+                key={slugify(badgeProps.label)}
             />,
         );
         const description = this.props.description

--- a/src/components/svg/Svg.tsx
+++ b/src/components/svg/Svg.tsx
@@ -1,8 +1,7 @@
+import * as VaporSVG from 'coveo-styleguide';
 import * as React from 'react';
 import {extend, omit} from 'underscore';
-
-// tslint:disable-next-line
-const svgsEnum = require('../../../node_modules/coveo-styleguide/dist/svg/CoveoStyleGuideSvg.json') as {[key: string]: string};
+import * as s from 'underscore.string';
 
 /**
  * Pass the required svgName to get your svg.
@@ -35,8 +34,12 @@ export class Svg extends React.Component<ISvgProps, any> {
         return parser.innerHTML;
     }
 
+    private getFormattedSvgName(): string {
+        return s.camelize(this.props.svgName);
+    }
+
     render() {
-        const svgString: string = svgsEnum[this.props.svgName];
+        const svgString: string = VaporSVG.svg[this.getFormattedSvgName()] && VaporSVG.svg[this.getFormattedSvgName()].svgString;
 
         // Omit Svg props to avoid warnings.
         const svgSpanProps = extend({}, omit(this.props, svgPropsToOmit));

--- a/src/components/svg/Svg.tsx
+++ b/src/components/svg/Svg.tsx
@@ -1,7 +1,7 @@
 import * as VaporSVG from 'coveo-styleguide';
 import * as React from 'react';
 import {extend, omit} from 'underscore';
-import * as s from 'underscore.string';
+import {camelize} from 'underscore.string';
 
 /**
  * Pass the required svgName to get your svg.
@@ -35,7 +35,7 @@ export class Svg extends React.Component<ISvgProps, any> {
     }
 
     private getFormattedSvgName(): string {
-        return s.camelize(this.props.svgName);
+        return camelize(this.props.svgName);
     }
 
     render() {

--- a/src/components/svg/Svg.tsx
+++ b/src/components/svg/Svg.tsx
@@ -34,12 +34,9 @@ export class Svg extends React.Component<ISvgProps, any> {
         return parser.innerHTML;
     }
 
-    private getFormattedSvgName(): string {
-        return camelize(this.props.svgName);
-    }
-
     render() {
-        const svgString: string = VaporSVG.svg[this.getFormattedSvgName()] && VaporSVG.svg[this.getFormattedSvgName()].svgString;
+        const formattedSvgName: string = camelize(this.props.svgName);
+        const svgString: string = VaporSVG.svg[formattedSvgName] && VaporSVG.svg[formattedSvgName].svgString;
 
         // Omit Svg props to avoid warnings.
         const svgSpanProps = extend({}, omit(this.props, svgPropsToOmit));

--- a/src/components/svg/tests/Svg.spec.tsx
+++ b/src/components/svg/tests/Svg.spec.tsx
@@ -1,90 +1,156 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
-// tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
-import * as _ from 'underscore';
+
 import {ISvgProps, Svg} from '../Svg';
 
-describe('<Svg>', () => {
-    let svgWrapper: ReactWrapper<ISvgProps, any>;
-    let svgProps: ISvgProps;
+describe('Svg', () => {
+    let svg: ReactWrapper<ISvgProps, any>;
 
-    beforeEach(() => {
-        svgProps = {
-            svgName: 'clear',
-            className: 'icon',
-            svgClass: 'fill-medium-blue',
-        };
-    });
+    const BASIC_SVG: ISvgProps = {
+        svgName: 'clear',
+        className: 'icon',
+        svgClass: 'fill-medium-blue',
+    };
+
+    const INVALID_SVG_NAME: ISvgProps = {
+        svgName: 'some-invalid-svg-name',
+        className: 'icon',
+        svgClass: 'fill-medium-blue',
+    };
+
+    const DASHED_SVG_NAME: ISvgProps = {
+        svgName: 'source-custom',
+        className: 'icon',
+        svgClass: 'fill-medium-blue',
+    };
+
+    const CAMELIZED_SVG_NAME: ISvgProps = {
+        svgName: 'sourceCustom',
+        className: 'icon',
+        svgClass: 'fill-medium-blue',
+    };
 
     it('should render without error', () => {
         expect(() => shallow(
-            <Svg {...svgProps} />,
+            <Svg {...BASIC_SVG} />,
         )).not.toThrow();
     });
 
-    it('should mount and unmount/detach without error', () => {
-        expect(() => {
-            svgWrapper = mount(
-                <Svg {...svgProps} />,
+    describe('<Svg />', () => {
+
+        const mountWithProps = (props: ISvgProps) => {
+            svg = mount(
+                <Svg {...props} />,
                 {attachTo: document.getElementById('App')},
             );
-        }).not.toThrow();
+        };
 
-        expect(() => {
-            svgWrapper.unmount();
-            svgWrapper.detach();
-        }).not.toThrow();
-    });
-
-    describe('Props handling', () => {
         afterEach(() => {
-            svgWrapper.unmount();
-            svgWrapper.detach();
+            svg.unmount();
+            svg.detach();
         });
 
-        it('should handle an invalid svgName', () => {
-            svgProps = _.extend(svgProps, {
-                svgName: 'an-icon-that-does-not-exist',
-            });
-
+        it('should mount and unmount/detach without error', () => {
             expect(() => {
-                svgWrapper = mount(
-                    <Svg {...svgProps} />,
-                    {attachTo: document.getElementById('App')},
-                );
+                mountWithProps(BASIC_SVG);
             }).not.toThrow();
 
-            expect(document.querySelector('#App').querySelector('svg')).toBeDefined();
+            expect(() => {
+                svg.unmount();
+                svg.detach();
+            }).not.toThrow();
         });
 
-        it('should handle an undefined className', () => {
-            svgProps = _.extend(svgProps, {
-                className: undefined,
+        describe('Valid svg name', () => {
+            let svgDomNode: SVGSVGElement;
+
+            beforeEach(() => {
+                mountWithProps(BASIC_SVG);
+                svgDomNode = svg.getDOMNode().querySelector('svg');
             });
 
-            expect(() => {
-                svgWrapper = mount(
-                    <Svg {...svgProps} />,
-                    {attachTo: document.getElementById('App')},
-                );
-            }).not.toThrow();
+            it('should render a non-empty svg tag', () => {
+                expect(svgDomNode).toBeDefined();
+                expect(svgDomNode.hasChildNodes()).toBe(true);
+            });
 
-            expect(document.querySelector('#App').querySelector('svg')).toBeDefined();
+            it('should render the svgClass if specified as props on the svg tag', () => {
+                expect(svgDomNode.classList.toString()).toBe(BASIC_SVG.svgClass);
+            });
         });
 
-        it('should handle an undefined svgClass', () => {
-            svgProps = _.extend(svgProps, {
-                svgClass: undefined,
+        describe('Invalid svg name', () => {
+            beforeEach(() => {
+                mountWithProps(INVALID_SVG_NAME);
             });
 
-            expect(() => {
-                svgWrapper = mount(
-                    <Svg {...svgProps} />,
-                    {attachTo: document.getElementById('App')},
-                );
-            }).not.toThrow();
+            it('should render an empty svg tag', () => {
+                expect(svg.find('svg').exists()).toBe(true);
+            });
 
-            expect(document.querySelector('#App').querySelector('svg')).toBeDefined();
+            it('should render the svgClass if specified as props on the svg tag', () => {
+                expect(svg.find('svg').hasClass(INVALID_SVG_NAME.svgClass)).toBe(true);
+            });
+
+            it('should render className prop on the container', () => {
+                expect(svg.hasClass(INVALID_SVG_NAME.className)).toBe(true);
+            });
+        });
+
+        describe('Dashed svg name', () => {
+            let svgDomNode: SVGSVGElement;
+
+            beforeEach(() => {
+                mountWithProps(DASHED_SVG_NAME);
+                svgDomNode = svg.getDOMNode().querySelector('svg');
+            });
+
+            it('should render an non-empty svg tag', () => {
+                expect(svgDomNode).toBeDefined();
+                expect(svgDomNode.hasChildNodes()).toBe(true);
+            });
+
+            it('should render the svgClass if specified as props on the svg tag', () => {
+                expect(svgDomNode.classList.toString()).toBe(DASHED_SVG_NAME.svgClass);
+            });
+
+            it('should render className prop on the container', () => {
+                expect(svg.hasClass(DASHED_SVG_NAME.className)).toBe(true);
+            });
+        });
+
+        describe('Camelized svg name', () => {
+            let svgDomNode: SVGSVGElement;
+
+            beforeEach(() => {
+                mountWithProps(CAMELIZED_SVG_NAME);
+                svgDomNode = svg.getDOMNode().querySelector('svg');
+            });
+
+            it('should render an empty svg tag', () => {
+                expect(svgDomNode).toBeDefined();
+                expect(svgDomNode.hasChildNodes()).toBe(true);
+            });
+
+            it('should render the svgClass if specified as props on the svg tag', () => {
+                expect(svgDomNode.classList.toString()).toBe(CAMELIZED_SVG_NAME.svgClass);
+            });
+
+            it('should render className prop on the container', () => {
+                expect(svg.hasClass(CAMELIZED_SVG_NAME.className)).toBe(true);
+            });
+        });
+
+        it('should render the same svg for both of its names', () => {
+            mountWithProps(DASHED_SVG_NAME);
+
+            const dashedSVG = svg.getDOMNode().querySelector('svg').innerHTML;
+
+            mountWithProps(CAMELIZED_SVG_NAME);
+
+            const camelizedSVG = svg.getDOMNode().querySelector('svg').innerHTML;
+
+            expect(dashedSVG).toBe(camelizedSVG);
         });
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,11 +11,12 @@
     "removeComments": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "target": "ES5"
+    "target": "ES5",
   },
   "include": [
     "src/**/*.tsx",
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "types/**/*.d.ts"
   ],
   "exclude": [
     "src/**/*.spec.*"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -13,6 +13,7 @@
   },
   "include": [
     "src/**/*.tsx",
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "types/**/*.d.ts"
   ]
 }

--- a/types/coveo-styleguide/index.d.ts
+++ b/types/coveo-styleguide/index.d.ts
@@ -1,0 +1,10 @@
+declare module VaporSVG {
+    const SVG: (icon: string, classes?: string, spanClasses?: string) => string;
+    const svgFromName: (icon: string, classes?: string, spanClasses?: string, title?: string) => string;
+    const svg: any;
+    const version: string;
+}
+
+declare module 'coveo-styleguide' {
+    export = VaporSVG;
+}


### PR DESCRIPTION
Before:
`<Svg svgName='source-custom' />` Works :smile_cat:
`<Svg svgName='sourceCustom' />` Doesn't work :crying_cat_face: 
After:
`<Svg svgName='source-custom' />` Works :smile_cat:
`<Svg svgName='sourceCustom' />` Works :smile_cat: 

This allows to use Svg component like so:
`<Svg svgName={VaporSVG.svg.sourceCustom.name} />` 
