### PR TITLE
Numeric input selectors type fix

### DIFF
--- a/src/components/numericInput/NumericInputReducers.ts
+++ b/src/components/numericInput/NumericInputReducers.ts
@@ -1,9 +1,10 @@
+import * as React from 'react';
 import * as _ from 'underscore';
 import {IReduxAction} from '../../utils/ReduxUtils';
 import {ISetNumericInputPayload, NumericInputActionTypes} from './NumericInputActions';
 
 export interface INumericInputState {
-    value: number | string;
+    value: React.ReactText;
     hasError: boolean;
 }
 

--- a/src/components/numericInput/NumericInputSelectors.ts
+++ b/src/components/numericInput/NumericInputSelectors.ts
@@ -18,6 +18,6 @@ const getHasError: (state: IReactVaporState, ownProps: {id: string}) => boolean 
 );
 
 export const NumericInputSelectors = {
-    getHasError,
     getValue,
+    getHasError,
 };

--- a/src/components/numericInput/NumericInputSelectors.ts
+++ b/src/components/numericInput/NumericInputSelectors.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {createSelector} from 'reselect';
 import {IReactVaporState} from '../../ReactVapor';
 import {initialNumericInputState, INumericInputState} from './NumericInputReducers';
@@ -6,7 +7,7 @@ const getNumericInput = (state: IReactVaporState, ownProps: {id: string}): INume
     return state && state.numericInputs[ownProps.id] || initialNumericInputState;
 };
 
-const getValue: (state: IReactVaporState, ownProps: {id: string}) => number | string = createSelector(
+const getValue: (state: IReactVaporState, ownProps: {id: string}) => React.ReactText = createSelector(
     getNumericInput,
     (numericInput: INumericInputState) => numericInput.value,
 );
@@ -17,6 +18,6 @@ const getHasError: (state: IReactVaporState, ownProps: {id: string}) => boolean 
 );
 
 export const NumericInputSelectors = {
-    getValue,
     getHasError,
+    getValue,
 };


### PR DESCRIPTION
so the type generation task was first transforming `string | number` to `import("react").ReactText` , which was then removed through cleanDefs , and thus was breaking the types file...this change fixes the issue. Prefer React.ReactText instead of string | number in the future, I feel there is not much we can do in the build process to fix this since the breaking change comes from the way dtsGenerator generates the types. 