### PR TITLE
Update collapsible info box style

### DIFF
--- a/src/components/collapsible/CollapsibleInfoBox.tsx
+++ b/src/components/collapsible/CollapsibleInfoBox.tsx
@@ -16,7 +16,7 @@ export class CollapsibleInfoBox extends React.PureComponent<CollapsibleInfoBoxPr
         return (
             <CollapsibleConnected
                 id={this.props.id}
-                className={classNames(styles.container, 'text-grey-9')}
+                className={classNames(styles.container, 'text-grey-9 mod-rounded-border-2')}
                 headerClasses='p1'
                 toggleIconClassName='fill-medium-blue'
                 headerContent={this.getHeader()}

--- a/src/components/collapsible/styles/CollapsibleInfoBox.scss
+++ b/src/components/collapsible/styles/CollapsibleInfoBox.scss
@@ -4,7 +4,6 @@
 $collapsible-timeout: 200ms;
 
 .container {
-    border-radius: $collapsible-infobox-border-radius;
     transition: background-color $collapsible-timeout ease-in-out;
     &:hover {
         background-color: $white;


### PR DESCRIPTION
I needed to publish a new patch version to get the new styles from coveo-styleguide, so while at it I updated the collapsible info box styles to use the new rounded border classes.