### PR TITLE
Remove full-content-x on StepProgressBar children

### DIFF
--- a/src/components/stepProgressBar/StepProgressBar.tsx
+++ b/src/components/stepProgressBar/StepProgressBar.tsx
@@ -20,7 +20,7 @@ export const StepProgressBar = (props: IStepProgressBarProps) => {
     const stepProgressBarSteps = range(numberOfSteps).map((stepNumber: number) => (
         <div
             key={`step-progress-bar-${uniqueId()}`}
-            className={classNames('step-progress-bar full-content-x', {
+            className={classNames('step-progress-bar', {
                 'step-progress-bar-done': stepNumber < currentStep,
                 'step-progress-bar-doing': stepNumber === currentStep,
                 'step-progress-bar-to-do': stepNumber > currentStep,


### PR DESCRIPTION
Requires an update from vapor that adds `flex: 1` to children:

See here for details: https://github.com/coveo/vapor/pull/490