### PR TITLE
Fix default to empty table data on table initial load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vapor",
-  "version": "2.19.7",
+  "version": "2.19.8",
   "description": "Vapor CSS components implemented with React!",
   "keywords": [
     "coveo",

--- a/src/components/tables/TableConstants.tsx
+++ b/src/components/tables/TableConstants.tsx
@@ -7,7 +7,7 @@ export enum TableSortingOrder {
 }
 
 export const DEFAULT_TABLE_PER_PAGE = 100000; // show any number of rows if per page is not present
-export const DEFAULT_TABLE_DATA: ITableData = Object.freeze({byId: {}, allIds: [], displayedIds: [], totalEntries: 0, totalPages: 0, selectedIds: []});
+export const DEFAULT_TABLE_DATA: ITableData = Object.freeze({byId: {}, allIds: [], displayedIds: [], totalEntries: 0, totalPages: 0, selectedIds: [], DEFAULT_TABLE_DATA: true});
 
 export const TABLE_PREDICATE_DEFAULT_VALUE = 'ALL';
 export const TOGGLE_ARROW_CELL_COUNT = 1;

--- a/src/components/tables/TableConstants.tsx
+++ b/src/components/tables/TableConstants.tsx
@@ -7,7 +7,7 @@ export enum TableSortingOrder {
 }
 
 export const DEFAULT_TABLE_PER_PAGE = 100000; // show any number of rows if per page is not present
-export const DEFAULT_TABLE_DATA: ITableData = Object.freeze({byId: {}, allIds: [], displayedIds: [], totalEntries: 0, totalPages: 0, selectedIds: [], DEFAULT_TABLE_DATA: true});
+export const DEFAULT_TABLE_DATA: ITableData = Object.freeze({byId: {}, allIds: [], displayedIds: [], totalEntries: 0, totalPages: 0, selectedIds: [], IS_DEFAULT_TABLE_DATA: true});
 
 export const TABLE_PREDICATE_DEFAULT_VALUE = 'ALL';
 export const TOGGLE_ARROW_CELL_COUNT = 1;

--- a/src/components/tables/TableReducers.ts
+++ b/src/components/tables/TableReducers.ts
@@ -27,6 +27,11 @@ export interface ITableData {
     totalEntries: number;
     totalPages: number;
     selectedIds?: string[];
+    /**
+     * Only used by DEFAULT_TABLE_DATA object in TableConstants.tsx.
+     * Useful for differientiating it from empty table data during the table initial load logic
+     */
+    DEFAULT_TABLE_DATA?: boolean;
 }
 
 export interface ITablesState {

--- a/src/components/tables/TableReducers.ts
+++ b/src/components/tables/TableReducers.ts
@@ -31,7 +31,7 @@ export interface ITableData {
      * Only used by DEFAULT_TABLE_DATA object in TableConstants.tsx.
      * Useful for differientiating it from empty table data during the table initial load logic
      */
-    DEFAULT_TABLE_DATA?: boolean;
+    IS_DEFAULT_TABLE_DATA?: boolean;
 }
 
 export interface ITablesState {

--- a/src/components/tables/tests/Table.spec.tsx
+++ b/src/components/tables/tests/Table.spec.tsx
@@ -151,6 +151,19 @@ describe('<Table />', () => {
             expect(tableAsAny.isInitialLoad).toBe(false);
         });
 
+        it('should set isInitialLoad to false after tableCompositeState.data changes from DEFAULT_TABLE_DATA to new table data, even if new data is empty', () => {
+            const tableCompositeState = {...tablePropsMock.tableCompositeState, data: DEFAULT_TABLE_DATA};
+            const tableAsAny = new Table({...tablePropsMock, tableCompositeState}) as any;
+
+            expect(tableAsAny.props.tableCompositeState.data).toEqual(DEFAULT_TABLE_DATA);
+            expect(tableAsAny.isInitialLoad).toBe(true);
+
+            tableAsAny.props.tableCompositeState.data = _.omit(DEFAULT_TABLE_DATA, 'DEFAULT_TABLE_DATA');
+            tableAsAny.componentDidUpdate();
+
+            expect(tableAsAny.isInitialLoad).toBe(false);
+        });
+
         it('should not render a table wrapper if there are no displayed rows', () => {
             expect(mountComponentWithProps(tablePropsMock).find(TableChildBody).length).toBe(0);
         });

--- a/src/components/tables/tests/Table.spec.tsx
+++ b/src/components/tables/tests/Table.spec.tsx
@@ -1,6 +1,7 @@
 import {mount, ReactWrapper} from 'enzyme';
 import * as React from 'react';
 import {Provider, Store} from 'react-redux';
+import * as _ from 'underscore';
 import {IReactVaporState} from '../../../ReactVapor';
 import {clearState} from '../../../utils/ReduxUtils';
 import {TestUtils} from '../../../utils/TestUtils';

--- a/src/components/tables/tests/Table.spec.tsx
+++ b/src/components/tables/tests/Table.spec.tsx
@@ -159,7 +159,7 @@ describe('<Table />', () => {
             expect(tableAsAny.props.tableCompositeState.data).toEqual(DEFAULT_TABLE_DATA);
             expect(tableAsAny.isInitialLoad).toBe(true);
 
-            tableAsAny.props.tableCompositeState.data = _.omit(DEFAULT_TABLE_DATA, 'DEFAULT_TABLE_DATA');
+            tableAsAny.props.tableCompositeState.data = _.omit(DEFAULT_TABLE_DATA, 'IS_DEFAULT_TABLE_DATA');
             tableAsAny.componentDidUpdate();
 
             expect(tableAsAny.isInitialLoad).toBe(false);


### PR DESCRIPTION
since we now make a comparison with `JSON.stringify` to toggle  the initial load, an empty table data could be identical to DEFAULT_TABLE_DATA, and we need something to differentiate the two for the initial load to work properly.