### PR TITLE
+ Add close timeout prop in modal

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -6,6 +6,7 @@ export interface IModalOwnProps {
     id?: string;
     classes?: IClassName;
     closeCallback?: () => void;
+    closeTimeout?: number;
 }
 
 export interface IModalStateProps {
@@ -29,7 +30,7 @@ export class Modal extends React.Component<IModalProps, {}> {
 
     componentWillUnmount() {
         if (this.props.closeCallback && this.props.isOpened) {
-            this.props.closeCallback();
+            this.closeModal();
         }
         if (this.props.onDestroy) {
             this.props.onDestroy();
@@ -38,6 +39,14 @@ export class Modal extends React.Component<IModalProps, {}> {
 
     componentWillReceiveProps(nextProps: IModalProps) {
         if (this.props.isOpened && !nextProps.isOpened && this.props.closeCallback) {
+            this.closeModal();
+        }
+    }
+
+    private closeModal() {
+        if (this.props.closeTimeout) {
+            setTimeout(() => this.props.closeCallback(), this.props.closeTimeout);
+        } else {
             this.props.closeCallback();
         }
     }

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -29,7 +29,7 @@ export class Modal extends React.Component<IModalProps, {}> {
     }
 
     componentWillUnmount() {
-        if (this.props.closeCallback && this.props.isOpened) {
+        if (this.props.isOpened) {
             this.closeModal();
         }
         if (this.props.onDestroy) {
@@ -38,16 +38,18 @@ export class Modal extends React.Component<IModalProps, {}> {
     }
 
     componentWillReceiveProps(nextProps: IModalProps) {
-        if (this.props.isOpened && !nextProps.isOpened && this.props.closeCallback) {
+        if (this.props.isOpened && !nextProps.isOpened) {
             this.closeModal();
         }
     }
 
     private closeModal() {
-        if (this.props.closeTimeout) {
-            setTimeout(() => this.props.closeCallback(), this.props.closeTimeout);
-        } else {
-            this.props.closeCallback();
+        if (this.props.closeCallback) {
+            if (this.props.closeTimeout) {
+                setTimeout(() => this.props.closeCallback(), this.props.closeTimeout);
+            } else {
+                this.props.closeCallback();
+            }
         }
     }
 

--- a/src/components/modal/tests/Modal.spec.tsx
+++ b/src/components/modal/tests/Modal.spec.tsx
@@ -89,6 +89,22 @@ describe('Modal', () => {
             expect(closeCallbackSpy).toHaveBeenCalledTimes(1);
         });
 
+        it('should call the prop closeCallback with a timeout if specified when closing the modal', () => {
+            jasmine.clock().install();
+
+            const closeCallbackSpy: jasmine.Spy = jasmine.createSpy('closeCallback');
+            modal.setProps({isOpened: true, closeCallback: closeCallbackSpy, closeTimeout: 5});
+            modal.setProps({isOpened: false});
+
+            expect(closeCallbackSpy).toHaveBeenCalledTimes(0);
+
+            jasmine.clock().tick(5);
+
+            expect(closeCallbackSpy).toHaveBeenCalledTimes(1);
+
+            jasmine.clock().uninstall();
+        });
+
         it('should set container class when the container class is specified', () => {
             const containerClass = 'mod-small';
             const classes = [containerClass];


### PR DESCRIPTION
This will allow to specify a timeout before executing the closeCallback, ensuring a user can wait for the fade animation to be done to perform any cleanup.