### PR TITLE
Add set collapsible row opened

### DIFF
--- a/src/components/tables/TableRowActions.ts
+++ b/src/components/tables/TableRowActions.ts
@@ -5,6 +5,7 @@ export const TableRowActions = {
     remove: 'REMOVE_ROW',
     select: 'SELECT_ROW',
     toggleOpen: 'TOGGLE_COLLAPSE_ROW',
+    open: 'EXPAND_ROW',
     unselectAll: 'UNSELECT_ALL_ROW',
 };
 
@@ -12,6 +13,7 @@ export interface ITableRowActionPayload {
     id?: string;
     tableId?: string;
     rowId?: string;
+    opened?: boolean;
 }
 
 export const addRow = (id: string, tableId?: string): IReduxAction<ITableRowActionPayload> => ({
@@ -44,6 +46,15 @@ export const toggleRowOpened = (id: string, tableId?: string, rowId?: string): I
         id,
         tableId,
         rowId,
+    },
+});
+
+export const setRowOpened = (id: string, opened: boolean, tableId?: string): IReduxAction<ITableRowActionPayload> => ({
+    type: TableRowActions.open,
+    payload: {
+        id,
+        opened,
+        tableId,
     },
 });
 

--- a/src/components/tables/TableRowActions.ts
+++ b/src/components/tables/TableRowActions.ts
@@ -5,7 +5,6 @@ export const TableRowActions = {
     remove: 'REMOVE_ROW',
     select: 'SELECT_ROW',
     toggleOpen: 'TOGGLE_COLLAPSE_ROW',
-    open: 'EXPAND_ROW',
     unselectAll: 'UNSELECT_ALL_ROW',
 };
 
@@ -40,21 +39,13 @@ export const selectRow = (id: string, tableId?: string, rowId?: string): IReduxA
     },
 });
 
-export const toggleRowOpened = (id: string, tableId?: string, rowId?: string): IReduxAction<ITableRowActionPayload> => ({
+export const toggleRowOpened = (id: string, tableId?: string, rowId?: string, opened?: boolean): IReduxAction<ITableRowActionPayload> => ({
     type: TableRowActions.toggleOpen,
     payload: {
         id,
         tableId,
         rowId,
-    },
-});
-
-export const setRowOpened = (id: string, opened: boolean, tableId?: string): IReduxAction<ITableRowActionPayload> => ({
-    type: TableRowActions.open,
-    payload: {
-        id,
         opened,
-        tableId,
     },
 });
 

--- a/src/components/tables/TableRowReducers.ts
+++ b/src/components/tables/TableRowReducers.ts
@@ -23,6 +23,10 @@ export const tableRowReducer = (state: ITableRowState = tableRowInitialState, ac
                 opened: false,
                 selected: false,
             };
+        case TableRowActions.open:
+            return state.tableId === action.payload.tableId
+                ? {...state, opened: state.id === action.payload.id && !!action.payload.opened}
+                : state;
         case TableRowActions.toggleOpen:
             return state.tableId === action.payload.tableId
                 ? {...state, opened: state.id === action.payload.id && !state.opened}
@@ -51,6 +55,7 @@ export const tableRowsReducer = (state: ITableRowState[] = tableRowsInitialState
                 return action.payload.id === row.id;
             });
         case TableRowActions.toggleOpen:
+        case TableRowActions.open:
         case TableRowActions.select:
         case TableRowActions.unselectAll:
             return state.map((row: ITableRowState) => tableRowReducer(row, action));

--- a/src/components/tables/TableRowReducers.ts
+++ b/src/components/tables/TableRowReducers.ts
@@ -23,14 +23,13 @@ export const tableRowReducer = (state: ITableRowState = tableRowInitialState, ac
                 opened: false,
                 selected: false,
             };
-        case TableRowActions.open:
-            return state.tableId === action.payload.tableId
-                ? {...state, opened: state.id === action.payload.id && !!action.payload.opened}
-                : state;
         case TableRowActions.toggleOpen:
-            return state.tableId === action.payload.tableId
+            if (state.tableId !== action.payload.tableId) {
+                return state;
+            }
+            return _.isUndefined(action.payload.opened)
                 ? {...state, opened: state.id === action.payload.id && !state.opened}
-                : state;
+                : {...state, opened: state.id === action.payload.id && action.payload.opened};
         case TableRowActions.select:
             return state.tableId === action.payload.tableId
                 ? {...state, selected: state.id === action.payload.id}
@@ -55,7 +54,6 @@ export const tableRowsReducer = (state: ITableRowState[] = tableRowsInitialState
                 return action.payload.id === row.id;
             });
         case TableRowActions.toggleOpen:
-        case TableRowActions.open:
         case TableRowActions.select:
         case TableRowActions.unselectAll:
             return state.map((row: ITableRowState) => tableRowReducer(row, action));

--- a/src/components/tables/tests/TableRowReducers.spec.ts
+++ b/src/components/tables/tests/TableRowReducers.spec.ts
@@ -1,5 +1,5 @@
 import {IReduxAction} from '../../../utils/ReduxUtils';
-import {ITableRowActionPayload, setRowOpened, TableRowActions, unselectAllRows} from '../TableRowActions';
+import {ITableRowActionPayload, TableRowActions, unselectAllRows} from '../TableRowActions';
 import {
     ITableRowState,
     tableRowInitialState,
@@ -114,27 +114,7 @@ describe('Tables', () => {
                 ];
             });
 
-            it('should set the opened property to the value specified in the paylaod when the action is "EXPAND_ROW"', () => {
-                const setOpenedAction = setRowOpened('row1', true);
-                const setCollapsedAction = setRowOpened('row1', false);
-                let collapsibleRowsState: ITableRowState[] = tableRowsReducer(oldState, setOpenedAction);
-
-                expect(collapsibleRowsState.length).toBe(oldState.length);
-                expect(collapsibleRowsState.filter((row) => row.id === setOpenedAction.payload.id)[0].opened).toBe(true);
-                expect(collapsibleRowsState.filter((row) => row.id !== setOpenedAction.payload.id)[0].opened).toBe(openValue);
-
-                collapsibleRowsState = tableRowsReducer(collapsibleRowsState, setOpenedAction);
-
-                expect(collapsibleRowsState.filter((row) => row.id === setOpenedAction.payload.id)[0].opened).toBe(true);
-                expect(collapsibleRowsState.filter((row) => row.id !== setOpenedAction.payload.id)[0].opened).toBe(openValue);
-
-                collapsibleRowsState = tableRowsReducer(collapsibleRowsState, setCollapsedAction);
-
-                expect(collapsibleRowsState.filter((row) => row.id === setCollapsedAction.payload.id)[0].opened).toBe(false);
-                expect(collapsibleRowsState.filter((row) => row.id !== setCollapsedAction.payload.id)[0].opened).toBe(openValue);
-            });
-
-            it('should toggle the opened property to true if the action is "TOGGLE_COLLAPSE_ROW"', () => {
+            it('should toggle the opened property if the action is "TOGGLE_COLLAPSE_ROW" and opened is not specified', () => {
                 const action: IReduxAction<ITableRowActionPayload> = {
                     type: TableRowActions.toggleOpen,
                     payload: {id: 'row1'},
@@ -151,7 +131,39 @@ describe('Tables', () => {
                 expect(collapsibleRowsState.filter((row) => row.id !== action.payload.id)[0].opened).toBe(openValue);
             });
 
-            it('should return the old state when the action does not target the specified tableId', () => {
+            it('should set the opened property to the value specified by the action "TOGGLE_COLLAPSE_ROW"', () => {
+                const setToTrue: IReduxAction<ITableRowActionPayload> = {
+                    type: TableRowActions.toggleOpen,
+                    payload: {
+                        id: 'row1',
+                        opened: true,
+                    },
+                };
+                const setToFalse: IReduxAction<ITableRowActionPayload> = {
+                    type: TableRowActions.toggleOpen,
+                    payload: {
+                        id: 'row1',
+                        opened: false,
+                    },
+                };
+                let collapsibleRowsState: ITableRowState[] = tableRowsReducer(oldState, setToTrue);
+
+                expect(collapsibleRowsState.length).toBe(oldState.length);
+                expect(collapsibleRowsState.filter((row) => row.id === setToTrue.payload.id)[0].opened).toBe(true);
+                expect(collapsibleRowsState.filter((row) => row.id !== setToTrue.payload.id)[0].opened).toBe(openValue);
+
+                collapsibleRowsState = tableRowsReducer(collapsibleRowsState, setToTrue);
+
+                expect(collapsibleRowsState.filter((row) => row.id === setToTrue.payload.id)[0].opened).toBe(true);
+                expect(collapsibleRowsState.filter((row) => row.id !== setToTrue.payload.id)[0].opened).toBe(openValue);
+
+                collapsibleRowsState = tableRowsReducer(collapsibleRowsState, setToFalse);
+
+                expect(collapsibleRowsState.filter((row) => row.id === setToTrue.payload.id)[0].opened).toBe(false);
+                expect(collapsibleRowsState.filter((row) => row.id !== setToTrue.payload.id)[0].opened).toBe(openValue);
+            });
+
+            it('should return the old state when the action "TOGGLE_COLLAPSE_ROW" does not target the specified tableId', () => {
                 oldState = [
                     {
                         id: 'row2',

--- a/src/components/tables/tests/TableRowReducers.spec.ts
+++ b/src/components/tables/tests/TableRowReducers.spec.ts
@@ -1,5 +1,5 @@
 import {IReduxAction} from '../../../utils/ReduxUtils';
-import {ITableRowActionPayload, TableRowActions, unselectAllRows, setRowOpened} from '../TableRowActions';
+import {ITableRowActionPayload, setRowOpened, TableRowActions, unselectAllRows} from '../TableRowActions';
 import {
     ITableRowState,
     tableRowInitialState,
@@ -133,7 +133,6 @@ describe('Tables', () => {
                 expect(collapsibleRowsState.filter((row) => row.id === setCollapsedAction.payload.id)[0].opened).toBe(false);
                 expect(collapsibleRowsState.filter((row) => row.id !== setCollapsedAction.payload.id)[0].opened).toBe(openValue);
             });
-
 
             it('should toggle the opened property to true if the action is "TOGGLE_COLLAPSE_ROW"', () => {
                 const action: IReduxAction<ITableRowActionPayload> = {

--- a/src/components/tables/tests/TableRowReducers.spec.ts
+++ b/src/components/tables/tests/TableRowReducers.spec.ts
@@ -1,5 +1,5 @@
 import {IReduxAction} from '../../../utils/ReduxUtils';
-import {ITableRowActionPayload, TableRowActions, unselectAllRows} from '../TableRowActions';
+import {ITableRowActionPayload, TableRowActions, unselectAllRows, setRowOpened} from '../TableRowActions';
 import {
     ITableRowState,
     tableRowInitialState,
@@ -113,6 +113,27 @@ describe('Tables', () => {
                     {id: 'row1', opened: openValue, selected: doesNotMatter},
                 ];
             });
+
+            it('should set the opened property to the value specified in the paylaod when the action is "EXPAND_ROW"', () => {
+                const setOpenedAction = setRowOpened('row1', true);
+                const setCollapsedAction = setRowOpened('row1', false);
+                let collapsibleRowsState: ITableRowState[] = tableRowsReducer(oldState, setOpenedAction);
+
+                expect(collapsibleRowsState.length).toBe(oldState.length);
+                expect(collapsibleRowsState.filter((row) => row.id === setOpenedAction.payload.id)[0].opened).toBe(true);
+                expect(collapsibleRowsState.filter((row) => row.id !== setOpenedAction.payload.id)[0].opened).toBe(openValue);
+
+                collapsibleRowsState = tableRowsReducer(collapsibleRowsState, setOpenedAction);
+
+                expect(collapsibleRowsState.filter((row) => row.id === setOpenedAction.payload.id)[0].opened).toBe(true);
+                expect(collapsibleRowsState.filter((row) => row.id !== setOpenedAction.payload.id)[0].opened).toBe(openValue);
+
+                collapsibleRowsState = tableRowsReducer(collapsibleRowsState, setCollapsedAction);
+
+                expect(collapsibleRowsState.filter((row) => row.id === setCollapsedAction.payload.id)[0].opened).toBe(false);
+                expect(collapsibleRowsState.filter((row) => row.id !== setCollapsedAction.payload.id)[0].opened).toBe(openValue);
+            });
+
 
             it('should toggle the opened property to true if the action is "TOGGLE_COLLAPSE_ROW"', () => {
                 const action: IReduxAction<ITableRowActionPayload> = {


### PR DESCRIPTION
We had a redux action to toggle a table collapsible row collapsed/expanded. I needed a way to set a collapsible row opened no matter what the current state is.