### PR TITLE
make option optional in on option click

### DIFF
--- a/src/components/itemBox/ItemBox.tsx
+++ b/src/components/itemBox/ItemBox.tsx
@@ -18,7 +18,7 @@ export interface IItemBoxProps {
     classes?: string[];
     prepend?: IContentProps;
     append?: IContentProps;
-    onOptionClick?: (option: IItemBoxProps) => void;
+    onOptionClick?: (option?: IItemBoxProps) => void;
     selectedDisplayValue?: string;
 }
 


### PR DESCRIPTION
passing option to onOptionClick is not always relevant, therefore it should be optional