### PR TITLE
Allow to specify table header classes

### DIFF
--- a/src/components/tables/Table.tsx
+++ b/src/components/tables/Table.tsx
@@ -1,7 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
-import {IAdditionalClass} from '../../utils/ClassNameUtils';
+import {IAdditionalClass, IClassName} from '../../utils/ClassNameUtils';
 import {IThunkAction} from '../../utils/ReduxUtils';
 import {IActionOptions} from '../actions/Action';
 import {IActionBarProps} from '../actions/ActionBar';
@@ -48,6 +48,7 @@ export interface ITableHeadingAttribute {
     attributeFormatter?: IAttributeFormatter;
     onClickCell?: (event?: any, data?: any) => void;
     additionalCellClasses?: IAdditionalClass[];
+    headerClasses?: IClassName;
 }
 
 export interface ITablePredicate {
@@ -59,9 +60,10 @@ export interface ITablePredicate {
 export interface ITableOwnProps extends React.ClassAttributes<Table>, ITableBodyInheritedFromTableProps {
     id: string;
     blankSlateDefault: IBlankSlateProps;
-    tableContainerClasses?: string[];
-    tableClasses?: string[];
-    tableBodyClasses?: string[];
+    tableContainerClasses?: IClassName;
+    tableClasses?: IClassName;
+    tableBodyClasses?: IClassName;
+    tableHeaderClasses?: IClassName;
     initialTableData?: ITableData;
     actionBar?: true | IActionBarProps;
     blankSlateNoResultsOnAction?: IBlankSlateProps;

--- a/src/components/tables/TableHeader.tsx
+++ b/src/components/tables/TableHeader.tsx
@@ -1,12 +1,14 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
+import {IClassName} from '../../utils/ClassNameUtils';
 import {IReduxStatePossibleProps} from '../../utils/ReduxUtils';
 import {ITableHeaderCellProps, TableHeaderCell} from './TableHeaderCell';
 import {TableHeaderCellConnected} from './TableHeaderCellConnected';
 
 export interface ITableHeaderProps extends React.ClassAttributes<TableHeader>, IReduxStatePossibleProps {
     columns: ITableHeaderCellProps[];
-    headerClass?: string;
+    headerClass?: IClassName;
 }
 
 export class TableHeader extends React.Component<ITableHeaderProps, any> {
@@ -25,7 +27,7 @@ export class TableHeader extends React.Component<ITableHeaderProps, any> {
         });
 
         return (
-            <thead className={this.props.headerClass}>
+            <thead className={classNames(this.props.headerClass)}>
                 <tr>{columns}</tr>
             </thead>
         );

--- a/src/components/tables/TableHeaderCell.tsx
+++ b/src/components/tables/TableHeaderCell.tsx
@@ -1,6 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
+import {IClassName} from '../../utils/ClassNameUtils';
 import {Svg} from '../svg/Svg';
 import {TableSortingOrder} from './TableConstants';
 
@@ -9,7 +10,7 @@ export interface ITableHeaderCellOwnProps extends React.ClassAttributes<TableHea
     id?: string;
     attributeToSort?: string;
     tableId?: string;
-    className?: string;
+    className?: IClassName;
     withFixedHeader?: boolean;
     onClickCallback?: (e: React.MouseEvent<HTMLTableHeaderCellElement>) => void;
 }

--- a/src/components/tables/table-children/TableChildHeader.tsx
+++ b/src/components/tables/table-children/TableChildHeader.tsx
@@ -19,7 +19,8 @@ export const TableChildHeader = (props: ITableProps): JSX.Element => {
         return {id, title, className, withFixedHeader: props.withFixedHeader, ...tableSortInformation} as ITableHeaderCellOwnProps;
     });
 
-    const headerClass = classNames(props.tableHeaderClasses,
+    const headerClass = classNames(
+        props.tableHeaderClasses,
         'mod-no-border-top',
         {'mod-deactivate-pointer': !!props.tableCompositeState.isLoading},
     );

--- a/src/components/tables/table-children/TableChildHeader.tsx
+++ b/src/components/tables/table-children/TableChildHeader.tsx
@@ -11,14 +11,15 @@ export const TableChildHeader = (props: ITableProps): JSX.Element => {
     const tableHeaderCells: ITableHeaderCellOwnProps[] = props.headingAttributes.map((headingAttribute: ITableHeadingAttribute) => {
         const id = `${getTableChildComponentId(props.id, TableChildComponent.TABLE_HEADER_CELL)}${headingAttribute.attributeName}`;
         const title: React.ReactNode = (headingAttribute.titleFormatter as (args: string) => JSXRenderable)(headingAttribute.attributeName);
+        const className = headingAttribute.headerClasses;
         const tableSortInformation = !!headingAttribute.sort
             ? {tableId: props.id, attributeToSort: headingAttribute.attributeName}
             : {};
 
-        return {id, title, withFixedHeader: props.withFixedHeader, ...tableSortInformation};
+        return {id, title, className, withFixedHeader: props.withFixedHeader, ...tableSortInformation} as ITableHeaderCellOwnProps;
     });
 
-    const headerClass = classNames(
+    const headerClass = classNames(props.tableHeaderClasses,
         'mod-no-border-top',
         {'mod-deactivate-pointer': !!props.tableCompositeState.isLoading},
     );

--- a/src/components/tables/tests/TableChildHeader.spec.tsx
+++ b/src/components/tables/tests/TableChildHeader.spec.tsx
@@ -38,6 +38,12 @@ describe('<TableChildHeader />', () => {
             }).not.toThrow();
         });
 
+        it('should have as many non-connected header cells as there are headerAttribute', () => {
+            const tableHeader = mountComponentWithProps(tablePropsMock).find(TableHeader);
+
+            expect(tableHeader.find(TableHeaderCell).length).toBe(tablePropsMock.headingAttributes.length);
+        });
+
         it('should render with a mod-no-border-top and no mod-deactivate-pointer class by default', () => {
             const tableHeader = mountComponentWithProps(tablePropsMock).find(TableHeader);
 
@@ -51,6 +57,23 @@ describe('<TableChildHeader />', () => {
 
             expect(tableHeader.props().headerClass).toContain('mod-no-border-top');
             expect(tableHeader.props().headerClass).toContain('mod-deactivate-pointer');
+        });
+
+        it('should render with class name if defined', () => {
+            const newClassToAdd = 'wow';
+            const tableHeader = mountComponentWithProps({...tablePropsMock, tableHeaderClasses: [newClassToAdd]}).find(TableHeader);
+
+            expect(tableHeader.props().headerClass).toContain(newClassToAdd);
+        });
+
+        it('should have class on header when defined in the attributes', () => {
+            const newClassToAdd = 'wow';
+            const headerAttributesWithHeaderClasses = tablePropsMock.headingAttributes.map((attribute) => ({...attribute, headerClasses: [newClassToAdd]}));
+            const tableHeader = mountComponentWithProps({...tablePropsMock, headingAttributes: headerAttributesWithHeaderClasses}).find(TableHeader);
+
+            tableHeader.find(TableHeaderCell).forEach((headerCell) => {
+                expect(headerCell.props().className).toContain(newClassToAdd);
+            });
         });
 
         it('should have no connected header cells if no headerAttribute has sort', () => {


### PR DESCRIPTION
There was no way to add classes to specify attributes in the **header cells** like it is possible to do with row cells, so here it is.

Plus, added a way to specify a class directly on the **thead** too.