### PR TITLE
implement sticky footer and withEditing hoc

### DIFF
--- a/docs/Index.tsx
+++ b/docs/Index.tsx
@@ -108,7 +108,7 @@ import {ToastConnectedExamples} from '../src/components/toast/examples/ToastConn
 import {ToastExamples} from '../src/components/toast/examples/ToastExamples';
 import {TooltipExamples} from '../src/components/tooltip/examples/TooltipExamples';
 import {UserFeedbackExample} from '../src/components/userFeedback/examples/UserFeedbackExample';
-import {ComponentWithEditingExampleHOC} from '../src/hoc/withEditing/examples/WithEditingExamples';
+import {ComponentWithEditingExampleHOC} from '../src/hoc/withEditing/examples/withEditingExamples';
 import {MembersExample} from './members-example/MembersExample';
 import {ReactVaporStore} from './ReactVaporStore';
 

--- a/docs/Index.tsx
+++ b/docs/Index.tsx
@@ -150,8 +150,10 @@ class Header extends React.Component<{}, HeaderState> {
                         document.dispatchEvent(new Event(SideNavigation.toggleEvent));
                     }}
                 >
-                    {!this.state.sideNavOpened && <Svg svgName='hamburger' svgClass='icon mod-lg ml2 fill-pure-white' />}
-                    {this.state.sideNavOpened && <Svg svgName='arrow-left' svgClass='icon mod-lg ml2 fill-pure-white' />}
+                    <Svg
+                        svgName={this.state.sideNavOpened ? 'arrow-left' : 'hamburger'}
+                        svgClass='icon mod-lg ml2 fill-pure-white'
+                    />
                 </div>
                 <div className='h1 p2'>React Vapor</div>
             </div>

--- a/docs/Index.tsx
+++ b/docs/Index.tsx
@@ -2,6 +2,7 @@ import 'codemirror/lib/codemirror.css';
 import 'coveo-styleguide/dist/css/CoveoStyleGuide.css';
 import './style.scss';
 
+import * as classNames from 'classnames';
 import * as React from 'react';
 import {render as ReactDOMRender} from 'react-dom';
 import {Provider} from 'react-redux';
@@ -81,15 +82,18 @@ import {MultiSelectExamples} from '../src/components/select/examples/MultiSelect
 import {SingleSelectExamples} from '../src/components/select/examples/SingleSelectExamples';
 import {SideNavigationExample} from '../src/components/sideNavigation/examples/SideNavigationExample';
 import {SideNavigationLoadingExample} from '../src/components/sideNavigation/examples/SideNavigationLoadingExample';
+import {SideNavigation} from '../src/components/sideNavigation/SideNavigation';
 import {SliderExamples} from '../src/components/slider/examples/SliderExamples';
 import {SplitLayoutExamples} from '../src/components/splitlayout/examples/SplitLayoutExamples';
 import {StatusCardExamples} from '../src/components/statusCard/examples/StatusCardExamples';
 import {StepProgressBarExamples} from '../src/components/stepProgressBar/examples/StepProgressBarExamples';
+import {StickyFooterExamples} from '../src/components/stickyFooter/examples/StickyFooterExamples';
 import {SubNavigationConnectedExamples} from '../src/components/subNavigation/examples/SubNavigationConnectedExamples';
 import {SubNavigationExamples} from '../src/components/subNavigation/examples/SubNavigationExamples';
 import {SubNavigation} from '../src/components/subNavigation/SubNavigation';
 import {LinkSvgExamples} from '../src/components/svg/examples/LinkSvgExamples';
 import {SvgExamples} from '../src/components/svg/examples/SvgExamples';
+import {Svg} from '../src/components/svg/Svg';
 import {SyncFeedbackExample} from '../src/components/syncFeedback/examples/SyncFeedbackExample';
 import {TabsExamples} from '../src/components/tab/examples/TabConnectedExample';
 import {TableWithDisabledRowsExamples} from '../src/components/tables/examples/TableDisabledRowsExamples';
@@ -104,6 +108,7 @@ import {ToastConnectedExamples} from '../src/components/toast/examples/ToastConn
 import {ToastExamples} from '../src/components/toast/examples/ToastExamples';
 import {TooltipExamples} from '../src/components/tooltip/examples/TooltipExamples';
 import {UserFeedbackExample} from '../src/components/userFeedback/examples/UserFeedbackExample';
+import {ComponentWithEditingExampleHOC} from '../src/hoc/withEditing/examples/WithEditingExamples';
 import {MembersExample} from './members-example/MembersExample';
 import {ReactVaporStore} from './ReactVaporStore';
 
@@ -112,10 +117,47 @@ interface ExampleProps {
     component: any;
 }
 
-interface AppState {
-    activeComponentId: string;
+interface HeaderState {
+    sideNavOpened: boolean;
 }
 
+interface AppState {
+    activeComponentId: string;
+    sideNavOpened: boolean;
+}
+
+class Header extends React.Component<{}, HeaderState> {
+    constructor(props: {}, state: HeaderState) {
+        super(props, state);
+
+        this.state = {
+            sideNavOpened: true,
+        };
+    }
+
+    componentDidMount() {
+        document.addEventListener(SideNavigation.toggleEvent, () => {
+            this.setState({sideNavOpened: !this.state.sideNavOpened});
+        });
+    }
+
+    render() {
+        return (
+            <div className='flex flex-colum flex-center'>
+                <div
+                    className='cursor-pointer'
+                    onClick={() => {
+                        document.dispatchEvent(new Event(SideNavigation.toggleEvent));
+                    }}
+                >
+                    {!this.state.sideNavOpened && <Svg svgName='hamburger' svgClass='icon mod-lg ml2 fill-pure-white' />}
+                    {this.state.sideNavOpened && <Svg svgName='arrow-left' svgClass='icon mod-lg ml2 fill-pure-white' />}
+                </div>
+                <div className='h1 p2'>React Vapor</div>
+            </div>
+        );
+    }
+}
 class App extends React.Component<{}, AppState> {
     private components = [
         {component: MenuExamples, componentName: 'Menu'},
@@ -214,6 +256,8 @@ class App extends React.Component<{}, AppState> {
         {component: ActionableItemExamples, componentName: 'ActionableItem'},
         {component: PopoverConnectedExamples, componentName: 'Popover'},
         {component: ColorExamples, componentName: 'Color'},
+        {component: StickyFooterExamples, componentName: 'StickyFooter'},
+        {component: ComponentWithEditingExampleHOC, componentName: 'ComponentWithEditing'},
     ];
 
     constructor(props: {}, state: AppState) {
@@ -223,6 +267,7 @@ class App extends React.Component<{}, AppState> {
         const firstComponentId = this.components.sort(this.sortComponentsByName);
         this.state = {
             activeComponentId: this.getSelectedComponent(componentIdFromHash) && componentIdFromHash || firstComponentId[0].componentName,
+            sideNavOpened: true,
         };
     }
 
@@ -232,14 +277,17 @@ class App extends React.Component<{}, AppState> {
         if (el) {
             el.scrollIntoView({behavior: 'instant', block: 'center'});
         }
+
+        document.addEventListener(SideNavigation.toggleEvent, () => {
+            this.setState({sideNavOpened: !this.state.sideNavOpened});
+        });
     }
 
     render() {
-        const selectedComponent: any = this.getSelectedComponent(this.state.activeComponentId);
         return (
             <Provider store={ReactVaporStore}>
                 <div className='coveo-form flex full-content'>
-                    <div className='flex flex-column'>
+                    <div className={classNames('flex flex-column', {'hide': !this.state.sideNavOpened, 'navigation-wrapper-opened': this.state.sideNavOpened})} style={{maxWidth: '245px'}}>
                         <SubNavigation
                             selected={this.state.activeComponentId}
                             items={this.components.sort(this.sortComponentsByName).map(this.formatComponentsExamples)}
@@ -247,7 +295,10 @@ class App extends React.Component<{}, AppState> {
                         />
                     </div>
                     <div className='flex-auto my2 px2 overflow-auto'>
-                        {this.state.activeComponentId && React.createElement(selectedComponent)}
+                        {
+                            this.state.activeComponentId
+                            && React.createElement(this.getSelectedComponent(this.state.activeComponentId))
+                        }
                     </div>
                 </div>
             </Provider>
@@ -267,4 +318,5 @@ class App extends React.Component<{}, AppState> {
     }
 }
 
+ReactDOMRender(<Header />, document.getElementById('header'));
 ReactDOMRender(<App />, document.getElementById('App'));

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,10 +6,8 @@
     <meta charset="UTF-8">
 </head>
 <body class="flex full-content">
-<div class="header flex" style="min-height: 65px;">
-    <div class="header-section h1 p2 flex flex-center">
-        React Vapor
-    </div>
+<div id="header" class="header flex" style="min-height: 65px;">
+
 </div>
 <div class="container flex-auto" style="height: 0;">
     <div id="App" class="full-content"></div>

--- a/src/ReactVapor.ts
+++ b/src/ReactVapor.ts
@@ -42,6 +42,7 @@ import {ITableRowState} from './components/tables/TableRowReducers';
 import {ITextAreaState} from './components/textarea/TextAreaReducers';
 import {IToastsState} from './components/toast/ToastReducers';
 import {IStringListCompositeState} from './reusableState/customList/StringListReducers';
+import {ComponentID} from './utils/ComponentUtils';
 
 export interface IReactVaporState {
     autocompletes?: IAutocompleteState[];
@@ -83,6 +84,7 @@ export interface IReactVaporState {
     stringList?: IStringListCompositeState;
     selectWithFilter?: ISelectWithFilterCompositeState;
     lastAction?: Redux.Action;
+    dirtyComponents?: ComponentID[];
 }
 
 export interface IReduxActionsPayload {
@@ -125,4 +127,5 @@ export interface IReduxActionsPayload {
     yPosition?: number;
     disabledValues?: string[];
     isOpen?: boolean;
+    isDirty?: boolean;
 }

--- a/src/ReactVapor.ts
+++ b/src/ReactVapor.ts
@@ -42,7 +42,7 @@ import {ITableRowState} from './components/tables/TableRowReducers';
 import {ITextAreaState} from './components/textarea/TextAreaReducers';
 import {IToastsState} from './components/toast/ToastReducers';
 import {IStringListCompositeState} from './reusableState/customList/StringListReducers';
-import {ComponentID} from './utils/ComponentUtils';
+import {ComponentId} from './utils/ComponentUtils';
 
 export interface IReactVaporState {
     autocompletes?: IAutocompleteState[];
@@ -84,7 +84,7 @@ export interface IReactVaporState {
     stringList?: IStringListCompositeState;
     selectWithFilter?: ISelectWithFilterCompositeState;
     lastAction?: Redux.Action;
-    dirtyComponents?: ComponentID[];
+    dirtyComponents?: ComponentId[];
 }
 
 export interface IReduxActionsPayload {

--- a/src/ReactVaporReducers.ts
+++ b/src/ReactVaporReducers.ts
@@ -1,5 +1,4 @@
 import {ReducersMapObject} from 'redux';
-
 import {membersReducers} from '../docs/members-example/reducers/MembersReducers';
 import {actionBarsReducer} from './components/actions/ActionBarReducers';
 import {itemFiltersReducer} from './components/actions/filters/ItemFilterReducers';
@@ -37,6 +36,7 @@ import {tablesReducer} from './components/tables/TableReducers';
 import {tableRowsReducer} from './components/tables/TableRowReducers';
 import {textAreasReducer} from './components/textarea/TextAreaReducers';
 import {toastsContainerReducer} from './components/toast/ToastReducers';
+import {withEditingReducer} from './hoc/withEditing/withEditingReducers';
 import {IReactVaporState} from './ReactVapor';
 import {IReduxAction} from './utils/ReduxUtils';
 
@@ -83,5 +83,6 @@ export const ReactVaporReducers: ReducersMapObject = {
     radioSelects: radioSelectsReducer,
     popovers: popoversReducer,
     selectWithFilter: selectWithFilterCompositeReducer,
+    dirtyComponents: withEditingReducer,
     lastAction,
 };

--- a/src/components/sideNavigation/SideNavigation.tsx
+++ b/src/components/sideNavigation/SideNavigation.tsx
@@ -9,11 +9,18 @@ export interface ISideNavProps extends IReduxStatePossibleProps {
     opened?: boolean;
 }
 
-export const SideNavigation = (props: ISideNavProps) =>
-    <nav className={classNames(props.className, 'navigation', {'navigation-opened': props.withReduxState ? props.opened : true})}>
-        <div className='navigation-menu'>
-            <div className='navigation-menu-sections'>
-                {props.children}
-            </div>
-        </div>
-    </nav>;
+export class SideNavigation extends React.Component<ISideNavProps> {
+    static toggleEvent = 'side-navigation-toggle';
+
+    render() {
+        return (
+            <nav className={classNames(this.props.className, 'navigation', {'navigation-opened': this.props.withReduxState ? this.props.opened : true})}>
+                <div className='navigation-menu'>
+                    <div className='navigation-menu-sections'>
+                        {this.props.children}
+                    </div>
+                </div>
+            </nav>
+        );
+    }
+}

--- a/src/components/sideNavigation/SideNavigation.tsx
+++ b/src/components/sideNavigation/SideNavigation.tsx
@@ -14,13 +14,21 @@ export class SideNavigation extends React.Component<ISideNavProps> {
 
     render() {
         return (
-            <nav className={classNames(this.props.className, 'navigation', {'navigation-opened': this.props.withReduxState ? this.props.opened : true})}>
+            <nav className={this.getClasses()}>
                 <div className='navigation-menu'>
                     <div className='navigation-menu-sections'>
                         {this.props.children}
                     </div>
                 </div>
             </nav>
+        );
+    }
+
+    private getClasses(): string {
+        return classNames(
+            this.props.className,
+            'navigation',
+            {'navigation-opened': this.props.withReduxState ? this.props.opened : true},
         );
     }
 }

--- a/src/components/stickyFooter/StickyFooter.scss
+++ b/src/components/stickyFooter/StickyFooter.scss
@@ -1,0 +1,45 @@
+@import '~coveo-styleguide/scss/common/palette.scss';
+@import '~coveo-styleguide/scss/variables.scss';
+
+$stickyFooterHeight: 58px;
+
+:export { stickyFooterHeight: $stickyFooterHeight; }
+
+.stickyFooter {
+    position: fixed;
+    width: 100%;
+    bottom: 0;
+    right: 0;
+    align-items: center;
+    justify-content: flex-end;
+  
+    display: flex;
+    overflow: hidden;
+  
+    box-shadow: 0 -1px 5px 0 rgba(0,0,0,0.3);
+    background-color: $white;
+    border-radius: 0 0 $border-radius $border-radius;
+    padding: $modal-footer-small-padding;
+
+
+    margin-bottom: -$navigation-width;
+
+    transform: translate3d(0, 0, 0);
+
+    transition: margin-bottom $navigation-toggle-duration ease-in-out, width $navigation-toggle-duration ease-in-out;
+    will-change: transform;
+}
+
+.stickyFooterOpened {
+  margin-bottom: 0;
+}
+
+.stickyFooterPadding {
+  padding-bottom: $stickyFooterHeight; 
+}
+
+$stickyFooterWithSideNavClass: sticky-footer-with-side-nav;
+:global(.#{$stickyFooterWithSideNavClass}) {
+  width: calc(100% - #{$navigation-width});
+}
+:export { stickyFooterWithSideNavClass: $stickyFooterWithSideNavClass }

--- a/src/components/stickyFooter/StickyFooter.scss.d.ts
+++ b/src/components/stickyFooter/StickyFooter.scss.d.ts
@@ -1,0 +1,5 @@
+export const stickyFooterHeight: string;
+export const stickyFooterWithSideNavClass: string;
+export const stickyFooter: string;
+export const stickyFooterOpened: string;
+export const stickyFooterPadding: string;

--- a/src/components/stickyFooter/StickyFooter.tsx
+++ b/src/components/stickyFooter/StickyFooter.tsx
@@ -1,0 +1,55 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import {IClassName} from '../../utils/ClassNameUtils';
+import {SideNavigation} from '../sideNavigation/SideNavigation';
+import * as styles from './StickyFooter.scss';
+
+export interface IStickyFooterProps {
+    classes?: IClassName;
+}
+
+export interface IStickyFooterState {
+    withSideNav?: boolean;
+}
+
+export class StickyFooter extends React.Component<IStickyFooterProps, IStickyFooterState> {
+    static ID = 'StickyFooter';
+    static withSideNavClass = styles.stickyFooterWithSideNavClass;
+
+    constructor(props: IStickyFooterProps, state: IStickyFooterProps) {
+        super(props, state);
+        this.state = {};
+
+        this.setFooterState = this.setFooterState.bind(this);
+    }
+
+    componentDidMount() {
+        this.setState({withSideNav: !!document.querySelector('.navigation-wrapper-opened')});
+        document.addEventListener(SideNavigation.toggleEvent, this.setFooterState);
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener(SideNavigation.toggleEvent, this.setFooterState);
+    }
+
+    render() {
+        return (
+            <div
+                id={StickyFooter.ID}
+                className={
+                    classNames(
+                        styles.stickyFooter,
+                        {[styles.stickyFooterWithSideNavClass]: !!this.state.withSideNav},
+                        this.props.classes,
+                    )
+                }
+            >
+                {this.props.children}
+            </div>
+        );
+    }
+
+    setFooterState() {
+        this.setState({withSideNav: !this.state.withSideNav});
+    }
+}

--- a/src/components/stickyFooter/StickyFooter.tsx
+++ b/src/components/stickyFooter/StickyFooter.tsx
@@ -34,22 +34,21 @@ export class StickyFooter extends React.Component<IStickyFooterProps, IStickyFoo
 
     render() {
         return (
-            <div
-                id={StickyFooter.ID}
-                className={
-                    classNames(
-                        styles.stickyFooter,
-                        {[styles.stickyFooterWithSideNavClass]: !!this.state.withSideNav},
-                        this.props.classes,
-                    )
-                }
-            >
+            <div id={StickyFooter.ID} className={this.getClasses()}>
                 {this.props.children}
             </div>
         );
     }
 
-    setFooterState() {
+    private setFooterState() {
         this.setState({withSideNav: !this.state.withSideNav});
+    }
+
+    private getClasses(): string {
+        return classNames(
+            styles.stickyFooter,
+            {[styles.stickyFooterWithSideNavClass]: !!this.state.withSideNav},
+            this.props.classes,
+        );
     }
 }

--- a/src/components/stickyFooter/StickyFooter.tsx
+++ b/src/components/stickyFooter/StickyFooter.tsx
@@ -19,8 +19,6 @@ export class StickyFooter extends React.Component<IStickyFooterProps, IStickyFoo
     constructor(props: IStickyFooterProps, state: IStickyFooterProps) {
         super(props, state);
         this.state = {};
-
-        this.setFooterState = this.setFooterState.bind(this);
     }
 
     componentDidMount() {
@@ -40,15 +38,11 @@ export class StickyFooter extends React.Component<IStickyFooterProps, IStickyFoo
         );
     }
 
-    private setFooterState() {
-        this.setState({withSideNav: !this.state.withSideNav});
-    }
+    private setFooterState = () => this.setState({withSideNav: !this.state.withSideNav});
 
-    private getClasses(): string {
-        return classNames(
-            styles.stickyFooter,
-            {[styles.stickyFooterWithSideNavClass]: !!this.state.withSideNav},
-            this.props.classes,
-        );
-    }
+    private getClasses = () => classNames(
+        styles.stickyFooter,
+        {[styles.stickyFooterWithSideNavClass]: !!this.state.withSideNav},
+        this.props.classes,
+    )
 }

--- a/src/components/stickyFooter/examples/StickyFooterExamples.tsx
+++ b/src/components/stickyFooter/examples/StickyFooterExamples.tsx
@@ -1,0 +1,30 @@
+import * as classNames from 'classnames';
+import * as loremIpsum from 'lorem-ipsum';
+import * as React from 'react';
+import {Button} from '../../button/Button';
+import {StickyFooter} from '../../stickyFooter/StickyFooter';
+import * as styles from '../../stickyFooter/StickyFooter.scss';
+
+const lorem = loremIpsum({count: 200});
+
+export class StickyFooterExamples extends React.Component<{}, {isOpened: boolean}> {
+    constructor(props: {}, state: {isOpened: boolean}) {
+        super(props, state);
+
+        this.state = {
+            isOpened: false,
+        };
+    }
+
+    render() {
+        return (
+            <div className='mt2'>
+                <Button name='toggle footer' onClick={() => this.setState({isOpened: !this.state.isOpened})} />
+                <div className='mt2' style={{paddingBottom: '58px'}}>{lorem}</div>
+                <StickyFooter classes={classNames({[styles.stickyFooterOpened]: this.state.isOpened})}>
+                    <Button primary name='Save' />
+                </StickyFooter>
+            </div>
+        );
+    }
+}

--- a/src/hoc/withEditing/examples/withEditingExamples.tsx
+++ b/src/hoc/withEditing/examples/withEditingExamples.tsx
@@ -1,0 +1,36 @@
+import * as loremIpsum from 'lorem-ipsum';
+import * as React from 'react';
+import {ReactVaporStore} from '../../../../docs/ReactVaporStore';
+import {Button} from '../../../components/button/Button';
+import {Input} from '../../../components/input/Input';
+import {withEditing} from '../withEditing';
+import {toggleDirtyComponent} from '../withEditingActions';
+
+const lorem = loremIpsum({count: 200});
+
+class ComponentWithEditingExample extends React.Component {
+    static ID = 'ComponentWithEdit';
+
+    static footerChildren = (
+        <Button primary name='Save' />
+    );
+
+    render() {
+        return (
+            <div className='mt2'>
+                <div className='mb2'>
+                    <Input
+                        id='input'
+                        labelTitle='Enter something, go ahead, make me dirty...'
+                        onChange={() => ReactVaporStore.dispatch(toggleDirtyComponent(ComponentWithEditingExample.ID, true))}
+                    />
+                </div>
+                {lorem}
+            </div>
+        );
+    }
+}
+
+export const ComponentWithEditingExampleHOC = withEditing(
+    {id: ComponentWithEditingExample.ID, footerChildren: ComponentWithEditingExample.footerChildren},
+)(ComponentWithEditingExample);

--- a/src/hoc/withEditing/withEditing.tsx
+++ b/src/hoc/withEditing/withEditing.tsx
@@ -23,7 +23,7 @@ export interface IWithEditDispatchProps {
 
 export const withEditing = (config: IWithEditing) => (Component: React.ComponentClass<any, any>): React.ComponentClass<any, any> => {
     const mapStateToProps = (state: IReactVaporState): IWithEditStateProps => ({
-        isDirty: !!_.find(state.dirtyComponents, (id) => id === config.id),
+        isDirty: !!_.contains(state.dirtyComponents, config.id),
     });
 
     const mapDispatchToProps = (dispatch: IDispatch): IWithEditDispatchProps => ({

--- a/src/hoc/withEditing/withEditing.tsx
+++ b/src/hoc/withEditing/withEditing.tsx
@@ -6,6 +6,7 @@ import {IReactVaporState} from '../../ReactVapor';
 import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
 import {toggleDirtyComponent} from './withEditingActions';
+import {getIsDirty} from './withEditingReducers';
 
 export interface IWithEditing {
     id: string;
@@ -23,7 +24,7 @@ export interface IWithEditDispatchProps {
 
 export const withEditing = (config: IWithEditing) => (Component: React.ComponentClass<any, any>): React.ComponentClass<any, any> => {
     const mapStateToProps = (state: IReactVaporState): IWithEditStateProps => ({
-        isDirty: !!_.contains(state.dirtyComponents, config.id),
+        isDirty: getIsDirty(state, config.id),
     });
 
     const mapDispatchToProps = (dispatch: IDispatch): IWithEditDispatchProps => ({

--- a/src/hoc/withEditing/withEditing.tsx
+++ b/src/hoc/withEditing/withEditing.tsx
@@ -42,14 +42,11 @@ export const withEditing = (config: IWithEditing) => (Component: React.Component
                     <Component {..._.omit(this.props, 'isDirty', 'footerChildren')}>
                         {this.props.children}
                     </Component>
-                    {config.footerChildren
-                        ? (
-                            <StickyFooter classes={{[styles.stickyFooterOpened]: this.props.isDirty}}>
-                                {config.footerChildren}
-                            </StickyFooter>
-                        )
-                        : null
-                    }
+                    {config.footerChildren && (
+                        <StickyFooter classes={{[styles.stickyFooterOpened]: this.props.isDirty}}>
+                            {config.footerChildren}
+                        </StickyFooter>
+                    )}
                 </div>
             );
         }

--- a/src/hoc/withEditing/withEditing.tsx
+++ b/src/hoc/withEditing/withEditing.tsx
@@ -22,13 +22,13 @@ export interface IWithEditDispatchProps {
 }
 
 export const withEditing = (config: IWithEditing) => (Component: React.ComponentClass<any, any>): React.ComponentClass<any, any> => {
-    const mapStateToProps = (state: IReactVaporState): IWithEditStateProps => {
-        return {isDirty: !!_.find(state.dirtyComponents, (id) => id === config.id)};
-    };
+    const mapStateToProps = (state: IReactVaporState): IWithEditStateProps => ({
+        isDirty: !!_.find(state.dirtyComponents, (id) => id === config.id),
+    });
 
-    const mapDispatchToProps = (dispatch: IDispatch): IWithEditDispatchProps => {
-        return {toggleDirtyComponent: (isDirty: boolean) => dispatch(toggleDirtyComponent(config.id, isDirty))};
-    };
+    const mapDispatchToProps = (dispatch: IDispatch): IWithEditDispatchProps => ({
+        toggleDirtyComponent: (isDirty: boolean) => dispatch(toggleDirtyComponent(config.id, isDirty)),
+    });
 
     @ReduxConnect(mapStateToProps, mapDispatchToProps)
     class ComponentWithEditing extends React.Component<any, any> {

--- a/src/hoc/withEditing/withEditing.tsx
+++ b/src/hoc/withEditing/withEditing.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import * as _ from 'underscore';
+import {StickyFooter} from '../../components/stickyFooter/StickyFooter';
+import * as styles from '../../components/stickyFooter/StickyFooter.scss';
+import {IReactVaporState} from '../../ReactVapor';
+import {callIfDefined} from '../../utils/FalsyValuesUtils';
+import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
+import {toggleDirtyComponent} from './withEditingActions';
+
+export interface IWithEditing {
+    id: string;
+    isDirty?: boolean;
+    footerChildren?: React.ReactNode;
+}
+
+export interface IWithEditStateProps {
+    isDirty: boolean;
+}
+
+export interface IWithEditDispatchProps {
+    toggleDirtyComponent: (isDirty: boolean) => void;
+}
+
+export const withEditing = (config: IWithEditing) => (Component: React.ComponentClass<any, any>): React.ComponentClass<any, any> => {
+    const mapStateToProps = (state: IReactVaporState): IWithEditStateProps => {
+        return {isDirty: !!_.find(state.dirtyComponents, (id) => id === config.id)};
+    };
+
+    const mapDispatchToProps = (dispatch: IDispatch): IWithEditDispatchProps => {
+        return {toggleDirtyComponent: (isDirty: boolean) => dispatch(toggleDirtyComponent(config.id, isDirty))};
+    };
+
+    @ReduxConnect(mapStateToProps, mapDispatchToProps)
+    class ComponentWithEditing extends React.Component<any, any> {
+        componentWillUnmount() {
+            callIfDefined(this.props.toggleDirtyComponent, false);
+        }
+
+        render() {
+            return (
+                <div className={styles.stickyFooterPadding}>
+                    <Component {..._.omit(this.props, 'isDirty', 'footerChildren')}>
+                        {this.props.children}
+                    </Component>
+                    {config.footerChildren
+                        ? (
+                            <StickyFooter classes={{[styles.stickyFooterOpened]: this.props.isDirty}}>
+                                {config.footerChildren}
+                            </StickyFooter>
+                        )
+                        : null
+                    }
+                </div>
+            );
+        }
+    }
+
+    return ComponentWithEditing;
+};

--- a/src/hoc/withEditing/withEditingActions.tsx
+++ b/src/hoc/withEditing/withEditingActions.tsx
@@ -1,0 +1,15 @@
+import {IReduxAction} from '../../utils/ReduxUtils';
+
+export const WithEditingActions = {
+    toggle: 'TOGGLE_DIRTY_COMPONENT',
+};
+
+export interface IWithEditingPayload {
+    id: string;
+    isDirty: boolean;
+}
+
+export const toggleDirtyComponent = (id: string, isDirty: boolean): IReduxAction<IWithEditingPayload> => ({
+    type: WithEditingActions.toggle,
+    payload: {id, isDirty},
+});

--- a/src/hoc/withEditing/withEditingReducers.tsx
+++ b/src/hoc/withEditing/withEditingReducers.tsx
@@ -1,0 +1,21 @@
+import * as _ from 'underscore';
+import {IReduxActionsPayload} from '../../ReactVapor';
+import {ComponentID} from '../../utils/ComponentUtils';
+import {IReduxAction} from '../../utils/ReduxUtils';
+import {WithEditingActions} from './withEditingActions';
+
+export const dirtyComponentsInitialState: ComponentID[] = [];
+
+export const withEditingReducer = (
+    state: ComponentID[] = dirtyComponentsInitialState,
+    action: IReduxAction<IReduxActionsPayload>,
+): ComponentID[] => {
+    switch (action.type) {
+        case WithEditingActions.toggle:
+            return action.payload.isDirty
+                ? _.uniq([...state, action.payload.id])
+                : _.reject(state, (id: ComponentID) => id === action.payload.id);
+        default:
+            return state;
+    }
+};

--- a/src/hoc/withEditing/withEditingReducers.tsx
+++ b/src/hoc/withEditing/withEditingReducers.tsx
@@ -4,6 +4,9 @@ import {ComponentId} from '../../utils/ComponentUtils';
 import {IReduxAction} from '../../utils/ReduxUtils';
 import {WithEditingActions} from './withEditingActions';
 
+export const getIsDirty = (state: {dirtyComponents: ComponentId[], [key: string]: any}, id: ComponentId) =>
+    !!_.contains(state.dirtyComponents, id);
+
 export const dirtyComponentsInitialState: ComponentId[] = [];
 
 export const withEditingReducer = (

--- a/src/hoc/withEditing/withEditingReducers.tsx
+++ b/src/hoc/withEditing/withEditingReducers.tsx
@@ -1,20 +1,20 @@
 import * as _ from 'underscore';
 import {IReduxActionsPayload} from '../../ReactVapor';
-import {ComponentID} from '../../utils/ComponentUtils';
+import {ComponentId} from '../../utils/ComponentUtils';
 import {IReduxAction} from '../../utils/ReduxUtils';
 import {WithEditingActions} from './withEditingActions';
 
-export const dirtyComponentsInitialState: ComponentID[] = [];
+export const dirtyComponentsInitialState: ComponentId[] = [];
 
 export const withEditingReducer = (
-    state: ComponentID[] = dirtyComponentsInitialState,
+    state: ComponentId[] = dirtyComponentsInitialState,
     action: IReduxAction<IReduxActionsPayload>,
-): ComponentID[] => {
+): ComponentId[] => {
     switch (action.type) {
         case WithEditingActions.toggle:
             return action.payload.isDirty
                 ? _.uniq([...state, action.payload.id])
-                : _.reject(state, (id: ComponentID) => id === action.payload.id);
+                : _.reject(state, (id: ComponentId) => id === action.payload.id);
         default:
             return state;
     }

--- a/src/hoc/withEditing/withEditingReducers.tsx
+++ b/src/hoc/withEditing/withEditingReducers.tsx
@@ -4,8 +4,8 @@ import {ComponentId} from '../../utils/ComponentUtils';
 import {IReduxAction} from '../../utils/ReduxUtils';
 import {WithEditingActions} from './withEditingActions';
 
-export const getIsDirty = (state: {dirtyComponents: ComponentId[], [key: string]: any}, id: ComponentId) =>
-    !!_.contains(state.dirtyComponents, id);
+export const getIsDirty = (state: {dirtyComponents?: ComponentId[], [key: string]: any}, id: ComponentId): boolean =>
+    !!_.contains(state.dirtyComponents || [], id);
 
 export const dirtyComponentsInitialState: ComponentId[] = [];
 

--- a/src/utils/ComponentUtils.ts
+++ b/src/utils/ComponentUtils.ts
@@ -1,5 +1,7 @@
 import {ILinkSvgProps} from '../components/svg/LinkSvg';
 
+export type ComponentID = string;
+
 /**
  * DisplayClass is a reflection of the atomic display classes available in Vapor
  * see https://github.com/coveo/vapor/blob/04372c42cbabb06ddd79130c13902137a7956ad7/scss/utility/layout.scss

--- a/src/utils/ComponentUtils.ts
+++ b/src/utils/ComponentUtils.ts
@@ -1,6 +1,6 @@
 import {ILinkSvgProps} from '../components/svg/LinkSvg';
 
-export type ComponentID = string;
+export type ComponentId = string;
 
 /**
  * DisplayClass is a reflection of the atomic display classes available in Vapor


### PR DESCRIPTION
With the new UX for editable views/components/panels coming in the admin, we'll need to have a pattern to specify when the panel is dirty to 1) implement the PreventNavigateBack pattern out of it, and 2) show/hide the save footer accordingly (UX desired pattern).

The sticky footer and the withEditing hoc in this PR suggest a part of this pattern we could adopt in the future, also @tommy-tran will need this soon for the feature he's working on

this kind of editable view: 

<img width="1398" alt="screen shot 2018-11-09 at 1 01 29 pm" src="https://user-images.githubusercontent.com/9539763/48279786-9cc3d900-e41f-11e8-8639-e9daa622cbc1.png">


the HOC could also be used for components without a footer (step by step ml model creation for example) just to have the `isDirty` state on it
  

demo:
https://coveo.github.io/react-vapor/sticky-footer-and-with-editing/#StickyFooter
https://coveo.github.io/react-vapor/sticky-footer-and-with-editing/#ComponentWithEditing
