### PR TITLE
add border by default for code editors

### DIFF
--- a/docs/Index.tsx
+++ b/docs/Index.tsx
@@ -72,7 +72,6 @@ import {MultiSelectExamples} from '../src/components/select/examples/MultiSelect
 import {SingleSelectExamples} from '../src/components/select/examples/SingleSelectExamples';
 import {SideNavigationExample} from '../src/components/sideNavigation/examples/SideNavigationExample';
 import {SideNavigationLoadingExample} from '../src/components/sideNavigation/examples/SideNavigationLoadingExample';
-import {SimpleDropdownSearchExamples} from '../src/components/simpleDropdownSearch/examples/SimpleDropdownSearchExamples';
 import {SliderExamples} from '../src/components/slider/examples/SliderExamples';
 import {SplitLayoutExamples} from '../src/components/splitlayout/examples/SplitLayoutExamples';
 import {StepProgressBarExamples} from '../src/components/stepProgressBar/examples/StepProgressBarExamples';
@@ -207,7 +206,6 @@ class App extends React.Component<any, any> {
                         {component: JSONEditorExamples, componentName: 'JSONEditorExamples'},
                         {component: CodeEditorExamples, componentName: 'CodeEditorExamples'},
                         {component: DropdownSearchExamples, componentName: 'DropdownSearchExamples'},
-                        {component: SimpleDropdownSearchExamples, componentName: 'SimpleDropdownSearchExamples'},
                     ].map((component) => <ExampleWrapper key={component.componentName} componentName={component.componentName} component={component.component} />)}
                 </div>
             </Provider>

--- a/src/components/editor/CodeEditor.tsx
+++ b/src/components/editor/CodeEditor.tsx
@@ -23,9 +23,14 @@ export interface ICodeEditorProps {
     errorMessage?: string;
     mode: any; // string or object ex.: {name: "javascript", json: true}
     extraKeywords?: string[];
+    className?: string;
 }
 
 export class CodeEditor extends React.Component<ICodeEditorProps> {
+    static defaultProps: Partial<ICodeEditorProps> = {
+        className: 'mod-border',
+    };
+
     static Options: CodeMirror.EditorConfiguration = {
         lineNumbers: true,
         foldGutter: true,
@@ -67,6 +72,7 @@ export class CodeEditor extends React.Component<ICodeEditorProps> {
                 value={this.props.value}
                 onChange={(editor, data, code: string) => this.handleChange(code)}
                 options={_.extend({}, CodeEditor.Options, {readOnly: this.props.readOnly, mode: this.props.mode})}
+                className={this.props.className}
             />
         );
     }

--- a/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/src/components/editor/tests/CodeEditor.spec.tsx
@@ -114,5 +114,9 @@ describe('CodeEditor', () => {
             expect(newList).not.toEqual(currentKeywords);
             expect(newList).toEqual(currentKeywords.concat(expectedNewKeywords));
         });
+
+        it('should have a border by default', () => {
+            expect(CodeEditor.defaultProps).toContain('mod-border');
+        });
     });
 });

--- a/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/src/components/editor/tests/CodeEditor.spec.tsx
@@ -116,7 +116,6 @@ describe('CodeEditor', () => {
         });
 
         it('should have a border by default', () => {
-            expect(CodeEditor.defaultProps.className).toBe('mod-border');
             expect(codeEditor.find(ReactCodeMirror.UnControlled).props().className).toBe('mod-border');
         });
     });

--- a/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/src/components/editor/tests/CodeEditor.spec.tsx
@@ -116,7 +116,8 @@ describe('CodeEditor', () => {
         });
 
         it('should have a border by default', () => {
-            expect(CodeEditor.defaultProps.className).toContain('mod-border');
+            expect(CodeEditor.defaultProps.className).toBe('mod-border');
+            expect(codeEditor.find(ReactCodeMirror.UnControlled).props().className).toBe('mod-border');
         });
     });
 });

--- a/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/src/components/editor/tests/CodeEditor.spec.tsx
@@ -116,7 +116,7 @@ describe('CodeEditor', () => {
         });
 
         it('should have a border by default', () => {
-            expect(CodeEditor.defaultProps).toContain('mod-border');
+            expect(CodeEditor.defaultProps.className).toContain('mod-border');
         });
     });
 });


### PR DESCRIPTION
requested by the UX team  
  
<img width="1424" alt="screen shot 2018-06-27 at 5 53 59 pm" src="https://user-images.githubusercontent.com/9539763/42001863-5cb0662c-7a33-11e8-88e4-6e743b98a096.png">
