### PR TITLE
fix: Remove the duplicate label for checkboxes

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -146,7 +146,9 @@ export class Input extends React.Component<IInputProps, IInputComponentState> {
 
     private getLabel(): JSX.Element {
         const {labelProps, labelTitle} = this.props;
-        return <Label key={this.props.id + 'label'} htmlFor={this.props.id} {...labelProps}>{labelTitle}</Label>;
+        return labelTitle || this.props.validate
+            ? <Label key={this.props.id + 'label'} htmlFor={this.props.id} {...labelProps}>{labelTitle}</Label>
+            : null;
     }
 
     render() {

--- a/src/components/input/tests/Input.spec.tsx
+++ b/src/components/input/tests/Input.spec.tsx
@@ -135,8 +135,8 @@ describe('<Input />', () => {
             expect(spyOnKeyUp).toHaveBeenCalledTimes(1);
         });
 
-        it('should always render the label event if the labelTitle and labelProps is not defined', () => {
-            shallowInput();
+        it('should render the label even if the labelTitle is undefined when validate prop exists', () => {
+            shallowInput({validate: () => false});
             expect(input.find(Label).length).toBe(1);
         });
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/35579930/52279306-42a3b880-2927-11e9-88b5-b63f5dd7ecf8.png)

After:
![image](https://user-images.githubusercontent.com/35579930/52279285-37508d00-2927-11e9-8690-fc8131888f4c.png)
