### PR TITLE
Remove table rows selection action when there are no actions to display

### DIFF
--- a/src/components/tables/TableHeadingRow.tsx
+++ b/src/components/tables/TableHeadingRow.tsx
@@ -1,5 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
+
+import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {TableCollapsibleRowToggle} from './TableCollapsibleRowToggle';
 
 export interface ITableHeadingRowOwnProps extends React.ClassAttributes<TableHeadingRow> {
@@ -11,6 +13,7 @@ export interface ITableHeadingRowOwnProps extends React.ClassAttributes<TableHea
     onDoubleClick?: () => void;
     className?: string;
     isMultiSelect?: boolean;
+    selectionDisabled?: boolean;
 }
 
 export interface ITableHeadingRowStateProps {
@@ -64,18 +67,17 @@ export class TableHeadingRow extends React.Component<ITableHeadingRowProps, any>
     }
 
     private handleClick(e: React.MouseEvent<any>) {
-        if (this.props.onClick) {
-            this.props.onClick((e.metaKey || e.ctrlKey) && this.props.isMultiSelect);
-        }
+        if (!this.props.selectionDisabled) {
+            const hasMultipleSelectedRow = (e.metaKey || e.ctrlKey) && this.props.isMultiSelect;
 
-        if (this.props.onClickCallback) {
-            this.props.onClickCallback();
+            callIfDefined(this.props.onClick, hasMultipleSelectedRow);
+            callIfDefined(this.props.onClickCallback);
         }
     }
 
     private handleDoubleClick() {
-        if (this.props.onDoubleClick) {
-            this.props.onDoubleClick();
+        if (!this.props.selectionDisabled) {
+            callIfDefined(this.props.onDoubleClick);
         }
     }
 }

--- a/src/components/tables/table-children/TableChildBody.tsx
+++ b/src/components/tables/table-children/TableChildBody.tsx
@@ -86,6 +86,7 @@ export const TableChildBody = (props: ITableChildBodyProps): JSX.Element => {
                 .forEach((action) => action.trigger())
             }
             isMultiSelect={props.isMultiSelect}
+            selectionDisabled={props.getActions(props.rowData).length < 1}
         >
             {tableHeadingRowContent}
         </TableHeadingRowConnected>

--- a/src/components/tables/tests/Table.spec.tsx
+++ b/src/components/tables/tests/Table.spec.tsx
@@ -157,7 +157,7 @@ describe('<Table />', () => {
             const table: ReactWrapper<ITableProps, {}> = mountComponentWithProps(tablePropsMockWithData);
             table.find(TableChildBody).first().props().getActions({id: 'any'});
 
-            expect(tablePropsMockWithData.getActions).toHaveBeenCalledTimes(1);
+            expect(tablePropsMockWithData.getActions).toHaveBeenCalled();
         });
 
         describe('componentWillReceiveProps', () => {

--- a/src/components/tables/tests/TableChildBody.spec.tsx
+++ b/src/components/tables/tests/TableChildBody.spec.tsx
@@ -160,16 +160,16 @@ describe('<TableChildBody />', () => {
             const newProps: ITableChildBodyProps = _.extend({}, tableChildBodyProps, {rowData: _.extend({}, tableChildBodyProps.rowData, {disabled: true})});
             expect(mountComponentWithProps(newProps).find('.disabled').length).toBe(1);
         });
-        
+
         it('should set the selectionDisabled prop to false on the <TableHeadingRow /> if there are actions defined for the row', () => {
             expect(mountComponentWithProps().find(TableHeadingRow).props().selectionDisabled).toBe(false);
         });
-        
+
         it('should set the selectionDisabled prop to true on the <TableHeadingRow /> if there are no actions defined for the row', () => {
             const newProps: ITableChildBodyProps = _.extend({}, tableChildBodyProps, {
                 getActions: jasmine.createSpy('getActions').and.returnValue([]),
             });
-    
+
             expect(mountComponentWithProps(newProps).find(TableHeadingRow).props().selectionDisabled).toBe(true);
         });
     });

--- a/src/components/tables/tests/TableChildBody.spec.tsx
+++ b/src/components/tables/tests/TableChildBody.spec.tsx
@@ -15,7 +15,11 @@ import {TableHeadingRow} from '../TableHeadingRow';
 describe('<TableChildBody />', () => {
     const spyOnRowClick: jasmine.Spy = jasmine.createSpy('onRowClick');
     const spyHandleOnRowClick: jasmine.Spy = jasmine.createSpy('handleOnRowClick');
-    const someActions: IActionOptions[] = [];
+    const someActions: IActionOptions[] = [{
+        name: 'some-action',
+        trigger: jasmine.createSpy('triggerMethod'),
+        enabled: true,
+    }];
     const tableChildBodyProps: ITableChildBodyProps = {
         tableId: 'best-table',
         rowData: {
@@ -134,7 +138,7 @@ describe('<TableChildBody />', () => {
 
             mountComponentWithProps(newProps).find(TableHeadingRow).simulate('dblclick');
 
-            expect(getActionsSpy).toHaveBeenCalledTimes(1);
+            expect(getActionsSpy).toHaveBeenCalled();
             expect(actionSpy).toHaveBeenCalledTimes(1);
         });
 
@@ -147,14 +151,26 @@ describe('<TableChildBody />', () => {
             expect(mountComponentWithProps(newProps).find('.disabled').length).toBe(0);
         });
 
-        it('should send send disabled as a class to the <TableHeadingRow /> if the enabled property is set to false on the row data', () => {
+        it('should send disabled as a class to the <TableHeadingRow /> if the enabled property is set to false on the row data', () => {
             const newProps: ITableChildBodyProps = _.extend({}, tableChildBodyProps, {rowData: _.extend({}, tableChildBodyProps.rowData, {enabled: false})});
             expect(mountComponentWithProps(newProps).find('.disabled').length).toBe(1);
         });
 
-        it('should send send disabled as a class to the <TableHeadingRow /> if the disabled property is set to true on the row data', () => {
+        it('should send disabled as a class to the <TableHeadingRow /> if the disabled property is set to true on the row data', () => {
             const newProps: ITableChildBodyProps = _.extend({}, tableChildBodyProps, {rowData: _.extend({}, tableChildBodyProps.rowData, {disabled: true})});
             expect(mountComponentWithProps(newProps).find('.disabled').length).toBe(1);
+        });
+        
+        it('should set the selectionDisabled prop to false on the <TableHeadingRow /> if there are actions defined for the row', () => {
+            expect(mountComponentWithProps().find(TableHeadingRow).props().selectionDisabled).toBe(false);
+        });
+        
+        it('should set the selectionDisabled prop to true on the <TableHeadingRow /> if there are no actions defined for the row', () => {
+            const newProps: ITableChildBodyProps = _.extend({}, tableChildBodyProps, {
+                getActions: jasmine.createSpy('getActions').and.returnValue([]),
+            });
+    
+            expect(mountComponentWithProps(newProps).find(TableHeadingRow).props().selectionDisabled).toBe(true);
         });
     });
 });

--- a/src/components/tables/tests/TableHeadingRow.spec.tsx
+++ b/src/components/tables/tests/TableHeadingRow.spec.tsx
@@ -107,10 +107,9 @@ describe('Tables', () => {
             const onClickSpy = jasmine.createSpy('onClick');
             const newTabledHeadingRowProps = _.extend({}, basicTableHeadingRowProps, {onClick: onClickSpy});
 
-            expect(() => (tableHeadingRowInstance['handleClick'].call(tableHeadingRowInstance))).not.toThrow();
-
             tableHeadingRow.setProps(newTabledHeadingRowProps);
             tableHeadingRow.find('tr').simulate('click');
+
             expect(onClickSpy).toHaveBeenCalled();
         });
 
@@ -118,10 +117,9 @@ describe('Tables', () => {
             const onDoubleClickSpy = jasmine.createSpy('onDoubleClick');
             const newTabledHeadingRowProps = _.extend({}, basicTableHeadingRowProps, {onDoubleClick: onDoubleClickSpy});
 
-            expect(() => (tableHeadingRowInstance['handleDoubleClick'].call(tableHeadingRowInstance))).not.toThrow();
-
             tableHeadingRow.setProps(newTabledHeadingRowProps);
             tableHeadingRow.find('tr').simulate('dblclick');
+
             expect(onDoubleClickSpy).toHaveBeenCalledTimes(1);
         });
 
@@ -133,6 +131,27 @@ describe('Tables', () => {
             tableHeadingRow.find('tr').simulate('click');
 
             expect(onClickCallback).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not call the onClick props when selectionDisabled is set to true', () => {
+            const onClickSpy = jasmine.createSpy('onClick');
+            const onClickCallbackSpy = jasmine.createSpy('onClickCallback');
+            const onDoubleClickSpy = jasmine.createSpy('onDoubleClick');
+
+            const newTabledHeadingRowProps = _.extend({}, basicTableHeadingRowProps, {
+                selectionDisabled: true,
+                onClick: onClickSpy,
+                onClickCallback: onClickCallbackSpy,
+                onDoubleClick: onDoubleClickSpy,
+            });
+
+            tableHeadingRow.setProps(newTabledHeadingRowProps);
+
+            tableHeadingRow.find('tr').simulate('click');
+
+            expect(onClickSpy).not.toHaveBeenCalled();
+            expect(onClickCallbackSpy).not.toHaveBeenCalled();
+            expect(onDoubleClickSpy).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
Made each table row selectable only when the `getActions` function returns one or more item.