### PR TITLE
No render on facets without rows

### DIFF
--- a/src/components/facets/Facet.tsx
+++ b/src/components/facets/Facet.tsx
@@ -85,20 +85,25 @@ export class Facet extends React.Component<IFacetProps, any> {
     }
 
     render() {
+        if (!this.props.facetRows.length && !this.props.selectedFacetRows.length) {
+            return null;
+        }
         const removeSelectedClass: string = 'facet-header-eraser' + (this.props.selectedFacetRows.length ? '' : ' hidden');
         const selected: IFacet[] = this.sortFacetRows(this.props.selectedFacetRows);
         const unselected: IFacet[] = this.sortFacetRows(this.props.facetRows);
         const allRows: IFacet[] = _.union(selected, unselected);
         const facetRows: IFacet[] = _.uniq(allRows, false, (item) => item.name);
         const rows: JSX.Element[] = _.map(facetRows, (facetRow: IFacet) => {
-            return (<FacetRow
-                key={facetRow.name}
-                facet={this.props.facet.name}
-                facetRow={facetRow}
-                onToggleFacet={this.buildFacet}
-                isChecked={_.contains(_.pluck(this.props.selectedFacetRows, 'name'), facetRow.name)}
-                maxTooltipLabelLength={this.props.maxTooltipLabelLength}
-            />);
+            return (
+                <FacetRow
+                    key={facetRow.name}
+                    facet={this.props.facet.name}
+                    facetRow={facetRow}
+                    onToggleFacet={this.buildFacet}
+                    isChecked={_.contains(_.pluck(this.props.selectedFacetRows, 'name'), facetRow.name)}
+                    maxTooltipLabelLength={this.props.maxTooltipLabelLength}
+                />
+            );
         });
         const rowsToShow: number = Math.max(this.props.selectedFacetRows.length, this.props.maxRowsToShow);
         // If there is only 1 extra row, show it instead of the moreRowsToggle

--- a/src/components/facets/Facet.tsx
+++ b/src/components/facets/Facet.tsx
@@ -93,18 +93,16 @@ export class Facet extends React.Component<IFacetProps, any> {
         const unselected: IFacet[] = this.sortFacetRows(this.props.facetRows);
         const allRows: IFacet[] = _.union(selected, unselected);
         const facetRows: IFacet[] = _.uniq(allRows, false, (item) => item.name);
-        const rows: JSX.Element[] = _.map(facetRows, (facetRow: IFacet) => {
-            return (
-                <FacetRow
-                    key={facetRow.name}
-                    facet={this.props.facet.name}
-                    facetRow={facetRow}
-                    onToggleFacet={this.buildFacet}
-                    isChecked={_.contains(_.pluck(this.props.selectedFacetRows, 'name'), facetRow.name)}
-                    maxTooltipLabelLength={this.props.maxTooltipLabelLength}
-                />
-            );
-        });
+        const rows: JSX.Element[] = _.map(facetRows, (facetRow: IFacet) => (
+            <FacetRow
+                key={facetRow.name}
+                facet={this.props.facet.name}
+                facetRow={facetRow}
+                onToggleFacet={this.buildFacet}
+                isChecked={_.contains(_.pluck(this.props.selectedFacetRows, 'name'), facetRow.name)}
+                maxTooltipLabelLength={this.props.maxTooltipLabelLength}
+            />
+        ));
         const rowsToShow: number = Math.max(this.props.selectedFacetRows.length, this.props.maxRowsToShow);
         // If there is only 1 extra row, show it instead of the moreRowsToggle
         const moreRowsToggle: JSX.Element = rows.length > rowsToShow + 1

--- a/src/components/facets/tests/Facet.spec.tsx
+++ b/src/components/facets/tests/Facet.spec.tsx
@@ -41,9 +41,7 @@ describe('Facets', () => {
                 maxRowsToShow,
             };
             facetComponent = mount(
-                <Facet
-                    {...facetBasicAttributes}
-                />,
+                <Facet {...facetBasicAttributes} />,
                 {attachTo: document.getElementById('App')},
             );
             facetInstance = facetComponent.instance() as Facet;
@@ -52,6 +50,15 @@ describe('Facets', () => {
         afterEach(() => {
             facetComponent.unmount();
             facetComponent.detach();
+        });
+
+        it('should not render anything when there are no rows to display', () => {
+            expect(facetComponent.html()).toBeNull();
+        });
+
+        it('should render som ehtml when there are rows to display', () => {
+            facetComponent.setProps({...facetBasicAttributes, facetRows: [{name: 'a', formattedName: 'b'}]});
+            expect(facetComponent.html()).not.toBeNull();
         });
 
         it('should call prop onRender on mounting if set', () => {
@@ -208,7 +215,7 @@ describe('Facets', () => {
 
         it('should have class "facet-open" if it has isOpened prop set to true', () => {
             const expectedClass = '.facet-opened';
-            const newFacetAttributes = _.extend({}, facetBasicAttributes, {isOpened: true});
+            const newFacetAttributes = _.extend({}, facetBasicAttributes, {isOpened: true, facetRows: [{name: 'a', formattedName: 'b'}]});
 
             expect(facetComponent.find(expectedClass).length).toBe(0);
 
@@ -216,6 +223,7 @@ describe('Facets', () => {
             facetComponent.mount();
             expect(facetComponent.find(expectedClass).length).toBe(1);
         });
+
 
         const callBuildCategoryFacet = () => {
             facetInstance['buildFacet'].call(facetInstance, {name: '1', formattedName: '1'});

--- a/src/components/facets/tests/Facet.spec.tsx
+++ b/src/components/facets/tests/Facet.spec.tsx
@@ -56,7 +56,7 @@ describe('Facets', () => {
             expect(facetComponent.html()).toBeNull();
         });
 
-        it('should render som ehtml when there are rows to display', () => {
+        it('should render some html when there are rows to display', () => {
             facetComponent.setProps({...facetBasicAttributes, facetRows: [{name: 'a', formattedName: 'b'}]});
             expect(facetComponent.html()).not.toBeNull();
         });

--- a/src/components/facets/tests/Facet.spec.tsx
+++ b/src/components/facets/tests/Facet.spec.tsx
@@ -224,7 +224,6 @@ describe('Facets', () => {
             expect(facetComponent.find(expectedClass).length).toBe(1);
         });
 
-
         const callBuildCategoryFacet = () => {
             facetInstance['buildFacet'].call(facetInstance, {name: '1', formattedName: '1'});
         };


### PR DESCRIPTION
This was previously done in the other repos, but the facets were not added to the state. By doing this here, we remove repetition and make sure everything is cleanly in the state.