### PR TITLE
Fix exclusion behavior and style on facets

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "classnames": "2.2.5",
     "codecov": "3.0.2",
     "codemirror": "5.38.0",
-    "coveo-styleguide": "3.2.0",
+    "coveo-styleguide": "3.2.3",
     "css-loader": "0.28.11",
     "del": "3.0.0",
     "dts-generator": "2.1.0",

--- a/src/components/facets/Facet.tsx
+++ b/src/components/facets/Facet.tsx
@@ -25,6 +25,7 @@ export interface IFacetOwnProps extends React.ClassAttributes<Facet> {
     clearFacetLabel?: string;
     maxRowsToShow?: number;
     maxTooltipLabelLength?: number;
+    excludeTooltipMessage?(facetsRowName: string): string;
 }
 
 export interface IFacetStateProps extends IReduxStatePossibleProps {
@@ -106,6 +107,7 @@ export class Facet extends React.Component<IFacetProps, any> {
                     isChecked={isSelected}
                     enableExclusions={this.props.enableExclusions}
                     maxTooltipLabelLength={this.props.maxTooltipLabelLength}
+                    excludeTooltipMessage={this.props.excludeTooltipMessage}
                 />
             );
         });

--- a/src/components/facets/FacetReducers.ts
+++ b/src/components/facets/FacetReducers.ts
@@ -47,10 +47,13 @@ const changeFacet = (state: IFacetState, action: (IReduxAction<IReduxActionsPayl
     }
 
     let selected = state.selected;
-    if (_.some(state.selected, (facetRow: IFacet) => facetRow.name === action.payload.facetRow.name && !action.payload.facetRow.exclude)) {
-        selected = _.reject(state.selected, (facetRow: IFacet) => {
-            return facetRow.name === action.payload.facetRow.name;
-        });
+    if (_.some(state.selected, (facetRow: IFacet) => facetRow.name === action.payload.facetRow.name)) {
+        const selectedIndex: number = _.findIndex(state.selected, {name: action.payload.facetRow.name});
+        if (!selected[selectedIndex].exclude && action.payload.facetRow.exclude) {
+            selected[selectedIndex] = {...selected[selectedIndex], exclude: true};
+        } else {
+            selected = _.reject(state.selected, (facetRow: IFacet, index: number) => index === selectedIndex);
+        }
     } else {
         selected = [
             action.payload.facetRow,

--- a/src/components/facets/FacetRow.tsx
+++ b/src/components/facets/FacetRow.tsx
@@ -12,7 +12,7 @@ export interface IFacetRowProps extends React.ClassAttributes<FacetRow> {
     isChecked: boolean;
     maxTooltipLabelLength?: number;
     enableExclusions?: boolean;
-    excludeTooltipMessage(facetsRowName: string): string;
+    excludeTooltipMessage?(facetsRowName: string): string;
 }
 
 export class FacetRow extends React.Component<IFacetRowProps, any> {

--- a/src/components/facets/FacetRow.tsx
+++ b/src/components/facets/FacetRow.tsx
@@ -12,6 +12,7 @@ export interface IFacetRowProps extends React.ClassAttributes<FacetRow> {
     isChecked: boolean;
     maxTooltipLabelLength?: number;
     enableExclusions?: boolean;
+    excludeTooltipMessage(facetsRowName: string): string;
 }
 
 export class FacetRow extends React.Component<IFacetRowProps, any> {
@@ -94,12 +95,18 @@ export class FacetRow extends React.Component<IFacetRowProps, any> {
                         onClick={this.stopEvent}
                         onChange={_.noop}
                     />
-                    <Tooltip className='exclude-button' title={`Exclude ${this.props.facetRow.formattedName} logs`}>
-                        <Svg svgName='exclude' className='icon' svgClass='fill-medium-grey' />
-                    </Tooltip>
+                    {this.getExcludeButton()}
                 </div>
             );
         }
+    }
+
+    private getExcludeButton(): JSX.Element {
+        return this.props.excludeTooltipMessage
+            ? <Tooltip className='exclude-button' title={this.props.excludeTooltipMessage(this.props.facetRow.formattedName)}>
+                <Svg svgName='exclude' className='icon' svgClass='fill-medium-grey' />
+            </Tooltip>
+            : <Svg svgName='exclude' className='exclude-button icon' svgClass='fill-medium-grey' />;
     }
 
     private stopEvent(event: React.MouseEvent<HTMLInputElement>): void {

--- a/src/components/facets/FacetRow.tsx
+++ b/src/components/facets/FacetRow.tsx
@@ -94,9 +94,9 @@ export class FacetRow extends React.Component<IFacetRowProps, any> {
                         onClick={this.stopEvent}
                         onChange={_.noop}
                     />
-                    <span className='center-align exclude-button' >
-                        <Svg svgName='clear' className='icon' svgClass='fill-medium-grey' />
-                    </span>
+                    <Tooltip className='exclude-button' title={`Exclude ${this.props.facetRow.formattedName} logs`}>
+                        <Svg svgName='exclude' className='icon' svgClass='fill-medium-grey' />
+                    </Tooltip>
                 </div>
             );
         }
@@ -108,7 +108,7 @@ export class FacetRow extends React.Component<IFacetRowProps, any> {
     }
 
     private toggleFacetToExclude(): void {
-        this.props.onToggleFacet({...this.props.facetRow, exclude: true});
+        this.props.onToggleFacet({...this.props.facetRow, exclude: !this.isExclude});
     }
 
     private toggleFacet(): void {

--- a/src/components/facets/tests/FacetReducers.spec.ts
+++ b/src/components/facets/tests/FacetReducers.spec.ts
@@ -198,7 +198,7 @@ describe('Facets', () => {
             expect(facetsState.filter((f) => f.facet !== action.payload.facet)[0].selected.length).toBe(selectedRows.length);
         });
 
-        it('should set selected property to an empty array the facet when the action is "EMPTY_FACET', () => {
+        it('should set the selected facet exclude property to true if it aleady selected to not exclude', () => {
             const selectedRows: IFacet[] = [{
                 name: 'row',
                 formattedName: 'Row',

--- a/src/components/facets/tests/FacetReducers.spec.ts
+++ b/src/components/facets/tests/FacetReducers.spec.ts
@@ -1,4 +1,5 @@
 import {IReduxAction} from '../../../utils/ReduxUtils';
+import {IFacet} from '../Facet';
 import {emptyAllFacets, FacetActions, IChangeFacetActionPayload, IFacetActionPayload} from '../FacetActions';
 import {facetInitialState, facetReducer, facetsInitialState, facetsReducer, IFacetState} from '../FacetReducers';
 
@@ -195,6 +196,38 @@ describe('Facets', () => {
             expect(facetsState.length).toBe(oldState.length);
             expect(facetsState.filter((f) => f.facet === action.payload.facet)[0].selected.length).toBe(0);
             expect(facetsState.filter((f) => f.facet !== action.payload.facet)[0].selected.length).toBe(selectedRows.length);
+        });
+
+        it('should set selected property to an empty array the facet when the action is "EMPTY_FACET', () => {
+            const selectedRows: IFacet[] = [{
+                name: 'row',
+                formattedName: 'Row',
+                exclude: false,
+            }];
+            const oldState: IFacetState[] = [
+                {
+                    facet: 'some-facet2',
+                    opened: true,
+                    selected: selectedRows,
+                }, {
+                    facet: 'some-facet1',
+                    opened: false,
+                    selected: [],
+                },
+            ];
+            const action: IReduxAction<IChangeFacetActionPayload> = {
+                type: FacetActions.changeFacet,
+                payload: {
+                    facet: 'some-facet2',
+                    facetRow: {
+                        ...selectedRows[0],
+                        exclude: true,
+                    },
+                },
+            };
+            const facetsState: IFacetState[] = facetsReducer(oldState, action);
+
+            expect(facetsState[0].selected[0].exclude).toBeTruthy();
         });
 
         it('should set selected property to an empty array in all facets when the action is "EMPTY_ALL_FACET', () => {

--- a/src/components/facets/tests/FacetRow.spec.tsx
+++ b/src/components/facets/tests/FacetRow.spec.tsx
@@ -203,6 +203,21 @@ describe('Facets', () => {
             it('should display two .text-exclude when exclude behavior is enabled and checkbox is checked as exclude', () => {
                 expect(facetRowExcludeView.find('.text-exclude').length).toBe(2);
             });
+
+            it('should display a <Tooltip /> if the excludeTooltipMessage is defined', () => {
+                const facetRow: IFacet = {
+                    name: 'something',
+                    formattedName: 'Something',
+                    count: '11',
+                };
+                const newProps: IFacetRowProps = {...FACET_ROW_PROPS, facetRow, excludeTooltipMessage: () => 'test exclude tooltip'};
+
+                expect(facetRowExcludeView.find('Tooltip').length).toBe(0);
+
+                facetRowExcludeView.setProps(newProps);
+
+                expect(facetRowExcludeView.find('Tooltip').length).toBe(1);
+            });
         });
     });
 });

--- a/src/components/select/examples/SingleSelectExamples.tsx
+++ b/src/components/select/examples/SingleSelectExamples.tsx
@@ -61,7 +61,6 @@ export class SingleSelectExamples extends React.Component<{}, ISingleSelectExamp
                         id={UUID.generate()}
                         items={this.state.first}
                         placeholder='Select something'
-                        onSelectOptionCallback={console.log}
                     />
                 </div>
                 <div className='form-group'>


### PR DESCRIPTION
Facets' rows style should respect these criteria:
- Icon like this https://thenounproject.com/search/?q=dont&i=10550.
- Show the icon en grey on hover the facet's row. Became blue on hover the button hit zone.
- Show a tooltip “Exclude [row_name] logs“ on hover the button hit zone.

When you click on exclude facet already exclude it should not be add again in state.