### PR TITLE
Fix Date Picker Duplicated Labels

### DIFF
--- a/src/components/datePicker/DatePickerDropdown.tsx
+++ b/src/components/datePicker/DatePickerDropdown.tsx
@@ -217,8 +217,11 @@ export class DatePickerDropdown extends React.Component<IDatePickerDropdownProps
         if (this.props.datePicker && this.props.datePicker.appliedLowerLimit) {
             label = this.formatDate(this.props.datePicker.appliedLowerLimit);
             if (this.props.datePicker.isRange) {
-                toLabel = <span className='to-label'> {this.props.toLabel} </span>;
-                labelSecondPart = this.formatDate(this.props.datePicker.appliedUpperLimit);
+                const formattedUpper = this.formatDate(this.props.datePicker.appliedUpperLimit);
+                if (formattedUpper !== label) {
+                    toLabel = <span className='to-label'> {this.props.toLabel} </span>;
+                    labelSecondPart = formattedUpper;
+                }
             }
         }
 

--- a/src/components/datePicker/tests/DatePickerDropdown.spec.tsx
+++ b/src/components/datePicker/tests/DatePickerDropdown.spec.tsx
@@ -1,4 +1,5 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
+import * as moment from 'moment';
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
 import * as _ from 'underscore';
@@ -215,6 +216,31 @@ describe('Date picker', () => {
             });
             datePickerDropdown.setProps(newProps);
             expect(datePickerDropdown.find('.dropdown-selected-value').text()).toContain('EMPTY_LABEL');
+        });
+
+        it('should not display the to-label and the upperlimit if it is equal to the lower limit', () => {
+            const start = moment().startOf('day').toDate();
+            const end = moment().endOf('day').toDate();
+            const formattedNow: string = DateUtils.getSimpleDate(start);
+            datePicker = {
+                id: 'id',
+                calendarId: 'calendarId',
+                color: 'color',
+                lowerLimit: start,
+                upperLimit: end,
+                isRange: true,
+                isClearable: false,
+                selected: '',
+                appliedLowerLimit: start,
+                appliedUpperLimit: end,
+                inputLowerLimit: start,
+                inputUpperLimit: end,
+            };
+            const propsWithDatePicker: IDatePickerDropdownProps = _.extend({}, DATE_PICKER_DROPDOWN_BASIC_PROPS, {datePicker});
+            datePickerDropdown.setProps(propsWithDatePicker);
+
+            expect(datePickerDropdown.find('.dropdown-selected-value').text()).toBe(formattedNow);
+            expect(datePickerDropdown.find('.to-label').length).toBe(0);
         });
 
         it('should call handleClick when clicking the dropdown toggle', () => {

--- a/src/components/datePicker/tests/DatePickerDropdown.spec.tsx
+++ b/src/components/datePicker/tests/DatePickerDropdown.spec.tsx
@@ -1,6 +1,5 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as moment from 'moment';
-// tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
 import * as _ from 'underscore';
 import {DateUtils} from '../../../utils/DateUtils';


### PR DESCRIPTION
Added condition when the picker is a range to avoid duplicated labels
Added unit tests

![date-range](https://user-images.githubusercontent.com/260007/39873573-522d2836-5439-11e8-8fa4-9d71032ddf79.gif)
