### PR TITLE
SingleSelectConnected improvements

### DIFF
--- a/src/components/select/SelectConnected.tsx
+++ b/src/components/select/SelectConnected.tsx
@@ -98,7 +98,7 @@ export class SelectConnected extends React.Component<ISelectProps & ISelectSpeci
     private renderChildren() {
         if (this.props.children) {
             return (
-                <div className='flex p2 flex-center bg-white flex-column'>
+                <div className='flex p2 flex-center bg-white flex-column mod-border-bottom'>
                     {this.props.children}
                 </div>
             );

--- a/src/components/select/SingleSelectConnected.tsx
+++ b/src/components/select/SingleSelectConnected.tsx
@@ -1,6 +1,9 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
+
 import {IReactVaporState} from '../../ReactVapor';
+import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
 import {Content} from '../content/Content';
 import {IItemBoxProps} from '../itemBox/ItemBox';
@@ -8,6 +11,8 @@ import {ISelectButtonProps, ISelectProps, SelectConnected} from './SelectConnect
 
 export interface ISingleSelectOwnProps extends ISelectProps {
     placeholder?: string;
+    toggleClasses?: string;
+    onSelectOptionCallback?: (option: string) => void;
 }
 
 export interface ISingleSelectStateProps {
@@ -34,6 +39,12 @@ export class SingleSelectConnected extends React.Component<ISingleSelectProps, {
         placeholder: 'Select an option',
     };
 
+    componentDidUpdate(prevProps: ISingleSelectProps) {
+        if (prevProps.selected !== this.props.selected) {
+            callIfDefined(this.props.onSelectOptionCallback, this.props.selected);
+        }
+    }
+
     render() {
         return (
             <SelectConnected
@@ -49,7 +60,7 @@ export class SingleSelectConnected extends React.Component<ISingleSelectProps, {
         const option = _.findWhere(this.props.items, {value: this.props.selected});
         return (
             <button
-                className='btn dropdown-toggle'
+                className={classNames(['btn', 'dropdown-toggle', this.props.toggleClasses])}
                 type='button'
                 onMouseUp={props.onMouseUp}
                 onKeyDown={props.onKeyDown}

--- a/src/components/select/examples/SingleSelectExamples.tsx
+++ b/src/components/select/examples/SingleSelectExamples.tsx
@@ -57,7 +57,12 @@ export class SingleSelectExamples extends React.Component<{}, ISingleSelectExamp
                 <div className='form-group'>
                     <label className='form-control-label'>A Simple Single Select with a Custom Placeholder</label>
                     <br />
-                    <SingleSelectConnected id={UUID.generate()} items={this.state.first} placeholder='Select something' />
+                    <SingleSelectConnected
+                        id={UUID.generate()}
+                        items={this.state.first}
+                        placeholder='Select something'
+                        onSelectOptionCallback={console.log}
+                    />
                 </div>
                 <div className='form-group'>
                     <label className='form-control-label'>A Single Select With Filter</label>

--- a/src/components/select/tests/SingleSelectConnected.spec.tsx
+++ b/src/components/select/tests/SingleSelectConnected.spec.tsx
@@ -77,7 +77,7 @@ describe('Select', () => {
             expect(singleSelect.html()).toContain(expectedPlaceholder);
         });
 
-        it('should contains a the selected value', () => {
+        it('should contain the selected value', () => {
             const selectedValue = 'dis 1';
             mountSingleSelect([
                 {value: 'a'},
@@ -87,7 +87,7 @@ describe('Select', () => {
             expect(singleSelect.html()).toContain(selectedValue);
         });
 
-        it('should contains the display value when the selected value has one', () => {
+        it('should contain the display value when the selected value has one', () => {
             const selectedDisplayValue = 'dis 2';
             mountSingleSelect([
                 {value: 'a'},
@@ -97,7 +97,7 @@ describe('Select', () => {
             expect(singleSelect.html()).toContain(selectedDisplayValue);
         });
 
-        it('should contains the selected item as a prop', () => {
+        it('should contain the selected item as a prop', () => {
             const selectedValue = 'dis 1';
             mountSingleSelect([
                 {value: 'a'},
@@ -108,7 +108,7 @@ describe('Select', () => {
             expect(value).toBe(selectedValue);
         });
 
-        it('should contains the prepend and append in the button when selected', () => {
+        it('should contain the prepend and append in the button when selected', () => {
             const prepend = 'pre';
             const append = 'post';
             mountSingleSelect([
@@ -121,7 +121,7 @@ describe('Select', () => {
             expect(buttonHTML).toContain(append);
         });
 
-        it('should not contains the prepend and append in the button when not selected', () => {
+        it('should not contain the prepend and append in the button when not selected', () => {
             const prepend = 'pre';
             const append = 'post';
             mountSingleSelect([
@@ -133,6 +133,17 @@ describe('Select', () => {
 
             expect(buttonHTML).not.toContain(prepend);
             expect(buttonHTML).not.toContain(append);
+        });
+
+        it('should call with the selected option the onSelectOptionCallback prop when defined', () => {
+            const onSelectOptionCallbackSpy = jasmine.createSpy('onSelectOptionCallback');
+
+            mountSingleSelect([{value: 'a'}, {value: 'b'}], {onSelectOptionCallback: onSelectOptionCallbackSpy});
+
+            singleSelect.find('.dropdown-toggle').simulate('click');
+            singleSelect.find('.item-box').first().simulate('click');
+
+            expect(onSelectOptionCallbackSpy).toHaveBeenCalledWith('a');
         });
 
         describe('keyboard events', () => {

--- a/src/components/select/tests/SingleSelectConnected.spec.tsx
+++ b/src/components/select/tests/SingleSelectConnected.spec.tsx
@@ -108,6 +108,14 @@ describe('Select', () => {
             expect(value).toBe(selectedValue);
         });
 
+        it('should set the toggleClasses prop if any on the dropdown-toggle', () => {
+            mountSingleSelect([], {
+                toggleClasses: 'some-class',
+            });
+
+            expect(singleSelect.find('.dropdown-toggle').hasClass('some-class')).toBe(true);
+        });
+
         it('should contain the prepend and append in the button when selected', () => {
             const prepend = 'pre';
             const append = 'post';


### PR DESCRIPTION
- Removed the black border to fix the rest of the dropdowns and fit mockups
- Added a `toggleClasses` prop to be more flexible with the toggle styling
- Added a `onSelectOptionCallback` prop that is called when the selected option changes