### PR TITLE
Allow additional classnames on loading component

### DIFF
--- a/src/components/loading/Loading.tsx
+++ b/src/components/loading/Loading.tsx
@@ -1,7 +1,11 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
+import {keys} from 'ts-transformer-keys';
+import {omit} from 'underscore';
 
 export interface ILoadingOwnProps extends React.ClassAttributes<Loading> {
     id?: string;
+    className?: string;
 }
 
 export interface ILoadingDispatchProps {
@@ -11,7 +15,7 @@ export interface ILoadingDispatchProps {
 
 export interface ILoadingProps extends ILoadingOwnProps, ILoadingDispatchProps {}
 
-export class Loading extends React.Component<ILoadingProps, any> {
+export class Loading extends React.Component<ILoadingProps & React.HTMLProps<HTMLDivElement>, any> {
 
     componentWillMount() {
         if (this.props.onRender) {
@@ -27,7 +31,7 @@ export class Loading extends React.Component<ILoadingProps, any> {
 
     render() {
         return (
-            <div className='spinner'>
+            <div className={classNames('spinner', this.props.className)} {...omit(this.props, keys<ILoadingProps>())} >
                 <div className='bounce1'></div>
                 <div className='bounce2'></div>
                 <div className='bounce3'></div>

--- a/src/components/loading/tests/Loading.spec.tsx
+++ b/src/components/loading/tests/Loading.spec.tsx
@@ -15,6 +15,11 @@ describe('<Loading />', () => {
         expect(loading.find('.spinner').length).toBe(1);
     });
 
+    it('should render the optional classes if any in addition to the default spinner class', () => {
+        const loading: ShallowWrapper<ILoadingProps, any> = shallow(<Loading className='p2' />);
+        expect(loading.find('.spinner.p2').length).toBe(1);
+    });
+
     it('should call onRender if prop is set when mounting', () => {
         const onRenderSpy = jasmine.createSpy('onRender');
         const loading: ReactWrapper<ILoadingProps, any> = mount(


### PR DESCRIPTION
Before: `<Loading className='p2' />` would render `<div class="spinner">.......</div>`

After: `<Loading className='p2' />` will render `<div class="spinner p2">.......</div>`