### PR TITLE
fix: adding class "flippable-ie" to flippables when the browser is IE

### DIFF
--- a/src/components/flippable/Flippable.tsx
+++ b/src/components/flippable/Flippable.tsx
@@ -4,6 +4,8 @@ import * as ReactDOM from 'react-dom';
 import {keys} from 'ts-transformer-keys';
 import * as _ from 'underscore';
 
+import {BrowserUtils} from '../../utils/BrowserUtils';
+
 export interface IFlippableOwnProps {
     id?: string;
     front?: React.ReactNode;
@@ -64,7 +66,7 @@ export class Flippable extends React.Component<IFlippableProps & React.HTMLProps
 
     render() {
         const containerClassName = classNames(
-            Flippable.CONTAINER_CLASSNAME,
+            BrowserUtils.isIE() ? 'flippable-ie' : Flippable.CONTAINER_CLASSNAME,
             this.props.isFlipped ? 'show-on-top' : '',
             this.props.className,
         );

--- a/src/components/flippable/exemples/FlippableExamples.tsx
+++ b/src/components/flippable/exemples/FlippableExamples.tsx
@@ -30,7 +30,7 @@ export class FlippableExamples extends React.Component<any, any> {
                 </div>
                 <div className='form-group'>
                     <label className='form-control-label'>Flippable with redux state</label>
-                    <div className='form-control flex'>
+                    <div className='form-control flex' style={{width: '300px'}}>
                         <FlippableConnected
                             id='flippable-example2'
                             front={
@@ -39,7 +39,7 @@ export class FlippableExamples extends React.Component<any, any> {
                                 </div>
                             }
                             back={
-                                <div className='bg-light-grey bold p2'>
+                                <div className='bg-light-grey bold p2' style={{width: '300px'}}>
                                     Some content on the back.
                                 </div>
                             }

--- a/src/components/flippable/tests/Flippable.spec.tsx
+++ b/src/components/flippable/tests/Flippable.spec.tsx
@@ -1,6 +1,8 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
+import {shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
 
+import {BrowserUtils} from '../../../utils/BrowserUtils';
 import {Flippable, IFlippableProps} from '../Flippable';
 
 describe('Flippable', () => {
@@ -50,6 +52,13 @@ describe('Flippable', () => {
 
         it('should have the default flippable class', () => {
             expect(flippable.find(`.${Flippable.CONTAINER_CLASSNAME}`).length).toBe(1);
+        });
+
+        it('should have the flippable-ie class when the browser is IE', () => {
+            spyOn(BrowserUtils, 'isIE').and.returnValue(true);
+            const component = shallowWithState(<Flippable />, {});
+
+            expect(component.hasClass('flippable-ie')).toBe(true);
         });
 
         it('should render a flipper div', () => {

--- a/src/components/modal/examples/ModalExamples.tsx
+++ b/src/components/modal/examples/ModalExamples.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {ActionableItem} from '../../actionable-item/ActionableItem';
 import {Svg} from '../../svg/Svg';
 import {Tooltip} from '../../tooltip/Tooltip';
 import {Modal} from '../Modal';
@@ -6,7 +7,6 @@ import {ModalBackdrop} from '../ModalBackdrop';
 import {ModalBody} from '../ModalBody';
 import {ModalFooter} from '../ModalFooter';
 import {ModalHeader} from '../ModalHeader';
-import {ActionableItem} from '../../actionable-item/ActionableItem';
 
 export interface IModalExamplesState {
     isOpened: boolean;
@@ -42,8 +42,8 @@ export class ModalExamples extends React.Component<any, IModalExamplesState> {
                             </ModalHeader>
                             <ModalBody classes={['mod-header-padding mod-form-top-bottom-padding']}>
                                 Modal content
-                                <ActionableItem actions={[{value:'hello', onOptionClick: () => 1}]}>hello</ActionableItem>
-              </ModalBody>
+                                <ActionableItem actions={[{value: 'hello', onOptionClick: () => 1}]}>hello</ActionableItem>
+                            </ModalBody>
                             <ModalFooter>
                                 <button className='btn' onClick={() => this.closeModal()}>Close</button>
                             </ModalFooter>

--- a/src/utils/BrowserUtils.ts
+++ b/src/utils/BrowserUtils.ts
@@ -1,0 +1,6 @@
+// https://stackoverflow.com/questions/21825157/internet-explorer-11-detection#answer-22242528
+const isIE = () => navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > -1;
+
+export const BrowserUtils = {
+    isIE,
+};


### PR DESCRIPTION
- Added `BrowserUtils.isIE()`. It detects if the browser is IE (FYI: returns false in MsEdge);
- Flippables will now have the class `flippable-ie` when the browser is IE;