### PR TITLE
+ Make sure list box items get updated when changing SelectConnected items prop

### DIFF
--- a/src/components/itemBox/ItemBox.tsx
+++ b/src/components/itemBox/ItemBox.tsx
@@ -1,5 +1,6 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
+
 import {Content, IContentProps} from '../content/Content';
 import {PartialStringMatch} from '../partial-string-match/PartialStringMatch';
 import {ITooltipProps, Tooltip} from '../tooltip/Tooltip';
@@ -20,7 +21,7 @@ export interface IItemBoxProps {
     onOptionClick?: (option: IItemBoxProps) => void;
 }
 
-export class ItemBox extends React.Component<IItemBoxProps, any> {
+export class ItemBox extends React.Component<IItemBoxProps> {
 
     static defaultProps: Partial<IItemBoxProps> = {
         tooltip: {
@@ -28,14 +29,15 @@ export class ItemBox extends React.Component<IItemBoxProps, any> {
         },
         highlight: '',
     };
-    private el: any;
 
-    componentDidUpdate(prevProps: IItemBoxProps, prevState: IItemBoxProps) {
+    private listItem: HTMLLIElement;
+
+    componentDidUpdate(prevProps: IItemBoxProps) {
         if (!prevProps.active && this.props.active) {
             // First parent is the span of the tooltip, second is the list
-            const container = this.el.offsetParent;
+            const container = this.listItem.offsetParent as HTMLElement;
             if (container) {
-                this.scrollIfNeeded(this.el, container);
+                this.scrollIfNeeded(this.listItem, container);
             }
         }
     }
@@ -74,7 +76,7 @@ export class ItemBox extends React.Component<IItemBoxProps, any> {
         return (
             <Tooltip {...this.props.tooltip}>
                 <li
-                    ref={(li) => this.el = li}
+                    ref={(li: HTMLLIElement) => this.listItem = li}
                     className={this.getClasses()}
                     onClick={() => this.handleOnOptionClick()}
                     data-value={this.props.value}>

--- a/src/components/listBox/ListBox.tsx
+++ b/src/components/listBox/ListBox.tsx
@@ -40,15 +40,11 @@ export class ListBox extends React.Component<IListBoxProps, {}> {
     };
 
     componentWillMount() {
-        if (this.props.onRender) {
-            this.props.onRender();
-        }
+        callIfDefined(this.props.onRender);
     }
 
     componentWillUnmount() {
-        if (this.props.onDestroy) {
-            this.props.onDestroy();
-        }
+        callIfDefined(this.props.onDestroy);
     }
 
     private getClasses(): string {

--- a/src/components/listBox/ListBoxActions.ts
+++ b/src/components/listBox/ListBoxActions.ts
@@ -20,6 +20,7 @@ export interface IListBoxPayload {
     items?: IItemBoxProps[];
     diff?: number;
     resetSelected?: boolean;
+    updateSelected?: boolean;
 }
 
 export const addListBox = (id: string, items: IItemBoxProps[]): IReduxAction<IListBoxPayload> => ({
@@ -57,7 +58,7 @@ export const clearListBoxOption = (id: string): IReduxAction<IListBoxPayload> =>
     payload: {id},
 });
 
-export const updateListBoxOption = (id: string, items: IItemBoxProps[], resetSelected: boolean = false): IReduxAction<IListBoxPayload> => ({
+export const updateListBoxOption = (id: string, items: IItemBoxProps[], resetSelected = false, updateSelected = false): IReduxAction<IListBoxPayload> => ({
     type: ListBoxActions.update,
-    payload: {id, items, resetSelected},
+    payload: {id, items, resetSelected, updateSelected},
 });

--- a/src/components/listBox/ListBoxConnected.tsx
+++ b/src/components/listBox/ListBoxConnected.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import {connect} from 'react-redux';
 import * as _ from 'underscore';
+
 import {IReactVaporState} from '../../ReactVapor';
-import {ReduxUtils} from '../../utils/ReduxUtils';
-import {IReduxAction} from '../../utils/ReduxUtils';
+import {IDispatch, ReduxUtils} from '../../utils/ReduxUtils';
 import {IItemBoxProps} from '../itemBox/ItemBox';
 import {IListBoxDispatchProps, IListBoxOwnProps, IListBoxProps, IListBoxStateProps, ListBox} from './ListBox';
-import {addListBox, IListBoxPayload, removeListBox, selectListBoxOption} from './ListBoxActions';
+import {addListBox, removeListBox, selectListBoxOption} from './ListBoxActions';
 import {IListBoxState} from './ListBoxReducers';
 
 const mapStateToProps = (state: IReactVaporState, ownProps: IListBoxOwnProps): IListBoxStateProps => {
@@ -19,10 +19,7 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IListBoxOwnProps): I
     };
 };
 
-const mapDispatchToProps = (
-    dispatch: (action: IReduxAction<IListBoxPayload>) => void,
-    ownProps: IListBoxOwnProps,
-): IListBoxDispatchProps => ({
+const mapDispatchToProps = (dispatch: IDispatch, ownProps: IListBoxOwnProps): IListBoxDispatchProps => ({
     onRender: () => dispatch(addListBox(ownProps.id, ownProps.items)),
     onDestroy: () => dispatch(removeListBox(ownProps.id)),
     onOptionClick: (option: IItemBoxProps) => dispatch(selectListBoxOption(ownProps.id, ownProps.multi, option.value)),

--- a/src/components/listBox/ListBoxReducers.ts
+++ b/src/components/listBox/ListBoxReducers.ts
@@ -63,10 +63,15 @@ export const listBoxReducer = (state: IListBoxState = listBoxInitialState, actio
             return {...state, active};
         case ListBoxActions.update:
             let selectedUpdated = [];
-            if (!action.payload.resetSelected) {
+            if (!action.payload.resetSelected && !action.payload.updateSelected) {
                 selectedUpdated = _.chain(action.payload.items)
                     .pluck('value')
                     .intersection(state.selected)
+                    .value();
+            } else if (!action.payload.resetSelected && action.payload.updateSelected) {
+                selectedUpdated = _.chain(action.payload.items)
+                    .where({selected: true})
+                    .pluck('value')
                     .value();
             }
             return {

--- a/src/components/listBox/tests/ListBoxReducers.spec.ts
+++ b/src/components/listBox/tests/ListBoxReducers.spec.ts
@@ -358,6 +358,15 @@ describe('ListBox', () => {
                 expect(newState.items).toBe(newItems);
                 expect(newState.selected).toEqual([]);
             });
+
+            it('should update items in the state and update the selected value when payload has updateSelected = true', () => {
+                const oldState: IListBoxState = {...listBoxInitialState, id, items: items, selected: [items[0].value]};
+                const newState: IListBoxState = listBoxReducer(oldState, updateListBoxOption(id, newItems, false, true));
+
+                expect(newState.id).toBe(id);
+                expect(newState.items).toBe(newItems);
+                expect(newState.selected).toEqual(['b']);
+            });
         });
 
         describe('CLEAR_ITEM_LIST_BOX', () => {

--- a/src/components/select/SelectConnected.tsx
+++ b/src/components/select/SelectConnected.tsx
@@ -2,13 +2,14 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as _ from 'underscore';
+
 import {IReactVaporState, IReduxActionsPayload} from '../../ReactVapor';
 import {mod} from '../../utils/DataStructuresUtils';
 import {keyCode} from '../../utils/InputUtils';
 import {IReduxAction, ReduxConnect} from '../../utils/ReduxUtils';
 import {Content} from '../content/Content';
 import {IItemBoxProps} from '../itemBox/ItemBox';
-import {selectListBoxOption, setActiveListBoxOption} from '../listBox/ListBoxActions';
+import {selectListBoxOption, setActiveListBoxOption, updateListBoxOption} from '../listBox/ListBoxActions';
 import {ListBoxConnected} from '../listBox/ListBoxConnected';
 import {IListBoxState} from '../listBox/ListBoxReducers';
 import {addSelect, removeSelect, toggleSelect} from './SelectActions';
@@ -39,6 +40,7 @@ export interface ISelectDispatchProps {
     onToggleDropdown?: () => void;
     onSelectValue?: (value: string, isMulti: boolean) => void;
     setActive?: (diff: number) => void;
+    onItemsHaveChanged?: (items: IItemBoxProps[]) => void;
 }
 
 export interface ISelectButtonProps {
@@ -72,6 +74,7 @@ const mapDispatchToProps = (
     onToggleDropdown: () => dispatch(toggleSelect(ownProps.id)),
     onSelectValue: (value: string, isMulti: boolean) => dispatch(selectListBoxOption(ownProps.id, isMulti, value)),
     setActive: (diff: number) => dispatch(setActiveListBoxOption(ownProps.id, diff)),
+    onItemsHaveChanged: (items: IItemBoxProps[]) => dispatch(updateListBoxOption(ownProps.id, items, false, true)),
 });
 
 @ReduxConnect(mapStateToProps, mapDispatchToProps)
@@ -88,6 +91,12 @@ export class SelectConnected extends React.Component<ISelectProps & ISelectSpeci
     componentWillUnmount() {
         document.removeEventListener('mousedown', this.handleDocumentClick);
         this.props.onDestroy();
+    }
+
+    componentWillReceiveProps(nextProps: ISelectProps) {
+        if (JSON.stringify(nextProps.items) !== JSON.stringify(this.props.items)) {
+            this.props.onItemsHaveChanged(nextProps.items);
+        }
     }
 
     componentWillUpdate(nextProps: ISelectProps): any {


### PR DESCRIPTION
I had many `SingleSelectConnected` components rendered by the `attributeFormatter` inside a `TableConnected`. Their `items` prop is changing to reflect the changes occuring in the table's state, but when the prop changes, it isn't actually updating the items of the `SingleSelectConnected`. 

The problem was that the `ListBoxConnected` used by the underlying `SelectConnected` component only updates its items if they change inside the redux store, but not when the `items` prop itself changes. 

To counter that, I dispatched an action to update the `ListBox` items in the store when the `SelectConnected`'s `items` prop changes. With that addition, my table now works flawlessly without any hassle.