### PR TITLE
Implement doubleclick behavior on table rows and disabled style

### DIFF
--- a/src/components/table-hoc/TableRowConnected.tsx
+++ b/src/components/table-hoc/TableRowConnected.tsx
@@ -29,6 +29,7 @@ export interface ITableRowOwnProps {
     actions?: IActionOptions[];
     isMultiselect?: boolean;
     collapsible?: CollapsibleRowProps;
+    disabled?: boolean;
 }
 
 export interface ITableRowStateProps {
@@ -149,9 +150,11 @@ class TableRowConnected extends React.PureComponent<ITableRowConnectedProps & Re
                             selected: this.props.selected,
                             opened: this.props.opened,
                             'heading-row': rowIsCollapsible,
+                            'row-disabled': this.props.disabled,
                         },
                     )}
                     onClick={this.handleClick}
+                    onDoubleClick={this.handleDoubleClick}
                 >
                     {this.props.children}
                     {collapsibleRowToggle}
@@ -170,6 +173,12 @@ class TableRowConnected extends React.PureComponent<ITableRowConnectedProps & Re
             const isMulti = (e.metaKey || e.ctrlKey) && this.props.isMultiselect;
             this.props.onClick(isMulti);
         }
+    }
+
+    private handleDoubleClick = () => {
+        _(this.props.actions)
+            .filter((action: IActionOptions) => action.callOnDoubleClick)
+            .forEach((action: IActionOptions) => action.trigger());
     }
 }
 

--- a/src/components/table-hoc/examples/TableHOCServerExamples.tsx
+++ b/src/components/table-hoc/examples/TableHOCServerExamples.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as _ from 'underscore';
+
 import {IDispatch, ReduxConnect} from '../../../utils/ReduxUtils';
 import {IReactVaporTestState} from '../../../utils/TestUtils';
 import {LastUpdated} from '../../lastUpdated/LastUpdated';
@@ -74,8 +75,9 @@ export class TableHOCServerExamples extends React.Component<TableHOCServerProps>
                 id={data.username}
                 tableId={TableHOCServerExamples.TABLE_ID}
                 key={data.username}
-                actions={[{primary: true, icon: 'edit', name: 'edit', enabled: true, trigger: () => alert(data.username)}]}
+                actions={[{primary: true, icon: 'edit', name: 'edit', enabled: true, trigger: () => alert(data.username), callOnDoubleClick: true}]}
                 isMultiselect
+                disabled={i % 3 === 0}
             >
                 <TableRowNumberColumn number={i + 1} />
                 <td key='city'>{data.city}</td>

--- a/src/components/table-hoc/tests/TableRowConnected.spec.tsx
+++ b/src/components/table-hoc/tests/TableRowConnected.spec.tsx
@@ -48,6 +48,11 @@ describe('Table HOC', () => {
             expect(wrapper.find('tr').hasClass('selected')).toBe(true);
         });
 
+        it('should have the class "row-disabled" if the row has disabled prop to true', () => {
+            const wrapper = shallowWithStore(<TableRowConnected id='a' tableId='b' disabled />, store).dive();
+            expect(wrapper.find('tr').hasClass('row-disabled')).toBe(true);
+        });
+
         it('should not have the class selected if the row is not selected in the state', () => {
             store = createMockStore({
                 tableHOCRow: [{
@@ -140,6 +145,21 @@ describe('Table HOC', () => {
 
             wrapper.find('tr').simulate('click', {ctrlKey: false});
             expect(store.isActionDispatched(expectedActionWithoutMulti)).toBe(true);
+        });
+
+        it('should dispatch trigger actions with callOnDoubleClick=true when double clicking the row', () => {
+            const triggerActionSpy = jasmine.createSpy('triggerAction');
+
+            const wrapper = shallowWithStore(
+                <TableRowConnected
+                    {...defaultProps}
+                    actions={[{enabled: true, name: 'action', callOnDoubleClick: true, trigger: triggerActionSpy}]}
+                />,
+                store,
+            ).dive();
+
+            wrapper.find('tr').simulate('doubleclick');
+            expect(triggerActionSpy).toHaveBeenCalledTimes(1);
         });
 
         describe('when the row is collapsible', () => {


### PR DESCRIPTION
- `TableRowConnected` with prop `disabled` set to true will now output a `tr` with the `row-disabled` class. It won't prevent any action from being triggered, if you want such behavior you should handle it in your callback;
- `TableRowConnected` will now trigger all of its actions that have the prop `callOnDoubleClick` set to true;