### PR TITLE
Fix SelectConnected component's focus behavior

### DIFF
--- a/src/components/select/MultiSelectConnected.tsx
+++ b/src/components/select/MultiSelectConnected.tsx
@@ -74,6 +74,7 @@ export class MultiSelectConnected extends React.Component<IMultiSelectProps, {}>
                 items={this.props.items}
                 noResultItem={this.props.noResultItem}
                 selectClasses={this.props.selectClasses}
+                hasFocusableChild={this.props.hasFocusableChild}
                 multi>
                 {this.props.children}
             </SelectConnected>

--- a/src/components/select/MultiSelectConnected.tsx
+++ b/src/components/select/MultiSelectConnected.tsx
@@ -70,6 +70,7 @@ export class MultiSelectConnected extends React.Component<IMultiSelectProps, {}>
         return (
             <SelectConnected
                 id={this.props.id}
+                key={this.props.id}
                 button={(props: ISelectButtonProps) => this.getButton(props)}
                 items={this.props.items}
                 noResultItem={this.props.noResultItem}
@@ -142,7 +143,10 @@ export class MultiSelectConnected extends React.Component<IMultiSelectProps, {}>
 
     private getButton(props: ISelectButtonProps): JSX.Element {
         const classes = classNames('multiselect-input', {'mod-sortable': this.props.sortable});
-        const buttonAttrs = !this.props.noDisabled && this.props.selected && this.props.selected.length === this.props.items.length ? {disabled: true} : {};
+        const buttonAttrs = !this.props.noDisabled
+            && this.props.selected
+            && this.props.selected.length === this.props.items.length
+            ? {disabled: true} : {};
         return (
             <div className={classes} style={this.props.multiSelectStyle}>
                 {this.props.connectDropTarget(

--- a/src/components/select/SelectConnected.tsx
+++ b/src/components/select/SelectConnected.tsx
@@ -25,10 +25,11 @@ export interface ISelectOwnProps {
     placeholder?: string;
     noResultItem?: IItemBoxProps;
     selectClasses?: string;
+    items?: IItemBoxProps[];
+    hasFocusableChild?: boolean;
 }
 
 export interface ISelectStateProps {
-    items?: IItemBoxProps[];
     isOpen?: boolean;
     active?: number;
     selectedValues?: string[];
@@ -95,7 +96,7 @@ export class SelectConnected extends React.Component<ISelectProps & ISelectSpeci
 
     componentWillUpdate(nextProps: ISelectProps): any {
         const button = this.getButton();
-        this.keepFocus = !nextProps.isOpen && document.activeElement === button;
+        this.keepFocus = document.activeElement === button && (!nextProps.hasFocusableChild || !nextProps.isOpen);
     }
 
     componentDidUpdate(prevProps: ISelectProps, prevState: null, snapshot: any) {
@@ -107,11 +108,12 @@ export class SelectConnected extends React.Component<ISelectProps & ISelectSpeci
     render() {
         const pickerClasses = classNames(
             'select-dropdown dropdown',
-            this.props.selectClasses || '',
+            this.props.selectClasses,
             {
                 open: this.props.isOpen,
                 'mod-multi': this.props.multi,
-            });
+            },
+        );
         const dropdownClasses = classNames('select-dropdown-container absolute bg-pure-white', {hidden: !this.props.isOpen});
         return (
             <div className={pickerClasses} ref={(ref: HTMLDivElement) => this.dropdown = ref}>
@@ -123,7 +125,12 @@ export class SelectConnected extends React.Component<ISelectProps & ISelectSpeci
                 }} />
                 <div className={dropdownClasses} ref={(ref: HTMLDivElement) => this.menu = ref}>
                     {this.renderChildren()}
-                    <ListBoxConnected id={this.props.id} items={this.props.items} multi={this.props.multi} noResultItem={this.props.noResultItem || undefined} />
+                    <ListBoxConnected
+                        id={this.props.id}
+                        items={this.props.items}
+                        multi={this.props.multi}
+                        noResultItem={this.props.noResultItem || undefined}
+                    />
                 </div>
             </div>
         );

--- a/src/components/select/SelectConnected.tsx
+++ b/src/components/select/SelectConnected.tsx
@@ -1,6 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import {createStructuredSelector} from 'reselect';
 import * as _ from 'underscore';
 
 import {IReactVaporState, IReduxActionsPayload} from '../../ReactVapor';
@@ -11,9 +12,8 @@ import {Content} from '../content/Content';
 import {IItemBoxProps} from '../itemBox/ItemBox';
 import {selectListBoxOption, setActiveListBoxOption} from '../listBox/ListBoxActions';
 import {ListBoxConnected} from '../listBox/ListBoxConnected';
-import {IListBoxState} from '../listBox/ListBoxReducers';
 import {addSelect, removeSelect, toggleSelect} from './SelectActions';
-import {ISelectState} from './SelectReducers';
+import {SelectSelector} from './SelectSelector';
 
 export interface ISelectSpecificProps {
     button: React.ReactNode;
@@ -30,10 +30,9 @@ export interface ISelectOwnProps {
 }
 
 export interface ISelectStateProps {
-    isOpen?: boolean;
+    isOpened?: boolean;
     active?: number;
     selectedValues?: string[];
-    selectedLength?: number;
 }
 
 export interface ISelectDispatchProps {
@@ -54,16 +53,14 @@ export interface ISelectButtonProps {
 
 export interface ISelectProps extends ISelectOwnProps, ISelectStateProps, ISelectDispatchProps {}
 
-const mapStateToProps = (state: IReactVaporState, ownProps: ISelectOwnProps): ISelectStateProps => {
-    const select: ISelectState = _.findWhere(state.selects, {id: ownProps.id});
-    const list: IListBoxState = _.findWhere(state.listBoxes, {id: ownProps.id});
+const makeMapStateToProps = () => {
+    const statePropsSelector = createStructuredSelector({
+        selectedValues: SelectSelector.getListBoxSelected,
+        isOpened: SelectSelector.getSelectOpened,
+        active: SelectSelector.getListBoxActive,
+    });
 
-    return {
-        isOpen: select && select.open,
-        active: list && list.active,
-        selectedValues: list && list.selected,
-        selectedLength: list && list.selected.length || 0,
-    };
+    return (state: IReactVaporState, ownProps: ISelectOwnProps): ISelectStateProps => statePropsSelector(state, ownProps);
 };
 
 const mapDispatchToProps = (
@@ -78,13 +75,14 @@ const mapDispatchToProps = (
     setActive: (diff: number) => dispatch(setActiveListBoxOption(ownProps.id, diff)),
 });
 
-@ReduxConnect(mapStateToProps, mapDispatchToProps)
-export class SelectConnected extends React.Component<ISelectProps & ISelectSpecificProps, {}> {
+// const serializeStateProps = (props: any) => JSON.stringify(_.pick(props, 'active', 'isOpened', 'selectedValues'));
+
+@ReduxConnect(makeMapStateToProps, mapDispatchToProps)
+export class SelectConnected extends React.PureComponent<ISelectProps & ISelectSpecificProps, {}> {
     private dropdown: HTMLDivElement;
     private menu: HTMLDivElement;
-    private keepFocus: boolean;
 
-    componentWillMount() {
+    componentDidMount() {
         this.props.onRender();
         document.addEventListener('mousedown', this.handleDocumentClick);
     }
@@ -94,15 +92,19 @@ export class SelectConnected extends React.Component<ISelectProps & ISelectSpeci
         this.props.onDestroy();
     }
 
-    componentWillUpdate(nextProps: ISelectProps): any {
-        const button = this.getButton();
-        this.keepFocus = document.activeElement === button && (!nextProps.hasFocusableChild || !nextProps.isOpen);
-    }
+    componentDidUpdate(prevProps: ISelectProps) {
+        const wentFromOpenedToClosed = prevProps.isOpened && !this.props.isOpened;
+        const selectionChanged = prevProps.selectedValues.length <= this.props.selectedValues.length;
+        // const focusOnButton = this.getButton() === document.activeElement;
 
-    componentDidUpdate(prevProps: ISelectProps, prevState: null, snapshot: any) {
-        if (this.keepFocus || (prevProps.isOpen && !this.props.isOpen && prevProps.selectedLength <= this.props.selectedLength)) {
+        console.log('component did update');
+        console.log(prevProps);
+        console.log(this.props);
+        if ((this.props.isOpened && !this.props.hasFocusableChild)
+            || (wentFromOpenedToClosed && selectionChanged)) {
             this.focusOnButton();
         }
+        console.log(document.activeElement);
     }
 
     render() {
@@ -110,11 +112,11 @@ export class SelectConnected extends React.Component<ISelectProps & ISelectSpeci
             'select-dropdown dropdown',
             this.props.selectClasses,
             {
-                open: this.props.isOpen,
+                open: this.props.isOpened,
                 'mod-multi': this.props.multi,
             },
         );
-        const dropdownClasses = classNames('select-dropdown-container absolute bg-pure-white', {hidden: !this.props.isOpen});
+        const dropdownClasses = classNames('select-dropdown-container absolute bg-pure-white', {hidden: !this.props.isOpened});
         return (
             <div className={pickerClasses} ref={(ref: HTMLDivElement) => this.dropdown = ref}>
                 <Content content={this.props.button} classes={['select-dropdown-button']} componentProps={{
@@ -137,7 +139,7 @@ export class SelectConnected extends React.Component<ISelectProps & ISelectSpeci
     }
 
     private renderChildren() {
-        if (this.props.children && this.props.isOpen) {
+        if (this.props.children && this.props.isOpened) {
             const newChildren = React.Children.map(this.props.children, (child: React.ReactElement<any>) => {
                 if (child) {
                     return React.cloneElement(child, {
@@ -160,7 +162,8 @@ export class SelectConnected extends React.Component<ISelectProps & ISelectSpeci
     }
 
     private focusOnButton() {
-        this.getButton() && this.getButton().focus();
+        const button = this.getButton();
+        button && button.focus();
     }
 
     private setDropdownPosition() {
@@ -178,23 +181,23 @@ export class SelectConnected extends React.Component<ISelectProps & ISelectSpeci
         e.preventDefault();
 
         this.props.onToggleDropdown();
+        this.focusOnButton();
     }
 
     private onKeyDown(e: React.KeyboardEvent<HTMLElement>) {
         if (_.contains([keyCode.escape, keyCode.downArrow, keyCode.upArrow, keyCode.enter], e.keyCode)
-            || (e.keyCode === keyCode.tab && this.props.isOpen)) {
+            || (e.keyCode === keyCode.tab && this.props.isOpened)) {
             e.stopPropagation();
             e.preventDefault();
         }
     }
 
     private onKeyUp(e: React.KeyboardEvent<HTMLElement>) {
-        if (keyCode.escape === e.keyCode && this.props.isOpen) {
+        if (keyCode.escape === e.keyCode && this.props.isOpened) {
             this.onToggleDropdown(e);
-            this.focusOnButton();
         }
 
-        if (_.contains([keyCode.enter, keyCode.tab], e.keyCode) && this.props.isOpen) {
+        if (_.contains([keyCode.enter, keyCode.tab], e.keyCode) && this.props.isOpened) {
             const actives = _.chain(this.props.items)
                 .filter((item: IItemBoxProps) => !item.hidden && (!this.props.multi || !_.contains(this.props.selectedValues, item.value)) && !item.disabled)
                 .value();
@@ -208,17 +211,17 @@ export class SelectConnected extends React.Component<ISelectProps & ISelectSpeci
 
         if (keyCode.downArrow === e.keyCode) {
             this.setDropdownPosition();
-            this.props.setActive(this.props.isOpen ? 1 : 0);
+            this.props.setActive(this.props.isOpened ? 1 : 0);
         }
 
         if (keyCode.upArrow === e.keyCode) {
             this.setDropdownPosition();
-            this.props.setActive(this.props.isOpen ? -1 : 0);
+            this.props.setActive(this.props.isOpened ? -1 : 0);
         }
     }
 
     private handleDocumentClick = (e: MouseEvent) => {
-        if (this.props.isOpen && document.contains(e.target as HTMLElement)) {
+        if (this.props.isOpened && document.contains(e.target as HTMLElement)) {
             const dropdown: Element | Text = ReactDOM.findDOMNode(this.menu);
 
             if (!dropdown.contains(e.target as Node) && !this.getButton().contains(e.target as Node)) {

--- a/src/components/select/SelectSelector.ts
+++ b/src/components/select/SelectSelector.ts
@@ -1,11 +1,14 @@
 import {createSelector} from 'reselect';
 import * as _ from 'underscore';
+
 import {IReactVaporState} from '../../ReactVapor';
 import {convertStringListToItemsBox} from '../../reusableState/customList/StringListReducers';
 import {defaultMatchFilter} from '../../utils/FilterUtils';
 import {IFilterState} from '../filterBox/FilterBoxReducers';
 import {IItemBoxProps} from '../itemBox/ItemBox';
 import {IListBoxState} from '../listBox/ListBoxReducers';
+import {ISelectProps} from './SelectConnected';
+import {ISelectState, selectInitialState} from './SelectReducers';
 import {ISelectWithFilterProps} from './SelectWithFilter';
 
 export type MatchFilter = (filterValue: string, item: IItemBoxProps) => boolean;
@@ -15,12 +18,17 @@ const getFilterText = (state: IReactVaporState, ownProps: ISelectWithFilterProps
     return (filter && filter.filterText) || '';
 };
 
-const getListState = (state: IReactVaporState, ownProps: ISelectWithFilterProps): string[] =>
+const getListState = (state: IReactVaporState, ownProps: ISelectProps): string[] =>
     state.selectWithFilter && state.selectWithFilter[ownProps.id] ? state.selectWithFilter[ownProps.id].list : [];
 
-const getListBox = (state: IReactVaporState, ownProps: ISelectWithFilterProps): Partial<IListBoxState> => _.findWhere(state.listBoxes, {id: ownProps.id}) || {};
+const getListBox = (state: IReactVaporState, ownProps: ISelectProps): Partial<IListBoxState> => _.findWhere(state.listBoxes, {id: ownProps.id}) || {};
 
-const getItems = (state: IReactVaporState, ownProps: ISelectWithFilterProps): IItemBoxProps[] => ownProps.items || [];
+const getSelect = (state: IReactVaporState, ownProps: ISelectProps): ISelectState => {
+    const select: ISelectState = _.findWhere(state.selects, {id: ownProps.id});
+    return select || selectInitialState;
+};
+
+const getItems = (state: IReactVaporState, ownProps: ISelectProps): IItemBoxProps[] => ownProps.items || [];
 
 const getMatchFilter = (state: IReactVaporState, ownProps: ISelectWithFilterProps): MatchFilter => _.isUndefined(ownProps.matchFilter)
     ? defaultMatchFilter
@@ -54,9 +62,19 @@ const listBoxSelectedCombiner = (
     listBox: IListBoxState,
 ): string[] => listBox && listBox.selected ? listBox.selected : [];
 
-const getListBoxSelected: (state: IReactVaporState, ownProps: ISelectWithFilterProps) => string[] = createSelector(
+const getListBoxSelected: (state: IReactVaporState, ownProps: ISelectProps) => string[] = createSelector(
     getListBox,
     listBoxSelectedCombiner,
+);
+
+const getListBoxActive: (state: IReactVaporState, ownProps: ISelectProps) => number = createSelector(
+    getListBox,
+    (listBox: IListBoxState) => listBox.active,
+);
+
+const getSelectOpened: (state: IReactVaporState, ownProps: ISelectProps) => boolean = createSelector(
+    getSelect,
+    (select: ISelectState) => select.open,
 );
 
 export const SelectSelector = {
@@ -71,4 +89,6 @@ export const SelectSelector = {
     getCustomItems,
     listBoxSelectedCombiner,
     getListBoxSelected,
+    getListBoxActive,
+    getSelectOpened,
 };

--- a/src/components/select/SelectWithFilter.tsx
+++ b/src/components/select/SelectWithFilter.tsx
@@ -128,7 +128,7 @@ export const selectWithFilter = (Component: (React.ComponentClass<ISelectWithFil
             }
         }
 
-        private getButton(): React.ReactNode {
+        private getAddValueButton(): React.ReactNode {
             return this.props.customValues && (
                 <div className='ml1'>
                     <Button classes={['p1']} onClick={this.handleOnClick} {...this.props.filterButton}>
@@ -174,12 +174,11 @@ export const selectWithFilter = (Component: (React.ComponentClass<ISelectWithFil
 
             const newProps = {
                 ..._.omit(this.props, [...SelectWithFilterPropsToOmit, 'selected']),
-                hasFocusableChild: true,
                 items,
             };
 
             return (
-                <Component {...newProps} noResultItem={noResultItem} noDisabled={this.props.customValues}>
+                <Component {...newProps} noResultItem={noResultItem} noDisabled={this.props.customValues} hasFocusableChild>
                     <FilterBoxConnected
                         {...this.props.filter}
                         id={this.props.id}
@@ -188,7 +187,7 @@ export const selectWithFilter = (Component: (React.ComponentClass<ISelectWithFil
                         className={filterBoxClassNames}
                         isAutoFocus
                     >
-                        {this.getButton()}
+                        {this.getAddValueButton()}
                     </FilterBoxConnected>
                     {this.props.children}
                 </Component>

--- a/src/components/select/SingleSelectConnected.tsx
+++ b/src/components/select/SingleSelectConnected.tsx
@@ -29,7 +29,9 @@ export interface ISingleSelectProps extends ISingleSelectOwnProps, ISingleSelect
 const mapStateToProps = (state: IReactVaporState, ownProps: ISingleSelectOwnProps): ISingleSelectStateProps => {
     const customSelected: string[] = SelectSelector.getListState(state, ownProps);
     return {
-        selectedOption: customSelected.length ? customSelected[customSelected.length - 1] : SelectSelector.getListBoxSelected(state, ownProps)[0],
+        selectedOption: customSelected.length
+            ? customSelected[customSelected.length - 1]
+            : SelectSelector.getListBoxSelected(state, ownProps)[0],
     };
 };
 
@@ -50,18 +52,19 @@ export class SingleSelectConnected extends React.Component<ISingleSelectProps & 
         return (
             <SelectConnected
                 id={this.props.id}
-                button={(props: ISelectButtonProps) => this.getButton(props)}
+                button={this.getButton}
                 items={this.props.items}
                 selectClasses={this.props.selectClasses}
+                hasFocusableChild={this.props.hasFocusableChild}
             >
                 {this.props.children}
             </SelectConnected>
         );
     }
 
-    private getButton(props: ISelectButtonProps): JSX.Element {
+    private getButton = (props: ISelectButtonProps): JSX.Element => {
         const option = _.findWhere(this.props.items, {value: this.props.selectedOption});
-        const buttonClasses = classNames('btn', 'dropdown-toggle', this.props.toggleClasses, {
+        const buttonClasses = classNames('btn dropdown-toggle', this.props.toggleClasses, {
             'dropdown-toggle-placeholder': !option,
         });
 

--- a/src/components/select/examples/MultiSelectExamples.tsx
+++ b/src/components/select/examples/MultiSelectExamples.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import * as _ from 'underscore';
 import {UUID} from '../../../utils/UUID';
-import {IFlatSelectOptionProps} from '../../flatSelect/FlatSelectOption';
+// import {IFlatSelectOptionProps} from '../../flatSelect/FlatSelectOption';
 import {IItemBoxProps} from '../../itemBox/ItemBox';
-import {MultiSelectConnected} from '../MultiSelectConnected';
-import {MultiSelectWithFilter, MultiSelectWithPredicate, MultiSelectWithPredicateAndFilter} from '../SelectComponents';
+import {MultiSelectWithFilter} from '../SelectComponents';
+// import {MultiSelectConnected} from '../MultiSelectConnected';
+// import {MultiSelectWithFilter, MultiSelectWithPredicate, MultiSelectWithPredicateAndFilter} from '../SelectComponents';
 
 const defaultItems: IItemBoxProps[] = [
     {displayValue: 'Test', value: '0'},
@@ -17,11 +18,11 @@ const defaultItems: IItemBoxProps[] = [
     {displayValue: 'Seven', value: '7'},
 ];
 
-const defaultFlatSelectOptions: IFlatSelectOptionProps[] = [
-    {id: UUID.generate(), option: {content: 'All'}, selected: true},
-    {id: UUID.generate(), option: {content: 'even'}},
-    {id: UUID.generate(), option: {content: 'odd'}},
-];
+// const defaultFlatSelectOptions: IFlatSelectOptionProps[] = [
+//     {id: UUID.generate(), option: {content: 'All'}, selected: true},
+//     {id: UUID.generate(), option: {content: 'even'}},
+//     {id: UUID.generate(), option: {content: 'odd'}},
+// ];
 
 export interface IMultiSelectExamplesState {
     first: IItemBoxProps[];
@@ -52,7 +53,7 @@ export class MultiSelectExamples extends React.Component<{}, IMultiSelectExample
         return (
             <div>
                 <h1>Multi Select</h1>
-                <div className='form-group'>
+                {/* <div className='form-group'>
                     <label className='form-control-label'>A Simple Multi Select without items</label>
                     <br />
                     <MultiSelectConnected id={UUID.generate()} items={[]} />
@@ -86,13 +87,13 @@ export class MultiSelectExamples extends React.Component<{}, IMultiSelectExample
                     <label className='form-control-label'>A Multi Select With Filter, Custom Values and no items</label>
                     <br />
                     <MultiSelectWithFilter id={UUID.generate()} items={[]} customValues />
-                </div>
+                </div> */}
                 <div className='form-group'>
                     <label className='form-control-label'>A Multi Select With Filter, Custom Values and list of items selectable</label>
                     <br />
                     <MultiSelectWithFilter id={UUID.generate()} items={[{value: 'a'}, {value: 'b'}]} customValues />
                 </div>
-                <div className='form-group'>
+                {/* <div className='form-group'>
                     <label className='form-control-label'>A Multi Select With Filter and list of items selectable</label>
                     <br />
                     <MultiSelectWithFilter id={UUID.generate()} items={[{value: 'a'}, {value: 'b'}]} />
@@ -146,21 +147,21 @@ export class MultiSelectExamples extends React.Component<{}, IMultiSelectExample
                         options={defaultFlatSelectOptions}
                         matchPredicate={(p: string, i: IItemBoxProps) => this.matchPredicate(p, i)}
                         customValues />
-                </div>
+                </div> */}
             </div>
         );
     }
 
-    private matchPredicate(predicate: string, item: IItemBoxProps) {
-        const value = parseInt(item.value, 10);
-        if (predicate === defaultFlatSelectOptions[0].id) {
-            return true;
-        } else if (predicate === defaultFlatSelectOptions[1].id) {
-            return value % 2 === 0;
-        } else if (predicate === defaultFlatSelectOptions[2].id) {
-            return value % 2 === 1;
-        } else {
-            return true;
-        }
-    }
+    // private matchPredicate(predicate: string, item: IItemBoxProps) {
+    //     const value = parseInt(item.value, 10);
+    //     if (predicate === defaultFlatSelectOptions[0].id) {
+    //         return true;
+    //     } else if (predicate === defaultFlatSelectOptions[1].id) {
+    //         return value % 2 === 0;
+    //     } else if (predicate === defaultFlatSelectOptions[2].id) {
+    //         return value % 2 === 1;
+    //     } else {
+    //         return true;
+    //     }
+    // }
 }

--- a/src/components/tables/examples/TableExamples.tsx
+++ b/src/components/tables/examples/TableExamples.tsx
@@ -3,6 +3,7 @@ import * as loremIpsum from 'lorem-ipsum';
 import * as moment from 'moment';
 import * as React from 'react';
 import * as _ from 'underscore';
+
 import {ReactVaporStore} from '../../../../docs/ReactVaporStore';
 import {IDispatch, IThunkAction} from '../../../utils/ReduxUtils';
 import {triggerAlertFunction} from '../../../utils/TestUtils';
@@ -14,12 +15,16 @@ import {GroupableCheckboxConnected} from '../../checkbox/GroupableCheckboxConnec
 import {SELECTION_BOXES_LONG} from '../../datePicker/examples/DatePickerExamplesCommon';
 import {IDropdownOption} from '../../dropdownSearch/DropdownSearch';
 import {defaultTitle, link1} from '../../headers/examples/ExamplesUtils';
-import {IData, ITableRowData} from '../Table';
-import {ITableOwnProps} from '../Table';
+import {SingleSelectConnected} from '../../select/SingleSelectConnected';
+import {IData, ITableOwnProps, ITableRowData} from '../Table';
 import {addTableDataEntry, deleteTableDataEntry, modifyState, setIsInError, updateTableDataEntry} from '../TableActions';
 import {TableConnected} from '../TableConnected';
 import {DEFAULT_TABLE_DATA, TABLE_PREDICATE_DEFAULT_VALUE} from '../TableConstants';
-import {defaultTableStateModifier, dispatchPostTableStateModification, dispatchPreTableStateModification} from '../TableDataModifier';
+import {
+    defaultTableStateModifier,
+    dispatchPostTableStateModification,
+    dispatchPreTableStateModification,
+} from '../TableDataModifier';
 import {ITableCompositeState, ITableData, ITablesState, ITableState} from '../TableReducers';
 
 const generateText = () => loremIpsum({count: 1, sentenceUpperBound: 3});
@@ -623,7 +628,13 @@ export class TableExamples extends React.Component<any, any> {
                                 attributeName: 'attribute3',
                                 titleFormatter: _.identity,
                                 sort: true,
-                                attributeFormatter: _.identity,
+                                attributeFormatter: (a, b, c) => (
+                                    <SingleSelectConnected
+                                        key={c.id}
+                                        id={c.id}
+                                        items={[{value: 'a'}, {value: 'b'}]}
+                                    />
+                                ),
                             },
                         ]}
                         actionBar={{


### PR DESCRIPTION
When rendering `SingleSelectConnected` in table rows, the underlying `SelectConnected` was loosing its focus somewhere in the life cycle making it impossible to use the keyboard to select items.

The solution was to fix the boolean check for `SelectConnected.keepFocus` by passing down a new prop called `hasFocusableChild` from the withFilter HOC. This way, the `keepFocus` variable stays to `true` for `SelectConnected` that don't have focusable children and is set to `false` for the ones that render focusable children.

Also did some minor refactoring while at it.