### PR TITLE
Add automatic infinite scroll for DropdownSearch

### DIFF
--- a/src/components/dropdownSearch/DropdownSearch.tsx
+++ b/src/components/dropdownSearch/DropdownSearch.tsx
@@ -136,7 +136,8 @@ export class DropdownSearch extends React.Component<IDropdownSearchProps, {}> {
     }
 
     protected getDropdownOptions(): JSX.Element[] {
-        const ElementTag: string = this.props.infiniteScroll ? 'div' : 'li';
+        const hasInfiniteScrolling = !!this.props.infiniteScroll || !!this.props.internalInfiniteScroll;
+        const ElementTag: string = hasInfiniteScrolling ? 'div' : 'li';
         const options = _.chain(this.getDisplayedOptions())
             .filter((option: IDropdownOption) => {
                 const value = option.displayValue || option.value;

--- a/src/components/dropdownSearch/DropdownSearch.tsx
+++ b/src/components/dropdownSearch/DropdownSearch.tsx
@@ -10,8 +10,8 @@ import {Content} from '../content/Content';
 import {FilterBox} from '../filterBox/FilterBox';
 import {ISvgProps, Svg} from '../svg/Svg';
 import {ITooltipProps, Tooltip} from '../tooltip/Tooltip';
-import {DropdownSearchInfiniteScrollOptions} from './DropdownSearchInfiniteScrollOptions';
 import {DropdownSearchAutoInfiniteScroll, IDropdownSearchAutoInfiniteScrollOptions} from './DropdownSearchAutoInfiniteScroll';
+import {DropdownSearchInfiniteScrollOptions} from './DropdownSearchInfiniteScrollOptions';
 
 export interface IDropdownOption {
     svg?: ISvgProps;

--- a/src/components/dropdownSearch/DropdownSearch.tsx
+++ b/src/components/dropdownSearch/DropdownSearch.tsx
@@ -11,6 +11,7 @@ import {FilterBox} from '../filterBox/FilterBox';
 import {ISvgProps, Svg} from '../svg/Svg';
 import {ITooltipProps, Tooltip} from '../tooltip/Tooltip';
 import {DropdownSearchInfiniteScrollOptions} from './DropdownSearchInfiniteScrollOptions';
+import {DropdownSearchInternalInfiniteScroll, IDropdownSearchInternalInfiniteScrollOptions} from './DropdownSearchInternalInfiniteScroll';
 
 export interface IDropdownOption {
     svg?: ISvgProps;
@@ -59,6 +60,7 @@ export interface IDropdownSearchOwnProps {
     infiniteScroll?: InfiniteScrollProps;
     hasMoreItems?: () => boolean;
     customFiltering?: (filterText: string) => void;
+    internalInfiniteScroll?: IDropdownSearchInternalInfiniteScrollOptions;
 }
 
 export interface IDropdownSearchDispatchProps {
@@ -370,8 +372,20 @@ export class DropdownSearch extends React.Component<IDropdownSearchProps, {}> {
             return null;
         }
         const dropdownOptions: JSX.Element[] = this.getDropdownOptions();
-        return this.props.infiniteScroll
-            ? (
+
+        if (this.props.internalInfiniteScroll) {
+            return (
+                <DropdownSearchInternalInfiniteScroll
+                    {...this.props.internalInfiniteScroll}
+                    options={dropdownOptions}
+                    onMouseEnter={() => this.handleOnMouseEnter()}
+                    ulElementRefFunction={(menu: HTMLElement) => this.ulElement = menu}
+                />
+            );
+        }
+
+        if (this.props.infiniteScroll) {
+            return (
                 <DropdownSearchInfiniteScrollOptions
                     infiniteScroll={{
                         ...this.props.infiniteScroll,
@@ -382,14 +396,16 @@ export class DropdownSearch extends React.Component<IDropdownSearchProps, {}> {
                     ulElementRefFunction={(menu: HTMLElement) => this.ulElement = menu}
                     options={dropdownOptions}
                 />
-            )
-            : (
-                <ul className='dropdown-menu'
-                    ref={(menu: HTMLUListElement) => {this.ulElement = menu;}}
-                    onMouseEnter={() => this.handleOnMouseEnter()}>
-                    {dropdownOptions}
-                </ul>
             );
+        }
+
+        return (
+            <ul className='dropdown-menu'
+                ref={(menu: HTMLUListElement) => {this.ulElement = menu;}}
+                onMouseEnter={() => this.handleOnMouseEnter()}>
+                {dropdownOptions}
+            </ul>
+        );
     }
 
     private getSelectedOptionElement(): JSX.Element[] {

--- a/src/components/dropdownSearch/DropdownSearch.tsx
+++ b/src/components/dropdownSearch/DropdownSearch.tsx
@@ -11,7 +11,7 @@ import {FilterBox} from '../filterBox/FilterBox';
 import {ISvgProps, Svg} from '../svg/Svg';
 import {ITooltipProps, Tooltip} from '../tooltip/Tooltip';
 import {DropdownSearchInfiniteScrollOptions} from './DropdownSearchInfiniteScrollOptions';
-import {DropdownSearchInternalInfiniteScroll, IDropdownSearchInternalInfiniteScrollOptions} from './DropdownSearchInternalInfiniteScroll';
+import {DropdownSearchAutoInfiniteScroll, IDropdownSearchAutoInfiniteScrollOptions} from './DropdownSearchAutoInfiniteScroll';
 
 export interface IDropdownOption {
     svg?: ISvgProps;
@@ -60,7 +60,7 @@ export interface IDropdownSearchOwnProps {
     infiniteScroll?: InfiniteScrollProps;
     hasMoreItems?: () => boolean;
     customFiltering?: (filterText: string) => void;
-    internalInfiniteScroll?: IDropdownSearchInternalInfiniteScrollOptions;
+    autoInfiniteScroll?: IDropdownSearchAutoInfiniteScrollOptions;
 }
 
 export interface IDropdownSearchDispatchProps {
@@ -136,7 +136,7 @@ export class DropdownSearch extends React.Component<IDropdownSearchProps, {}> {
     }
 
     protected getDropdownOptions(): JSX.Element[] {
-        const hasInfiniteScrolling = !!this.props.infiniteScroll || !!this.props.internalInfiniteScroll;
+        const hasInfiniteScrolling = !!this.props.infiniteScroll || !!this.props.autoInfiniteScroll;
         const ElementTag: string = hasInfiniteScrolling ? 'div' : 'li';
         const options = _.chain(this.getDisplayedOptions())
             .filter((option: IDropdownOption) => {
@@ -374,10 +374,10 @@ export class DropdownSearch extends React.Component<IDropdownSearchProps, {}> {
         }
         const dropdownOptions: JSX.Element[] = this.getDropdownOptions();
 
-        if (this.props.internalInfiniteScroll) {
+        if (this.props.autoInfiniteScroll) {
             return (
-                <DropdownSearchInternalInfiniteScroll
-                    {...this.props.internalInfiniteScroll}
+                <DropdownSearchAutoInfiniteScroll
+                    {...this.props.autoInfiniteScroll}
                     options={dropdownOptions}
                     onMouseEnter={() => this.handleOnMouseEnter()}
                     ulElementRefFunction={(menu: HTMLElement) => this.ulElement = menu}

--- a/src/components/dropdownSearch/DropdownSearchAutoInfiniteScroll.tsx
+++ b/src/components/dropdownSearch/DropdownSearchAutoInfiniteScroll.tsx
@@ -3,32 +3,32 @@ import * as _ from 'underscore';
 
 import {DropdownSearchInfiniteScrollOptions} from './DropdownSearchInfiniteScrollOptions';
 
-export interface IDropdownSearchInternalInfiniteScrollOptions {
+export interface IDropdownSearchAutoInfiniteScrollOptions {
     optionsPerPage: number;
     endMessage?: React.ReactNode;
     loader?: React.ReactNode;
 }
 
-export interface IDropdownSearchInternalInfiniteScrollProps
-    extends IDropdownSearchInternalInfiniteScrollOptions {
+export interface IDropdownSearchAutoInfiniteScrollProps
+    extends IDropdownSearchAutoInfiniteScrollOptions {
     options: JSX.Element[];
     onMouseEnter: () => void;
     ulElementRefFunction: (menu: HTMLElement) => void;
 }
 
-interface IDropdownSearchInternalInfiniteScrollState {
+interface IDropdownSearchAutoInfiniteScrollState {
     activeOptions: JSX.Element[];
 }
 
-export class DropdownSearchInternalInfiniteScroll extends React.Component<IDropdownSearchInternalInfiniteScrollProps, IDropdownSearchInternalInfiniteScrollState> {
-    constructor(props: IDropdownSearchInternalInfiniteScrollProps, state: IDropdownSearchInternalInfiniteScrollState) {
+export class DropdownSearchAutoInfiniteScroll extends React.Component<IDropdownSearchAutoInfiniteScrollProps, IDropdownSearchAutoInfiniteScrollState> {
+    constructor(props: IDropdownSearchAutoInfiniteScrollProps, state: IDropdownSearchAutoInfiniteScrollState) {
         super(props, state);
         this.state = {
             activeOptions: props.options.slice(0, props.optionsPerPage),
         };
     }
 
-    componentWillUpdate(nextProps: IDropdownSearchInternalInfiniteScrollProps) {
+    componentWillUpdate(nextProps: IDropdownSearchAutoInfiniteScrollProps) {
         if (!_.isEqual(this.props.options, nextProps.options)) {
             this.setState({activeOptions: nextProps.options.slice(0, this.props.optionsPerPage)});
         }

--- a/src/components/dropdownSearch/DropdownSearchAutoInfiniteScroll.tsx
+++ b/src/components/dropdownSearch/DropdownSearchAutoInfiniteScroll.tsx
@@ -39,7 +39,6 @@ export class DropdownSearchAutoInfiniteScroll extends React.Component<IDropdownS
     }
 
     private get showEndMessage() {
-        // Don't show endMessage if infinite scrolling is unused
         if (this.props.endMessage && this.props.options.length > this.props.optionsPerPage) {
             return this.props.endMessage;
         }

--- a/src/components/dropdownSearch/DropdownSearchInternalInfiniteScroll.tsx
+++ b/src/components/dropdownSearch/DropdownSearchInternalInfiniteScroll.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import * as _ from 'underscore';
+
+import {DropdownSearchInfiniteScrollOptions} from './DropdownSearchInfiniteScrollOptions';
+
+export interface IDropdownSearchInternalInfiniteScrollOptions {
+    optionsPerPage: number;
+    endMessage?: React.ReactNode;
+    loader?: React.ReactNode;
+}
+
+export interface IDropdownSearchInternalInfiniteScrollProps
+    extends IDropdownSearchInternalInfiniteScrollOptions {
+    options: JSX.Element[];
+    onMouseEnter: () => void;
+    ulElementRefFunction: (menu: HTMLElement) => void;
+}
+
+interface IDropdownSearchInternalInfiniteScrollState {
+    activeOptions: JSX.Element[];
+}
+
+export class DropdownSearchInternalInfiniteScroll extends React.Component<IDropdownSearchInternalInfiniteScrollProps, IDropdownSearchInternalInfiniteScrollState> {
+    constructor(props: IDropdownSearchInternalInfiniteScrollProps, state: IDropdownSearchInternalInfiniteScrollState) {
+        super(props, state);
+        this.state = {
+            activeOptions: props.options.slice(0, props.optionsPerPage),
+        };
+    }
+
+    componentWillUpdate(nextProps: IDropdownSearchInternalInfiniteScrollProps) {
+        if (!_.isEqual(this.props.options, nextProps.options)) {
+            this.setState({activeOptions: nextProps.options.slice(0, this.props.optionsPerPage)});
+        }
+    }
+
+    private get hasMoreOptions() {
+        return this.state.activeOptions.length < this.props.options.length;
+    }
+
+    private get showEndMessage() {
+        // Don't show endMessage if infinite scrolling is unused
+        if (this.props.endMessage && this.props.options.length > this.props.optionsPerPage) {
+            return this.props.endMessage;
+        }
+
+        return null;
+    }
+
+    private next() {
+        const index = this.state.activeOptions.length;
+        const additionalOptions = this.props.options.slice(index, index + this.props.optionsPerPage);
+        this.setState({activeOptions: this.state.activeOptions.concat(additionalOptions)});
+    }
+
+    render() {
+        return (
+            <DropdownSearchInfiniteScrollOptions
+                infiniteScroll={{
+                    next: () => this.next(),
+                    dataLength: this.state.activeOptions.length,
+                    hasMore: this.hasMoreOptions,
+                    endMessage: this.showEndMessage,
+                    loader: this.props.loader || null,
+                }}
+                onMouseEnter={this.props.onMouseEnter}
+                ulElementRefFunction={this.props.ulElementRefFunction}
+                options={this.state.activeOptions}
+            />
+        );
+    }
+}

--- a/src/components/dropdownSearch/examples/DropdownSearchExamples.tsx
+++ b/src/components/dropdownSearch/examples/DropdownSearchExamples.tsx
@@ -78,21 +78,6 @@ export class DropdownSearchExamples extends React.Component<DropdownSearchExampl
         return (
             <div className='mt2'>
                 <h1 className='text-blue mb1 bold'>Dropdown List</h1>
-                {/* TODO: put at the end */}
-                <div className='form-group'>
-                    <label className='form-control-label'>Dropdown with an infinite scroll & filters on all options</label>
-                    <div className='form-control'>
-                        <DropdownSearchConnected
-                            {...manyOptions}
-                            autoInfiniteScroll={{
-                                optionsPerPage: 10,
-                                endMessage: <div className='option-wrapper'><span className='dropdown-option'>No more items to show</span></div>,
-                                loader: <div className='option-wrapper'><span className='dropdown-option'>Loading more items...</span></div>,
-                            }}
-                            id={this.ids[14]}
-                        />
-                    </div>
-                </div>
                 <div className='form-group'>
                     <label className='form-control-label'>Multiselect Dropdown</label>
                     <div className='form-control'>
@@ -201,6 +186,20 @@ export class DropdownSearchExamples extends React.Component<DropdownSearchExampl
                             }}
                             hasMoreItems={() => this.optionsPage < maxPage - 1} // Used to overwrite the hasMore prop for the infinite scroll
                             customFiltering={(filterText: string) => this.filter(filterText)}
+                        />
+                    </div>
+                </div>
+                <div className='form-group'>
+                    <label className='form-control-label'>Dropdown with an infinite scroll & filters on all options</label>
+                    <div className='form-control'>
+                        <DropdownSearchConnected
+                            {...manyOptions}
+                            autoInfiniteScroll={{
+                                optionsPerPage: 10,
+                                endMessage: <div className='option-wrapper'><span className='dropdown-option'>No more items to show</span></div>,
+                                loader: <div className='option-wrapper'><span className='dropdown-option'>Loading more items...</span></div>,
+                            }}
+                            id={this.ids[14]}
                         />
                     </div>
                 </div>

--- a/src/components/dropdownSearch/examples/DropdownSearchExamples.tsx
+++ b/src/components/dropdownSearch/examples/DropdownSearchExamples.tsx
@@ -28,7 +28,7 @@ export class DropdownSearchExamples extends React.Component<DropdownSearchExampl
 
     componentWillMount() {
         // Generate ids ONCE for the components below
-        for (let i = 0; i < 14; i++) {
+        for (let i = 0; i < 15; i++) {
             this.ids[i] = UUID.generate();
         }
 
@@ -78,7 +78,21 @@ export class DropdownSearchExamples extends React.Component<DropdownSearchExampl
         return (
             <div className='mt2'>
                 <h1 className='text-blue mb1 bold'>Dropdown List</h1>
-
+                {/* TODO: put at the end */}
+                <div className='form-group'>
+                    <label className='form-control-label'>Dropdown with an infinite scroll & filters on all options</label>
+                    <div className='form-control'>
+                        <DropdownSearchConnected
+                            {...manyOptions}
+                            internalInfiniteScroll={{
+                                optionsPerPage: 10,
+                                endMessage: <div className='option-wrapper'><span className='dropdown-option'>No more items to show</span></div>,
+                                loader: <div className='option-wrapper'><span className='dropdown-option'>Loading more items...</span></div>,
+                            }}
+                            id={this.ids[14]}
+                        />
+                    </div>
+                </div>
                 <div className='form-group'>
                     <label className='form-control-label'>Multiselect Dropdown</label>
                     <div className='form-control'>

--- a/src/components/dropdownSearch/examples/DropdownSearchExamples.tsx
+++ b/src/components/dropdownSearch/examples/DropdownSearchExamples.tsx
@@ -84,7 +84,7 @@ export class DropdownSearchExamples extends React.Component<DropdownSearchExampl
                     <div className='form-control'>
                         <DropdownSearchConnected
                             {...manyOptions}
-                            internalInfiniteScroll={{
+                            autoInfiniteScroll={{
                                 optionsPerPage: 10,
                                 endMessage: <div className='option-wrapper'><span className='dropdown-option'>No more items to show</span></div>,
                                 loader: <div className='option-wrapper'><span className='dropdown-option'>Loading more items...</span></div>,

--- a/src/components/dropdownSearch/tests/DropdownSearch.spec.tsx
+++ b/src/components/dropdownSearch/tests/DropdownSearch.spec.tsx
@@ -9,8 +9,8 @@ import {Content} from '../../content/Content';
 import {FilterBox} from '../../filterBox/FilterBox';
 import {Tooltip} from '../../tooltip/Tooltip';
 import {DropdownSearch, IDropdownOption, IDropdownSearchProps} from '../DropdownSearch';
-import {DropdownSearchInfiniteScrollOptions} from '../DropdownSearchInfiniteScrollOptions';
 import {DropdownSearchAutoInfiniteScroll, IDropdownSearchAutoInfiniteScrollOptions} from '../DropdownSearchAutoInfiniteScroll';
+import {DropdownSearchInfiniteScrollOptions} from '../DropdownSearchInfiniteScrollOptions';
 import {defaultSelectedOptionPlaceholder} from '../DropdownSearchReducers';
 
 describe('DropdownSearch', () => {

--- a/src/components/dropdownSearch/tests/DropdownSearch.spec.tsx
+++ b/src/components/dropdownSearch/tests/DropdownSearch.spec.tsx
@@ -1,5 +1,6 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
+import {InfiniteScrollProps} from 'react-infinite-scroll-component';
 import * as _ from 'underscore';
 
 import {keyCode} from '../../../utils/InputUtils';
@@ -9,6 +10,7 @@ import {FilterBox} from '../../filterBox/FilterBox';
 import {Tooltip} from '../../tooltip/Tooltip';
 import {DropdownSearch, IDropdownOption, IDropdownSearchProps} from '../DropdownSearch';
 import {DropdownSearchInfiniteScrollOptions} from '../DropdownSearchInfiniteScrollOptions';
+import {DropdownSearchInternalInfiniteScroll, IDropdownSearchInternalInfiniteScrollOptions} from '../DropdownSearchInternalInfiniteScroll';
 import {defaultSelectedOptionPlaceholder} from '../DropdownSearchReducers';
 
 describe('DropdownSearch', () => {
@@ -30,6 +32,18 @@ describe('DropdownSearch', () => {
         isDisabled: false,
         isOpened: false,
         searchThresold: 1,
+    };
+
+    const infiniteScrollProps: InfiniteScrollProps = {
+        dataLength: 2,
+        hasMore: true,
+        next: jasmine.createSpy('next'),
+        endMessage: 'no more',
+        loader: null,
+    };
+
+    const internalInfiniteScrollOptions: IDropdownSearchInternalInfiniteScrollOptions = {
+        optionsPerPage: 10,
     };
 
     describe('<DropdownSearch />', () => {
@@ -314,20 +328,22 @@ describe('DropdownSearch', () => {
             });
 
             describe('getDropdownOptions', () => {
-                it('should return li elements if the infiniteScrollProps are undefined', () => {
+                it('should return li elements if the infiniteScroll and internalInfiniteScroll props are undefined', () => {
                     expect(dropdownSearchInstanceAsAny.getDropdownOptions()[0].type).toBe('li');
                 });
 
                 it('should return div elements if the infiniteScrollProps are defined', () => {
                     dropdownSearch.setProps({
                         ...ownProps,
-                        infiniteScroll: {
-                            dataLength: 2,
-                            hasMore: true,
-                            next: jasmine.createSpy('next'),
-                            endMessage: 'no more',
-                            loader: undefined,
-                        },
+                        infiniteScroll: {...infiniteScrollProps},
+                    });
+                    expect(dropdownSearchInstanceAsAny.getDropdownOptions()[0].type).toBe('div');
+                });
+
+                it('should return div elements if the internalInfiniteScroll prop is defined', () => {
+                    dropdownSearch.setProps({
+                        ...ownProps,
+                        internalInfiniteScroll: {...internalInfiniteScrollOptions},
                     });
                     expect(dropdownSearchInstanceAsAny.getDropdownOptions()[0].type).toBe('div');
                 });
@@ -338,7 +354,7 @@ describe('DropdownSearch', () => {
                     expect(dropdownSearchInstanceAsAny.getDropdownMenu()).toBeNull();
                 });
 
-                it('should return a ul if the infiniteScrollProps are undefined', () => {
+                it('should return a ul if the infiniteScroll and internalInfiniteScroll props are undefined', () => {
                     dropdownSearch.setProps({
                         ...ownProps,
                         isOpened: true,
@@ -346,19 +362,22 @@ describe('DropdownSearch', () => {
                     expect(dropdownSearchInstanceAsAny.getDropdownMenu().type).toBe('ul');
                 });
 
-                it('should return a DropdownSearchInfiniteScrollOptions if the infiniteScrollProps are defined', () => {
+                it('should return a DropdownSearchInfiniteScrollOptions if the infiniteScroll prop is defined', () => {
                     dropdownSearch.setProps({
                         ...ownProps,
                         isOpened: true,
-                        infiniteScroll: {
-                            dataLength: 2,
-                            hasMore: true,
-                            next: jasmine.createSpy('next'),
-                            endMessage: 'no more',
-                            loader: undefined,
-                        },
+                        infiniteScroll: {...infiniteScrollProps},
                     });
                     expect(dropdownSearchInstanceAsAny.getDropdownMenu().type).toBe(DropdownSearchInfiniteScrollOptions);
+                });
+
+                it('should return a DropdownSearchInfiniteScrollOptions if the internalInfiniteScroll prop is defined', () => {
+                    dropdownSearch.setProps({
+                        ...ownProps,
+                        isOpened: true,
+                        internalInfiniteScroll: {...internalInfiniteScrollOptions},
+                    });
+                    expect(dropdownSearchInstanceAsAny.getDropdownMenu().type).toBe(DropdownSearchInternalInfiniteScroll);
                 });
 
                 it('should call the hasMoreItems prop to let the infinite scroll if there are more items', () => {
@@ -366,13 +385,7 @@ describe('DropdownSearch', () => {
                     dropdownSearch.setProps({
                         ...ownProps,
                         isOpened: true,
-                        infiniteScroll: {
-                            dataLength: 2,
-                            hasMore: true,
-                            next: jasmine.createSpy('next'),
-                            endMessage: 'no more',
-                            loader: undefined,
-                        },
+                        infiniteScroll: {...infiniteScrollProps},
                         hasMoreItems: hasMoreItemsSpy,
                     });
                     const hasMoreItemsCallsCount = hasMoreItemsSpy.calls.count();
@@ -381,25 +394,35 @@ describe('DropdownSearch', () => {
                     expect(hasMoreItemsSpy).toHaveBeenCalledTimes(hasMoreItemsCallsCount + 1);
                 });
 
-                it('should call handleOnMouseEnter when calling DropdownSearchInfiniteScrollOptions onMouseEnter prop', () => {
-                    const handleOnMouseEnterSpy = spyOn<any>(dropdownSearchInstance, 'handleOnMouseEnter');
+                it(`if infiniteScroll prop is defined
+                    should call handleOnMouseEnter when calling DropdownSearchInfiniteScrollOptions onMouseEnter prop`, () => {
+                        const handleOnMouseEnterSpy = spyOn<any>(dropdownSearchInstance, 'handleOnMouseEnter');
 
-                    dropdownSearch.setProps({
-                        ...ownProps,
-                        isOpened: true,
-                        infiniteScroll: {
-                            dataLength: 2,
-                            hasMore: true,
-                            next: jasmine.createSpy('next'),
-                            endMessage: 'no more',
-                            loader: undefined,
-                        },
+                        dropdownSearch.setProps({
+                            ...ownProps,
+                            isOpened: true,
+                            infiniteScroll: {...infiniteScrollProps},
+                        });
+
+                        dropdownSearchInstanceAsAny.getDropdownMenu().props.onMouseEnter();
+
+                        expect(handleOnMouseEnterSpy).toHaveBeenCalledTimes(1);
                     });
 
-                    dropdownSearchInstanceAsAny.getDropdownMenu().props.onMouseEnter();
+                it(`if internalInfiniteScroll prop is defined
+                    should call handleOnMouseEnter when calling DropdownSearchInfiniteScrollOptions onMouseEnter prop`, () => {
+                        const handleOnMouseEnterSpy = spyOn<any>(dropdownSearchInstance, 'handleOnMouseEnter');
 
-                    expect(handleOnMouseEnterSpy).toHaveBeenCalledTimes(1);
-                });
+                        dropdownSearch.setProps({
+                            ...ownProps,
+                            isOpened: true,
+                            internalInfiniteScroll: {...internalInfiniteScrollOptions},
+                        });
+
+                        dropdownSearchInstanceAsAny.getDropdownMenu().props.onMouseEnter();
+
+                        expect(handleOnMouseEnterSpy).toHaveBeenCalledTimes(1);
+                    });
             });
         });
 

--- a/src/components/dropdownSearch/tests/DropdownSearch.spec.tsx
+++ b/src/components/dropdownSearch/tests/DropdownSearch.spec.tsx
@@ -10,7 +10,7 @@ import {FilterBox} from '../../filterBox/FilterBox';
 import {Tooltip} from '../../tooltip/Tooltip';
 import {DropdownSearch, IDropdownOption, IDropdownSearchProps} from '../DropdownSearch';
 import {DropdownSearchInfiniteScrollOptions} from '../DropdownSearchInfiniteScrollOptions';
-import {DropdownSearchInternalInfiniteScroll, IDropdownSearchInternalInfiniteScrollOptions} from '../DropdownSearchInternalInfiniteScroll';
+import {DropdownSearchAutoInfiniteScroll, IDropdownSearchAutoInfiniteScrollOptions} from '../DropdownSearchAutoInfiniteScroll';
 import {defaultSelectedOptionPlaceholder} from '../DropdownSearchReducers';
 
 describe('DropdownSearch', () => {
@@ -42,7 +42,7 @@ describe('DropdownSearch', () => {
         loader: null,
     };
 
-    const internalInfiniteScrollOptions: IDropdownSearchInternalInfiniteScrollOptions = {
+    const autoInfiniteScrollOptions: IDropdownSearchAutoInfiniteScrollOptions = {
         optionsPerPage: 10,
     };
 
@@ -328,7 +328,7 @@ describe('DropdownSearch', () => {
             });
 
             describe('getDropdownOptions', () => {
-                it('should return li elements if the infiniteScroll and internalInfiniteScroll props are undefined', () => {
+                it('should return li elements if the infiniteScroll and autoInfiniteScroll props are undefined', () => {
                     expect(dropdownSearchInstanceAsAny.getDropdownOptions()[0].type).toBe('li');
                 });
 
@@ -340,10 +340,10 @@ describe('DropdownSearch', () => {
                     expect(dropdownSearchInstanceAsAny.getDropdownOptions()[0].type).toBe('div');
                 });
 
-                it('should return div elements if the internalInfiniteScroll prop is defined', () => {
+                it('should return div elements if the autoInfiniteScroll prop is defined', () => {
                     dropdownSearch.setProps({
                         ...ownProps,
-                        internalInfiniteScroll: {...internalInfiniteScrollOptions},
+                        autoInfiniteScroll: {...autoInfiniteScrollOptions},
                     });
                     expect(dropdownSearchInstanceAsAny.getDropdownOptions()[0].type).toBe('div');
                 });
@@ -354,7 +354,7 @@ describe('DropdownSearch', () => {
                     expect(dropdownSearchInstanceAsAny.getDropdownMenu()).toBeNull();
                 });
 
-                it('should return a ul if the infiniteScroll and internalInfiniteScroll props are undefined', () => {
+                it('should return a ul if the infiniteScroll and autoInfiniteScroll props are undefined', () => {
                     dropdownSearch.setProps({
                         ...ownProps,
                         isOpened: true,
@@ -371,13 +371,13 @@ describe('DropdownSearch', () => {
                     expect(dropdownSearchInstanceAsAny.getDropdownMenu().type).toBe(DropdownSearchInfiniteScrollOptions);
                 });
 
-                it('should return a DropdownSearchInfiniteScrollOptions if the internalInfiniteScroll prop is defined', () => {
+                it('should return a DropdownSearchInfiniteScrollOptions if the autoInfiniteScroll prop is defined', () => {
                     dropdownSearch.setProps({
                         ...ownProps,
                         isOpened: true,
-                        internalInfiniteScroll: {...internalInfiniteScrollOptions},
+                        autoInfiniteScroll: {...autoInfiniteScrollOptions},
                     });
-                    expect(dropdownSearchInstanceAsAny.getDropdownMenu().type).toBe(DropdownSearchInternalInfiniteScroll);
+                    expect(dropdownSearchInstanceAsAny.getDropdownMenu().type).toBe(DropdownSearchAutoInfiniteScroll);
                 });
 
                 it('should call the hasMoreItems prop to let the infinite scroll if there are more items', () => {
@@ -409,14 +409,14 @@ describe('DropdownSearch', () => {
                         expect(handleOnMouseEnterSpy).toHaveBeenCalledTimes(1);
                     });
 
-                it(`if internalInfiniteScroll prop is defined
+                it(`if autoInfiniteScroll prop is defined
                     should call handleOnMouseEnter when calling DropdownSearchInfiniteScrollOptions onMouseEnter prop`, () => {
                         const handleOnMouseEnterSpy = spyOn<any>(dropdownSearchInstance, 'handleOnMouseEnter');
 
                         dropdownSearch.setProps({
                             ...ownProps,
                             isOpened: true,
-                            internalInfiniteScroll: {...internalInfiniteScrollOptions},
+                            autoInfiniteScroll: {...autoInfiniteScrollOptions},
                         });
 
                         dropdownSearchInstanceAsAny.getDropdownMenu().props.onMouseEnter();

--- a/src/components/dropdownSearch/tests/DropdownSearchAutoInfiniteScroll.spec.tsx
+++ b/src/components/dropdownSearch/tests/DropdownSearchAutoInfiniteScroll.spec.tsx
@@ -1,0 +1,105 @@
+import {mount, ReactWrapper, shallow} from 'enzyme';
+import * as React from 'react';
+import * as _ from 'underscore';
+
+import {DropdownSearchAutoInfiniteScroll, IDropdownSearchAutoInfiniteScrollProps} from '../DropdownSearchAutoInfiniteScroll';
+import {DropdownSearchInfiniteScrollOptions} from '../DropdownSearchInfiniteScrollOptions';
+
+describe('DropdownSearchAutoInfiniteScroll', () => {
+    let basicProps: IDropdownSearchAutoInfiniteScrollProps;
+    const totalOptions = 23;
+    const optionsPerPage = 10;
+
+    function getOptions(prependText: string, total: number) {
+        return _.times(total, (n: number) => <div key={n}>{prependText} {n}</div>);
+    }
+
+    beforeEach(() => {
+        basicProps = {
+            onMouseEnter: jasmine.createSpy('onMouseEnter'),
+            options: getOptions('Test', totalOptions),
+            ulElementRefFunction: jasmine.createSpy('refFunction'),
+            endMessage: 'the end',
+            optionsPerPage,
+        };
+    });
+
+    it('should render without errors', () => {
+        expect(() => shallow(<DropdownSearchAutoInfiniteScroll {...basicProps} />)).not.toThrow();
+    });
+
+    describe('<DropdownSearchAutoInfiniteScroll />', () => {
+        let autoInfiniteScroll: ReactWrapper<IDropdownSearchAutoInfiniteScrollProps, any>;
+
+        beforeEach(() => {
+            autoInfiniteScroll = mount(
+                <DropdownSearchAutoInfiniteScroll {...basicProps} />,
+                {attachTo: document.getElementById('App')},
+            );
+        });
+
+        afterEach(() => {
+            autoInfiniteScroll.detach();
+        });
+
+        it('should get what to do on mouse enter as a prop', () => {
+            const onMouseEnterProp = autoInfiniteScroll.props().onMouseEnter;
+
+            expect(onMouseEnterProp).toBeDefined();
+
+            onMouseEnterProp();
+
+            expect(basicProps.onMouseEnter).toHaveBeenCalledTimes(1);
+        });
+
+        it('should get the options as a prop', () => {
+            const optionsProp = autoInfiniteScroll.props().options;
+
+            expect(optionsProp).toBeDefined();
+            expect(optionsProp.length).toBe(basicProps.options.length);
+        });
+
+        it('should get the menu ref function as a prop and call it on render', () => {
+            const ulElementRefFunctionProp = autoInfiniteScroll.props().ulElementRefFunction;
+
+            expect(ulElementRefFunctionProp).toBeDefined();
+            expect(ulElementRefFunctionProp).toHaveBeenCalledTimes(1);
+        });
+
+        it('should display a <DropdownSearchInfiniteScrollOptions /> component', () => {
+            expect(autoInfiniteScroll.find(DropdownSearchInfiniteScrollOptions)).toBeDefined();
+        });
+
+        it('should call onMouseEnter prop on mouse enter', () => {
+            autoInfiniteScroll.find('.dropdown-menu').simulate('mouseenter');
+
+            expect(basicProps.onMouseEnter).toHaveBeenCalledTimes(1);
+        });
+
+        it('should update activeOptions and respect the paging when loading additional options', () => {
+            expect(autoInfiniteScroll.state('activeOptions')).toEqual(basicProps.options.slice(0, optionsPerPage));
+
+            autoInfiniteScroll.find(DropdownSearchInfiniteScrollOptions).props().infiniteScroll.next();
+            expect(autoInfiniteScroll.state('activeOptions')).toEqual(basicProps.options.slice(0, optionsPerPage * 2));
+
+            autoInfiniteScroll.find(DropdownSearchInfiniteScrollOptions).props().infiniteScroll.next();
+            expect(autoInfiniteScroll.state('activeOptions')).toEqual(basicProps.options);
+        });
+
+        it('should update activeOptions and respect the paging when setting new options', () => {
+            const newOptions = getOptions('Other options', 33);
+
+            autoInfiniteScroll.setProps({options: newOptions});
+            expect(autoInfiniteScroll.state('activeOptions')).toEqual(newOptions.slice(0, optionsPerPage));
+        });
+
+        it('should not show endMessage if infinite scrolling is unused (less options shown then per page)', () => {
+            expect(autoInfiniteScroll.find(DropdownSearchInfiniteScrollOptions).props().infiniteScroll.endMessage).toBe(basicProps.endMessage);
+
+            const newOptions = getOptions('Other options', optionsPerPage - 1);
+            autoInfiniteScroll.setProps({options: newOptions});
+
+            expect(autoInfiniteScroll.find(DropdownSearchInfiniteScrollOptions).props().infiniteScroll.endMessage).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
I wanted to give the DropdownSearch component a bunch of options and tell it to manage the infinite scrolling itself by setting a number of options per pages
I wanted the filter to search through all the options given instead of just those displayed at a given moment by the infinite scroll which was the default behaviour.
All this without having to refactor the DropdownSearch too much!

Comments and tips are greatly appreciated! 😄 