### PR TITLE
Fix INavigationChildrenProps's onPerPageClick

### DIFF
--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -21,7 +21,7 @@ export interface INavigationChildrenProps {
     onPageClick?: (pageNb: number) => void;
     perPageLabel?: string;
     perPageNumbers?: number[];
-    onPerPageClick?: () => void;
+    onPerPageClick?: (newPerPage: number, currentPerPage: number, currentPage: number) => void;
     hidePages?: boolean;
     currentPerPage?: number;
     currentPage?: number;

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -21,7 +21,7 @@ export interface INavigationChildrenProps {
     onPageClick?: (pageNb: number) => void;
     perPageLabel?: string;
     perPageNumbers?: number[];
-    onPerPageClick?: (newPerPage: number, currentPerPage: number, currentPage: number) => void;
+    onPerPageClick?: (newPerPage: number, currentPerPage?: number, currentPage?: number) => void;
     hidePages?: boolean;
     currentPerPage?: number;
     currentPage?: number;

--- a/src/components/navigation/examples/NavigationExamples.tsx
+++ b/src/components/navigation/examples/NavigationExamples.tsx
@@ -8,6 +8,8 @@ export class NavigationExamples extends React.Component<any, any> {
             totalPages: 10,
             totalEntries: 50,
             currentPerPage: 10,
+            onPageClick: (newPage) => alert('New page selected: ' + (newPage + 1)),
+            onPerPageClick: (newPerPage) => alert('New per page option selected: ' + newPerPage),
         };
         return (
             <div className='mt2'>

--- a/src/components/navigation/perPage/NavigationPerPage.tsx
+++ b/src/components/navigation/perPage/NavigationPerPage.tsx
@@ -21,7 +21,7 @@ export interface INavigationPerPageStateProps {
 export interface INavigationPerPageDispatchProps {
     onRender?: (perPageNb: number) => void;
     onDestroy?: () => void;
-    onPerPageClick?: (perPageNb: number, oldPerPageNb: number, currentPage: number) => void;
+    onPerPageClick?: (newPerPage: number, currentPerPage?: number, currentPage?: number) => void;
 }
 
 export interface INavigationPerPageProps extends INavigationPerPageOwnProps, INavigationPerPageStateProps,

--- a/src/components/navigation/tests/Navigation.spec.tsx
+++ b/src/components/navigation/tests/Navigation.spec.tsx
@@ -6,6 +6,7 @@ import {Loading} from '../../loading/Loading';
 import {INavigationProps, Navigation} from '../Navigation';
 import {NavigationPagination} from '../pagination/NavigationPagination';
 import {NavigationPerPage, PER_PAGE_NUMBERS} from '../perPage/NavigationPerPage';
+import {NavigationPerPageSelect} from '../perPage/NavigationPerPageSelect';
 
 describe(' navigation', () => {
     const basicNavigationProps: INavigationProps = {
@@ -81,6 +82,15 @@ describe(' navigation', () => {
 
             navigation.setProps(newNavigationProps).update();
             expect(navigation.find(NavigationPerPage).props().currentPerPage).toBe(expectedPerPage);
+        });
+
+        it('should call onPerPageClick prop with the correct values when it is set', () => {
+            const onPerPageClick = jasmine.createSpy('mockOnPerPageClick');
+            const perPageNumbers: number[] = [2, 3, 4];
+            const currentPerPage: number = 3;
+            const newNavigationProps: INavigationProps = _.extend({}, basicNavigationProps, {currentPerPage, perPageNumbers, onPerPageClick});
+            navigation.setProps(newNavigationProps).update().find(NavigationPerPageSelect).last().simulate('click');
+            expect(onPerPageClick).toHaveBeenCalledWith(4, 3, undefined); // newPerPage, currentPerPage, currentPage (currentPerPage and currentPage are undefined unless passed as props)
         });
     });
 });

--- a/src/components/navigation/tests/Navigation.spec.tsx
+++ b/src/components/navigation/tests/Navigation.spec.tsx
@@ -87,10 +87,12 @@ describe(' navigation', () => {
         it('should call onPerPageClick prop with the correct values when it is set', () => {
             const onPerPageClick = jasmine.createSpy('mockOnPerPageClick');
             const perPageNumbers: number[] = [2, 3, 4];
-            const currentPerPage: number = 3;
+            const currentPerPage: number = perPageNumbers[1];
+            const expectedPerPage: number = perPageNumbers[perPageNumbers.length - 1];
+
             const newNavigationProps: INavigationProps = _.extend({}, basicNavigationProps, {currentPerPage, perPageNumbers, onPerPageClick});
             navigation.setProps(newNavigationProps).update().find(NavigationPerPageSelect).last().simulate('click');
-            expect(onPerPageClick).toHaveBeenCalledWith(4, 3, undefined); // newPerPage, currentPerPage, currentPage (currentPerPage and currentPage are undefined unless passed as props)
+            expect(onPerPageClick).toHaveBeenCalledWith(expectedPerPage, currentPerPage, undefined); // newPerPage, currentPerPage, currentPage (currentPerPage and currentPage are undefined unless passed as props)
         });
     });
 });


### PR DESCRIPTION
Changes:
- Change to onPerPageClick definition in Navigation and NavigationPerPage interfaces
- Added test for proper arguments being used in onPerPageClick
- Alert the value of onPerPageClick and onPageClick in component examples

