### PR TITLE
Fix table initial load

### DIFF
--- a/src/components/tables/Table.tsx
+++ b/src/components/tables/Table.tsx
@@ -141,7 +141,7 @@ export class Table extends React.Component<ITableProps> {
     }
 
     componentDidUpdate() {
-        if (this.isInitialLoad && !_.isUndefined(this.props.tableCompositeState.data)) {
+        if (this.isInitialLoad && JSON.stringify(this.props.tableCompositeState.data) !== JSON.stringify(DEFAULT_TABLE_DATA)) {
             this.isInitialLoad = false;
         }
     }

--- a/src/components/tables/Table.tsx
+++ b/src/components/tables/Table.tsx
@@ -175,8 +175,7 @@ export class Table extends React.Component<ITableProps> {
             this.props.tableClasses,
         );
 
-        const tableData = this.props.tableCompositeState.data || this.props.initialTableData;
-        const tableBodyNode: React.ReactNode = tableData.displayedIds.length || this.props.tableCompositeState.isLoading || this.isInitialLoad
+        const tableBodyNode: React.ReactNode = this.shouldShowTableBody()
             ? this.getTableBody()
             : <TableChildBlankSlate {...this.props} />;
 
@@ -263,5 +262,12 @@ export class Table extends React.Component<ITableProps> {
                     {tableBodyNode}
                 </tbody>
             );
+    }
+
+    private shouldShowTableBody(): boolean {
+        const tableData = this.props.tableCompositeState.data || this.props.initialTableData;
+
+        return !this.props.tableCompositeState.isInError
+            && !!(tableData.displayedIds.length || this.props.tableCompositeState.isLoading || this.isInitialLoad);
     }
 }

--- a/src/components/tables/TableConnected.tsx
+++ b/src/components/tables/TableConnected.tsx
@@ -17,7 +17,7 @@ import {IPaginationState} from '../navigation/pagination/NavigationPaginationRed
 import {IPerPageState} from '../navigation/perPage/NavigationPerPageReducers';
 import {IData, ITableCompositeStateProps, ITableDispatchProps, ITableOwnProps, ITableProps, Table} from './Table';
 import {addTable, removeTable} from './TableActions';
-import {TABLE_PREDICATE_DEFAULT_VALUE, TableChildComponent} from './TableConstants';
+import {TABLE_PREDICATE_DEFAULT_VALUE, TableChildComponent, DEFAULT_TABLE_DATA} from './TableConstants';
 import {defaultTableStateModifierThunk} from './TableDataModifier';
 import {ITableHeaderCellState} from './TableHeaderCellReducers';
 import {ITableById, ITableCompositeState, ITableData, ITableState} from './TableReducers';
@@ -104,7 +104,7 @@ const mapDispatchToProps = (dispatch: IDispatch, ownProps: ITableOwnProps): ITab
         dispatch(
             addTable(
                 ownProps.id,
-                ownProps.initialTableData,
+                ownProps.initialTableData || DEFAULT_TABLE_DATA,
                 ownProps.predicates,
             ),
         );

--- a/src/components/tables/TableConnected.tsx
+++ b/src/components/tables/TableConnected.tsx
@@ -17,7 +17,7 @@ import {IPaginationState} from '../navigation/pagination/NavigationPaginationRed
 import {IPerPageState} from '../navigation/perPage/NavigationPerPageReducers';
 import {IData, ITableCompositeStateProps, ITableDispatchProps, ITableOwnProps, ITableProps, Table} from './Table';
 import {addTable, removeTable} from './TableActions';
-import {TABLE_PREDICATE_DEFAULT_VALUE, TableChildComponent, DEFAULT_TABLE_DATA} from './TableConstants';
+import {DEFAULT_TABLE_DATA, TABLE_PREDICATE_DEFAULT_VALUE, TableChildComponent} from './TableConstants';
 import {defaultTableStateModifierThunk} from './TableDataModifier';
 import {ITableHeaderCellState} from './TableHeaderCellReducers';
 import {ITableById, ITableCompositeState, ITableData, ITableState} from './TableReducers';

--- a/src/components/tables/tests/Table.spec.tsx
+++ b/src/components/tables/tests/Table.spec.tsx
@@ -9,7 +9,6 @@ import {TableChildBlankSlate} from '../table-children/TableChildBlankSlate';
 import {TableChildBody} from '../table-children/TableChildBody';
 import {TableChildLastUpdated} from '../table-children/TableChildLastUpdated';
 import {DEFAULT_TABLE_DATA, TableSortingOrder} from '../TableConstants';
-import {ITableData} from '../TableReducers';
 import {tablePossibleProps, tablePropsMock, tablePropsMockWithData} from './TableTestCommon';
 
 describe('<Table />', () => {
@@ -124,14 +123,14 @@ describe('<Table />', () => {
             expect(onUnmountSpy).toHaveBeenCalledTimes(1);
         });
 
-        it('should set isInitialLoad to false after tableCompositeState.data is defined with componentDidUpdate', () => {
-            const tableCompositeState = {...tablePropsMock.tableCompositeState, data: undefined as ITableData};
+        it('should set isInitialLoad to false after tableCompositeState.data changes from DEFAULT_TABLE_DATA to new table data', () => {
+            const tableCompositeState = {...tablePropsMock.tableCompositeState, data: DEFAULT_TABLE_DATA};
             const tableAsAny = new Table({...tablePropsMock, tableCompositeState}) as any;
 
-            expect(tableAsAny.props.tableCompositeState.data).toBeUndefined();
+            expect(tableAsAny.props.tableCompositeState.data).toEqual(DEFAULT_TABLE_DATA);
             expect(tableAsAny.isInitialLoad).toBe(true);
 
-            tableAsAny.props.tableCompositeState.data = DEFAULT_TABLE_DATA;
+            tableAsAny.props.tableCompositeState.data = {...DEFAULT_TABLE_DATA, allIds: ['trigger-change-in-default-table-data']};
             tableAsAny.componentDidUpdate();
 
             expect(tableAsAny.isInitialLoad).toBe(false);

--- a/src/components/tables/tests/Table.spec.tsx
+++ b/src/components/tables/tests/Table.spec.tsx
@@ -96,6 +96,34 @@ describe('<Table />', () => {
             expect(table.find(TableChildBlankSlate).length).toBe(1);
         });
 
+        it('should render a blankslate if no loading, empty table, isInError is true, and isInitialLoad is true', () => {
+            const tableAsAny: any = mountComponentWithProps({
+                ...tablePropsMock,
+                initialTableData: {...DEFAULT_TABLE_DATA, totalPages: 10, totalEntries: 1000},
+                tableCompositeState: {
+                    data: {byId: {'test': {}}, allIds: ['test'], displayedIds: [], totalEntries: 1, totalPages: 1},
+                    isLoading: false,
+                    isInError: true,
+                },
+            } as any);
+            tableAsAny.isInitialLoad = true;
+
+            expect(tableAsAny.find(TableChildBlankSlate).length).toBe(1);
+        });
+
+                it('should render a blankslate if no loading, empty table and isInitialLoad is false', () => {
+            const table: ReactWrapper<ITableProps, {}> = mountComponentWithProps({
+                ...tablePropsMock,
+                initialTableData: {...DEFAULT_TABLE_DATA, totalPages: 10, totalEntries: 1000},
+                tableCompositeState: {
+                    data: {byId: {'test': {}}, allIds: ['test'], displayedIds: [], totalEntries: 1, totalPages: 1},
+                    isLoading: false,
+                },
+            } as any);
+
+            expect(table.find(TableChildBlankSlate).length).toBe(1);
+        });
+
         it('should render with the wrapper fixed-header-table-container if the props withFixedHeader is true', () => {
             const table: ReactWrapper<ITableProps, {}> = mountComponentWithProps({
                 ...tablePropsMock,

--- a/src/components/tables/tests/Table.spec.tsx
+++ b/src/components/tables/tests/Table.spec.tsx
@@ -111,19 +111,6 @@ describe('<Table />', () => {
             expect(tableAsAny.find(TableChildBlankSlate).length).toBe(1);
         });
 
-        it('should render a blankslate if no loading, empty table and isInitialLoad is false', () => {
-            const table: ReactWrapper<ITableProps, {}> = mountComponentWithProps({
-                ...tablePropsMock,
-                initialTableData: {...DEFAULT_TABLE_DATA, totalPages: 10, totalEntries: 1000},
-                tableCompositeState: {
-                    data: {byId: {'test': {}}, allIds: ['test'], displayedIds: [], totalEntries: 1, totalPages: 1},
-                    isLoading: false,
-                },
-            } as any);
-
-            expect(table.find(TableChildBlankSlate).length).toBe(1);
-        });
-
         it('should render with the wrapper fixed-header-table-container if the props withFixedHeader is true', () => {
             const table: ReactWrapper<ITableProps, {}> = mountComponentWithProps({
                 ...tablePropsMock,

--- a/src/components/tables/tests/Table.spec.tsx
+++ b/src/components/tables/tests/Table.spec.tsx
@@ -96,7 +96,7 @@ describe('<Table />', () => {
             expect(table.find(TableChildBlankSlate).length).toBe(1);
         });
 
-        it('should render a blankslate if no loading, empty table, isInError is true, and isInitialLoad is true', () => {
+        it('should render a blankslate if no loading, empty table, isInError is true, and isInitialLoad is true (related issue: https://github.com/coveo/react-vapor/issues/621)', () => {
             const tableAsAny: any = mountComponentWithProps({
                 ...tablePropsMock,
                 initialTableData: {...DEFAULT_TABLE_DATA, totalPages: 10, totalEntries: 1000},
@@ -111,7 +111,7 @@ describe('<Table />', () => {
             expect(tableAsAny.find(TableChildBlankSlate).length).toBe(1);
         });
 
-                it('should render a blankslate if no loading, empty table and isInitialLoad is false', () => {
+        it('should render a blankslate if no loading, empty table and isInitialLoad is false', () => {
             const table: ReactWrapper<ITableProps, {}> = mountComponentWithProps({
                 ...tablePropsMock,
                 initialTableData: {...DEFAULT_TABLE_DATA, totalPages: 10, totalEntries: 1000},


### PR DESCRIPTION
![tableinitialload](https://user-images.githubusercontent.com/9539763/41431270-5ba13944-6fe0-11e8-92e6-821b331af6f1.gif)

As shown in the above gif, the initial load is currently not working properly. The blankslate pops up while the initial results are retrieved. The initial loading behavior should be displayed instead. This PR fixes the issue.    
  
also adressed the following issue:  https://github.com/coveo/react-vapor/issues/621