### PR TITLE
Collapsible infobox style improvements

### DIFF
--- a/src/components/collapsible/CollapsibleInfoBox.tsx
+++ b/src/components/collapsible/CollapsibleInfoBox.tsx
@@ -16,12 +16,13 @@ export class CollapsibleInfoBox extends React.PureComponent<CollapsibleInfoBoxPr
         return (
             <CollapsibleConnected
                 id={this.props.id}
-                className={classNames(styles.roundedBorders, 'bg-white text-grey-9 p1')}
+                className={classNames(styles.container, 'text-grey-9')}
+                headerClasses='p1'
                 toggleIconClassName='fill-medium-blue'
                 headerContent={this.getHeader()}
                 expandedOnMount={this.props.expandedOnMount}
             >
-                <div className={classNames(styles.alignWithIcon, 'pt1 mr3')}>
+                <div className={classNames(styles.alignWithIcon, 'px1 pb1 mr3')}>
                     {this.props.children}
                 </div>
             </CollapsibleConnected>

--- a/src/components/collapsible/styles/CollapsibleInfoBox.scss
+++ b/src/components/collapsible/styles/CollapsibleInfoBox.scss
@@ -1,8 +1,14 @@
 @import '~coveo-styleguide/scss/common/palette.scss';
 @import '~coveo-styleguide/scss/variables.scss';
 
-.roundedBorders {
+$collapsible-timeout: 200ms;
+
+.container {
     border-radius: $collapsible-infobox-border-radius;
+    transition: background-color $collapsible-timeout ease-in-out;
+    &:hover {
+        background-color: $white;
+    }
 }
 
 .alignWithIcon {

--- a/src/components/collapsible/styles/CollapsibleInfoBox.scss.d.ts
+++ b/src/components/collapsible/styles/CollapsibleInfoBox.scss.d.ts
@@ -1,2 +1,2 @@
-export const roundedBorders: string;
+export const container: string;
 export const alignWithIcon: string;


### PR DESCRIPTION
Made style improvements to the `CollapsibleInfoBox` component following UX review.

- Enlarge the clickable zone by applying padding to the collapsible header instead of the whole container
- Background color is shown only on hover with a transition