### PR TITLE
Feature Deep PartialStringMatch

### DIFF
--- a/src/components/itemBox/ItemBox.tsx
+++ b/src/components/itemBox/ItemBox.tsx
@@ -81,7 +81,9 @@ export class ItemBox extends React.Component<IItemBoxProps> {
                     onClick={() => this.handleOnOptionClick()}
                     data-value={this.props.value}>
                     {this.props.prepend ? <Content {...this.props.prepend} /> : null}
-                    <PartialStringMatch wholeString={this.props.displayValue || this.props.value} partialMatch={this.props.highlight} caseInsensitive />
+                    <PartialStringMatch partialMatch={this.props.highlight} caseInsensitive>
+                        {this.props.displayValue || this.props.value}
+                    </PartialStringMatch>
                     {this.props.append ? <Content {...this.props.append} /> : null}
                 </li>
             </Tooltip>

--- a/src/components/partial-string-match/PartialStringMatch.spec.tsx
+++ b/src/components/partial-string-match/PartialStringMatch.spec.tsx
@@ -7,38 +7,22 @@ import {PartialStringMatch} from './PartialStringMatch';
 describe('PartialStringMatch', () => {
     const testString = 'test-string';
 
-    it('should render an empty span if the wholeString is a falsy value', () => {
+    it('should render an empty string if the wholeString is a falsy value', () => {
         [undefined, ''].forEach((falsyVal) => {
-            expect(shallow(<PartialStringMatch wholeString={falsyVal} />).find('span').prop('dangerouslySetInnerHTML').__html)
-                .toBe('');
+            expect(shallow(<PartialStringMatch wholeString={falsyVal} />).html()).toBe(null);
         });
     });
 
     it('should render the wholeString unchanged if partialMatch is undefined', () => {
-        expect(
-            shallow(<PartialStringMatch wholeString={testString} />)
-                .find('span')
-                .prop('dangerouslySetInnerHTML')
-                .__html,
-        ).toBe(testString);
+        expect(shallow(<PartialStringMatch wholeString={testString} />).text()).toBe(testString);
     });
 
     it('should render the wholeString unchanged if partialMatch is not in the wholeString', () => {
-        expect(
-            shallow(<PartialStringMatch wholeString={testString} partialMatch='i am not in whole string' />)
-                .find('span')
-                .prop('dangerouslySetInnerHTML')
-                .__html,
-        ).toBe(testString);
+        expect(shallow(<PartialStringMatch wholeString={testString} partialMatch='i am not in whole string' />).text()).toBe(testString);
     });
 
     it('should render the wholeString unchanged if partialMatch is in the wholeString but with different casing (if case sensitive)', () => {
-        expect(
-            shallow(<PartialStringMatch wholeString={testString} partialMatch={testString.toUpperCase()} />)
-                .find('span')
-                .prop('dangerouslySetInnerHTML')
-                .__html,
-        ).toBe(testString);
+        expect(shallow(<PartialStringMatch wholeString={testString} partialMatch={testString.toUpperCase()} />).text()).toBe(testString);
     });
 
     it('should render a span with the partialString match in bold if contained in the wholeString', () => {

--- a/src/components/partial-string-match/PartialStringMatch.spec.tsx
+++ b/src/components/partial-string-match/PartialStringMatch.spec.tsx
@@ -1,11 +1,13 @@
 import {shallow} from 'enzyme';
-import * as escapeRegExp from 'escape-string-regexp';
 import * as React from 'react';
-import {escape} from 'underscore';
 import {PartialStringMatch} from './PartialStringMatch';
 
 describe('PartialStringMatch', () => {
     const testString = 'test-string';
+
+    it('should not throw when there is no children', () => {
+        expect(() => shallow(<PartialStringMatch partialMatch='a' />)).not.toThrow();
+    });
 
     it('should render an empty string if the wholeString is a falsy value', () => {
         [undefined, ''].forEach((falsyVal) => {
@@ -18,23 +20,18 @@ describe('PartialStringMatch', () => {
     });
 
     it('should render the wholeString unchanged if partialMatch is not in the wholeString', () => {
-        expect(shallow(<PartialStringMatch wholeString={testString} partialMatch='i am not in whole string' />).text()).toBe(testString);
+        expect(shallow(<PartialStringMatch wholeString={testString} partialMatch='i am not in whole string' />).find('span.bold').length).toBe(0);
     });
 
     it('should render the wholeString unchanged if partialMatch is in the wholeString but with different casing (if case sensitive)', () => {
-        expect(shallow(<PartialStringMatch wholeString={testString} partialMatch={testString.toUpperCase()} />).text()).toBe(testString);
+        expect(shallow(<PartialStringMatch wholeString={testString} partialMatch={testString.toUpperCase()} />).find('span.bold').length).toBe(0);
     });
 
     it('should render a span with the partialString match in bold if contained in the wholeString', () => {
         const partialMatch = testString.substr(3, 5);
         const component = shallow(<PartialStringMatch wholeString={testString} partialMatch={partialMatch} />);
 
-        expect(
-            component
-                .find('span')
-                .prop('dangerouslySetInnerHTML')
-                .__html,
-        ).toContain(`<span class='bold'>${partialMatch}</span>`);
+        expect(component.find('span.bold').length).toBe(1);
     });
 
     it('should escape partialString match if dangerous', () => {
@@ -42,24 +39,15 @@ describe('PartialStringMatch', () => {
         const wholeString = 'whole string <script>alert("I could be dangerous")</script> with scripting';
         const component = shallow(<PartialStringMatch wholeString={wholeString} partialMatch={partialMatch} />);
 
-        expect(
-            component
-                .find('span')
-                .prop('dangerouslySetInnerHTML')
-                .__html,
-        ).toContain(`<span class='bold'>${escape(partialMatch)}</span>`);
+        expect(component.find('span.bold').length).toBe(1);
+        expect(component.find('script').length).toBe(0); // it will still be a string
     });
 
     it('should render a span with the partialString in bold regardless of casing, when caseInsensitive is passed as prop', () => {
         const partialMatch = testString.substr(3, 5);
         const component = shallow(<PartialStringMatch wholeString={testString} partialMatch={partialMatch.toUpperCase()} caseInsensitive />);
 
-        expect(
-            component
-                .find('span')
-                .prop('dangerouslySetInnerHTML')
-                .__html,
-        ).toContain(`<span class='bold'>${escape(partialMatch)}</span>`);
+        expect(component.find('span.bold').length).toBe(1);
     });
 
     it('should wrap all matches in a string with a span.bold', () => {
@@ -67,13 +55,18 @@ describe('PartialStringMatch', () => {
         const multipleMatchString = 'match I have three match match';
         const component = shallow(<PartialStringMatch wholeString={multipleMatchString} partialMatch={partialMatch} />);
 
-        expect(
-            component
-                .find('span')
-                .prop('dangerouslySetInnerHTML')
-                .__html
-                .match(RegExp(escapeRegExp(`<span class='bold'>${escape(partialMatch)}</span>`), 'g'))
-                .length,
-        ).toBe(3);
+        expect(component.find('span.bold').length).toBe(3);
+    });
+
+    it('should correctly wrap all matches in a string with a span.bold when there is multiple children', () => {
+        const partialMatch = 'match';
+        const component = shallow((
+            <PartialStringMatch partialMatch={partialMatch}>
+                Wow, is this really working? Because the <span className='some-wrapper'>match</span> can already be in spans
+                <br />
+                <div>Or they can be in a div, like this match</div>
+            </PartialStringMatch>
+        ));
+        expect(component.find('span.bold').length).toBe(2);
     });
 });

--- a/src/components/partial-string-match/PartialStringMatch.tsx
+++ b/src/components/partial-string-match/PartialStringMatch.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {escape} from 'underscore';
 
 export interface PartialStringMatchProps {
-    wholeString: string;
+    wholeString: React.ReactNode;
     partialMatch?: string;
     caseInsensitive?: boolean;
 }
@@ -15,16 +15,50 @@ export class PartialStringMatch extends React.Component<PartialStringMatchProps>
     };
 
     render() {
-        return <span dangerouslySetInnerHTML={{__html: this.getFormattedString()}} />;
-    }
+        if (!this.props.partialMatch) {
+            return this.props.wholeString;
+        }
 
-    private getFormattedString(): string {
         const flags = this.props.caseInsensitive ? 'ig' : 'g';
         const regExp = new RegExp(escapeRegExp(escape(this.props.partialMatch)), flags);
-        const cleanWholeString = escape(this.props.wholeString.trim());
+        const it = this.deepReplaceStrings(this.props.wholeString, regExp);
+        let res = it.next();
 
-        return !cleanWholeString || !this.props.partialMatch
-            ? cleanWholeString
-            : cleanWholeString.replace(regExp, (match: string) => `<span class='bold'>${match}</span>`);
+        const els = [];
+        while (!res.done) {
+            els.push(res.value);
+            res = it.next();
+        }
+
+        return els;
+    }
+
+    private *deepReplaceStrings(component: React.ReactNode | React.ReactNode[], regExp: RegExp): IterableIterator<React.ReactNode> {
+        const cast = component as any;
+        if (!component) {
+            return;
+        } else if (component instanceof Array) {
+            for (let i = 0; i < component.length; i++) {
+                yield* this.deepReplaceStrings(component[i], regExp);
+            }
+        } else if (typeof component === 'string') {
+            const clean = escape(component);
+            if (regExp.test(clean)) {
+                yield <span dangerouslySetInnerHTML={{__html: clean.replace(regExp, (match: string) => `<span class='bold'>${match}</span>`)}} />;
+            } else {
+                yield clean;
+            }
+        } else if (cast.props && cast.props.children) {
+            const newChildren = [];
+            const childIterator = this.deepReplaceStrings(cast.props.children, regExp);
+
+            let result: IteratorResult<React.ReactNode>;
+            do {
+                result = childIterator.next();
+                newChildren.push(result.value);
+            } while (!result.done);
+
+            yield React.cloneElement(cast, {...cast.props, children: newChildren});
+        }
     }
 }

--- a/src/components/partial-string-match/PartialStringMatch.tsx
+++ b/src/components/partial-string-match/PartialStringMatch.tsx
@@ -21,16 +21,16 @@ export class PartialStringMatch extends React.Component<PartialStringMatchProps>
 
         const flags = this.props.caseInsensitive ? 'ig' : 'g';
         const regExp = new RegExp(escapeRegExp(escape(this.props.partialMatch)), flags);
-        const it = this.deepReplaceStrings(this.props.wholeString, regExp);
-        let res = it.next();
+        const iterator = this.deepReplaceStrings(this.props.wholeString, regExp);
 
-        const els = [];
-        while (!res.done) {
-            els.push(res.value);
-            res = it.next();
-        }
+        const children = [];
+        let result: IteratorResult<React.ReactNode>;
+        do {
+            result = iterator.next();
+            children.push(result.value);
+        } while (!result.done);
 
-        return els;
+        return children;
     }
 
     private *deepReplaceStrings(component: React.ReactNode | React.ReactNode[], regExp: RegExp): IterableIterator<React.ReactNode> {
@@ -50,11 +50,11 @@ export class PartialStringMatch extends React.Component<PartialStringMatchProps>
             }
         } else if (cast.props && cast.props.children) {
             const newChildren = [];
-            const childIterator = this.deepReplaceStrings(cast.props.children, regExp);
+            const iterator = this.deepReplaceStrings(cast.props.children, regExp);
 
             let result: IteratorResult<React.ReactNode>;
             do {
-                result = childIterator.next();
+                result = iterator.next();
                 newChildren.push(result.value);
             } while (!result.done);
 

--- a/src/components/partial-string-match/PartialStringMatchExamples.tsx
+++ b/src/components/partial-string-match/PartialStringMatchExamples.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import {InfoBox} from '../infoBox/InfoBox';
+import {InfoBoxLink} from '../infoBox/InfoBoxLink';
 import {PartialStringMatch} from './PartialStringMatch';
 
 export class PartialStringMatchExamples extends React.Component<any, any> {
@@ -43,6 +45,19 @@ export class PartialStringMatchExamples extends React.Component<any, any> {
                     <label className='form-control-label'>PartialStringMatch with dangerous match</label>
                     <div className='text-dark-grey'>
                         <PartialStringMatch wholeString='Hey <script>alert("I may be dangerous")</script>' partialMatch={'<script>alert("I may be dangerous")</script>'} />
+                    </div>
+                </div>
+
+                <div className='form-group'>
+                    <label className='form-control-label'>PartialStringMatch with children</label>
+                    <div className='text-dark-grey'>
+                        <PartialStringMatch wholeString={<><div>Hello</div><br /><div>World</div></>} partialMatch={'o'} />
+                        <PartialStringMatch caseInsensitive partialMatch={'hello'} wholeString={(
+                            <div className='py2'>
+                                <div className='my2'>Hello <span>is this working with deep structure? <span>(hello, still reading?)</span></span></div>
+                                <InfoBox>What about custom components? <InfoBoxLink>Can they contain hello?</InfoBoxLink></InfoBox>
+                            </div>
+                        )} />
                     </div>
                 </div>
             </div>

--- a/src/components/partial-string-match/PartialStringMatchExamples.tsx
+++ b/src/components/partial-string-match/PartialStringMatchExamples.tsx
@@ -11,34 +11,34 @@ export class PartialStringMatchExamples extends React.Component<any, any> {
                 <div className='form-group'>
                     <label className='form-control-label'>PartialStringMatch without match</label>
                     <div className='text-dark-grey'>
-                        <PartialStringMatch wholeString='I do not have a match' partialMatch='I do not match' />
+                        <PartialStringMatch partialMatch='I do not match'>I do not have a match</PartialStringMatch>
                     </div>
                 </div>
                 <div className='form-group'>
                     <label className='form-control-label'>PartialStringMatch with partial match undefined</label>
                     <div className='text-dark-grey'>
-                        <PartialStringMatch wholeString='I do not have a match because partialMatch was not passed as prop' />
+                        <PartialStringMatch>I do not have a match because partialMatch was not passed as prop</PartialStringMatch>
                     </div>
                 </div>
                 <div className='form-group'>
                     <label className='form-control-label'>PartialStringMatch with partial match</label>
                     <div className='text-dark-grey'>
-                        <PartialStringMatch wholeString='I match at the beginning' partialMatch='I match at the' />
+                        <PartialStringMatch partialMatch='I match at the'>I match at the beginning</PartialStringMatch>
                     </div>
                     <div className='text-dark-grey'>
-                        <PartialStringMatch wholeString='I match at the end' partialMatch='the end' />
+                        <PartialStringMatch partialMatch='the end'>I match at the end</PartialStringMatch>
                     </div>
                     <div className='text-dark-grey'>
-                        <PartialStringMatch wholeString='I match in the middle' partialMatch='in the' />
+                        <PartialStringMatch partialMatch='in the'>I match in the middle</PartialStringMatch>
                     </div>
                     <div className='text-dark-grey'>
-                        <PartialStringMatch wholeString='I match multiple times because I match multiple substrings' partialMatch='match multiple' />
+                        <PartialStringMatch partialMatch='match multiple'>I match multiple times because I match multiple substrings</PartialStringMatch>
                     </div>
                 </div>
                 <div className='form-group'>
                     <label className='form-control-label'>PartialStringMatch with partial match (caseInsensitive)</label>
                     <div className='text-dark-grey'>
-                        <PartialStringMatch wholeString='I match even if my partial match is in uppercase' partialMatch={'partial match'.toUpperCase()} caseInsensitive />
+                        <PartialStringMatch partialMatch={'partial match'.toUpperCase()} caseInsensitive>I match even if my partial match is in uppercase</PartialStringMatch>
                     </div>
                 </div>
                 <div className='form-group'>
@@ -51,13 +51,17 @@ export class PartialStringMatchExamples extends React.Component<any, any> {
                 <div className='form-group'>
                     <label className='form-control-label'>PartialStringMatch with children</label>
                     <div className='text-dark-grey'>
-                        <PartialStringMatch wholeString={<><div>Hello</div><br /><div>World</div></>} partialMatch={'o'} />
-                        <PartialStringMatch caseInsensitive partialMatch={'hello'} wholeString={(
+                        <PartialStringMatch key='a' partialMatch='o'>
+                            <div>Hello</div>
+                            <br />
+                            <div>World</div>
+                        </PartialStringMatch>
+                        <PartialStringMatch key='b' caseInsensitive partialMatch={'hello'}>
                             <div className='py2'>
                                 <div className='my2'>Hello <span>is this working with deep structure? <span>(hello, still reading?)</span></span></div>
                                 <InfoBox>What about custom components? <InfoBoxLink>Can they contain hello?</InfoBoxLink></InfoBox>
                             </div>
-                        )} />
+                        </PartialStringMatch>
                     </div>
                 </div>
             </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "downlevelIteration": true,
     "jsx": "react",
     "module": "commonjs",
     "allowJs": true,
@@ -14,10 +15,9 @@
     "sourceMap": true,
     "target": "ES5",
     "plugins": [
-    {
-        "transform": "ts-transformer-keys/transformer"
-    }
-  ]
+      {"transform": "ts-transformer-keys/transformer"}
+    ],
+    "lib": ["es2015", "dom"]
   },
   "include": [
     "src/**/*.tsx",
@@ -25,6 +25,8 @@
     "types/**/*.d.ts"
   ],
   "exclude": [
-    "src/**/*.spec.*"
+    "src/**/*.spec.*",
+    "src/utils/TestUtils.ts",
+    "src/components/tables/tests/TableTestCommon.tsx"
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "downlevelIteration": true,
     "inlineSourceMap": true,
     "jsx": "react",
     "allowJs": true,
@@ -13,10 +14,9 @@
     "sourceMap": false,
     "target": "ES5",
     "plugins": [
-    {
-      "transform": "ts-transformer-keys/transformer"
-    }
-  ]
+      {"transform": "ts-transformer-keys/transformer"}
+    ],
+    "lib": ["es2015", "dom"]
   },
   "include": [
     "src/**/*.tsx",


### PR DESCRIPTION
Replace wholeString with a React.ReactNode
Iterate on every children to match string by using a generator
Added example

![image](https://user-images.githubusercontent.com/260007/50352961-becb7380-0514-11e9-9853-3277187f2e98.png)
