### PR TITLE
Bind the code editor to its value prop

### DIFF
--- a/src/components/editor/JSONEditor.tsx
+++ b/src/components/editor/JSONEditor.tsx
@@ -2,7 +2,6 @@ import 'codemirror/mode/javascript/javascript';
 
 import * as classNames from 'classnames';
 import * as React from 'react';
-import {UnControlled} from 'react-codemirror2';
 
 import {Svg} from '../svg/Svg';
 import {CodeEditor} from './CodeEditor';
@@ -26,8 +25,6 @@ export class JSONEditor extends React.Component<IJSONEditorProps, IJSONEditorSta
         errorMessage: DEFAULT_JSON_ERROR_MESSAGE,
     };
 
-    private codemirror: UnControlled;
-
     constructor(props: IJSONEditorProps, state: IJSONEditorState) {
         super(props, state);
         this.state = {
@@ -47,7 +44,6 @@ export class JSONEditor extends React.Component<IJSONEditorProps, IJSONEditorSta
                 <CodeEditor
                     value={this.props.value}
                     onChange={(json: string) => this.handleChange(json)}
-                    onMount={(codemirror) => this.codemirror = codemirror}
                     mode={CodeMirrorModes.JSON}
                     readOnly={this.props.readOnly}
                 />

--- a/src/components/editor/JSONEditor.tsx
+++ b/src/components/editor/JSONEditor.tsx
@@ -3,6 +3,7 @@ import 'codemirror/mode/javascript/javascript';
 import * as classNames from 'classnames';
 import * as React from 'react';
 
+import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {Svg} from '../svg/Svg';
 import {CodeEditor} from './CodeEditor';
 import {CodeMirrorModes} from './EditorConstants';
@@ -72,12 +73,11 @@ export class JSONEditor extends React.Component<IJSONEditorProps, IJSONEditorSta
         }
         this.setState({
             isInError: inError,
-        }, () => this.callOnChange(json, inError));
+        });
+        this.callOnChange(json, inError);
     }
 
     private callOnChange(json: string, inError: boolean) {
-        if (this.props.onChange) {
-            this.props.onChange(json, inError);
-        }
+        callIfDefined(this.props.onChange, json, inError);
     }
 }

--- a/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/src/components/editor/tests/CodeEditor.spec.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import * as ReactCodeMirror from 'react-codemirror2';
 import * as _ from 'underscore';
 
-import {CodeEditor, ICodeEditorProps} from '../CodeEditor';
+import {CodeEditor, CodeEditorState, ICodeEditorProps} from '../CodeEditor';
 import {CodeMirrorModes} from '../EditorConstants';
 
 describe('CodeEditor', () => {
@@ -20,7 +20,7 @@ describe('CodeEditor', () => {
     });
 
     describe('<CodeEditor />', () => {
-        let codeEditor: ReactWrapper<ICodeEditorProps>;
+        let codeEditor: ReactWrapper<ICodeEditorProps, CodeEditorState>;
         let codeEditorInstance: CodeEditor;
 
         const mountWithProps = (props: Partial<ICodeEditorProps> = {}) => {
@@ -66,26 +66,15 @@ describe('CodeEditor', () => {
         });
 
         it('should display a <CodeMirror /> component', () => {
-            expect(codeEditor.find(ReactCodeMirror.UnControlled).length).toBe(1);
+            expect(codeEditor.find(ReactCodeMirror.Controlled).length).toBe(1);
         });
 
-        it('should call handleChange when the CodeMirror onChange prop is called', () => {
-            const handleChangeSpy: jasmine.Spy = spyOn<any>(CodeEditor.prototype, 'handleChange');
-            const expectedValue: string = 'anything at all really';
-
-            codeEditor.find(ReactCodeMirror.UnControlled).props().onChange(({} as any), ({} as any), expectedValue);
-
-            expect(handleChangeSpy).toHaveBeenCalledTimes(1);
-            expect(handleChangeSpy).toHaveBeenCalledWith(expectedValue);
-        });
-
-        it('should call the onChange prop if set when calling handleChange', () => {
+        it('should call onChange prop when its value prop changes', () => {
             const onChangeSpy: jasmine.Spy = jasmine.createSpy('onChange');
             const expectedValue: string = 'the expected value';
 
             mountWithProps({onChange: onChangeSpy});
-
-            (codeEditorInstance as any).handleChange(expectedValue);
+            codeEditor.setProps({value: expectedValue});
 
             expect(onChangeSpy).toHaveBeenCalledTimes(1);
             expect(onChangeSpy).toHaveBeenCalledWith(expectedValue);
@@ -116,7 +105,7 @@ describe('CodeEditor', () => {
         });
 
         it('should have a border by default', () => {
-            expect(codeEditor.find(ReactCodeMirror.UnControlled).props().className).toBe('mod-border');
+            expect(codeEditor.find(ReactCodeMirror.Controlled).props().className).toBe('mod-border');
         });
     });
 });

--- a/src/components/editor/tests/JSONEditor.spec.tsx
+++ b/src/components/editor/tests/JSONEditor.spec.tsx
@@ -1,6 +1,7 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
+
 import {CodeEditor} from '../CodeEditor';
 import {IJSONEditorProps, IJSONEditorState, JSONEditor} from '../JSONEditor';
 
@@ -82,6 +83,17 @@ describe('JSONEditor', () => {
             mountWithProps({onChange: onChangeSpy});
 
             (jsonEditorInstance as any).handleChange(expectedValue);
+
+            expect(onChangeSpy).toHaveBeenCalledTimes(1);
+            expect(onChangeSpy).toHaveBeenCalledWith(expectedValue, true);
+        });
+
+        it('should call onChange prop when the value prop changes', () => {
+            const onChangeSpy: jasmine.Spy = jasmine.createSpy('onChange');
+            const expectedValue: string = 'the expected value';
+
+            mountWithProps({onChange: onChangeSpy});
+            jsonEditor.setProps({value: expectedValue});
 
             expect(onChangeSpy).toHaveBeenCalledTimes(1);
             expect(onChangeSpy).toHaveBeenCalledWith(expectedValue, true);


### PR DESCRIPTION
The code editor now uses the `Controlled` version of reac-codemirror-2 which allows to have more control over how it handles its state. I fixed it so that its state changes both when the user inputs something, but also when its value changes programatically. 