### PR TITLE
Toggle rows open when switching to collapsible rows

### DIFF
--- a/src/components/table-hoc/TableRowConnected.tsx
+++ b/src/components/table-hoc/TableRowConnected.tsx
@@ -40,6 +40,7 @@ export interface ITableRowDispatchProps {
     onMount: () => void;
     onUnmount: () => void;
     onClick: (isMulti: boolean) => void;
+    onUpdateToCollapsibleRow: () => void;
 }
 
 export interface ITableRowConnectedProps extends
@@ -80,20 +81,27 @@ const mapDispatchToProps = (
             dispatch(TableRowActions.toggleCollapsible(ownProps.id));
         }
     },
+    onUpdateToCollapsibleRow: () => {
+        if (ownProps.collapsible.expandOnMount) {
+            dispatch(TableRowActions.toggleCollapsible(ownProps.id, true));
+        }
+    },
 });
 
 @ReduxConnect(mapStateToProps, mapDispatchToProps)
-export class TableRowConnected extends React.PureComponent<ITableRowConnectedProps & React.HTMLAttributes<HTMLTableRowElement>> {
-    static defaultProps: Partial<ITableRowOwnProps> = {
-        actions: [],
-        isMultiselect: false,
-        collapsible: {},
-    };
+class TableRowConnected extends React.PureComponent<ITableRowConnectedProps & React.HTMLAttributes<HTMLTableRowElement>> {
+    static defaultProps: Partial<ITableRowOwnProps>;
 
     private handleClick = (e: React.MouseEvent<HTMLTableRowElement>) => {
         if (!EventUtils.isClickingInsideElementWithClassname(e, 'dropdown')) {
             const isMulti = (e.metaKey || e.ctrlKey) && this.props.isMultiselect;
             this.props.onClick(isMulti);
+        }
+    }
+
+    componentDidUpdate(prevProps: ITableRowConnectedProps) {
+        if (!isCollapsible(prevProps) && isCollapsible(this.props)) {
+            this.props.onUpdateToCollapsibleRow();
         }
     }
 
@@ -160,3 +168,11 @@ export class TableRowConnected extends React.PureComponent<ITableRowConnectedPro
         );
     }
 }
+
+TableRowConnected.defaultProps = {
+    actions: [],
+    isMultiselect: false,
+    collapsible: {},
+};
+
+export {TableRowConnected};

--- a/src/components/table-hoc/tests/TableRowConnected.spec.tsx
+++ b/src/components/table-hoc/tests/TableRowConnected.spec.tsx
@@ -243,5 +243,65 @@ describe('Table HOC', () => {
 
             expect(store.isActionDispatched(expectedAction)).toBe(true);
         });
+
+        it('should dispatch a toggleCollapsible action with opened:true when changing from a non-collapsible to a collapsible row', () => {
+            const expectedAction = TableRowActions.toggleCollapsible(defaultProps.id, true);
+
+            store = createMockStore({
+                tableHOCRow: [{
+                    id: defaultProps.id,
+                    tableId: defaultProps.tableId,
+                    selected: false,
+                    opened: false,
+                }],
+            });
+
+            const row = shallowWithStore(
+                <TableRowConnected
+                    id={defaultProps.id}
+                    tableId={defaultProps.tableId}
+                    collapsible={{expandOnMount: true}}
+                />,
+                store,
+            ).dive();
+            expect(store.isActionDispatched(expectedAction)).toBe(false);
+
+            row.setProps({
+                collapsible: {
+                    expandOnMount: true,
+                    content: <div>Whatever</div>,
+                },
+            });
+            expect(store.isActionDispatched(expectedAction)).toBe(true);
+        });
+
+        it('should not dispatch a toggleCollapsible action when changing from a non-collapsible to a collapsible row if expandOnMount is false', () => {
+            const actionNotExpected = TableRowActions.toggleCollapsible(defaultProps.id, true);
+
+            store = createMockStore({
+                tableHOCRow: [{
+                    id: defaultProps.id,
+                    tableId: defaultProps.tableId,
+                    selected: false,
+                    opened: false,
+                }],
+            });
+
+            const row = shallowWithStore(
+                <TableRowConnected
+                    id={defaultProps.id}
+                    tableId={defaultProps.tableId}
+                />,
+                store,
+            ).dive();
+            expect(store.isActionDispatched(actionNotExpected)).toBe(false);
+
+            row.setProps({
+                collapsible: {
+                    content: <div>Whatever</div>,
+                },
+            });
+            expect(store.isActionDispatched(actionNotExpected)).toBe(false);
+        });
     });
 });


### PR DESCRIPTION
#### Previous behavior:
* `TableRowConnected` renders a collapsible row only if a collapsible content is specified. 
* When setting the `expandOnMount` prop to true, if the row is collapsible (has defined collapsible content), the row gets expanded on mount.

#### Problem
If we do the following:
1. Set `expandOnMount` to true
2. Mount the row with no collapsible content
3. Set collapsible content through props later on

The row will not get expanded because it is already mounted.

#### Solution implemented in this PR
If `expandOnMount` is set to true, the row will get toggled opened not just on mount, but also when switching from collapsible content being undefined to being defined. This behavior does more than the prop name says, but typically makes sense for users that want rows to be expanded on mount.