### PR TITLE
Fix flippable z-index on flip

### DIFF
--- a/src/components/flippable/Flippable.tsx
+++ b/src/components/flippable/Flippable.tsx
@@ -60,6 +60,7 @@ export class Flippable extends React.Component<IFlippableProps, any> {
     render() {
         const containerClassName = classNames(
             Flippable.CONTAINER_CLASSNAME,
+            this.props.isFlipped ? 'show-on-top' : '',
             this.props.className,
         );
         const flipperClassName = classNames(

--- a/src/components/flippable/tests/Flippable.spec.tsx
+++ b/src/components/flippable/tests/Flippable.spec.tsx
@@ -91,6 +91,14 @@ describe('Flippable', () => {
             expect(renderedBackSide.find('#MyBackContent').length).toBeGreaterThan(0);
         });
 
+        it('should render a "show-on-top" class on the flippable when it is flipped', () => {
+            flippable.setProps({
+                isFlipped: true,
+            });
+
+            expect(flippable.hasClass('show-on-top')).toBe(true);
+        });
+
         it('should call onFlip prop if any when clicking on the front side and flippable is not flipped', () => {
             const onFlipSpy = jasmine.createSpy('onFlip');
 


### PR DESCRIPTION
When multiple flippables are one on top of the other and flipping the one above, the backside is shown under the following flippables which is not what we want. This PR bumps the z-index of the flippable when it is being flipped.