### PR TITLE
Migrate stuff++

### DIFF
--- a/docs/Index.tsx
+++ b/docs/Index.tsx
@@ -64,6 +64,7 @@ import {PartialStringMatchExamples} from '../src/components/partial-string-match
 import {RadioExamples} from '../src/components/radio/examples/RadioExamples';
 import {MultiSelectExamples} from '../src/components/select/examples/MultiSelectExamples';
 import {SingleSelectExamples} from '../src/components/select/examples/SingleSelectExamples';
+import {SideNavigationExample} from '../src/components/sideNavigation/examples/SideNavigationExample';
 import {SideNavigationLoadingExample} from '../src/components/sideNavigation/examples/SideNavigationLoadingExample';
 import {SliderExamples} from '../src/components/slider/examples/SliderExamples';
 import {SplitLayoutExamples} from '../src/components/splitlayout/examples/SplitLayoutExamples';
@@ -143,6 +144,7 @@ class App extends React.Component<any, any> {
                     <NavigationConnectedExamples />
                     <SubNavigationExamples />
                     <SubNavigationConnectedExamples />
+                    <SideNavigationExample />
                     <SideNavigationLoadingExample />
                     <TabsExamples />
                     <ActionBarExamples />

--- a/src/components/sideNavigation/SideNavigationHeader.tsx
+++ b/src/components/sideNavigation/SideNavigationHeader.tsx
@@ -1,0 +1,25 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import {Svg} from '../svg/Svg';
+
+export interface ISideNavigationHeaderProps {
+    title: string;
+    svgName?: string;
+    svgClass?: string;
+}
+
+export class SideNavigationHeader extends React.Component<ISideNavigationHeaderProps> {
+    render() {
+        const svgClass = classNames('navigation-menu-section-header-icon icon mod-lg', this.props.svgClass);
+        const icon = this.props.svgName
+            ? <Svg svgName={this.props.svgName} svgClass={svgClass} />
+            : <span className='navigation-menu-section-header-icon' />;
+        return (
+            <div className='navigation-menu-section-header text-white'>
+                {icon}
+                {this.props.title}
+                {this.props.children}
+            </div>
+        );
+    }
+}

--- a/src/components/sideNavigation/SideNavigationItem.tsx
+++ b/src/components/sideNavigation/SideNavigationItem.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export interface ISideNavigationItemProps {
+    href: string;
+    title: string;
+    target?: string;
+}
+
+export const SideNavigationItem = (props: ISideNavigationItemProps) =>
+    <a className='block navigation-menu-section-item' href={props.href} target={props.target}>
+        <span className='navigation-menu-section-item-link'>
+            {props.title}
+        </span>
+    </a>;

--- a/src/components/sideNavigation/SideNavigationMenuSection.tsx
+++ b/src/components/sideNavigation/SideNavigationMenuSection.tsx
@@ -1,10 +1,58 @@
 import * as React from 'react';
+import {SlideY} from '../../animations/SlideY';
+import {Svg} from '../svg/Svg';
+import {ISideNavigationHeaderProps, SideNavigationHeader} from './SideNavigationHeader';
 import {SideNavigationLoadingHeader} from './SideNavigationLoadingHeader';
 
-export const SideNavigationMenuSection = (props: any) =>
-    <div className='block navigation-menu-section'>
-        <SideNavigationLoadingHeader />
-        <div className='navigation-menu-section-items'>
-            {props.children}
-        </div>
-    </div>;
+export interface ISideNavigationSectionOwnProps {
+    header?: ISideNavigationHeaderProps;
+    expandable?: boolean;
+}
+
+export interface ISideNavigationSectionStateProps {
+    expanded?: boolean;
+}
+
+export interface ISideNavigationSectionDispatchProps {
+    onClick?: () => void;
+}
+
+export interface ISideNavigationSectionProps extends ISideNavigationSectionOwnProps, ISideNavigationSectionStateProps, ISideNavigationSectionDispatchProps {}
+
+export class SideNavigationMenuSection extends React.Component<ISideNavigationSectionProps> {
+    private handleClick() {
+        if (this.props.onClick) {
+            this.props.onClick();
+        }
+    }
+
+    render() {
+        return (
+            <div className='block navigation-menu-section' onClick={() => this.handleClick()}>
+                {this.buildHeader()}
+                <SlideY in={!(this.props.expandable && !this.props.expanded)} timeout={350}>
+                    <div className='navigation-menu-section-items'>
+                        {this.props.children}
+                    </div>
+                </SlideY>
+            </div>
+        );
+    }
+
+    private buildHeader(): JSX.Element {
+        if (this.props.header) {
+            let arrow = null;
+            if (this.props.expandable) {
+                arrow = this.props.expanded
+                    ? <Svg svgName='arrow-top-rounded' className='collapsible-arrow icon fill-white' />
+                    : <Svg svgName='arrow-bottom-rounded' className='collapsible-arrow icon fill-white' />;
+            }
+            return (
+                <SideNavigationHeader {...this.props.header}>
+                    {arrow}
+                </SideNavigationHeader>
+            );
+        }
+        return <SideNavigationLoadingHeader />;
+    }
+}

--- a/src/components/sideNavigation/SideNavigationMenuSection.tsx
+++ b/src/components/sideNavigation/SideNavigationMenuSection.tsx
@@ -19,6 +19,8 @@ export interface ISideNavigationSectionDispatchProps {
 
 export interface ISideNavigationSectionProps extends ISideNavigationSectionOwnProps, ISideNavigationSectionStateProps, ISideNavigationSectionDispatchProps {}
 
+const arrowClassName = 'collapsible-arrow icon fill-white';
+
 export class SideNavigationMenuSection extends React.Component<ISideNavigationSectionProps> {
     private handleClick() {
         if (this.props.onClick) {
@@ -44,8 +46,8 @@ export class SideNavigationMenuSection extends React.Component<ISideNavigationSe
             let arrow = null;
             if (this.props.expandable) {
                 arrow = this.props.expanded
-                    ? <Svg svgName='arrow-top-rounded' className='collapsible-arrow icon fill-white' />
-                    : <Svg svgName='arrow-bottom-rounded' className='collapsible-arrow icon fill-white' />;
+                    ? <Svg svgName='arrow-top-rounded' className={arrowClassName} />
+                    : <Svg svgName='arrow-bottom-rounded' className={arrowClassName} />;
             }
             return (
                 <SideNavigationHeader {...this.props.header}>

--- a/src/components/sideNavigation/examples/SideNavigationExample.tsx
+++ b/src/components/sideNavigation/examples/SideNavigationExample.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {SideNavigation} from '../SideNavigation';
+import {SideNavigationItem} from '../SideNavigationItem';
+import {SideNavigationLoadingItem} from '../SideNavigationLoadingItem';
+import {SideNavigationMenuSection} from '../SideNavigationMenuSection';
+
+export class SideNavigationExample extends React.Component<any, any> {
+    constructor(prop: any, state: any) {
+        super(prop, state);
+
+        this.state = {
+            expanded: true,
+        };
+    }
+
+    click() {
+        this.setState({
+            expanded: !this.state.expanded,
+        });
+    }
+
+    render() {
+        return (
+            <div className='mt2'>
+                <label className='form-control-label'>Side Navigation</label>
+                <div className='flex flex-row flex-stretch'>
+                    <SideNavigation>
+                        <SideNavigationMenuSection header={{title: 'Section 1', svgName: 'identity-user'}}>
+                            <SideNavigationItem href='http://coveo.com' title='Link to Coveo' />
+                            <SideNavigationItem href='http://coveo.com' title='Another link to Coveo' />
+                        </SideNavigationMenuSection>
+                        <SideNavigationMenuSection header={{title: 'Section 2'}}>
+                            <SideNavigationLoadingItem className='mod-width-30' />
+                            <SideNavigationLoadingItem className='mod-width-50' />
+                            <SideNavigationLoadingItem className='mod-width-40' />
+                        </SideNavigationMenuSection>
+                        <SideNavigationMenuSection header={{title: 'Section 3', svgName: 'menu-content'}} expandable expanded={this.state.expanded} onClick={() => this.click()}>
+                            <SideNavigationItem href='http://coveo.com' title='Link to Coveo' />
+                            <SideNavigationItem href='http://coveo.com' title='Another link to Coveo' />
+                        </SideNavigationMenuSection>
+                    </SideNavigation>
+                </div>
+            </div>
+        );
+    }
+}

--- a/src/components/sideNavigation/tests/SideNavigationHeader.spec.tsx
+++ b/src/components/sideNavigation/tests/SideNavigationHeader.spec.tsx
@@ -1,0 +1,41 @@
+import {mount, ReactWrapper, shallow} from 'enzyme';
+import * as React from 'react';
+import {Svg} from '../../svg/Svg';
+import {ISideNavigationHeaderProps, SideNavigationHeader} from '../SideNavigationHeader';
+
+describe('<SideNavigationHeader />', () => {
+    const title = 'hello';
+    it('should render without errors', () => {
+        expect(() => {
+            shallow(
+                <SideNavigationHeader title={title} />,
+            );
+        }).not.toThrow();
+    });
+});
+
+describe('<SideNavigationHeader />', () => {
+    let wrapper: ReactWrapper<ISideNavigationHeaderProps, any>;
+    const title = 'hello';
+
+    beforeEach(() => {
+        wrapper = mount(
+            <SideNavigationHeader title={title} />,
+            {attachTo: document.getElementById('App')},
+        );
+    });
+
+    afterEach(() => {
+        wrapper.unmount();
+        wrapper.detach();
+    });
+
+    it('should render an icon if svgTitle prop is specified.', () => {
+        const svgName = 'menu-content';
+        wrapper.setProps({svgName, title});
+        wrapper.mount();
+
+        const icon = wrapper.find(Svg).first();
+        expect(icon).toBeDefined();
+    });
+});

--- a/src/components/sideNavigation/tests/SideNavigationItem.spec.tsx
+++ b/src/components/sideNavigation/tests/SideNavigationItem.spec.tsx
@@ -1,0 +1,13 @@
+import {shallow} from 'enzyme';
+import * as React from 'react';
+import {SideNavigationItem} from '../SideNavigationItem';
+
+describe('<SideNavigationItem />', () => {
+    it('should render without errors', () => {
+        expect(() => {
+            shallow(
+                <SideNavigationItem title='link to Coveo' href='http://coveo.com' />,
+            );
+        }).not.toThrow();
+    });
+});

--- a/src/components/sideNavigation/tests/SideNavigationMenuSection.spec.tsx
+++ b/src/components/sideNavigation/tests/SideNavigationMenuSection.spec.tsx
@@ -1,6 +1,9 @@
-import {shallow} from 'enzyme';
+import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
-import {SideNavigationMenuSection} from '../SideNavigationMenuSection';
+import {SlideY} from '../../../animations/SlideY';
+import {SideNavigationHeader} from '../SideNavigationHeader';
+import {SideNavigationLoadingHeader} from '../SideNavigationLoadingHeader';
+import {ISideNavigationSectionProps, SideNavigationMenuSection} from '../SideNavigationMenuSection';
 
 describe('<SideNavigationMenuSection />', () => {
     it('should render without errors', () => {
@@ -9,5 +12,60 @@ describe('<SideNavigationMenuSection />', () => {
                 <SideNavigationMenuSection />,
             );
         }).not.toThrow();
+    });
+});
+
+describe('<SideNavigationMenuSection />', () => {
+    const title = 'qwerty';
+    let wrapper: ReactWrapper<ISideNavigationSectionProps, any>;
+
+    beforeEach(() => {
+        wrapper = mount(
+            <SideNavigationMenuSection />,
+            {attachTo: document.getElementById('App')},
+        );
+    });
+
+    afterEach(() => {
+        wrapper.unmount();
+        wrapper.detach();
+    });
+
+    it('should render loading header when no header is specified.', () => {
+        const header = wrapper.find(SideNavigationLoadingHeader).first();
+
+        expect(header).toBeDefined();
+    });
+
+    it('should render normal header when header prop is specified.', () => {
+        wrapper.setProps({header: {title}});
+        wrapper.mount();
+
+        const header = wrapper.find(SideNavigationHeader).first();
+
+        expect(header).toBeDefined();
+    });
+
+    it('should hide children when expandable prop is true and expanded prop is false.', () => {
+        wrapper.setProps({header: {title}, expandable: true});
+        wrapper.mount();
+
+        expect(wrapper.find(SlideY).prop('in')).toBeDefined(false);
+    });
+
+    it('should not hide children when expandable prop is true and expanded prop is true.', () => {
+        wrapper.setProps({header: {title}, expandable: true, expanded: true});
+        wrapper.mount();
+
+        expect(wrapper.find(SlideY).prop('in')).toBeDefined(true);
+    });
+
+    it('should call onClick prop when clicked and onClick prop is specified', () => {
+        const onClickSpy = jasmine.createSpy('click');
+        wrapper.setProps({header: {title}, onClick: onClickSpy});
+        wrapper.mount();
+        wrapper.find('div').first().simulate('click');
+
+        expect(onClickSpy).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
Migrations de nos classes de side navigation du projet Dynamics. Modifiées pour ajouter des icônes et supporter vos truc cool de menu qui collapsent.

Il me reste encore un component qui utilise `react-dom` et `react-router-dom`, comme le `SideNavigationItem` que je viens d'ajouter, mais il render un [NavLink](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/NavLink.md) au lieu d'un anchor.
Vous ne voulez probablement pas de ça dans cette lib, right?