### PR TITLE
Collapsible rows for table HOC

### DIFF
--- a/src/components/collapsible/Collapsible.tsx
+++ b/src/components/collapsible/Collapsible.tsx
@@ -1,9 +1,9 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
 
-import * as classNames from 'classnames';
 import {SlideY} from '../../animations/SlideY';
 import {callIfDefined} from '../../utils/FalsyValuesUtils';
-import {Svg} from '../svg/Svg';
+import {CollapsibleToggle} from './CollapsibleToggle';
 
 export interface CollapsibleOwnProps {
     id: string;
@@ -52,13 +52,13 @@ export class Collapsible extends React.Component<CollapsibleProps> {
                     onClick={() => this.handleHeaderClick()}
                 >
                     {this.props.headerContent}
-                    <Svg
-                        svgName={this.props.expanded ? 'arrow-top-rounded' : 'arrow-bottom-rounded'}
-                        svgClass={classNames('icon', this.props.toggleIconClassName)}
+                    <CollapsibleToggle
+                        expanded={this.props.expanded}
+                        svgClassName={this.props.toggleIconClassName}
                         className='mr3'
                     />
                 </div>
-                <SlideY in={this.props.expanded} timeout={Collapsible.TIMEOUT} duration={Collapsible.TIMEOUT}>
+                <SlideY id={this.props.id} in={this.props.expanded} timeout={Collapsible.TIMEOUT} duration={Collapsible.TIMEOUT}>
                     {this.props.children}
                 </SlideY>
             </div>

--- a/src/components/collapsible/CollapsibleToggle.tsx
+++ b/src/components/collapsible/CollapsibleToggle.tsx
@@ -13,6 +13,6 @@ export const CollapsibleToggle: React.SFC<CollapsibleToggleProps> = ({expanded, 
     <Svg
         svgName={expanded ? 'arrow-top-rounded' : 'arrow-bottom-rounded'}
         svgClass={classNames('icon', svgClassName)}
-        className={classNames(className)}
+        className={className}
     />
 );

--- a/src/components/collapsible/CollapsibleToggle.tsx
+++ b/src/components/collapsible/CollapsibleToggle.tsx
@@ -1,0 +1,18 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+
+import {Svg} from '../svg/Svg';
+
+export interface CollapsibleToggleProps {
+    expanded: boolean;
+    className?: string;
+    svgClassName?: string;
+}
+
+export const CollapsibleToggle: React.SFC<CollapsibleToggleProps> = ({expanded, className, svgClassName}) => (
+    <Svg
+        svgName={expanded ? 'arrow-top-rounded' : 'arrow-bottom-rounded'}
+        svgClass={classNames('icon', svgClassName)}
+        className={classNames(className)}
+    />
+);

--- a/src/components/collapsible/tests/CollapsibleToggle.spec.tsx
+++ b/src/components/collapsible/tests/CollapsibleToggle.spec.tsx
@@ -1,0 +1,21 @@
+import {shallow} from 'enzyme';
+import * as React from 'react';
+
+import {Svg} from '../../svg/Svg';
+import {CollapsibleToggle} from '../CollapsibleToggle';
+
+describe('CollapsibleToggle', () => {
+    it('should render a Svg component with the icon "arrow-bottom-rounded" when expanded is false', () => {
+        const toggle = shallow(<CollapsibleToggle expanded={false} />);
+
+        expect(toggle.find(Svg).exists()).toBe(true);
+        expect(toggle.find(Svg).props().svgName).toBe('arrow-bottom-rounded');
+    });
+
+    it('should render a Svg component with the icon "arrow-top-rounded" when expanded is false', () => {
+        const toggle = shallow(<CollapsibleToggle expanded={true} />);
+
+        expect(toggle.find(Svg).exists()).toBe(true);
+        expect(toggle.find(Svg).props().svgName).toBe('arrow-top-rounded');
+    });
+});

--- a/src/components/modalPrompt/ModalPrompt.tsx
+++ b/src/components/modalPrompt/ModalPrompt.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+
+import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {Modal} from '../modal/Modal';
 import {ModalBody} from '../modal/ModalBody';
 import {ModalFooter} from '../modal/ModalFooter';
@@ -36,15 +38,11 @@ export class ModalPrompt extends React.Component<IModalPromptProps, any> {
     };
 
     private confirm() {
-        if (this.props.onConfirm) {
-            this.props.onConfirm(this.props.id);
-        }
+        callIfDefined(this.props.onConfirm, this.props.id);
     }
 
     private cancel() {
-        if (this.props.onCancel) {
-            this.props.onCancel(this.props.id);
-        }
+        callIfDefined(this.props.onCancel, this.props.id);
     }
 
     render() {

--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -8,22 +8,20 @@ export interface ISliderProps {
     hasTooltip?: boolean;
 }
 
-export class Slider extends React.Component<ISliderProps, {}> {
-
-    static defaultProps: Partial<ISliderProps> = {
-        slider: {},
-        hasTooltip: false,
-    };
-
-    render() {
-        const HtmlTag = this.props.hasTooltip ? createSliderWithTooltip(RCSlider) : RCSlider;
-        if (this.props.hasTooltip) {
-            (this.props.slider as any).tipProps = {
-                overlayClassName: 'vapor-slider-overlay',
-            };
-        }
-
-        const classes: string = classNames('vapor-slider', this.props.classes);
-        return <HtmlTag className={classes} {...this.props.slider} />;
+const Slider: React.SFC<ISliderProps> = ({hasTooltip, slider, classes}) => {
+    const HtmlTag = hasTooltip ? createSliderWithTooltip(RCSlider) : RCSlider;
+    if (hasTooltip) {
+        (slider as any).tipProps = {
+            overlayClassName: 'vapor-slider-overlay',
+        };
     }
-}
+
+    return <HtmlTag className={classNames('vapor-slider', classes)} {...slider} />;
+};
+
+Slider.defaultProps = {
+    slider: {},
+    hasTooltip: false,
+};
+
+export {Slider};

--- a/src/components/slider/tests/Slider.spec.tsx
+++ b/src/components/slider/tests/Slider.spec.tsx
@@ -1,0 +1,11 @@
+import {shallow} from 'enzyme';
+import * as React from 'react';
+
+import {Slider} from '../Slider';
+
+describe('Slider', () => {
+    it('should render without error', () => {
+        expect(() => shallow(<Slider />)).not.toThrow();
+        expect(() => shallow(<Slider hasTooltip />)).not.toThrow();
+    });
+});

--- a/src/components/table-hoc/TableHOC.tsx
+++ b/src/components/table-hoc/TableHOC.tsx
@@ -20,7 +20,7 @@ export interface ITableHOCOwnProps {
 
 export interface ITableHOCProps extends ITableHOCOwnProps {}
 
-export class TableHOC extends React.Component<ITableHOCProps & React.HTMLAttributes<HTMLTableElement>> {
+export class TableHOC extends React.PureComponent<ITableHOCProps & React.HTMLAttributes<HTMLTableElement>> {
     static defaultProps: Partial<ITableHOCOwnProps> = {
         isLoading: false,
         hasActionButtons: false,

--- a/src/components/table-hoc/TableRowConnected.tsx
+++ b/src/components/table-hoc/TableRowConnected.tsx
@@ -5,6 +5,7 @@ import * as _ from 'underscore';
 
 import {SlideY} from '../../animations/SlideY';
 import {IReactVaporState} from '../../ReactVapor';
+import {EventUtils} from '../../utils/EventUtils';
 import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
 import {IActionOptions} from '../actions/Action';
@@ -90,8 +91,10 @@ export class TableRowConnected extends React.PureComponent<ITableRowConnectedPro
     };
 
     private handleClick = (e: React.MouseEvent<HTMLTableRowElement>) => {
-        const isMulti = (e.metaKey || e.ctrlKey) && this.props.isMultiselect;
-        this.props.onClick(isMulti);
+        if (!EventUtils.isClickingInsideElementWithClassname(e, 'dropdown')) {
+            const isMulti = (e.metaKey || e.ctrlKey) && this.props.isMultiselect;
+            this.props.onClick(isMulti);
+        }
     }
 
     componentDidMount() {
@@ -126,7 +129,7 @@ export class TableRowConnected extends React.PureComponent<ITableRowConnectedPro
             </tr>
         );
 
-        let collapsibleRowToggle: React.ReactNode = null;
+        let collapsibleRowToggle: React.ReactNode = [];
         if (rowIsCollapsible) {
             const customToggle = callIfDefined(this.props.collapsible.renderCustomToggleCell, this.props.opened);
             collapsibleRowToggle = React.isValidElement(customToggle)

--- a/src/components/table-hoc/TableRowConnected.tsx
+++ b/src/components/table-hoc/TableRowConnected.tsx
@@ -129,7 +129,7 @@ export class TableRowConnected extends React.PureComponent<ITableRowConnectedPro
         let collapsibleRowToggle: React.ReactNode = null;
         if (rowIsCollapsible) {
             const customToggle = callIfDefined(this.props.collapsible.renderCustomToggleCell, this.props.opened);
-            collapsibleRowToggle = React.isValidElement(customToggle) || _.isString(customToggle)
+            collapsibleRowToggle = React.isValidElement(customToggle)
                 ? customToggle
                 : <td><CollapsibleToggle expanded={this.props.opened} svgClassName='mod-12' /></td>;
         }

--- a/src/components/table-hoc/TableRowConnected.tsx
+++ b/src/components/table-hoc/TableRowConnected.tsx
@@ -1,23 +1,38 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
-import {keys} from 'ts-transformer-keys/index';
+import {keys} from 'ts-transformer-keys';
 import * as _ from 'underscore';
+
+import {SlideY} from '../../animations/SlideY';
 import {IReactVaporState} from '../../ReactVapor';
+import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
 import {IActionOptions} from '../actions/Action';
 import {addActionsToActionBar} from '../actions/ActionBarActions';
+import {Collapsible} from '../collapsible/Collapsible';
+import {CollapsibleToggle} from '../collapsible/CollapsibleToggle';
 import {TableRowActions} from './actions/TableRowActions';
 import {ITableRowState} from './reducers/TableRowReducers';
+import {TableSelectors} from './TableSelectors';
+
+export interface CollapsibleRowProps {
+    content?: React.ReactNode;
+    className?: string;
+    expandOnMount?: boolean;
+    renderCustomToggleCell?: (opened: boolean) => React.ReactNode;
+}
 
 export interface ITableRowOwnProps {
     id: string;
     tableId: string;
     actions?: IActionOptions[];
     isMultiselect?: boolean;
+    collapsible?: CollapsibleRowProps;
 }
 
 export interface ITableRowStateProps {
     selected: boolean;
+    opened: boolean;
 }
 
 export interface ITableRowDispatchProps {
@@ -26,17 +41,21 @@ export interface ITableRowDispatchProps {
     onClick: (isMulti: boolean) => void;
 }
 
-export interface ITableHeaderWithSortProps extends
+export interface ITableRowConnectedProps extends
     ITableRowOwnProps,
     Partial<ITableRowStateProps>,
     Partial<ITableRowDispatchProps> {}
 
-const TableRowPropsToOmit = keys<ITableHeaderWithSortProps>();
+const TableRowPropsToOmit = keys<ITableRowConnectedProps>();
+
+const isCollapsible = (props: ITableRowOwnProps): boolean => props.collapsible
+    && (React.isValidElement(props.collapsible.content) || _.isString(props.collapsible.content));
 
 const mapStateToProps = (state: IReactVaporState, ownProps: ITableRowOwnProps) => {
-    const row: ITableRowState = _.findWhere(state.tableHOCRow, {id: ownProps.id});
+    const row: ITableRowState = TableSelectors.getTableRow(state, {id: ownProps.id});
     return {
         selected: row && row.selected,
+        opened: row && row.opened,
     };
 };
 
@@ -44,20 +63,30 @@ const mapDispatchToProps = (
     dispatch: IDispatch,
     ownProps: ITableRowOwnProps,
 ): ITableRowDispatchProps => ({
-    onMount: () => dispatch(TableRowActions.addTableRow(ownProps.id, ownProps.tableId)),
-    onUnmount: () => dispatch(TableRowActions.removeTableRow(ownProps.id)),
+    onMount: () => {
+        dispatch(TableRowActions.add(ownProps.id, ownProps.tableId));
+        if (isCollapsible(ownProps) && ownProps.collapsible.expandOnMount) {
+            dispatch(TableRowActions.toggleCollapsible(ownProps.id, true));
+        }
+    },
+    onUnmount: () => dispatch(TableRowActions.remove(ownProps.id)),
     onClick: (isMulti: boolean) => {
-        dispatch(addActionsToActionBar(ownProps.tableId, ownProps.actions));
-        dispatch(TableRowActions.selectRow(ownProps.id, isMulti));
+        if (!_.isEmpty(ownProps.actions)) {
+            dispatch(addActionsToActionBar(ownProps.tableId, ownProps.actions));
+            dispatch(TableRowActions.select(ownProps.id, isMulti));
+        }
+        if (isCollapsible(ownProps)) {
+            dispatch(TableRowActions.toggleCollapsible(ownProps.id));
+        }
     },
 });
 
 @ReduxConnect(mapStateToProps, mapDispatchToProps)
-export class TableRowConnected extends React.Component<ITableHeaderWithSortProps & React.HTMLAttributes<HTMLTableRowElement>> {
-
+export class TableRowConnected extends React.PureComponent<ITableRowConnectedProps & React.HTMLAttributes<HTMLTableRowElement>> {
     static defaultProps: Partial<ITableRowOwnProps> = {
         actions: [],
         isMultiselect: false,
+        collapsible: {},
     };
 
     private handleClick = (e: React.MouseEvent<HTMLTableRowElement>) => {
@@ -74,14 +103,57 @@ export class TableRowConnected extends React.Component<ITableHeaderWithSortProps
     }
 
     render() {
-        return (
+        const rowIsCollapsible = isCollapsible(this.props);
+        const collapsibleContentRow = rowIsCollapsible && (
             <tr
-                {..._.omit(this.props, TableRowPropsToOmit)}
-                className={classNames(this.props.className, {selected: this.props.selected})}
-                onClick={this.handleClick}
-            >
-                {this.props.children}
+                key={`${this.props.tableId}-${this.props.id}-collapsible`}
+                className={classNames(
+                    'collapsible-row',
+                    this.props.collapsible.className,
+                    {
+                        'mod-border-bottom': this.props.opened,
+                    },
+                )}>
+                <td colSpan={React.Children.count(this.props.children) + 1}>
+                    <SlideY
+                        id={`${this.props.tableId}-${this.props.id}-collapsible`}
+                        in={this.props.opened}
+                        timeout={Collapsible.TIMEOUT}
+                        duration={Collapsible.TIMEOUT}>
+                        {this.props.collapsible.content}
+                    </SlideY>
+                </td>
             </tr>
+        );
+
+        let collapsibleRowToggle: React.ReactNode = null;
+        if (rowIsCollapsible) {
+            const customToggle = callIfDefined(this.props.collapsible.renderCustomToggleCell, this.props.opened);
+            collapsibleRowToggle = React.isValidElement(customToggle) || _.isString(customToggle)
+                ? customToggle
+                : <td><CollapsibleToggle expanded={this.props.opened} svgClassName='mod-12' /></td>;
+        }
+
+        return (
+            <React.Fragment key={`${this.props.tableId}-${this.props.id}`}>
+                <tr
+                    key={`${this.props.tableId}-${this.props.id}-heading`}
+                    {..._.omit(this.props, TableRowPropsToOmit)}
+                    className={classNames(
+                        this.props.className,
+                        {
+                            selected: this.props.selected,
+                            opened: this.props.opened,
+                            'heading-row': rowIsCollapsible,
+                        },
+                    )}
+                    onClick={this.handleClick}
+                >
+                    {this.props.children}
+                    {collapsibleRowToggle}
+                </tr>
+                {collapsibleContentRow}
+            </React.Fragment>
         );
     }
 }

--- a/src/components/table-hoc/TableSelectors.ts
+++ b/src/components/table-hoc/TableSelectors.ts
@@ -1,5 +1,7 @@
 import * as _ from 'underscore';
+
 import {IReactVaporState} from '../../ReactVapor';
+import {ITableRowState} from './reducers/TableRowReducers';
 import {ITableWithSortState} from './reducers/TableWithSortReducers';
 
 export interface TableSelectorsProps {
@@ -21,8 +23,12 @@ const getSort = (state: IReactVaporState, props: TableSelectorsProps): ITableWit
     return _.find(state.tableHOCHeader, (v: ITableWithSortState) => v.tableId === props.id && _.isBoolean(v.isAsc));
 };
 
+const getTableRow = (state: IReactVaporState, {id}: {id: string}): ITableRowState =>
+    _.findWhere(state.tableHOCRow, {id});
+
 export const TableSelectors = {
     getIsEmpty,
     getDataCount,
     getSort,
+    getTableRow,
 };

--- a/src/components/table-hoc/actions/TableRowActions.ts
+++ b/src/components/table-hoc/actions/TableRowActions.ts
@@ -1,13 +1,13 @@
-import {IReduxAction} from '../../../utils/ReduxUtils';
+import {BasePayload, IReduxAction} from '../../../utils/ReduxUtils';
 
 export const TableRowActionsType = {
     add: 'ADD_TABLE_ROW',
     remove: 'REMOVE_TABLE_ROW',
     select: 'SELECT_TABLE_ROW',
+    toggleCollapsible: 'TOGGLE_TABLE_COLLAPSIBLE_ROW',
 };
 
-export interface ITableRowAddPayload {
-    id: string;
+export interface ITableRowAddPayload extends BasePayload {
     tableId: string;
 }
 
@@ -16,17 +16,12 @@ const addTableRow = (id: string, tableId: string): IReduxAction<ITableRowAddPayl
     payload: {id, tableId},
 });
 
-export interface ITableRowRemovePayload {
-    id: string;
-}
-
-const removeTableRow = (id: string): IReduxAction<ITableRowRemovePayload> => ({
+const removeTableRow = (id: string): IReduxAction<BasePayload> => ({
     type: TableRowActionsType.remove,
     payload: {id},
 });
 
-export interface ITableRowSelectPayload {
-    id: string;
+export interface ITableRowSelectPayload extends BasePayload {
     isMulti?: boolean;
 }
 
@@ -35,8 +30,18 @@ const selectRow = (id: string, isMulti: boolean = false): IReduxAction<ITableRow
     payload: {id, isMulti},
 });
 
+export interface ITableRowToggleCollapsiblePayload extends BasePayload {
+    opened?: boolean;
+}
+
+const toggleCollapsibleRow = (id: string, opened?: boolean): IReduxAction<ITableRowToggleCollapsiblePayload> => ({
+    type: TableRowActionsType.toggleCollapsible,
+    payload: {id, opened},
+});
+
 export const TableRowActions = {
-    addTableRow,
-    removeTableRow,
-    selectRow,
+    add: addTableRow,
+    remove: removeTableRow,
+    select: selectRow,
+    toggleCollapsible: toggleCollapsibleRow,
 };

--- a/src/components/table-hoc/examples/TableHOCExamples.tsx
+++ b/src/components/table-hoc/examples/TableHOCExamples.tsx
@@ -1,8 +1,10 @@
 import {helpers, seed} from 'faker';
 import * as React from 'react';
 import * as _ from 'underscore';
+
 import {TableHeaderWithSort} from '../TableHeaderWithSort';
 import {TableHOC} from '../TableHOC';
+import {TableRowConnected} from '../TableRowConnected';
 import {tableWithBlankSlate} from '../TableWithBlankSlate';
 import {tableWithFilter} from '../TableWithFilter';
 import {tableWithPagination} from '../TableWithPagination';
@@ -88,6 +90,13 @@ export class TableHOCExamples extends React.Component {
                 <td key='username'>{data.username.toLowerCase()}</td>
             </tr>
         ));
+        const generateCollapsibleRow = (data: IExampleRowData) => (
+            <div className='p2'>
+                <div>Hey there, I am collapsible information about</div>
+                <div>{JSON.stringify(data)}</div>
+            </div>
+        );
+
         return (
             <div className='mt2'>
                 <div className='form-group'>
@@ -100,6 +109,32 @@ export class TableHOCExamples extends React.Component {
                         data={generateData(3)}
                         renderBody={generateRows}
                         tableHeader={<thead><tr><th>City</th><th>Email</th><th>Username</th></tr></thead>}
+                    />
+                </div>
+
+                <div className='form-group'>
+                    <label className='form-control-label'>
+                        Tables with collapsible rows
+                    </label>
+                    <TableHOC
+                        id='collapsible-rows'
+                        className='table mod-collapsible-rows'
+                        data={generateData(3)}
+                        renderBody={(allData: IExampleRowData[]) => allData.map((data: IExampleRowData) => (
+                            <TableRowConnected
+                                tableId='collapsible-rows'
+                                key={data.username}
+                                id={data.username}
+                                collapsible={{
+                                    content: generateCollapsibleRow(data),
+                                }}
+                            >
+                                <td key='city'>{data.city}</td>
+                                <td key='email'>{data.email.toLowerCase()}</td>
+                                <td key='username'>{data.username.toLowerCase()}</td>
+                            </TableRowConnected>
+                        ))}
+                        tableHeader={<thead><tr><th>City</th><th>Email</th><th>Username</th><th></th></tr></thead>}
                     />
                 </div>
 

--- a/src/components/table-hoc/examples/TableHOCExamples.tsx
+++ b/src/components/table-hoc/examples/TableHOCExamples.tsx
@@ -2,6 +2,7 @@ import {helpers, seed} from 'faker';
 import * as React from 'react';
 import * as _ from 'underscore';
 
+import {SingleSelectConnected} from '../../select/SingleSelectConnected';
 import {TableHeaderWithSort} from '../TableHeaderWithSort';
 import {TableHOC} from '../TableHOC';
 import {TableRowConnected} from '../TableRowConnected';
@@ -131,7 +132,7 @@ export class TableHOCExamples extends React.Component {
                             >
                                 <td key='city'>{data.city}</td>
                                 <td key='email'>{data.email.toLowerCase()}</td>
-                                <td key='username'>{data.username.toLowerCase()}</td>
+                                <td key='username'><SingleSelectConnected id={data.username + 'dropdown'} /></td>
                             </TableRowConnected>
                         ))}
                         tableHeader={<thead><tr><th>City</th><th>Email</th><th>Username</th><th></th></tr></thead>}

--- a/src/components/table-hoc/reducers/TableRowReducers.ts
+++ b/src/components/table-hoc/reducers/TableRowReducers.ts
@@ -1,14 +1,21 @@
 import * as _ from 'underscore';
-import {IReduxAction} from '../../../utils/ReduxUtils';
+
+import {BasePayload, IReduxAction} from '../../../utils/ReduxUtils';
 import {PaginationActions} from '../../navigation/pagination/NavigationPaginationActions';
 import {PerPageActions} from '../../navigation/perPage/NavigationPerPageActions';
-import {ITableRowAddPayload, ITableRowRemovePayload, ITableRowSelectPayload, TableRowActionsType} from '../actions/TableRowActions';
+import {
+    ITableRowAddPayload,
+    ITableRowSelectPayload,
+    ITableRowToggleCollapsiblePayload,
+    TableRowActionsType,
+} from '../actions/TableRowActions';
 import {TableHOCUtils} from '../TableHOCUtils';
 
 export interface ITableRowState {
     id: string;
     tableId: string;
     selected: boolean;
+    opened: boolean;
 }
 
 const addTableRowReducer = (state: ITableRowState[], action: IReduxAction<ITableRowAddPayload>) => {
@@ -18,27 +25,46 @@ const addTableRowReducer = (state: ITableRowState[], action: IReduxAction<ITable
             id: action.payload.id,
             tableId: action.payload.tableId,
             selected: false,
+            opened: false,
         },
     ];
 };
 
-const removeTableRowReducer = (state: ITableRowState[], action: IReduxAction<ITableRowRemovePayload>) => {
+const removeTableRowReducer = (state: ITableRowState[], action: IReduxAction<BasePayload>) => {
     return _.reject(state, (header: ITableRowState) => header.id === action.payload.id);
 };
 
 const selectTableRowReducer = (state: ITableRowState[], action: IReduxAction<ITableRowSelectPayload>) => {
     const current = _.findWhere(state, {id: action.payload.id});
     if (current) {
-        return _.map(state, (header: ITableRowState) => {
-            if (header.id === current.id) {
+        return _.map(state, (row: ITableRowState) => {
+            if (row.id === current.id) {
                 return {
-                    ...header,
+                    ...row,
                     selected: true,
                 };
             }
-            return header.tableId === current.tableId
-                ? {...header, selected: header.selected && action.payload.isMulti}
-                : header;
+            return row.tableId === current.tableId
+                ? {...row, selected: row.selected && action.payload.isMulti}
+                : row;
+        });
+    }
+    return state;
+};
+
+const toggleCollasibleTableRowReducer = (state: ITableRowState[], action: IReduxAction<ITableRowToggleCollapsiblePayload>) => {
+    const current = _.findWhere(state, {id: action.payload.id});
+    if (current) {
+        return _.map(state, (row: ITableRowState) => {
+            if (row.id === current.id) {
+                return {
+                    ...row,
+                    opened: _.isBoolean(action.payload.opened) ? action.payload.opened : !current.opened,
+                };
+            }
+            return row.tableId === current.tableId
+                ? {...row, opened: false}
+                : row;
         });
     }
     return state;
@@ -56,11 +82,12 @@ const TableRowActionReducers: {[key: string]: (...args: any[]) => any} = {
     [TableRowActionsType.add]: addTableRowReducer,
     [TableRowActionsType.remove]: removeTableRowReducer,
     [TableRowActionsType.select]: selectTableRowReducer,
+    [TableRowActionsType.toggleCollapsible]: toggleCollasibleTableRowReducer,
     [PerPageActions.change]: deselectTableRowReducer,
     [PaginationActions.changePage]: deselectTableRowReducer,
 };
 
-type ITableRowPayload = ITableRowAddPayload | ITableRowRemovePayload | ITableRowSelectPayload;
+type ITableRowPayload = BasePayload | ITableRowAddPayload | ITableRowSelectPayload;
 export const TableRowReducers = (state: ITableRowState[] = [], action: IReduxAction<ITableRowPayload>) => {
     if (!_.isUndefined(TableRowActionReducers[action.type])) {
         return TableRowActionReducers[action.type](state, action);

--- a/src/components/table-hoc/reducers/TableRowReducers.ts
+++ b/src/components/table-hoc/reducers/TableRowReducers.ts
@@ -15,7 +15,7 @@ export interface ITableRowState {
     id: string;
     tableId: string;
     selected: boolean;
-    opened: boolean;
+    opened?: boolean;
 }
 
 const addTableRowReducer = (state: ITableRowState[], action: IReduxAction<ITableRowAddPayload>) => {

--- a/src/components/table-hoc/styles/TableRowNumber.scss
+++ b/src/components/table-hoc/styles/TableRowNumber.scss
@@ -1,27 +1,28 @@
 @import '~coveo-styleguide/scss/common/palette.scss';
 @import '~coveo-styleguide/scss/variables.scss';
+@import '~coveo-styleguide/scss/placeholders.scss';
 
 :global(.coveo-styleguide .table.table-numbered) {
-    td:nth-child(2) {
-        border-left: $table-selected-border-width solid transparent;
-        padding-left: $default-margin;
+  tr:global(.selected) td {
+    &:first-child::before {
+      display: none;
     }
-     tr:global(.selected) td:nth-child(2) {
-        border-left-color: $orange;
+
+    &:nth-child(2)::before {
+      @extend %selection-indicator;
     }
+  }
 }
 
 :global(.coveo-styleguide .table) .tableNumberedRow:first-child {
-    padding:0;
-    border-left: none;
-    width: 60px;
-    height: 40px;
+  padding:0;
+  width: 60px;
 } 
 
 :global(.coveo-styleguide .table) .tableNumberedRowContainer {
-    color: $medium-blue;
-    border-left: none;
-    width: 60px;
-    text-align: center;
-    padding: $default-margin;
+  color: $medium-blue;
+  border-left: none;
+  width: 60px;
+  text-align: center;
+  padding: $default-margin;
 } 

--- a/src/components/table-hoc/tests/TableRowConnected.spec.tsx
+++ b/src/components/table-hoc/tests/TableRowConnected.spec.tsx
@@ -1,6 +1,7 @@
 import {shallowWithStore} from 'enzyme-redux';
 import * as React from 'react';
 import {createMockStore, mockStore} from 'redux-test-utils';
+
 import {IReactVaporState} from '../../../ReactVapor';
 import {addActionsToActionBar} from '../../actions/ActionBarActions';
 import {TableRowActions} from '../actions/TableRowActions';
@@ -57,16 +58,16 @@ describe('Table HOC', () => {
             expect(wrapper.find('tr').hasClass('selected')).toBe(false);
         });
 
-        it('should dispatch a TableRowActions.addTableRow on componentDidMount', () => {
-            const expectedAction = TableRowActions.addTableRow(defaultProps.id, defaultProps.tableId);
+        it('should dispatch a TableRowActions.add on componentDidMount', () => {
+            const expectedAction = TableRowActions.add(defaultProps.id, defaultProps.tableId);
 
             shallowWithStore(<TableRowConnected {...defaultProps} />, store).dive();
 
             expect(store.isActionDispatched(expectedAction)).toBe(true);
         });
 
-        it('should dispatch an TableRowActions.removeTableRow on componentWillUnmount', () => {
-            const expectedAction = TableRowActions.removeTableRow(defaultProps.id);
+        it('should dispatch an TableRowActions.remove on componentWillUnmount', () => {
+            const expectedAction = TableRowActions.remove(defaultProps.id);
 
             const wrapper = shallowWithStore(<TableRowConnected {...defaultProps} />, store).dive();
             wrapper.unmount();
@@ -84,20 +85,26 @@ describe('Table HOC', () => {
             expect(store.isActionDispatched(expectedAction)).toBe(true);
         });
 
-        it('should dispatch an TableRowActions.selectRow on click', () => {
-            const expectedAction = TableRowActions.selectRow(defaultProps.id, false);
+        it('should dispatch a TableRowActions.select action on click when actions is not empty', () => {
+            const expectedAction = TableRowActions.select(defaultProps.id, false);
 
-            const wrapper = shallowWithStore(<TableRowConnected {...defaultProps} />, store).dive();
+            const wrapper = shallowWithStore(<TableRowConnected {...defaultProps} actions={[{enabled: true, name: 'action'}]} />, store).dive();
             wrapper.find('tr').simulate('click', {});
 
             expect(store.isActionDispatched(expectedAction)).toBe(true);
         });
 
-        it('should dispatch an TableRowActions.selectRow on click and handle multi-select', () => {
-            const expectedActionWithMulti = TableRowActions.selectRow(defaultProps.id, true);
-            const expectedActionWithoutMulti = TableRowActions.selectRow(defaultProps.id, false);
+        it('should dispatch an TableRowActions.select on click and handle multi-select', () => {
+            const expectedActionWithMulti = TableRowActions.select(defaultProps.id, true);
+            const expectedActionWithoutMulti = TableRowActions.select(defaultProps.id, false);
 
-            const wrapper = shallowWithStore(<TableRowConnected {...defaultProps} isMultiselect />, store).dive();
+            const wrapper = shallowWithStore(
+                <TableRowConnected
+                    {...defaultProps}
+                    actions={[{enabled: true, name: 'action'}]}
+                    isMultiselect />,
+                store,
+            ).dive();
 
             wrapper.find('tr').simulate('click', {ctrlKey: true});
             expect(store.isActionDispatched(expectedActionWithMulti)).toBe(true);

--- a/src/components/table-hoc/tests/TableRowConnected.spec.tsx
+++ b/src/components/table-hoc/tests/TableRowConnected.spec.tsx
@@ -1,11 +1,13 @@
+import {ShallowWrapper} from 'enzyme';
 import {shallowWithStore} from 'enzyme-redux';
 import * as React from 'react';
 import {createMockStore, mockStore} from 'redux-test-utils';
 
 import {IReactVaporState} from '../../../ReactVapor';
 import {addActionsToActionBar} from '../../actions/ActionBarActions';
+import {CollapsibleToggle} from '../../collapsible/CollapsibleToggle';
 import {TableRowActions} from '../actions/TableRowActions';
-import {TableRowConnected} from '../TableRowConnected';
+import {ITableRowConnectedProps, TableRowConnected} from '../TableRowConnected';
 
 describe('Table HOC', () => {
     describe('TableRowConnected', () => {
@@ -94,6 +96,15 @@ describe('Table HOC', () => {
             expect(store.isActionDispatched(expectedAction)).toBe(true);
         });
 
+        it('should not dispatch a TableRowActions.select action on click when actions is empty', () => {
+            const actionNotExpected = TableRowActions.select(defaultProps.id, false);
+
+            const wrapper = shallowWithStore(<TableRowConnected {...defaultProps} />, store).dive();
+            wrapper.find('tr').simulate('click', {});
+
+            expect(store.isActionDispatched(actionNotExpected)).toBe(false);
+        });
+
         it('should dispatch an TableRowActions.select on click and handle multi-select', () => {
             const expectedActionWithMulti = TableRowActions.select(defaultProps.id, true);
             const expectedActionWithoutMulti = TableRowActions.select(defaultProps.id, false);
@@ -111,6 +122,108 @@ describe('Table HOC', () => {
 
             wrapper.find('tr').simulate('click', {ctrlKey: false});
             expect(store.isActionDispatched(expectedActionWithoutMulti)).toBe(true);
+        });
+
+        describe('when the row is collapsible', () => {
+            let wrapper: ShallowWrapper<ITableRowConnectedProps>;
+            const collapsibleContent = <div>Collapsible content</div>;
+
+            beforeEach(() => {
+                store = createMockStore({
+                    tableHOCRow: [{
+                        id: defaultProps.id,
+                        tableId: defaultProps.tableId,
+                        selected: false,
+                        opened: true,
+                    }],
+                });
+
+                wrapper = shallowWithStore(
+                    <TableRowConnected
+                        id={defaultProps.id}
+                        tableId={defaultProps.tableId}
+                        collapsible={{
+                            content: collapsibleContent,
+                        }}
+                    >
+                        <td>Column 1</td>
+                        <td>Column 2</td>
+                        <td>Column 3</td>
+                    </TableRowConnected>,
+                    store,
+                ).dive();
+            });
+
+            it('should render an additional row for the collapsible content', () => {
+                expect(wrapper.find('tr').length).toBe(2);
+                expect(wrapper.find('tr').at(0).hasClass('heading-row')).toBe(true);
+                expect(wrapper.find('tr').at(1).hasClass('collapsible-row')).toBe(true);
+            });
+
+            it('should render a single cell in the collapsible row that spans accross all the columns +1 for the toggle', () => {
+                expect(wrapper.find('tr.collapsible-row td').props().colSpan).toBe(3 + 1);
+            });
+
+            it('should render the collapsible content node inside the collapsible row', () => {
+                expect(wrapper.find('tr.collapsible-row td').contains(collapsibleContent)).toBe(true);
+            });
+
+            it('should have the class opened if the row is opened in the state', () => {
+                expect(wrapper.find('tr.heading-row').hasClass('opened')).toBe(true);
+            });
+
+            it('should render a CollapsibleToggle as collapsed state indicator if no customToggle is specified', () => {
+                expect(wrapper.find(CollapsibleToggle).exists()).toBe(true);
+                expect(wrapper.find(CollapsibleToggle).props().expanded).toBe(true);
+            });
+
+            it('should render a collapsible row custom toggle when specified using the prop renderCustomToggleCell', () => {
+                const expectedToggle = <td>Opened</td>;
+                wrapper.setProps({
+                    collapsible: {
+                        content: collapsibleContent,
+                        renderCustomToggleCell: (opened: boolean) => expectedToggle,
+                    },
+                });
+
+                expect(wrapper.find('tr.heading-row td').last().equals(expectedToggle)).toBe(true);
+            });
+
+            it('should dispatch a toggleCollapsible action when clicking on a collapsible heading-row', () => {
+                const expectedAction = TableRowActions.toggleCollapsible(defaultProps.id);
+
+                wrapper.find('tr.heading-row').simulate('click', {});
+
+                expect(store.isActionDispatched(expectedAction)).toBe(true);
+            });
+
+        });
+
+        it('should dispatch a toggleCollapsible action with opened:true on mount when expandOnMount is set to true', () => {
+            const expectedAction = TableRowActions.toggleCollapsible(defaultProps.id, true);
+
+            store = createMockStore({
+                tableHOCRow: [{
+                    id: defaultProps.id,
+                    tableId: defaultProps.tableId,
+                    selected: false,
+                    opened: false,
+                }],
+            });
+
+            shallowWithStore(
+                <TableRowConnected
+                    id={defaultProps.id}
+                    tableId={defaultProps.tableId}
+                    collapsible={{
+                        content: <div>Whatever</div>,
+                        expandOnMount: true,
+                    }}
+                />,
+                store,
+            ).dive();
+
+            expect(store.isActionDispatched(expectedAction)).toBe(true);
         });
     });
 });

--- a/src/components/table-hoc/tests/TableRowConnected.spec.tsx
+++ b/src/components/table-hoc/tests/TableRowConnected.spec.tsx
@@ -1,5 +1,5 @@
 import {ShallowWrapper} from 'enzyme';
-import {shallowWithStore} from 'enzyme-redux';
+import {mountWithStore, shallowWithStore} from 'enzyme-redux';
 import * as React from 'react';
 import {createMockStore, mockStore} from 'redux-test-utils';
 
@@ -101,6 +101,24 @@ describe('Table HOC', () => {
 
             const wrapper = shallowWithStore(<TableRowConnected {...defaultProps} />, store).dive();
             wrapper.find('tr').simulate('click', {});
+
+            expect(store.isActionDispatched(actionNotExpected)).toBe(false);
+        });
+
+        it('should not dispatch a TableRowActions.select action on click when clicking inside an underlying dropdown', () => {
+            const actionNotExpected = TableRowActions.select(defaultProps.id, false);
+
+            // We must mount the component here because simulated events don't propagate throughout ShallowWrappers
+            const wrapper = mountWithStore(
+                <TableRowConnected
+                    {...defaultProps}
+                    actions={[{enabled: true, name: 'action'}]} >
+                    <td><div className='dropdown'></div></td>
+                </TableRowConnected>,
+                store,
+            );
+
+            wrapper.find('.dropdown').simulate('click');
 
             expect(store.isActionDispatched(actionNotExpected)).toBe(false);
         });

--- a/src/components/table-hoc/tests/TableRowReducers.spec.ts
+++ b/src/components/table-hoc/tests/TableRowReducers.spec.ts
@@ -92,6 +92,71 @@ describe('Table HOC', () => {
             expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).selected).toBe(false);
         });
 
+        it('should set opened on the table row when the action is "TableRowActions.toggleCollapsible"', () => {
+            const oldState: ITableRowState[] = [
+                {
+                    id: 'some-table-header-1',
+                    tableId: 'not-important',
+                    selected: false,
+                }, {
+                    id: 'some-table-header-2',
+                    tableId: 'not-important',
+                    selected: true,
+                },
+            ];
+
+            const action = TableRowActions.toggleCollapsible(oldState[0].id, true);
+            const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
+
+            expect(tableHeadersState.length).toBe(oldState.length);
+            expect(_.findWhere(tableHeadersState, {id: oldState[0].id}).opened).toBe(true);
+            expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).opened).toBe(false);
+        });
+
+        it('should toggle opened the row when the action is "TableRowActions.toggleCollapsible" and no opened payload is specified', () => {
+            const oldState: ITableRowState[] = [
+                {
+                    id: 'some-table-header-1',
+                    tableId: 'not-important',
+                    selected: false,
+                }, {
+                    id: 'some-table-header-2',
+                    tableId: 'not-important',
+                    selected: true,
+                },
+            ];
+
+            const action = TableRowActions.toggleCollapsible(oldState[0].id);
+            const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
+
+            expect(tableHeadersState.length).toBe(oldState.length);
+            expect(_.findWhere(tableHeadersState, {id: oldState[0].id}).opened).toBe(true);
+            expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).opened).toBe(false);
+        });
+
+        it('should collapse other rows of the same table row when the action is "TableRowActions.toggleCollapsible"', () => {
+            const oldState: ITableRowState[] = [
+                {
+                    id: 'some-table-header-1',
+                    tableId: 'not-important',
+                    selected: false,
+                    opened: true,
+                }, {
+                    id: 'some-table-header-2',
+                    tableId: 'not-important',
+                    selected: true,
+                    opened: false,
+                },
+            ];
+
+            const action = TableRowActions.toggleCollapsible(oldState[1].id);
+            const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
+
+            expect(tableHeadersState.length).toBe(oldState.length);
+            expect(_.findWhere(tableHeadersState, {id: oldState[0].id}).opened).toBe(false);
+            expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).opened).toBe(true);
+        });
+
         it('should not deselect other rows of the same table row when the action is "TableRowActions.selectRow" and multi is true', () => {
             const oldState: ITableRowState[] = [
                 {
@@ -113,6 +178,28 @@ describe('Table HOC', () => {
             expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).selected).toBe(true);
         });
 
+        it('should not collapse other rows of the same table row when the action is "TableRowActions.toggleCollapsibel"', () => {
+            const oldState: ITableRowState[] = [
+                {
+                    id: 'some-table-header-1',
+                    tableId: 'current-table',
+                    selected: false,
+                    opened: false,
+                }, {
+                    id: 'some-table-header-2',
+                    tableId: 'other-table',
+                    selected: true,
+                    opened: true,
+                },
+            ];
+
+            const action = TableRowActions.toggleCollapsible(oldState[0].id);
+            const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
+
+            expect(tableHeadersState.length).toBe(oldState.length);
+            expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).opened).toBe(true);
+        });
+
         it('should not modify the selected for the other tables when the action is "TableRowActions.selectRow"', () => {
             const oldState: ITableRowState[] = [
                 {
@@ -129,6 +216,13 @@ describe('Table HOC', () => {
             const action = TableRowActions.select(oldState[0].id);
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
             expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).selected).toBe(oldState[1].selected);
+        });
+
+        it('should not throw on toggleCollapsible if the table row does not exists', () => {
+            const oldState: ITableRowState[] = [];
+            const action = TableRowActions.toggleCollapsible('To toggle or not to toggle');
+
+            expect(() => TableRowReducers(oldState, action)).not.toThrow();
         });
 
         it('should not throw on select if the table row does not exists', () => {

--- a/src/components/table-hoc/tests/TableRowReducers.spec.ts
+++ b/src/components/table-hoc/tests/TableRowReducers.spec.ts
@@ -1,4 +1,5 @@
 import * as _ from 'underscore';
+
 import {IReduxAction} from '../../../utils/ReduxUtils';
 import {changePage} from '../../navigation/pagination/NavigationPaginationActions';
 import {changePerPage} from '../../navigation/perPage/NavigationPerPageActions';
@@ -33,7 +34,7 @@ describe('Table HOC', () => {
             const expectedId = 'a';
             const expectedTableId = 'b';
             const expectedSelected = false;
-            const action = TableRowActions.addTableRow(expectedId, expectedTableId);
+            const action = TableRowActions.add(expectedId, expectedTableId);
 
             const oldState: ITableRowState[] = [];
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
@@ -63,7 +64,7 @@ describe('Table HOC', () => {
                     selected: true,
                 },
             ];
-            const action = TableRowActions.removeTableRow(oldState[1].id);
+            const action = TableRowActions.remove(oldState[1].id);
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
 
             expect(tableHeadersState.length).toBe(oldState.length - 1);
@@ -83,7 +84,7 @@ describe('Table HOC', () => {
                 },
             ];
 
-            const action = TableRowActions.selectRow(oldState[0].id, false);
+            const action = TableRowActions.select(oldState[0].id, false);
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
 
             expect(tableHeadersState.length).toBe(oldState.length);
@@ -104,7 +105,7 @@ describe('Table HOC', () => {
                 },
             ];
 
-            const action = TableRowActions.selectRow(oldState[0].id, true);
+            const action = TableRowActions.select(oldState[0].id, true);
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
 
             expect(tableHeadersState.length).toBe(oldState.length);
@@ -125,14 +126,14 @@ describe('Table HOC', () => {
                 },
             ];
 
-            const action = TableRowActions.selectRow(oldState[0].id);
+            const action = TableRowActions.select(oldState[0].id);
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
             expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).selected).toBe(oldState[1].selected);
         });
 
         it('should not throw on select if the table row does not exists', () => {
             const oldState: ITableRowState[] = [];
-            const action = TableRowActions.selectRow('To be or not to be');
+            const action = TableRowActions.select('To be or not to be');
 
             expect(() => TableRowReducers(oldState, action)).not.toThrow();
         });


### PR DESCRIPTION
Implemented the collapsible row behavior inside the TableRowConnected, so that it can be easily used with the TableHOC

Also, I fixed the orange indicator for selected table rows inside the numbered table. (see commit a3faace)
See before: 
![image](https://user-images.githubusercontent.com/35579930/49467227-f675b400-f7cf-11e8-9b63-66ac1fd79a79.png)
