### PR TITLE
fix single-select-custom-plus-button

### DIFF
--- a/src/components/select/SelectWithFilter.tsx
+++ b/src/components/select/SelectWithFilter.tsx
@@ -17,6 +17,7 @@ import {IItemBoxProps} from '../itemBox/ItemBox';
 import {Svg} from '../svg/Svg';
 import {ISelectOwnProps, ISelectSpecificProps} from './SelectConnected';
 import {SelectSelector} from './SelectSelector';
+import {selectListBoxOption} from '../listBox/ListBoxActions';
 
 export interface ISelectWithFilterOwnProps {
     defaultCustomValues?: string[];
@@ -39,7 +40,7 @@ export interface ISelectWithFilterStateProps {
 export interface ISelectWithFilterDispatchProps {
     onRenderFilter: (items: string[]) => void;
     onDestroyFilter: () => void;
-    onSelectCustomValue: (filterValue: string) => void;
+    onSelectCustomValue: (filterValue: string, fromAddButton?: boolean) => void;
 }
 
 const SelectWithFilterPropsToOmit = keys<ISelectWithFilterOwnProps>();
@@ -65,7 +66,12 @@ export const selectWithFilter = (Component: (React.ComponentClass<ISelectWithFil
     const mapDispatchToProps = (dispatch: IDispatch, ownProps: ISelectOwnProps & ISelectSpecificProps): ISelectWithFilterDispatchProps => ({
         onRenderFilter: (items: string[]) => dispatch(addStringList(ownProps.id, items)),
         onDestroyFilter: () => dispatch(removeStringList(ownProps.id)),
-        onSelectCustomValue: (filterValue: string) => dispatch(addValueStringList(ownProps.id, filterValue)),
+        onSelectCustomValue: (filterValue: string, fromAddButton = false) => {
+            dispatch(addValueStringList(ownProps.id, filterValue));
+            if (fromAddButton) {
+                dispatch(selectListBoxOption(ownProps.id, true, filterValue));
+            }
+        },
     });
 
     @ReduxConnect(makeMapStateToProps, mapDispatchToProps)
@@ -129,7 +135,7 @@ export const selectWithFilter = (Component: (React.ComponentClass<ISelectWithFil
 
         private handleOnClick = () => {
             if (!_.isEmpty(this.props.filterValue)) {
-                this.props.onSelectCustomValue(this.props.filterValue);
+                this.props.onSelectCustomValue(this.props.filterValue, true);
             }
         }
 

--- a/src/components/select/examples/MultiSelectExamples.tsx
+++ b/src/components/select/examples/MultiSelectExamples.tsx
@@ -81,7 +81,7 @@ export class MultiSelectExamples extends React.Component<{}, IMultiSelectExample
                 <div className='form-group'>
                     <label className='form-control-label'>A Multi Select With Filter and Custom Values</label>
                     <br />
-                    <MultiSelectWithFilter id={UUID.generate()} items={this.state.hoc} customValues />
+                    <MultiSelectWithFilter id={'multi-predicate-custom'} items={this.state.hoc} customValues />
                 </div>
                 <div className='form-group'>
                     <label className='form-control-label'>A Multi Select With Filter, Custom Values and no items</label>
@@ -146,7 +146,8 @@ export class MultiSelectExamples extends React.Component<{}, IMultiSelectExample
                         items={this.state.hoc}
                         options={defaultFlatSelectOptions}
                         matchPredicate={(p: string, i: IItemBoxProps) => this.matchPredicate(p, i)}
-                        customValues />
+                        customValues
+                    />
                 </div>
             </div>
         );


### PR DESCRIPTION
the way we retrieve selected options for Select variants is through a listBox state. However, since the add button isn't a listBox option, when clicked it doesn't add the value as a selected option in the listBox state. We thus have to do it manually. 

![screen shot 2019-01-25 at 4 01 14 pm](https://user-images.githubusercontent.com/9539763/51772637-7d515980-20ba-11e9-8ecd-55c455e09749.png)
