### PR TITLE
implement table with numbered rows

### DIFF
--- a/src/components/table-hoc/TableRowNumberColumn.tsx
+++ b/src/components/table-hoc/TableRowNumberColumn.tsx
@@ -1,0 +1,11 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import * as styles from './styles/TableRowNumber.scss';
+
+export const TableRowNumberColumn = (props: {number: string | number}) => (
+    <td key='table-row-number' className={styles.tableNumberedRow}>
+        <div className={classNames('bg-grey-1 mod-border-right text-medium-blue flex flex-column flex-center center', styles.tableNumberedRowContainer)}>
+            {props.number}
+        </div>
+    </td>
+);

--- a/src/components/table-hoc/TableRowNumberColumn.tsx
+++ b/src/components/table-hoc/TableRowNumberColumn.tsx
@@ -4,7 +4,7 @@ import * as styles from './styles/TableRowNumber.scss';
 
 export const TableRowNumberColumn = (props: {number: string | number}) => (
     <td key='table-row-number' className={styles.tableNumberedRow}>
-        <div className={classNames('bg-grey-1 mod-border-right text-medium-blue flex flex-column flex-center center', styles.tableNumberedRowContainer)}>
+        <div className={classNames('bg-grey-1 mod-border-right text-lynch flex flex-column flex-center center', styles.tableNumberedRowContainer)}>
             {props.number}
         </div>
     </td>

--- a/src/components/table-hoc/TableRowNumberColumn.tsx
+++ b/src/components/table-hoc/TableRowNumberColumn.tsx
@@ -2,7 +2,7 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import * as styles from './styles/TableRowNumber.scss';
 
-export const TableRowNumberColumn = (props: {number: string | number}) => (
+export const TableRowNumberColumn = (props: {number: React.ReactNode}) => (
     <td key='table-row-number' className={styles.tableNumberedRow}>
         <div className={classNames('bg-grey-1 mod-border-right text-lynch flex flex-column flex-center center', styles.tableNumberedRowContainer)}>
             {props.number}

--- a/src/components/table-hoc/TableRowNumberHeader.tsx
+++ b/src/components/table-hoc/TableRowNumberHeader.tsx
@@ -1,0 +1,3 @@
+import * as React from 'react';
+
+export const TableRowNumberHeader = () => <th></th>;

--- a/src/components/table-hoc/examples/TableHOCServerExamples.tsx
+++ b/src/components/table-hoc/examples/TableHOCServerExamples.tsx
@@ -6,6 +6,8 @@ import {LastUpdated} from '../../lastUpdated/LastUpdated';
 import {TableHeaderWithSort} from '../TableHeaderWithSort';
 import {TableHOC} from '../TableHOC';
 import {TableRowConnected} from '../TableRowConnected';
+import {TableRowNumberColumn} from '../TableRowNumberColumn';
+import {TableRowNumberHeader} from '../TableRowNumberHeader';
 import {tableWithActions} from '../TableWithActions';
 import {tableWithBlankslate} from '../TableWithBlankslate';
 import {tableWithFilter} from '../TableWithFilter';
@@ -75,20 +77,22 @@ export class TableHOCServerExamples extends React.Component<TableHOCServerProps>
                 actions={[{primary: true, icon: 'edit', name: 'edit', enabled: true, trigger: () => alert(data.username)}]}
                 isMultiselect
             >
+                <TableRowNumberColumn number={i + 1} />
                 <td key='city'>{data.city}</td>
                 <td key='email'>{data.email.toLowerCase()}</td>
                 <td key='username'>{data.username.toLowerCase()}</td>
             </TableRowConnected>
         ));
+
         return (
             <div className='mt2'>
                 <div className='form-group'>
                     <label className='form-control-label'>
-                        Server table
+                        Server table with numbered rows
                     </label>
                     <ServerTable
                         id={TableHOCServerExamples.TABLE_ID}
-                        className='table'
+                        className='table table-numbered'
                         data={this.props.serverData}
                         renderData={generateRow}
                         tableHeader={this.renderHeader()}
@@ -106,6 +110,7 @@ export class TableHOCServerExamples extends React.Component<TableHOCServerProps>
         return (
             <thead>
                 <tr>
+                    <TableRowNumberHeader />
                     <TableHeaderWithSort id='address.city' tableId={TableHOCServerExamples.TABLE_ID}>City</TableHeaderWithSort>
                     <TableHeaderWithSort id='email' tableId={TableHOCServerExamples.TABLE_ID}>Email</TableHeaderWithSort>
                     <TableHeaderWithSort id='username' tableId={TableHOCServerExamples.TABLE_ID} isDefault>Username</TableHeaderWithSort>

--- a/src/components/table-hoc/styles/TableRowNumber.scss
+++ b/src/components/table-hoc/styles/TableRowNumber.scss
@@ -1,0 +1,27 @@
+@import '~coveo-styleguide/scss/common/palette.scss';
+@import '~coveo-styleguide/scss/variables.scss';
+
+:global(.coveo-styleguide .table.table-numbered) {
+    td:nth-child(2) {
+        border-left: $table-selected-border-width solid transparent;
+        padding-left: $default-margin;
+    }
+     tr:global(.selected) td:nth-child(2) {
+        border-left-color: $orange;
+    }
+}
+
+:global(.coveo-styleguide .table) .tableNumberedRow:first-child {
+    padding:0;
+    border-left: none;
+    width: 60px;
+    height: 40px;
+} 
+
+:global(.coveo-styleguide .table) .tableNumberedRowContainer {
+    color: $medium-blue;
+    border-left: none;
+    width: 60px;
+    text-align: center;
+    padding: $default-margin;
+} 

--- a/src/components/table-hoc/styles/TableRowNumber.scss.d.ts
+++ b/src/components/table-hoc/styles/TableRowNumber.scss.d.ts
@@ -1,0 +1,2 @@
+export const tableNumberedRow: string;
+export const tableNumberedRowContainer: string;

--- a/src/components/table-hoc/tests/TableRowNumberColumn.spec.tsx
+++ b/src/components/table-hoc/tests/TableRowNumberColumn.spec.tsx
@@ -1,0 +1,10 @@
+import {shallow} from 'enzyme';
+import * as React from 'react';
+import {TableRowNumberColumn} from '../TableRowNumberColumn';
+
+describe('TableRowNumberColumn', () => {
+    it('should render without error', () => {
+        expect(() => shallow(<TableRowNumberColumn number={1} />)).not.toThrow();
+        expect(() => shallow(<TableRowNumberColumn number={'10000'} />)).not.toThrow();
+    });
+});

--- a/src/components/table-hoc/tests/TableRowNumberHeader.spec.tsx
+++ b/src/components/table-hoc/tests/TableRowNumberHeader.spec.tsx
@@ -1,0 +1,9 @@
+import {shallow} from 'enzyme';
+import * as React from 'react';
+import {TableRowNumberHeader} from '../TableRowNumberHeader';
+
+describe('TableRowNumberHeader', () => {
+    it('should render without error', () => {
+        expect(() => shallow(<TableRowNumberHeader />)).not.toThrow();
+    });
+});


### PR DESCRIPTION
<img width="1098" alt="screen shot 2018-11-13 at 4 15 27 pm" src="https://user-images.githubusercontent.com/9539763/48443511-5e038b00-e75f-11e8-9eca-9fac4bbc5868.png">  

https://coveo.github.io/react-vapor/table-with-numbered-rows/#Table%20(server%20+%20hoc)
  
i don't think it was HOC worthy, especially since renderData is custom to each table, but definitely open for changes here.  

you need to do three things to add numbered rows for now:

- Add <TableRowNumberHeader /> in the header
- Add <TableRowNumberColumn /> as a column in renderData
- add the .table-numbered class on the table  

maybe there would be something simpler, thoughts are welcome  

@otaillon