### PR TITLE
Make manual more flexible

### DIFF
--- a/src/components/tables/Table.tsx
+++ b/src/components/tables/Table.tsx
@@ -76,17 +76,16 @@ export interface ITableOwnProps extends React.ClassAttributes<Table>, ITableBody
     handleOnRowClick?: (actions: IActionOptions[], rowData: IData) => void;
     rowsMultiSelect?: boolean;
     /**
-     * A custom thunk action replacing the default table state modification occuring each time an action is 
+     * A custom thunk action replacing the default table state modification taking place each time an action is 
      * performed on the table (page change, per page change, filtering, predicate selection, etc).  
      * 
      * The manual prop (thunk action) is thus dispatched each time the onModifyData prop is called,
-     * where the specified parameters (tableOwnProps, shouldResetPage, tableCompositeState, and previousTableCompositeState) are provided as arguments.  
-     * 
-     * The thunk action passed to the manual prop can also be dispatched outside the table component with or without the specified parameters  
-     * (for example, if you want to refresh the table data periodically at a specific time interval).
+     * where the specified parameters (tableOwnProps, shouldResetPage, tableCompositeState, and previousTableCompositeState)
+     * are provided as arguments.
      * 
      * This prop can be particularly useful in cases where new data needs to be fetched from the server
-     * on each table action (page change, per page change, filtering, predicate selection, etc).
+     * on each table action (page change, per page change, filtering, predicate selection, etc),
+     * or if you need to refresh the table data periodically.
      */
     manual?: (
         tableOwnProps?: Partial<ITableOwnProps>,

--- a/src/components/tables/Table.tsx
+++ b/src/components/tables/Table.tsx
@@ -75,8 +75,21 @@ export interface ITableOwnProps extends React.ClassAttributes<Table>, ITableBody
     withFixedHeader?: boolean;
     handleOnRowClick?: (actions: IActionOptions[], rowData: IData) => void;
     rowsMultiSelect?: boolean;
+    /**
+     * A custom thunk action replacing the default table state modification occuring each time an action is 
+     * performed on the table (page change, per page change, filtering, predicate selection, etc).  
+     * 
+     * The manual prop (thunk action) is thus dispatched each time the onModifyData prop is called,
+     * where the specified parameters (tableOwnProps, shouldResetPage, tableCompositeState, and previousTableCompositeState) are provided as arguments.  
+     * 
+     * The thunk action passed to the manual prop can also be dispatched outside the table component with or without the specified parameters  
+     * (for example, if you want to refresh the table data periodically at a specific time interval).
+     * 
+     * This prop can be particularly useful in cases where new data needs to be fetched from the server
+     * on each table action (page change, per page change, filtering, predicate selection, etc).
+     */
     manual?: (
-        tableOwnProps: Partial<ITableOwnProps>,
+        tableOwnProps?: Partial<ITableOwnProps>,
         shouldResetPage?: boolean,
         tableCompositeState?: ITableCompositeState,
         previousTableCompositeState?: ITableCompositeState,

--- a/src/components/tables/Table.tsx
+++ b/src/components/tables/Table.tsx
@@ -76,10 +76,10 @@ export interface ITableOwnProps extends React.ClassAttributes<Table>, ITableBody
     handleOnRowClick?: (actions: IActionOptions[], rowData: IData) => void;
     rowsMultiSelect?: boolean;
     manual?: (
-        tableOwnProps: ITableOwnProps,
-        shouldResetPage: boolean,
-        tableCompositeState: ITableCompositeState,
-        previousTableCompositeState: ITableCompositeState,
+        tableOwnProps: Partial<ITableOwnProps>,
+        shouldResetPage?: boolean,
+        tableCompositeState?: ITableCompositeState,
+        previousTableCompositeState?: ITableCompositeState,
     ) => IThunkAction;
 }
 


### PR DESCRIPTION
this change emerged from a discussion with @pochretien   
  
The argument is that you do not necessarily need to pass all these arguments to the manual thunk action when you use it from outside the table. You probably don't need all these if you do a simple table refresh, in fact you probably just need to pass the table id.  I added a comment to explain the concept of the manual prop, but it might be overkill, let me know what you think.