### PR TITLE
Don't minize the code twice

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -8,6 +8,7 @@ const isTravis = process.env.TRAVIS;
 const config = {
     entry: './Index.ts',
     mode: 'production',
+    optimization: {minimize: false},
     output: {
         path: path.join(__dirname, '/dist'),
         filename: 'react-vapor.js',


### PR DESCRIPTION
We have react-vapor.js and react-vapor.min.js, since the move to webpack 4 both of them are minified

You'll see what I say if you check https://github.com/coveo/react-vapor/blob/master/webpack.config.prod.minify.js and https://github.com/coveo/react-vapor/blob/master/package.json#L28

With my change react-vapor.js is not minified (and can be used it tests to find elements by their name instead of using a string) and react-vapor.min.js is