### PR TITLE
Fix the getListState select selector

### DIFF
--- a/src/components/select/SelectSelector.ts
+++ b/src/components/select/SelectSelector.ts
@@ -15,7 +15,8 @@ export const getFilterText = (state: IReactVaporState, ownProps: ISelectWithFilt
     return (filter && filter.filterText) || '';
 };
 
-export const getListState = (state: IReactVaporState, ownProps: ISelectWithFilterProps): string[] => state.selectWithFilter[ownProps.id] ? state.selectWithFilter[ownProps.id].list : [];
+export const getListState = (state: IReactVaporState, ownProps: ISelectWithFilterProps): string[] =>
+    state.selectWithFilter && state.selectWithFilter[ownProps.id] ? state.selectWithFilter[ownProps.id].list : [];
 
 export const getListBox = (state: IReactVaporState, ownProps: ISelectWithFilterProps): Partial<IListBoxState> => _.findWhere(state.listBoxes, {id: ownProps.id}) || {};
 

--- a/src/components/select/tests/SelectSelector.spec.ts
+++ b/src/components/select/tests/SelectSelector.spec.ts
@@ -40,6 +40,10 @@ describe('Select', () => {
         });
 
         describe('getListState', () => {
+            it('should not throw when passing falsy values and return an empty array', () => {
+                expect(getListState({}, defaultOwnProps)).toEqual([]);
+            });
+
             it('should return an empty list if the selectWithFilter is not in the state', () => {
                 expect(getListState(defaultState, defaultOwnProps)).toEqual([]);
             });


### PR DESCRIPTION
`getListState` selector was missing a check for `selectWithFilter` prop. Since its optional and can be undefined in the ReactVaporState the selector shouldn't throw IMHO. 

@pochretien does not agree with this. Feel free to argue with this here if you want.