### PR TITLE
Side-Navigation broken

### DIFF
--- a/src/components/sideNavigation/SideNavigation.tsx
+++ b/src/components/sideNavigation/SideNavigation.tsx
@@ -1,7 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import {JSXRenderable} from '../../utils/JSXUtils';
-import { IReduxStatePossibleProps } from '../../utils/ReduxUtils';
+import {IReduxStatePossibleProps} from '../../utils/ReduxUtils';
 
 export interface ISideNavProps extends IReduxStatePossibleProps {
     className?: string;
@@ -10,7 +10,7 @@ export interface ISideNavProps extends IReduxStatePossibleProps {
 }
 
 export const SideNavigation = (props: ISideNavProps) =>
-    <nav className={classNames(props.className, 'navigation', { 'navigation-opened': props.withReduxState ? props.opened : true })}>
+    <nav className={classNames(props.className, 'navigation', {'navigation-opened': props.withReduxState ? props.opened : true})}>
         <div className='navigation-menu'>
             <div className='navigation-menu-sections'>
                 {props.children}

--- a/src/components/sideNavigation/SideNavigation.tsx
+++ b/src/components/sideNavigation/SideNavigation.tsx
@@ -1,14 +1,16 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import {JSXRenderable} from '../../utils/JSXUtils';
+import { IReduxStatePossibleProps } from '../../utils/ReduxUtils';
 
-export interface ISideNavProps {
+export interface ISideNavProps extends IReduxStatePossibleProps {
     className?: string;
     children?: JSXRenderable;
+    opened?: boolean;
 }
 
 export const SideNavigation = (props: ISideNavProps) =>
-    <nav className={classNames(props.className, 'navigation')}>
+    <nav className={classNames(props.className, 'navigation', { 'navigation-opened': props.withReduxState ? props.opened : true })}>
         <div className='navigation-menu'>
             <div className='navigation-menu-sections'>
                 {props.children}

--- a/src/components/sideNavigation/tests/SideNavigation.spec.tsx
+++ b/src/components/sideNavigation/tests/SideNavigation.spec.tsx
@@ -32,4 +32,24 @@ describe('<SideNavigation />', () => {
         wrapper.mount();
         expect(container.hasClass(className)).toBe(true);
     });
+
+    it('should not have class navigation-opened if opened prop is true and withReduxState prop is false.', () => {
+        const container = wrapper.find('nav').first();
+        expect(container.hasClass('navigation-opened')).toBe(true);
+
+        wrapper.setProps({opened: true});
+        wrapper.mount();
+        expect(container.hasClass('navigation-opened')).toBe(true);
+    });
+
+    it('should have class navigation-opened if opened prop is true and withReduxState prop is true.', () => {
+        const container = wrapper.find('nav').first();
+        wrapper.setProps({opened: false, withReduxState: true});
+        wrapper.mount();
+        expect(container.hasClass('navigation-opened')).toBe(false);
+
+        wrapper.setProps({opened: true, withReduxState: true});
+        wrapper.mount();
+        expect(container.hasClass('navigation-opened')).toBe(true);
+    });
 });


### PR DESCRIPTION
New class `navigation-opened` was added to vapor, which means that the side-navigation in Dynamics is hidden by default.

- I added a property to control its state (`opened`)
- and used the `withReduxState` to control it and have it opened by default (not sure this is the best idea though)