### PR TITLE
Add base payload interface

### DIFF
--- a/docs/Index.tsx
+++ b/docs/Index.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 import {render as ReactDOMRender} from 'react-dom';
 import {Provider} from 'react-redux';
 
-
 // import {ActionBarConnectedExamples} from '../src/components/actions/examples/ActionBarConnectedExamples';
 // import {ActionBarExamples} from '../src/components/actions/examples/ActionBarExamples';
 // import {ItemFilterConnectedExamples} from '../src/components/actions/filters/examples/ItemFilterConnectedExamples';
@@ -163,7 +162,7 @@ class App extends React.Component<any, any> {
                     <ActionBarExamples />
                     <ActionBarConnectedExamples />
                     <ItemFilterExamples />
-                    <ItemFilterConnectedExamples /> 
+                    <ItemFilterConnectedExamples />
                     <TableRowExamples />
                     <TableRowConnectedExamples />
                     <TableEmptyRowExamples />

--- a/src/utils/ReduxUtils.ts
+++ b/src/utils/ReduxUtils.ts
@@ -23,6 +23,10 @@ export function ReduxConnect(mapStateToProps?: any, mapDispatchToProps?: any, me
     return (target) => (ReactRedux.connect(mapStateToProps, mapDispatchToProps, mergeProps, options)(target) as any);
 }
 
+export interface BasePayload {
+    id: string;
+}
+
 export interface IReduxAction<T = {}> extends Redux.Action {
     type: string;
     payload?: T;


### PR DESCRIPTION
Instead of declaring a new interface for each component that exposes a single `id` prop, use the `BasePayload`.

For example:
![image](https://user-images.githubusercontent.com/35579930/41109093-28a98844-6a44-11e8-85e7-bd36a1303f87.png)

Would become 
![image](https://user-images.githubusercontent.com/35579930/41109165-53828494-6a44-11e8-8fa8-90c39ca2ed69.png)

I didn't change all the existing interfaces, because that would cause breaking changes everywhere
