### PR TITLE
Implement a fixed prepend for the SingleSelectedComponent's toggle button

### DIFF
--- a/src/components/select/SingleSelectConnected.tsx
+++ b/src/components/select/SingleSelectConnected.tsx
@@ -15,6 +15,7 @@ export interface ISingleSelectOwnProps extends ISelectProps {
     toggleClasses?: string;
     onSelectOptionCallback?: (option: string) => void;
     items?: IItemBoxProps[];
+    togglePrepend?: React.ReactNode;
 }
 
 export interface ISingleSelectStateProps {
@@ -76,6 +77,7 @@ export class SingleSelectConnected extends React.Component<ISingleSelectProps & 
                 onKeyUp={props.onKeyUp}
                 {..._.omit(this.props, singleSelectPropsToOmit)}
             >
+                {this.props.togglePrepend}
                 {option && option.prepend ? <Content {...option.prepend} /> : null}
                 {this.getSelectedOptionElement(option)}
                 {option && option.append ? <Content {...option.append} /> : null}

--- a/src/components/select/SingleSelectConnected.tsx
+++ b/src/components/select/SingleSelectConnected.tsx
@@ -15,7 +15,7 @@ export interface ISingleSelectOwnProps extends ISelectProps {
     toggleClasses?: string;
     onSelectOptionCallback?: (option: string) => void;
     items?: IItemBoxProps[];
-    togglePrepend?: React.ReactNode;
+    buttonPrepend?: React.ReactNode;
 }
 
 export interface ISingleSelectStateProps {
@@ -77,7 +77,7 @@ export class SingleSelectConnected extends React.Component<ISingleSelectProps & 
                 onKeyUp={props.onKeyUp}
                 {..._.omit(this.props, singleSelectPropsToOmit)}
             >
-                {this.props.togglePrepend}
+                {this.props.buttonPrepend}
                 {option && option.prepend ? <Content {...option.prepend} /> : null}
                 {this.getSelectedOptionElement(option)}
                 {option && option.append ? <Content {...option.append} /> : null}

--- a/src/components/select/examples/SingleSelectExamples.tsx
+++ b/src/components/select/examples/SingleSelectExamples.tsx
@@ -73,6 +73,15 @@ export class SingleSelectExamples extends React.Component<{}, ISingleSelectExamp
                     />
                 </div>
                 <div className='form-group'>
+                    <label className='form-control-label'>Single Select with prepended text</label>
+                    <br />
+                    <SingleSelectConnected
+                        id={UUID.generate()}
+                        items={this.state.hoc}
+                        disabled
+                    />
+                </div>
+                <div className='form-group'>
                     <label className='form-control-label'>A Single Select With Filter</label>
                     <br />
                     <SingleSelectWithFilter id={UUID.generate()} items={this.state.hoc} />

--- a/src/components/select/tests/SingleSelectConnected.spec.tsx
+++ b/src/components/select/tests/SingleSelectConnected.spec.tsx
@@ -125,6 +125,13 @@ describe('Select', () => {
             expect(select.find('.dropdown-toggle').is('[disabled]')).toBe(true);
         });
 
+        it('should contain the toggle prepend in the toggle (button) if defined', () => {
+            const expectedPrepend = <span>{'some prepended text'}</span>;
+            mountSingleSelect([], {togglePrepend: expectedPrepend});
+
+            expect(select.find('.dropdown-toggle').children().first().equals(expectedPrepend)).toBe(true);
+        });
+
         it('should contain the prepend and append in the button when selected', () => {
             const prepend = 'pre';
             const append = 'post';

--- a/src/components/select/tests/SingleSelectConnected.spec.tsx
+++ b/src/components/select/tests/SingleSelectConnected.spec.tsx
@@ -127,7 +127,7 @@ describe('Select', () => {
 
         it('should contain the toggle prepend in the toggle (button) if defined', () => {
             const expectedPrepend = <span>{'some prepended text'}</span>;
-            mountSingleSelect([], {togglePrepend: expectedPrepend});
+            mountSingleSelect([], {buttonPrepend: expectedPrepend});
 
             expect(select.find('.dropdown-toggle').children().first().equals(expectedPrepend)).toBe(true);
         });


### PR DESCRIPTION
I needed a way to prepend some text before the selected value of a SingleSelectedComponent, but I did not wanted this prepend to be shown on options in the dropdown.