### PR TITLE
Fix collapsible table behavior

### DIFF
--- a/docs/Index.tsx
+++ b/docs/Index.tsx
@@ -6,95 +6,95 @@ import * as React from 'react';
 import {render as ReactDOMRender} from 'react-dom';
 import {Provider} from 'react-redux';
 
-/*import {ActionBarConnectedExamples} from '../src/components/actions/examples/ActionBarConnectedExamples';
-import {ActionBarExamples} from '../src/components/actions/examples/ActionBarExamples';
-import {ItemFilterConnectedExamples} from '../src/components/actions/filters/examples/ItemFilterConnectedExamples';
-import {ItemFilterExamples} from '../src/components/actions/filters/examples/ItemFilterExamples';
-import {AutocompleteExamples} from '../src/components/autocomplete/examples/AutocompleteExamples';
-import {BadgeExamples} from '../src/components/badge/examples/BadgeExamples';
-import {BlankSlateExample} from '../src/components/blankSlate/examples/BlankSlateExample';
-import {BorderedLineExamples} from '../src/components/borderedLine/examples/BorderedLineExamples';
-import {BreadcrumbsExamples} from '../src/components/breadcrumbs/examples/BreadcrumbsExamples';
-import {ButtonExamples} from '../src/components/button/examples/ButtonExamples';
-import {CalendarConnectedExamples} from '../src/components/calendar/examples/CalendarConnectedExamples';
-import {CheckboxConnectedExamples} from '../src/components/checkbox/examples/CheckboxConnectedExamples';
-import {CheckboxExamples} from '../src/components/checkbox/examples/CheckboxExamples';
-import {GroupableCheckboxConnectedExamples} from '../src/components/checkbox/examples/GroupableCheckboxConnectedExamples';
-import {ChildFormExamples} from '../src/components/childForm/examples/ChildFormExamples';
-import {ChosenSelectExamples} from '../src/components/chosen/examples/ChosenSelectExamples';
-import {CollapsibleContainerExamples} from '../src/components/collapsibleContainer/examples/CollapsibleContainerExamples';
-import {ColorBarExamples} from '../src/components/colorBar/ColorBarExamples';
-import {ContentExamples} from '../src/components/content/examples/ContentExamples';
-import {CornerRibbonExamples} from '../src/components/cornerRibbon/examples/CornerRibbonExamples';
-import {DatePickerBoxConnectedExamples} from '../src/components/datePicker/examples/DatePickerBoxConnectedExamples';
-import {DatePickerBoxExamples} from '../src/components/datePicker/examples/DatePickerBoxExamples';
-import {DatePickerDropdownConnectedExamples} from '../src/components/datePicker/examples/DatePickerDropdownConnectedExamples';
-import {
-    DatePickerDropdownConnectedSingleDateExamples,
-} from '../src/components/datePicker/examples/DatePickerDropdownConnectedSingleDateExamples';
-import {DatesSelectionConnectedExamples} from '../src/components/datePicker/examples/DatesSelectionConnectedExamples';
-import {DatesSelectionExamples} from '../src/components/datePicker/examples/DatesSelectionExamples';
-import {DropdownSearchExamples} from '../src/components/dropdownSearch/examples/DropdownSearchExamples';*/
-import {CodeEditorExamples} from '../src/components/editor/examples/CodeEditorExamples';
-import {JSONEditorExamples} from '../src/components/editor/examples/JSONEditorExamples';
-/*import {FacetConnectedExamples} from '../src/components/facets/examples/FacetConnectedExamples';
-import {FacetExamples} from '../src/components/facets/examples/FacetExamples';
-import {FilterBoxConnectedExamples} from '../src/components/filterBox/examples/FilterBoxConnectedExamples';
-import {FilterBoxExamples} from '../src/components/filterBox/examples/FilterBoxExamples';
-import {FlatSelectExamples} from '../src/components/flatSelect/examples/FlatSelectExamples';
-import {FlippableExamples} from '../src/components/flippable/exemples/FlippableExamples';
-import {BasicHeaderExamples} from '../src/components/headers/examples/BasicHeaderExamples';
-import {BreadcrumbHeaderExample} from '../src/components/headers/examples/BreadcrumbHeaderExample';
-import {InputAndInputConnectedExamples} from '../src/components/input/examples/InputAndInputConnectedExamples';
-import {ItemBoxExamples} from '../src/components/itemBox/examples/ItemBoxExamples';
-import {LabeledValueExamples} from '../src/components/labeledValue/examples/LabeledValueExamples';
-import {LastUpdatedConnectedExamples} from '../src/components/lastUpdated/examples/LastUpdatedConnectedExamples';
-import {LastUpdatedExamples} from '../src/components/lastUpdated/examples/LastUpdatedExamples';
-import {ListBoxExamples} from '../src/components/listBox/examples/ListBoxExamples';
-import {LoadingExamples} from '../src/components/loading/LoadingExamples';
-import {LogoCardExamples} from '../src/components/logoCard/examples/LogoCardExamples';
-import {ModalCompositeConnectedExamples} from '../src/components/modal/examples/ModalCompositeConnectedExamples';
-import {ModalCompositeExamples} from '../src/components/modal/examples/ModalCompositeExamples';
-import {ModalConnectedExamples} from '../src/components/modal/examples/ModalConnectedExamples';
-import {ModalExamples} from '../src/components/modal/examples/ModalExamples';
-import {ModalPromptExamples} from '../src/components/modalPrompt/exemples/ModalPromptExamples';
-import {MultilineInputExamples} from '../src/components/multilineInput/examples/MultilineInputExamples';
-import {SplitMultilineInputExamples} from '../src/components/multilineInput/examples/SplitMultilineExamples';
-import {MultiStepBarExamples} from '../src/components/multiStepBar/examples/MultiStepBarExamples';
-import {NavigationConnectedExamples} from '../src/components/navigation/examples/NavigationConnectedExamples';
-import {NavigationExamples} from '../src/components/navigation/examples/NavigationExamples';
-import {OptionsCycleConnectedExamples} from '../src/components/optionsCycle/examples/OptionsCycleConnectedExamples';
-import {OptionsCycleExamples} from '../src/components/optionsCycle/examples/OptionsCycleExamples';
-import {PartialStringMatchExamples} from '../src/components/partial-string-match/PartialStringMatchExamples';
-import {RadioExamples} from '../src/components/radio/examples/RadioExamples';
-import {SearchBarExamples} from '../src/components/searchBar/SearchBarExamples';
-import {MultiSelectExamples} from '../src/components/select/examples/MultiSelectExamples';
-import {SingleSelectExamples} from '../src/components/select/examples/SingleSelectExamples';
-import {SideNavigationExample} from '../src/components/sideNavigation/examples/SideNavigationExample';
-import {SideNavigationLoadingExample} from '../src/components/sideNavigation/examples/SideNavigationLoadingExample';
-import {SliderExamples} from '../src/components/slider/examples/SliderExamples';
-import {SplitLayoutExamples} from '../src/components/splitlayout/examples/SplitLayoutExamples';
-import {StepProgressBarExamples} from '../src/components/stepProgressBar/examples/StepProgressBarExamples';
-import {SubNavigationConnectedExamples} from '../src/components/subNavigation/examples/SubNavigationConnectedExamples';
-import {SubNavigationExamples} from '../src/components/subNavigation/examples/SubNavigationExamples';
-import {LinkSvgExamples} from '../src/components/svg/examples/LinkSvgExamples';
-import {SvgExamples} from '../src/components/svg/examples/SvgExamples';
-import {SyncFeedbackExample} from '../src/components/syncFeedback/examples/SyncFeedbackExample';
-import {TabsExamples} from '../src/components/tab/examples/TabConnectedExample';
+// import {ActionBarConnectedExamples} from '../src/components/actions/examples/ActionBarConnectedExamples';
+// import {ActionBarExamples} from '../src/components/actions/examples/ActionBarExamples';
+// import {ItemFilterConnectedExamples} from '../src/components/actions/filters/examples/ItemFilterConnectedExamples';
+// import {ItemFilterExamples} from '../src/components/actions/filters/examples/ItemFilterExamples';
+// import {AutocompleteExamples} from '../src/components/autocomplete/examples/AutocompleteExamples';
+// import {BadgeExamples} from '../src/components/badge/examples/BadgeExamples';
+// import {BlankSlateExample} from '../src/components/blankSlate/examples/BlankSlateExample';
+// import {BorderedLineExamples} from '../src/components/borderedLine/examples/BorderedLineExamples';
+// import {BreadcrumbsExamples} from '../src/components/breadcrumbs/examples/BreadcrumbsExamples';
+// import {ButtonExamples} from '../src/components/button/examples/ButtonExamples';
+// import {CalendarConnectedExamples} from '../src/components/calendar/examples/CalendarConnectedExamples';
+// import {CheckboxConnectedExamples} from '../src/components/checkbox/examples/CheckboxConnectedExamples';
+// import {CheckboxExamples} from '../src/components/checkbox/examples/CheckboxExamples';
+// import {GroupableCheckboxConnectedExamples} from '../src/components/checkbox/examples/GroupableCheckboxConnectedExamples';
+// import {ChildFormExamples} from '../src/components/childForm/examples/ChildFormExamples';
+// import {ChosenSelectExamples} from '../src/components/chosen/examples/ChosenSelectExamples';
+// import {CollapsibleContainerExamples} from '../src/components/collapsibleContainer/examples/CollapsibleContainerExamples';
+// import {ColorBarExamples} from '../src/components/colorBar/ColorBarExamples';
+// import {ContentExamples} from '../src/components/content/examples/ContentExamples';
+// import {CornerRibbonExamples} from '../src/components/cornerRibbon/examples/CornerRibbonExamples';
+// import {DatePickerBoxConnectedExamples} from '../src/components/datePicker/examples/DatePickerBoxConnectedExamples';
+// import {DatePickerBoxExamples} from '../src/components/datePicker/examples/DatePickerBoxExamples';
+// import {DatePickerDropdownConnectedExamples} from '../src/components/datePicker/examples/DatePickerDropdownConnectedExamples';
+// import {
+//     DatePickerDropdownConnectedSingleDateExamples,
+// } from '../src/components/datePicker/examples/DatePickerDropdownConnectedSingleDateExamples';
+// import {DatesSelectionConnectedExamples} from '../src/components/datePicker/examples/DatesSelectionConnectedExamples';
+// import {DatesSelectionExamples} from '../src/components/datePicker/examples/DatesSelectionExamples';
+// import {DropdownSearchExamples} from '../src/components/dropdownSearch/examples/DropdownSearchExamples';
+// import {CodeEditorExamples} from '../src/components/editor/examples/CodeEditorExamples';
+// import {JSONEditorExamples} from '../src/components/editor/examples/JSONEditorExamples';
+// import {FacetConnectedExamples} from '../src/components/facets/examples/FacetConnectedExamples';
+// import {FacetExamples} from '../src/components/facets/examples/FacetExamples';
+// import {FilterBoxConnectedExamples} from '../src/components/filterBox/examples/FilterBoxConnectedExamples';
+// import {FilterBoxExamples} from '../src/components/filterBox/examples/FilterBoxExamples';
+// import {FlatSelectExamples} from '../src/components/flatSelect/examples/FlatSelectExamples';
+// import {FlippableExamples} from '../src/components/flippable/exemples/FlippableExamples';
+// import {BasicHeaderExamples} from '../src/components/headers/examples/BasicHeaderExamples';
+// import {BreadcrumbHeaderExample} from '../src/components/headers/examples/BreadcrumbHeaderExample';
+// import {InputAndInputConnectedExamples} from '../src/components/input/examples/InputAndInputConnectedExamples';
+// import {ItemBoxExamples} from '../src/components/itemBox/examples/ItemBoxExamples';
+// import {LabeledValueExamples} from '../src/components/labeledValue/examples/LabeledValueExamples';
+// import {LastUpdatedConnectedExamples} from '../src/components/lastUpdated/examples/LastUpdatedConnectedExamples';
+// import {LastUpdatedExamples} from '../src/components/lastUpdated/examples/LastUpdatedExamples';
+// import {ListBoxExamples} from '../src/components/listBox/examples/ListBoxExamples';
+// import {LoadingExamples} from '../src/components/loading/LoadingExamples';
+// import {LogoCardExamples} from '../src/components/logoCard/examples/LogoCardExamples';
+// import {ModalCompositeConnectedExamples} from '../src/components/modal/examples/ModalCompositeConnectedExamples';
+// import {ModalCompositeExamples} from '../src/components/modal/examples/ModalCompositeExamples';
+// import {ModalConnectedExamples} from '../src/components/modal/examples/ModalConnectedExamples';
+// import {ModalExamples} from '../src/components/modal/examples/ModalExamples';
+// import {ModalPromptExamples} from '../src/components/modalPrompt/exemples/ModalPromptExamples';
+// import {MultilineInputExamples} from '../src/components/multilineInput/examples/MultilineInputExamples';
+// import {SplitMultilineInputExamples} from '../src/components/multilineInput/examples/SplitMultilineExamples';
+// import {MultiStepBarExamples} from '../src/components/multiStepBar/examples/MultiStepBarExamples';
+// import {NavigationConnectedExamples} from '../src/components/navigation/examples/NavigationConnectedExamples';
+// import {NavigationExamples} from '../src/components/navigation/examples/NavigationExamples';
+// import {OptionsCycleConnectedExamples} from '../src/components/optionsCycle/examples/OptionsCycleConnectedExamples';
+// import {OptionsCycleExamples} from '../src/components/optionsCycle/examples/OptionsCycleExamples';
+// import {PartialStringMatchExamples} from '../src/components/partial-string-match/PartialStringMatchExamples';
+// import {RadioExamples} from '../src/components/radio/examples/RadioExamples';
+// import {SearchBarExamples} from '../src/components/searchBar/SearchBarExamples';
+// import {MultiSelectExamples} from '../src/components/select/examples/MultiSelectExamples';
+// import {SingleSelectExamples} from '../src/components/select/examples/SingleSelectExamples';
+// import {SideNavigationExample} from '../src/components/sideNavigation/examples/SideNavigationExample';
+// import {SideNavigationLoadingExample} from '../src/components/sideNavigation/examples/SideNavigationLoadingExample';
+// import {SliderExamples} from '../src/components/slider/examples/SliderExamples';
+// import {SplitLayoutExamples} from '../src/components/splitlayout/examples/SplitLayoutExamples';
+// import {StepProgressBarExamples} from '../src/components/stepProgressBar/examples/StepProgressBarExamples';
+// import {SubNavigationConnectedExamples} from '../src/components/subNavigation/examples/SubNavigationConnectedExamples';
+// import {SubNavigationExamples} from '../src/components/subNavigation/examples/SubNavigationExamples';
+// import {LinkSvgExamples} from '../src/components/svg/examples/LinkSvgExamples';
+// import {SvgExamples} from '../src/components/svg/examples/SvgExamples';
+// import {SyncFeedbackExample} from '../src/components/syncFeedback/examples/SyncFeedbackExample';
+// import {TabsExamples} from '../src/components/tab/examples/TabConnectedExample';
 import {TableWithDisabledRowsExamples} from '../src/components/tables/examples/TableDisabledRowsExamples';
 import {TableEmptyRowExamples} from '../src/components/tables/examples/TableEmptyRowExamples';
 import {TableExamples} from '../src/components/tables/examples/TableExamples';
 import {TableHeaderExamples} from '../src/components/tables/examples/TableHeaderExamples';
 import {TableRowConnectedExamples} from '../src/components/tables/examples/TableRowConnectedExamples';
 import {TableRowExamples} from '../src/components/tables/examples/TableRowExamples';
-import {TextAreaExamples} from '../src/components/textarea/TextAreaExamples';
-import {TitleExamples} from '../src/components/title/examples/TitleExamples';
-import {ToastConnectedExamples} from '../src/components/toast/examples/ToastConnectedExamples';
-import {ToastExamples} from '../src/components/toast/examples/ToastExamples';
-import {TooltipExamples} from '../src/components/tooltip/examples/TooltipExamples';
-import {UserFeedbackExample} from '../src/components/userFeedback/examples/UserFeedbackExample';
+// import {TextAreaExamples} from '../src/components/textarea/TextAreaExamples';
+// import {TitleExamples} from '../src/components/title/examples/TitleExamples';
+// import {ToastConnectedExamples} from '../src/components/toast/examples/ToastConnectedExamples';
+// import {ToastExamples} from '../src/components/toast/examples/ToastExamples';
+// import {TooltipExamples} from '../src/components/tooltip/examples/TooltipExamples';
+// import {UserFeedbackExample} from '../src/components/userFeedback/examples/UserFeedbackExample';
 
-import {MembersExample} from './members-example/MembersExample';*/
+// import {MembersExample} from './members-example/MembersExample';
 
 import {ReactVaporStore} from './ReactVaporStore';
 
@@ -104,7 +104,7 @@ class App extends React.Component<any, any> {
         return (
             <Provider store={ReactVaporStore}>
                 <div className='coveo-form'>
-                    {/*<div className='form-group'>
+                    {/* <div className='form-group'>
                         <label className='form-control-label'>
                             My list of members
                         </label>
@@ -163,14 +163,14 @@ class App extends React.Component<any, any> {
                     <ActionBarExamples />
                     <ActionBarConnectedExamples />
                     <ItemFilterExamples />
-                    <ItemFilterConnectedExamples />
+                    <ItemFilterConnectedExamples /> */}
                     <TableRowExamples />
                     <TableRowConnectedExamples />
                     <TableEmptyRowExamples />
                     <TableHeaderExamples />
                     <TableExamples />
                     <TableWithDisabledRowsExamples />
-                    <OptionsCycleExamples />
+                    {/* <OptionsCycleExamples />
                     <OptionsCycleConnectedExamples />
                     <CalendarConnectedExamples />
                     <DatesSelectionExamples />
@@ -194,9 +194,9 @@ class App extends React.Component<any, any> {
                     <LabeledValueExamples />
                     <CollapsibleContainerExamples />
                     <SplitLayoutExamples />
-                    <SplitMultilineInputExamples />*/}
+                    <SplitMultilineInputExamples />
                     <JSONEditorExamples />
-                    <CodeEditorExamples />
+                    <CodeEditorExamples /> */}
                 </div>
             </Provider>
         );

--- a/src/components/tables/TableHeadingRow.tsx
+++ b/src/components/tables/TableHeadingRow.tsx
@@ -14,6 +14,7 @@ export interface ITableHeadingRowOwnProps extends React.ClassAttributes<TableHea
     className?: string;
     isMultiSelect?: boolean;
     selectionDisabled?: boolean;
+    isPartOfCollapsibleTable?: boolean;
 }
 
 export interface ITableHeadingRowStateProps {
@@ -47,7 +48,7 @@ export class TableHeadingRow extends React.Component<ITableHeadingRowProps, any>
     render() {
         const toggle: JSX.Element = this.props.isCollapsible
             ? <TableCollapsibleRowToggle isExpanded={this.props.opened} />
-            : null;
+            : this.props.isPartOfCollapsibleTable && <td></td>;
         const rowClasses = classNames({
             'heading-row': this.props.isCollapsible,
             'selected': this.props.selected,
@@ -67,17 +68,13 @@ export class TableHeadingRow extends React.Component<ITableHeadingRowProps, any>
     }
 
     private handleClick(e: React.MouseEvent<any>) {
-        if (!this.props.selectionDisabled) {
-            const hasMultipleSelectedRow = (e.metaKey || e.ctrlKey) && this.props.isMultiSelect;
+        const hasMultipleSelectedRow = (e.metaKey || e.ctrlKey) && this.props.isMultiSelect;
 
-            callIfDefined(this.props.onClick, hasMultipleSelectedRow);
-            callIfDefined(this.props.onClickCallback);
-        }
+        callIfDefined(this.props.onClick, hasMultipleSelectedRow);
+        callIfDefined(this.props.onClickCallback);
     }
 
     private handleDoubleClick() {
-        if (!this.props.selectionDisabled) {
-            callIfDefined(this.props.onDoubleClick);
-        }
+        callIfDefined(this.props.onDoubleClick);
     }
 }

--- a/src/components/tables/TableHeadingRow.tsx
+++ b/src/components/tables/TableHeadingRow.tsx
@@ -14,7 +14,7 @@ export interface ITableHeadingRowOwnProps extends React.ClassAttributes<TableHea
     className?: string;
     isMultiSelect?: boolean;
     selectionDisabled?: boolean;
-    isPartOfCollapsibleTable?: boolean;
+    tableHasCollapsibleRow?: boolean;
 }
 
 export interface ITableHeadingRowStateProps {
@@ -48,7 +48,7 @@ export class TableHeadingRow extends React.Component<ITableHeadingRowProps, any>
     render() {
         const toggle: JSX.Element = this.props.isCollapsible
             ? <TableCollapsibleRowToggle isExpanded={this.props.opened} />
-            : this.props.isPartOfCollapsibleTable && <td></td>;
+            : this.props.tableHasCollapsibleRow && <td></td>;
         const rowClasses = classNames({
             'heading-row': this.props.isCollapsible,
             'selected': this.props.selected,

--- a/src/components/tables/TableHeadingRowConnected.tsx
+++ b/src/components/tables/TableHeadingRowConnected.tsx
@@ -6,7 +6,7 @@ import {IDispatch, ReduxUtils} from '../../utils/ReduxUtils';
 import {updateSelectedRows} from './TableActions';
 import {ITableHeadingRowOwnProps, ITableHeadingRowProps, TableHeadingRow} from './TableHeadingRow';
 import {ITableState} from './TableReducers';
-import {addRow, removeRow, selectRow} from './TableRowActions';
+import {addRow, removeRow, selectRow, toggleRowOpened} from './TableRowActions';
 import {ITableRowState} from './TableRowReducers';
 
 const mapStateToProps = (state: IReactVaporState, ownProps: ITableHeadingRowOwnProps) => {
@@ -21,8 +21,13 @@ const mapStateToProps = (state: IReactVaporState, ownProps: ITableHeadingRowOwnP
 
 const mapDispatchToProps = (dispatch: IDispatch, ownProps: ITableHeadingRowOwnProps) => ({
     onClick: (hasMultipleSelectedRow: boolean) => {
-        dispatch(selectRow(ownProps.id, ownProps.isCollapsible, ownProps.tableId, ownProps.rowId));
-        dispatch(updateSelectedRows(ownProps.tableId, [ownProps.rowId], hasMultipleSelectedRow));
+        if (!ownProps.selectionDisabled) {
+            dispatch(selectRow(ownProps.id, ownProps.tableId, ownProps.rowId));
+            dispatch(updateSelectedRows(ownProps.tableId, [ownProps.rowId], hasMultipleSelectedRow));
+        }
+        if (ownProps.isCollapsible) {
+            dispatch(toggleRowOpened(ownProps.id, ownProps.tableId, ownProps.rowId));
+        }
     },
     onRender: () => dispatch(addRow(ownProps.id, ownProps.tableId)),
     onDestroy: () => dispatch(removeRow(ownProps.id)),

--- a/src/components/tables/TableRowActions.ts
+++ b/src/components/tables/TableRowActions.ts
@@ -4,12 +4,12 @@ export const TableRowActions = {
     add: 'ADD_ROW',
     remove: 'REMOVE_ROW',
     select: 'SELECT_ROW',
+    toggleOpen: 'TOGGLE_COLLAPSE_ROW',
     unselectAll: 'UNSELECT_ALL_ROW',
 };
 
 export interface ITableRowActionPayload {
     id?: string;
-    isCollapsible?: boolean;
     tableId?: string;
     rowId?: string;
 }
@@ -29,11 +29,19 @@ export const removeRow = (id: string): IReduxAction<ITableRowActionPayload> => (
     },
 });
 
-export const selectRow = (id: string, isCollapsible?: boolean, tableId?: string, rowId?: string): IReduxAction<ITableRowActionPayload> => ({
+export const selectRow = (id: string, tableId?: string, rowId?: string): IReduxAction<ITableRowActionPayload> => ({
     type: TableRowActions.select,
     payload: {
         id,
-        isCollapsible,
+        tableId,
+        rowId,
+    },
+});
+
+export const toggleRowOpened = (id: string, tableId?: string, rowId?: string): IReduxAction<ITableRowActionPayload> => ({
+    type: TableRowActions.toggleOpen,
+    payload: {
+        id,
         tableId,
         rowId,
     },

--- a/src/components/tables/TableRowReducers.ts
+++ b/src/components/tables/TableRowReducers.ts
@@ -23,18 +23,19 @@ export const tableRowReducer = (state: ITableRowState = tableRowInitialState, ac
                 opened: false,
                 selected: false,
             };
+        case TableRowActions.toggleOpen:
+            return state.tableId === action.payload.tableId
+                ? {...state, opened: state.id === action.payload.id && !state.opened}
+                : state;
         case TableRowActions.select:
-            if (state.tableId === action.payload.tableId) {
-                return state.id === action.payload.id
-                    ? {...state, selected: true, opened: !!action.payload.isCollapsible && !state.opened}
-                    : {...state, selected: false, opened: false};
-            }
+            return state.tableId === action.payload.tableId
+                ? {...state, selected: state.id === action.payload.id}
+                : state;
         case TableRowActions.unselectAll:
-            if (state.tableId === action.payload.tableId) {
-                return {...state, selected: false, opened: false};
-            }
-        default:
-            return state;
+            return state.tableId === action.payload.tableId
+                ? {...state, selected: false, opened: false}
+                : state;
+        default: return state;
     }
 };
 
@@ -49,6 +50,7 @@ export const tableRowsReducer = (state: ITableRowState[] = tableRowsInitialState
             return _.reject(state, (row: ITableRowState) => {
                 return action.payload.id === row.id;
             });
+        case TableRowActions.toggleOpen:
         case TableRowActions.select:
         case TableRowActions.unselectAll:
             return state.map((row: ITableRowState) => tableRowReducer(row, action));

--- a/src/components/tables/examples/TableExamples.tsx
+++ b/src/components/tables/examples/TableExamples.tsx
@@ -406,8 +406,11 @@ export class TableExamples extends React.Component<any, any> {
                     <TableConnected
                         id={_.uniqueId('react-vapor-table')}
                         initialTableData={tableData}
-                        collapsibleFormatter={(rowData: IData) => <div className='p2'>This is the collapsible row! And here's the value of
-                            attribute 3: {rowData.attribute3}</div>}
+                        collapsibleFormatter={(rowData: IData) => _.keys(tableDataById).indexOf(rowData.id) % 2 === 0 &&
+                            <div className='p2'>
+                                This is the collapsible row! And here's the value of attribute 3: {rowData.attribute3}
+                            </div>
+                        }
                         getActions={(rowData: IData) => ([
                             {
                                 name: 'Link to Coveo',

--- a/src/components/tables/table-children/TableChildBody.tsx
+++ b/src/components/tables/table-children/TableChildBody.tsx
@@ -87,12 +87,13 @@ export const TableChildBody = (props: ITableChildBodyProps): JSX.Element => {
             }
             isMultiSelect={props.isMultiSelect}
             selectionDisabled={props.getActions(props.rowData).length < 1}
+            isPartOfCollapsibleTable={!!props.collapsibleFormatter}
         >
             {tableHeadingRowContent}
         </TableHeadingRowConnected>
     );
 
-    return collapsibleRow
+    return collapsibleRow || !!props.collapsibleFormatter
         ? (
             <TableCollapsibleRowWrapper className={tableRowWrapperClasses}>
                 {tableHeadingRowConnectedNode}

--- a/src/components/tables/table-children/TableChildBody.tsx
+++ b/src/components/tables/table-children/TableChildBody.tsx
@@ -87,7 +87,7 @@ export const TableChildBody = (props: ITableChildBodyProps): JSX.Element => {
             }
             isMultiSelect={props.isMultiSelect}
             selectionDisabled={props.getActions(props.rowData).length < 1}
-            isPartOfCollapsibleTable={!!props.collapsibleFormatter}
+            tableHasCollapsibleRow={!!props.collapsibleFormatter}
         >
             {tableHeadingRowContent}
         </TableHeadingRowConnected>

--- a/src/components/tables/tests/TableHeadingRow.spec.tsx
+++ b/src/components/tables/tests/TableHeadingRow.spec.tsx
@@ -132,26 +132,5 @@ describe('Tables', () => {
 
             expect(onClickCallback).toHaveBeenCalledTimes(1);
         });
-
-        it('should not call the onClick props when selectionDisabled is set to true', () => {
-            const onClickSpy = jasmine.createSpy('onClick');
-            const onClickCallbackSpy = jasmine.createSpy('onClickCallback');
-            const onDoubleClickSpy = jasmine.createSpy('onDoubleClick');
-
-            const newTabledHeadingRowProps = _.extend({}, basicTableHeadingRowProps, {
-                selectionDisabled: true,
-                onClick: onClickSpy,
-                onClickCallback: onClickCallbackSpy,
-                onDoubleClick: onDoubleClickSpy,
-            });
-
-            tableHeadingRow.setProps(newTabledHeadingRowProps);
-
-            tableHeadingRow.find('tr').simulate('click');
-
-            expect(onClickSpy).not.toHaveBeenCalled();
-            expect(onClickCallbackSpy).not.toHaveBeenCalled();
-            expect(onDoubleClickSpy).not.toHaveBeenCalled();
-        });
     });
 });

--- a/src/components/tables/tests/TableHeadingRowConnected.spec.tsx
+++ b/src/components/tables/tests/TableHeadingRowConnected.spec.tsx
@@ -18,6 +18,20 @@ describe('Tables', () => {
         let tableHeadingRow: ReactWrapper<ITableHeadingRowProps, any>;
         let store: Store<IReactVaporState>;
 
+        const mountWithProps = (props?: Partial<ITableHeadingRowOwnProps>) => {
+            wrapper = mount(
+                <Provider store={store}>
+                    <table>
+                        <tbody>
+                            <TableHeadingRowConnected {...{...basicTableHeadingRowProps, ...props}} />
+                        </tbody>
+                    </table>
+                </Provider>,
+                {attachTo: document.getElementById('App')},
+            );
+            tableHeadingRow = wrapper.find(TableHeadingRow).first();
+        };
+
         beforeEach(() => {
             basicTableHeadingRowProps = {
                 id: 'heading-row',
@@ -25,18 +39,7 @@ describe('Tables', () => {
             };
 
             store = TestUtils.buildStore();
-
-            wrapper = mount(
-                <Provider store={store}>
-                    <table>
-                        <tbody>
-                            <TableHeadingRowConnected {...basicTableHeadingRowProps} />
-                        </tbody>
-                    </table>
-                </Provider>,
-                {attachTo: document.getElementById('App')},
-            );
-            tableHeadingRow = wrapper.find(TableHeadingRow).first();
+            mountWithProps();
         });
 
         afterEach(() => {
@@ -93,23 +96,29 @@ describe('Tables', () => {
             expect(_.findWhere(store.getState().rows, {id: basicTableHeadingRowProps.id}).opened).toBe(true);
         });
 
+        it('should set the selected property to true on click when the selectionDisabled prop is false', () => {
+            expect(_.findWhere(store.getState().rows, {id: basicTableHeadingRowProps.id}).selected).toBe(false);
+
+            tableHeadingRow.find('tr').simulate('click');
+            expect(_.findWhere(store.getState().rows, {id: basicTableHeadingRowProps.id}).selected).toBe(true);
+        });
+
+        it('should not set the selected property to true on click if the selectionDisabled prop is true', () => {
+            expect(_.findWhere(store.getState().rows, {id: basicTableHeadingRowProps.id}).selected).toBe(false);
+
+            mountWithProps({selectionDisabled: true});
+
+            tableHeadingRow.find('tr').simulate('click');
+            expect(_.findWhere(store.getState().rows, {id: basicTableHeadingRowProps.id}).selected).toBe(false);
+        });
+
         it('should not dispatch any action on render, on destroy and on click if not collapsible', () => {
             store.dispatch(clearState());
 
-            const newHeadingRowProps = _.extend({}, basicTableHeadingRowProps, {isCollapsible: false});
             const rowState = _.clone(store.getState().rows);
 
-            wrapper = mount(
-                <Provider store={store}>
-                    <table>
-                        <tbody>
-                            <TableHeadingRowConnected {...newHeadingRowProps} />
-                        </tbody>
-                    </table>
-                </Provider>,
-                {attachTo: document.getElementById('App')},
-            );
-            tableHeadingRow = wrapper.find(TableHeadingRow).first();
+            mountWithProps({isCollapsible: false});
+
             expect(store.getState().rows).toEqual(jasmine.objectContaining(rowState));
 
             tableHeadingRow.find('tr').simulate('click');

--- a/src/components/tables/tests/TableRowReducers.spec.ts
+++ b/src/components/tables/tests/TableRowReducers.spec.ts
@@ -130,6 +130,37 @@ describe('Tables', () => {
                 expect(collapsibleRowsState.filter((row) => row.id === action.payload.id)[0].opened).toBe(openValue);
                 expect(collapsibleRowsState.filter((row) => row.id !== action.payload.id)[0].opened).toBe(openValue);
             });
+
+            it('should return the old state when the action does not target the specified tableId', () => {
+                oldState = [
+                    {
+                        id: 'row2',
+                        tableId: 'table3',
+                        opened: false,
+                        selected: false,
+                    }, {
+                        id: 'row1',
+                        tableId: 'table3',
+                        opened: true,
+                        selected: false,
+                    }, {
+                        id: 'row3',
+                        tableId: 'table3',
+                        opened: false,
+                        selected: false,
+                    },
+                ];
+                const action: IReduxAction<ITableRowActionPayload> = {
+                    type: TableRowActions.toggleOpen,
+                    payload: {
+                        id: 'row1',
+                        tableId: 'table2',
+                    },
+                };
+                const nexState: ITableRowState[] = tableRowsReducer(oldState, action);
+
+                expect(nexState).toEqual(oldState);
+            });
         });
 
         describe('selected behavior', () => {
@@ -191,6 +222,37 @@ describe('Tables', () => {
                 const currentStateWithTableId = oldState.map((rowState) => ({...rowState, tableId: `different${tableId}`, selected: true}));
 
                 expect(tableRowsReducer(currentStateWithTableId, action).every((row) => row.selected)).toBe(true);
+            });
+
+            it('should return the old state when the action does not target the specified tableId', () => {
+                oldState = [
+                    {
+                        id: 'row2',
+                        tableId: 'table3',
+                        opened: false,
+                        selected: false,
+                    }, {
+                        id: 'row1',
+                        tableId: 'table3',
+                        opened: true,
+                        selected: false,
+                    }, {
+                        id: 'row3',
+                        tableId: 'table3',
+                        opened: false,
+                        selected: false,
+                    },
+                ];
+                const action: IReduxAction<ITableRowActionPayload> = {
+                    type: TableRowActions.select,
+                    payload: {
+                        id: 'row1',
+                        tableId: 'table2',
+                    },
+                };
+                const nexState: ITableRowState[] = tableRowsReducer(oldState, action);
+
+                expect(nexState).toEqual(oldState);
             });
         });
     });


### PR DESCRIPTION
Improved those following use cases:

* When a table had some collapsible rows mixed with some standard rows, it looked like the screenshot bellow. I added an empty `<td></td>` to the standard rows only when there is one or more collapsible table rows that exists in the table.
![image](https://user-images.githubusercontent.com/35579930/41067113-62bfc90e-69b2-11e8-8194-08bde9d58d5a.png)

* When a table row has no actions, it is not selectable and that is the expected behavior. The problem is that when its a collapsible row, the select action was not triggered, therefore the row wouldn't uncollapse. I separated the select action into 2: selectRow and toggleRow and added a reducer that goes with it.