### PR TITLE
add better type for withEditing hoc

### DIFF
--- a/src/hoc/withEditing/withEditing.tsx
+++ b/src/hoc/withEditing/withEditing.tsx
@@ -25,40 +25,41 @@ export interface IWithEditDispatchProps {
 
 export interface IWithEditingProps extends IWithEditStateProps, IWithEditDispatchProps {}
 
-export const withEditing = (config: IWithEditing) => (Component: React.ComponentClass): React.ComponentClass => {
-    const mapStateToProps = (state: IReactVaporState): IWithEditStateProps => ({
-        isDirty: getIsDirty(state, config.id),
-    });
+export const withEditing = <T, R = any>(config: IWithEditing) =>
+    (Component: React.ComponentClass): React.ComponentClass<IWithEditingProps & T, R> => {
+        const mapStateToProps = (state: IReactVaporState): IWithEditStateProps => ({
+            isDirty: getIsDirty(state, config.id),
+        });
 
-    const mapDispatchToProps = (dispatch: IDispatch): IWithEditDispatchProps => ({
-        toggleDirtyComponent: (isDirty: boolean) => dispatch(toggleDirtyComponent(config.id, isDirty)),
-    });
+        const mapDispatchToProps = (dispatch: IDispatch): IWithEditDispatchProps => ({
+            toggleDirtyComponent: (isDirty: boolean) => dispatch(toggleDirtyComponent(config.id, isDirty)),
+        });
 
-    @ReduxConnect(mapStateToProps, mapDispatchToProps)
-    class ComponentWithEditing extends React.Component<IWithEditingProps> {
-        componentDidMount() {
-            this.props.toggleDirtyComponent(config.isDirty);
+        @ReduxConnect(mapStateToProps, mapDispatchToProps)
+        class ComponentWithEditing extends React.Component<IWithEditingProps & T, R> {
+            componentDidMount() {
+                this.props.toggleDirtyComponent(config.isDirty);
+            }
+
+            componentWillUnmount() {
+                this.props.toggleDirtyComponent(false);
+            }
+
+            render() {
+                return (
+                    <div>
+                        <Component {...this.props}>
+                            {this.props.children}
+                        </Component>
+                        {config.footerChildren && (
+                            <StickyFooter className={classNames({[styles.stickyFooterOpened]: this.props.isDirty}, config.footerClassName)}>
+                                {config.footerChildren}
+                            </StickyFooter>
+                        )}
+                    </div>
+                );
+            }
         }
 
-        componentWillUnmount() {
-            this.props.toggleDirtyComponent(false);
-        }
-
-        render() {
-            return (
-                <div>
-                    <Component {...this.props}>
-                        {this.props.children}
-                    </Component>
-                    {config.footerChildren && (
-                        <StickyFooter className={classNames({[styles.stickyFooterOpened]: this.props.isDirty}, config.footerClassName)}>
-                            {config.footerChildren}
-                        </StickyFooter>
-                    )}
-                </div>
-            );
-        }
-    }
-
-    return ComponentWithEditing;
-};
+        return ComponentWithEditing;
+    };

--- a/src/hoc/withEditing/withEditing.tsx
+++ b/src/hoc/withEditing/withEditing.tsx
@@ -26,7 +26,7 @@ export interface IWithEditDispatchProps {
 export interface IWithEditingProps extends IWithEditStateProps, IWithEditDispatchProps {}
 
 export const withEditing = <T, R = any>(config: IWithEditing) =>
-    (Component: React.ComponentClass): React.ComponentClass<IWithEditingProps & T, R> => {
+    (Component: React.ComponentClass): React.ComponentClass<Partial<IWithEditingProps> & T, R> => {
         const mapStateToProps = (state: IReactVaporState): IWithEditStateProps => ({
             isDirty: getIsDirty(state, config.id),
         });
@@ -36,7 +36,7 @@ export const withEditing = <T, R = any>(config: IWithEditing) =>
         });
 
         @ReduxConnect(mapStateToProps, mapDispatchToProps)
-        class ComponentWithEditing extends React.Component<IWithEditingProps & T, R> {
+        class ComponentWithEditing extends React.Component<Partial<IWithEditingProps> & T, R> {
             componentDidMount() {
                 this.props.toggleDirtyComponent(config.isDirty);
             }


### PR DESCRIPTION
![screen shot 2018-12-03 at 1 56 03 pm](https://user-images.githubusercontent.com/9539763/49395039-6407de80-f703-11e8-917f-9fa957503b23.png)
  

good catch from @tommy-tran , the hoc was returning the wrong prop signature. You can now pass the props interface and state interface to the hoc if needed.