### PR TITLE
fix: popover component

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-bootstrap": "0.31.3",
     "react-codemirror2": "5.1.0",
     "react-infinite-scroll-component": "4.2.0",
-    "react-tether": "0.5.7",
+    "react-tether": "1.0.4",
     "react-textarea-autosize": "7.0.4",
     "unidiff": "0.0.4"
   },
@@ -79,7 +79,7 @@
     "@types/react-dom": "16.0.7",
     "@types/react-infinite-scroll-component": "4.2.3",
     "@types/react-redux": "6.0.9",
-    "@types/react-tether": "0.5.3",
+    "@types/react-tether": "0.5.4",
     "@types/react-textarea-autosize": "4.3.3",
     "@types/react-transition-group": "2.0.14",
     "@types/redux-logger": "3.0.6",

--- a/src/components/popover/examples/PopoverConnectedExamples.tsx
+++ b/src/components/popover/examples/PopoverConnectedExamples.tsx
@@ -1,17 +1,16 @@
 import * as React from 'react';
+
 import {PopoverConnected} from '../PopoverConnected';
 
 export const PopoverConnectedExamples = () => (
     <div className='mt2'>
         <h1 className='text-blue mb1 bold'>Popover Connected</h1>
-
         <PopoverConnected
-            id='popover-connected-example'
-            renderElementTo='.js-popover-connected'
+            id='popover-connected-example1'
             attachment='top left'
             targetAttachment='bottom left'
         >
-            <div className='btn js-popover-connected'>Click to toggle the popover</div>
+            <div className='btn'>Click to toggle the popover</div>
             <div className='coveo-child'>I am popping under the button</div>
         </PopoverConnected>
     </div>

--- a/src/components/popover/tests/Popover.spec.tsx
+++ b/src/components/popover/tests/Popover.spec.tsx
@@ -2,7 +2,7 @@ import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
 
-import {IPopoverProps, Popover} from './Popover';
+import {IPopoverProps, Popover} from '../Popover';
 
 describe('<Popover>', () => {
     let popoverProps: IPopoverProps;
@@ -70,7 +70,7 @@ describe('<Popover>', () => {
             }).not.toThrow();
         });
 
-        it('should not throw when redering a Popover without childrens', () => {
+        it('should not throw when redering a Popover without children', () => {
             expect(() => {
                 shallow(
                     <Popover {...popoverProps} />,


### PR DESCRIPTION
- [x] updated react-tether version so that it supports react 16
- [x] refactored popover component so that it uses the new way to declare refs in react 16.3^ (https://medium.com/@sgroff04/introduction-to-refs-in-react-16-3-d94505b45a73) 