### PR TITLE
Fix modal close callback

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -28,7 +28,7 @@ export class Modal extends React.Component<IModalProps, {}> {
     }
 
     componentWillUnmount() {
-        if (this.props.closeCallback) {
+        if (this.props.closeCallback && this.props.isOpened) {
             this.props.closeCallback();
         }
         if (this.props.onDestroy) {

--- a/src/components/modal/tests/Modal.spec.tsx
+++ b/src/components/modal/tests/Modal.spec.tsx
@@ -59,14 +59,26 @@ describe('Modal', () => {
             expect(destroySpy.calls.count()).toBe(1);
         });
 
-        it('should call prop closeCallback on unmounting if set', () => {
+        it('should call prop closeCallback on unmounting if set and if modal is opened', () => {
             const closeCallbackSpy: jasmine.Spy = jasmine.createSpy('closeCallback');
 
-            modal.setProps({closeCallback: closeCallbackSpy});
+            modal.setProps({
+                closeCallback: closeCallbackSpy,
+                isOpened: false,
+            });
             modal.mount();
             modal.unmount();
 
-            expect(closeCallbackSpy.calls.count()).toBe(1);
+            expect(closeCallbackSpy).not.toHaveBeenCalled();
+
+            modal.setProps({
+                closeCallback: closeCallbackSpy,
+                isOpened: true,
+            });
+            modal.mount();
+            modal.unmount();
+
+            expect(closeCallbackSpy).toHaveBeenCalledTimes(1);
         });
 
         it('should call the prop closeCallback if it exists when closing the modal', () => {


### PR DESCRIPTION
When we called unmount on a modal mounted by not opened, it was calling `closeCallback` prop which was causing some issues further down the road.