### PR TITLE
Doc link icon integrated to modal header

### DIFF
--- a/src/components/modal/ModalComposite.tsx
+++ b/src/components/modal/ModalComposite.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'underscore';
 import {IClassName} from '../../utils/ClassNameUtils';
-import {JSXRenderable} from '../../utils/JSXUtils';
 import {IReduxStatePossibleProps} from '../../utils/ReduxUtils';
 import {IModalProps, Modal} from './Modal';
 import {IModalBackdropProps, ModalBackdrop} from './ModalBackdrop';
@@ -13,11 +12,11 @@ import {IModalHeaderProps, ModalHeader} from './ModalHeader';
 import {ModalHeaderConnected} from './ModalHeaderConnected';
 
 export interface IModalCompositeOwnProps extends IModalProps, IModalHeaderProps, IModalFooterProps, IModalBackdropProps {
-    modalHeaderChildren?: JSXRenderable;
+    modalHeaderChildren?: React.ReactNode;
     modalHeaderClasses?: IClassName;
-    modalBodyChildren?: JSXRenderable;
+    modalBodyChildren?: React.ReactNode;
     modalBodyClasses?: IClassName;
-    modalFooterChildren?: JSXRenderable;
+    modalFooterChildren?: React.ReactNode;
     modalFooterClasses?: IClassName;
     isPrompt?: boolean;
 }
@@ -42,7 +41,7 @@ export class ModalComposite extends React.Component<IModalCompositeProps> {
         );
     }
 
-    private getModal(children: JSXRenderable) {
+    private getModal(children: React.ReactNode) {
         const basicProps: IModalProps = {
             id: this.props.id,
             classes: this.props.classes,
@@ -69,6 +68,7 @@ export class ModalComposite extends React.Component<IModalCompositeProps> {
             id: this.props.id,
             title: this.props.title,
             classes: this.props.modalHeaderClasses,
+            docLink: this.props.docLink,
         };
         const onCloseProp = this.props.onClose ? () => this.props.onClose() : undefined;
 

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -2,9 +2,9 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
 import {IClassName} from '../../utils/ClassNameUtils';
+import {TooltipPlacement} from '../../utils/TooltipUtils';
 import {Svg} from '../svg/Svg';
 import {Tooltip} from '../tooltip/Tooltip';
-import {TooltipPlacement} from '../../utils/TooltipUtils';
 
 export interface IModalHeaderOwnProps {
     id?: string;

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -3,11 +3,17 @@ import * as React from 'react';
 import * as _ from 'underscore';
 import {IClassName} from '../../utils/ClassNameUtils';
 import {Svg} from '../svg/Svg';
+import {Tooltip} from '../tooltip/Tooltip';
+import {TooltipPlacement} from '../../utils/TooltipUtils';
 
 export interface IModalHeaderOwnProps {
     id?: string;
     title: string;
     classes?: IClassName;
+    docLink?: {
+        url: string;
+        tooltip: string;
+    };
 }
 
 export interface IModalHeaderStateProps {
@@ -56,16 +62,11 @@ export class ModalHeader extends React.Component<IModalHeaderProps, {}> {
 
         return (
             <header className={classes}>
-                {
-                    !!this.props.children
-                        ? (
-                            <div>
-                                {this.getTitle()}
-                                {this.props.children}
-                            </div>
-                        )
-                        : this.getTitle()
-                }
+                <div>
+                    {this.getTitle()}
+                    {this.getDocLink()}
+                    {this.props.children}
+                </div>
                 {closeComponent}
             </header>
         );
@@ -73,8 +74,27 @@ export class ModalHeader extends React.Component<IModalHeaderProps, {}> {
 
     private getTitle(): JSX.Element {
         const titleClass: string = classNames({
-            inline: !!this.props.children,
+            inline: !!this.props.children || !!this.props.docLink,
         });
         return <h1 className={titleClass}>{this.props.title}</h1>;
+    }
+
+    private getDocLink(): JSX.Element {
+        return this.props.docLink
+            ? (
+                <Tooltip
+                    title={this.props.docLink.tooltip}
+                    placement={TooltipPlacement.Bottom}
+                >
+                    <a
+                        href={this.props.docLink.url}
+                        target='_blank'
+                        className='inline-doc-link ml1'
+                    >
+                        <Svg svgName='help' className='mod-lg icon fill-orange' />
+                    </a>
+                </Tooltip>
+            )
+            : null;
     }
 }

--- a/src/components/modal/examples/ModalCompositeConnectedExamples.tsx
+++ b/src/components/modal/examples/ModalCompositeConnectedExamples.tsx
@@ -44,6 +44,7 @@ export class ModalCompositeConnectedExamples extends React.Component<IModalExamp
                             modalBodyChildren='The content of the modal'
                             modalFooterChildren={<button className='btn' onClick={() => this.closeModal(modalId)}>Close</button>}
                             modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
+                            docLink={{url: 'https://www.coveo.com', tooltip: 'Go to coveo.com'}}
                         />
                     </div>
                 </div>

--- a/src/components/modal/tests/ModalHeader.spec.tsx
+++ b/src/components/modal/tests/ModalHeader.spec.tsx
@@ -1,6 +1,8 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
+import {Svg} from '../../svg/Svg';
+import {Tooltip} from '../../tooltip/Tooltip';
 import {IModalHeaderProps, ModalHeader} from '../ModalHeader';
 
 describe('ModalHeader', () => {
@@ -97,12 +99,18 @@ describe('ModalHeader', () => {
             expect(modal.find('h1').hasClass(expectedClass)).toBe(true);
         });
 
-        it('should have a div wrapper arround the title only if there are children', () => {
-            expect(modal.find('h1').parent().type()).not.toBe('div');
+        it('should not have a tooltip, anchor, and svg for doclink by default', () => {
+            expect(modal.find(Tooltip).length).toBe(0);
+        });
 
-            setChildren();
+        it('should have a tooltip, anchor, and svg for doclink if the prop is passed', () => {
+            const docLink = {url: 'testomax', tooltip: 'doclinktooltip'};
+            modal.setProps({docLink});
 
-            expect(modal.find('h1').parent().type()).toBe('div');
+            expect(modal.find(Tooltip).length).toBe(1);
+            expect(modal.find(Tooltip).prop('title')).toBe(docLink.tooltip);
+            expect(modal.find(Tooltip).find('a').prop('href')).toBe(docLink.url);
+            expect(modal.find(Tooltip).find('a').find(Svg).prop('svgName')).toBe('help');
         });
     });
 });


### PR DESCRIPTION
add prop to standardize the way doc link is rendered across all modal composite and modal header usage  
  
<img width="959" alt="screen shot 2018-08-24 at 2 17 45 pm" src="https://user-images.githubusercontent.com/9539763/44600826-830fdf80-a7a8-11e8-851d-a69456b5464f.png">
