### PR TITLE
Add callIfDefined util

### DIFF
--- a/src/utils/FalsyValuesUtils.spec.tsx
+++ b/src/utils/FalsyValuesUtils.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {convertUndefinedAndNullToEmptyString} from './FalsyValuesUtils';
+import {callIfDefined, convertUndefinedAndNullToEmptyString} from './FalsyValuesUtils';
 
 describe('FalsyValuesUtils', () => {
     it('should return empty string if the value is undefined', () => {
@@ -14,5 +14,43 @@ describe('FalsyValuesUtils', () => {
         [1000, 'non empty string', '', <div>testing a jsx element</div>].forEach((value: any) => {
             expect(convertUndefinedAndNullToEmptyString(value)).toBe(value);
         });
+    });
+});
+
+describe('callIfDefined', () => {
+    let callbackSpy: jasmine.Spy;
+
+    beforeEach(() => {
+        callbackSpy = jasmine.createSpy('callback');
+    });
+
+    it('should call the callback when it is a defined function', () => {
+        callIfDefined(callbackSpy);
+
+        expect(callbackSpy).toHaveBeenCalled();
+    });
+
+    it('should call the callback and pass down args properly', () => {
+        const args = [
+            'some'
+            ['args'],
+            -10,
+            true,
+            () => 'ooookay',
+        ];
+
+        callIfDefined(callbackSpy, ...args);
+
+        expect(callbackSpy).toHaveBeenCalledWith(...args);
+    });
+
+    it('should not throw errors when calling with undefined values', () => {
+        const someDeclaredButNotAssignedCallback: () => any = undefined;
+
+        expect(() => callIfDefined(undefined)).not.toThrow();
+        expect(() => callIfDefined(null)).not.toThrow();
+        expect(() => callIfDefined('')).not.toThrow();
+        expect(() => callIfDefined('askjdh')).not.toThrow();
+        expect(() => callIfDefined(someDeclaredButNotAssignedCallback)).not.toThrow();
     });
 });

--- a/src/utils/FalsyValuesUtils.ts
+++ b/src/utils/FalsyValuesUtils.ts
@@ -4,3 +4,9 @@ export const convertUndefinedAndNullToEmptyString = (value: any) =>
     _.isUndefined(value) || _.isNull(value)
         ? ''
         : value;
+
+export const callIfDefined = (callback: any, ...args: any[]) => {
+    if (typeof callback === typeof Function) {
+        callback(...args);
+    }
+};


### PR DESCRIPTION
Since we often do the following logic, I added a small util to make it a one liner:
```ts
if (someFunctionThatMayBeUndefined) {
    someFunctionThatMayBeUndefined(someArg, someOtherArg, ...);
}
```
Becomes this
```ts
callIfDefined(someFunctionThatMayBeUndefined, someArg, someOtherArg, ...);
```