### PR TITLE
reduce build logs by changing karma reporter in travis

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,5 @@
 const webpackConfig = require('./webpack.config.test.js');
+const mainReporter = !!process.env.TRAVIS ? 'progress' : 'mocha';
 
 module.exports = (config) => {
     config.set({
@@ -20,7 +21,7 @@ module.exports = (config) => {
             noInfo: true,
         },
 
-        reporters: ['mocha', 'coverage'],
+        reporters: [mainReporter, 'coverage'],
 
         mochaReporter: {
             ignoreSkipped: true,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,5 @@
 const webpackConfig = require('./webpack.config.test.js');
-const mainReporter = !!process.env.TRAVIS ? 'progress' : 'mocha';
+const mainReporter = !!process.env.TRAVIS ? 'dots' : 'mocha';
 
 module.exports = (config) => {
     config.set({


### PR DESCRIPTION
i was tired of scrolling all the way down the build logs to get the demo link, this should help reduce the logs of the build. It will only print the failed UTs if any to the console, and the warnings.