### PR TITLE
Moves onclick handler

### DIFF
--- a/src/components/sideNavigation/SideNavigationHeader.tsx
+++ b/src/components/sideNavigation/SideNavigationHeader.tsx
@@ -6,16 +6,23 @@ export interface ISideNavigationHeaderProps {
     title: string;
     svgName?: string;
     svgClass?: string;
+    onClick?: () => void;
 }
 
 export class SideNavigationHeader extends React.Component<ISideNavigationHeaderProps> {
+    private handleClick() {
+        if (this.props.onClick) {
+            this.props.onClick();
+        }
+    }
+
     render() {
         const svgClass = classNames('navigation-menu-section-header-icon icon mod-lg', this.props.svgClass);
         const icon = this.props.svgName
             ? <Svg svgName={this.props.svgName} svgClass={svgClass} />
             : <span className='navigation-menu-section-header-icon' />;
         return (
-            <div className='navigation-menu-section-header text-white'>
+            <div className='navigation-menu-section-header text-white' onClick={() => this.handleClick()}>
                 {icon}
                 {this.props.title}
                 {this.props.children}

--- a/src/components/sideNavigation/SideNavigationMenuSection.tsx
+++ b/src/components/sideNavigation/SideNavigationMenuSection.tsx
@@ -30,7 +30,7 @@ export class SideNavigationMenuSection extends React.Component<ISideNavigationSe
 
     render() {
         return (
-            <div className='block navigation-menu-section' onClick={() => this.handleClick()}>
+            <div className='block navigation-menu-section'>
                 {this.buildHeader()}
                 <SlideY in={!(this.props.expandable && !this.props.expanded)} timeout={350}>
                     <div className='navigation-menu-section-items'>
@@ -50,7 +50,7 @@ export class SideNavigationMenuSection extends React.Component<ISideNavigationSe
                     : <Svg svgName='arrow-bottom-rounded' className={arrowClassName} />;
             }
             return (
-                <SideNavigationHeader {...this.props.header}>
+                <SideNavigationHeader {...this.props.header} onClick={() => this.handleClick()}>
                     {arrow}
                 </SideNavigationHeader>
             );

--- a/src/components/sideNavigation/examples/SideNavigationExample.tsx
+++ b/src/components/sideNavigation/examples/SideNavigationExample.tsx
@@ -35,7 +35,7 @@ export class SideNavigationExample extends React.Component<any, any> {
                             <SideNavigationLoadingItem className='mod-width-40' />
                         </SideNavigationMenuSection>
                         <SideNavigationMenuSection header={{title: 'Section 3', svgName: 'menu-content'}} expandable expanded={this.state.expanded} onClick={() => this.click()}>
-                            <SideNavigationItem href='http://coveo.com' title='Link to Coveo' />
+                            <SideNavigationItem href='http://coveo.com' target='_blank' title='Link to Coveo' />
                             <SideNavigationItem href='http://coveo.com' title='Another link to Coveo' />
                         </SideNavigationMenuSection>
                     </SideNavigation>

--- a/src/components/sideNavigation/tests/SideNavigationMenuSection.spec.tsx
+++ b/src/components/sideNavigation/tests/SideNavigationMenuSection.spec.tsx
@@ -60,11 +60,11 @@ describe('<SideNavigationMenuSection />', () => {
         expect(wrapper.find(SlideY).prop('in')).toBeDefined(true);
     });
 
-    it('should call onClick prop when clicked and onClick prop is specified', () => {
+    it('should call onClick prop when header clicked and onClick prop is specified', () => {
         const onClickSpy = jasmine.createSpy('click');
         wrapper.setProps({header: {title}, onClick: onClickSpy});
         wrapper.mount();
-        wrapper.find('div').first().simulate('click');
+        wrapper.find(SideNavigationHeader).first().simulate('click');
 
         expect(onClickSpy).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
A side navigation item with target "_blank" would collapse the menu section.
Fixed it by moving the onclick handler on the section header.