### PR TITLE
Fix ReduxUtils generic types

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,6 @@ gulp.task('ts:definitions', 'Generate the project definition file', (done) => {
 
 gulp.task('internalDefs', false, () =>
     dtsGenerator.default({
-        name: 'ReactVapor',
         project: './',
         out: 'dist/react-vapor.d.ts',
         exclude: ['node_modules/**/*.d.ts', 'src/Index.ts', '**/*Examples*', '**/*Example*', '**/*.spec.*', 'src/utils/TestUtils.ts'],

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "css-loader": "1.0.1",
     "del": "3.0.0",
     "dnd-core": "2.5.1",
-    "dts-generator": "2.1.0",
+    "dts-generator": "3.0.0",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.7.1",
     "enzyme-redux": "0.2.1",

--- a/src/utils/ReduxUtils.ts
+++ b/src/utils/ReduxUtils.ts
@@ -1,9 +1,12 @@
-import * as ReactRedux from 'react-redux';
+import {connect} from 'react-redux';
 import * as Redux from 'redux';
+import {ThunkAction, ThunkDispatch} from 'redux-thunk';
 import {extend} from 'underscore';
 
-export type IDispatch<T = void> = (action: IReduxAction<any> | IThunkAction) => T;
-export type IThunkAction<T = void> = (dispatch: IDispatch, getState?: () => any) => T;
+import {IReactVaporState} from '../ReactVapor';
+
+export type IThunkAction<R = any, S extends IReactVaporState = IReactVaporState> = ThunkAction<R, S, any, Redux.Action>;
+export type IDispatch<S extends IReactVaporState = IReactVaporState> = ThunkDispatch<S, any, Redux.Action>;
 
 export class ReduxUtils {
     static mergeProps(stateProps: any, dispatchProps: any, ownProps: any) {
@@ -26,7 +29,7 @@ export const clearState = (): Redux.Action => ({
 });
 
 export function ReduxConnect(mapStateToProps?: any, mapDispatchToProps?: any, mergeProps?: any, options?: any): (target: any) => any {
-    return (target) => (ReactRedux.connect(mapStateToProps, mapDispatchToProps, mergeProps, options)(target) as any);
+    return (target) => connect(mapStateToProps, mapDispatchToProps, mergeProps, options)(target) as any;
 }
 
 export interface BasePayload {


### PR DESCRIPTION
`tslint` was complaining with our custom `IDispatch` and `IThunkAction` types. I refactored our types so that they use the proper types from redux-thunk.