### PR TITLE
! Fix table display when collapsable rows are mixed normal rows

### DIFF
--- a/src/components/tables/TableHeadingRow.tsx
+++ b/src/components/tables/TableHeadingRow.tsx
@@ -42,7 +42,7 @@ export class TableHeadingRow extends React.Component<ITableHeadingRowProps, any>
     render() {
         const toggle: JSX.Element = this.props.isCollapsible
             ? <TableCollapsibleRowToggle isExpanded={this.props.opened} />
-            : null;
+            : <td></td>;
         const rowClasses = classNames({
             'heading-row': this.props.isCollapsible,
             'selected': this.props.selected,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/35579930/39549201-fce4d9be-4e2a-11e8-82b8-a3004f993872.png)

After:
![image](https://user-images.githubusercontent.com/35579930/39549228-1184d04a-4e2b-11e8-90df-c02b1cd6e5e1.png)
