### PR TITLE
Feature Single Select Clear Button

### DIFF
--- a/src/components/labeledValue/LabeledValue.tsx
+++ b/src/components/labeledValue/LabeledValue.tsx
@@ -7,7 +7,7 @@ import {Tooltip} from '../tooltip/Tooltip';
 export interface ILabeledValueProps {
     label: string;
     value: React.ReactNode;
-    fullRow?: true;
+    fullRow?: boolean;
     information?: string;
     informationPlacement?: TooltipPlacement;
     padding?: boolean;

--- a/src/components/menu/examples/MenuExamples.tsx
+++ b/src/components/menu/examples/MenuExamples.tsx
@@ -6,7 +6,7 @@ import {ListBox} from '../../listBox/ListBox';
 import {Svg} from '../../svg/Svg';
 import {MenuConnected} from '../MenuConnected';
 
-export class MenuExamples extends React.Component {
+export class MenuExamples extends React.PureComponent {
 
     private getCustomSvg(): React.ReactNode {
         return (<Svg

--- a/src/components/select/SingleSelectConnected.tsx
+++ b/src/components/select/SingleSelectConnected.tsx
@@ -1,4 +1,5 @@
 import * as classNames from 'classnames';
+import * as VaporSVG from 'coveo-styleguide';
 import * as React from 'react';
 import * as _ from 'underscore';
 
@@ -121,7 +122,7 @@ export class SingleSelectConnected extends React.Component<ISingleSelectProps & 
     private getDeselectOptionButton(): React.ReactNode {
         return (
             <Tooltip title={this.props.deselectTooltipText} placement='top' noSpanWrapper onClick={this.props.deselect}>
-                <Svg svgName='clear' svgClass='icon mod-12' className='btn-append center-align' />
+                <Svg svgName={VaporSVG.svg.clear.name} svgClass='icon mod-12' className='btn-append center-align' />
             </Tooltip>
         );
     }

--- a/src/components/select/SingleSelectConnected.tsx
+++ b/src/components/select/SingleSelectConnected.tsx
@@ -21,8 +21,8 @@ export interface ISingleSelectOwnProps extends ISelectProps {
     onSelectOptionCallback?: (option: string) => void;
     items?: IItemBoxProps[];
     buttonPrepend?: React.ReactNode;
-    noFixedWidth?: true;
-    canClear?: true;
+    noFixedWidth?: boolean;
+    canClear?: boolean;
     deselectTooltipText?: string;
 }
 

--- a/src/components/select/examples/SingleSelectExamples.tsx
+++ b/src/components/select/examples/SingleSelectExamples.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react';
 import * as _ from 'underscore';
+
 import {UUID} from '../../../utils/UUID';
 import {IFlatSelectOptionProps} from '../../flatSelect/FlatSelectOption';
 import {IItemBoxProps} from '../../itemBox/ItemBox';
-import {
-    SingleSelectWithFilter,
-    SingleSelectWithPredicate,
-    SingleSelectWithPredicateAndFilter,
-} from '../SelectComponents';
+import {SingleSelectWithFilter, SingleSelectWithPredicate, SingleSelectWithPredicateAndFilter} from '../SelectComponents';
 import {SingleSelectConnected} from '../SingleSelectConnected';
 
 const defaultItems: IItemBoxProps[] = [
@@ -33,7 +30,7 @@ export interface ISingleSelectExamplesState {
     hoc: IItemBoxProps[];
 }
 
-export class SingleSelectExamples extends React.Component<{}, ISingleSelectExamplesState> {
+export class SingleSelectExamples extends React.PureComponent<{}, ISingleSelectExamplesState> {
     constructor(props: {}, state: ISingleSelectExamplesState) {
         super(props, state);
 
@@ -57,12 +54,15 @@ export class SingleSelectExamples extends React.Component<{}, ISingleSelectExamp
                 <div className='form-group'>
                     <label className='form-control-label'>A Simple Single Select with a Custom Placeholder</label>
                     <br />
-                    <SingleSelectConnected
-                        id={UUID.generate()}
-                        items={this.state.first}
-                        placeholder='Select something'
-                    />
+                    <SingleSelectConnected id={UUID.generate()} items={this.state.first} placeholder='Select something' />
                 </div>
+
+                <div className='form-group'>
+                    <label className='form-control-label'>A Simple Single Select with a Clear Button</label>
+                    <br />
+                    <SingleSelectConnected id={UUID.generate()} items={this.state.first} canClear />
+                </div>
+
                 <div className='form-group'>
                     <label className='form-control-label'>Disabled Simple Single Select</label>
                     <br />

--- a/src/components/select/tests/SingleSelectConnected.spec.tsx
+++ b/src/components/select/tests/SingleSelectConnected.spec.tsx
@@ -8,6 +8,7 @@ import {keyCode} from '../../../utils/InputUtils';
 import {clearState} from '../../../utils/ReduxUtils';
 import {TestUtils} from '../../../utils/TestUtils';
 import {IItemBoxProps} from '../../itemBox/ItemBox';
+import {clearListBoxOption} from '../../listBox/ListBoxActions';
 import {ISelectProps, ISelectSpecificProps, SelectConnected} from '../SelectConnected';
 import {ISingleSelectProps, SingleSelectConnected} from '../SingleSelectConnected';
 
@@ -143,6 +144,35 @@ describe('Select', () => {
 
             expect(buttonHTML).toContain(prepend);
             expect(buttonHTML).toContain(append);
+        });
+
+        it('should have a clear icon when a value selected and canClear is true', () => {
+            mountSingleSelect([{value: 'a', selected: true}], {canClear: true});
+
+            expect(select.find('.dropdown-toggle').hasClass('mod-append')).toBe(true);
+            expect(select.find('.btn-append').exists()).toBe(true);
+        });
+
+        it('should not have a clear icon when a value selected and canClear is undefined', () => {
+            mountSingleSelect([{value: 'a', selected: true}]);
+
+            expect(select.find('.dropdown-toggle').hasClass('mod-append')).toBe(false);
+            expect(select.find('.btn-append').exists()).toBe(false);
+        });
+
+        it('should not have a clear icon when no value is selected and canClear is true', () => {
+            mountSingleSelect([{value: 'a', selected: false}], {canClear: true});
+
+            expect(select.find('.dropdown-toggle').hasClass('mod-append')).toBe(false);
+            expect(select.find('.btn-append').exists()).toBe(false);
+        });
+
+        it('should clear the selected value when the deselect is clicked', () => {
+            const spy = spyOn(store, 'dispatch').and.callThrough();
+            mountSingleSelect([{value: 'a', selected: true}], {canClear: true});
+
+            select.find('.btn-append').first().simulate('click');
+            expect(spy).toHaveBeenCalledWith(clearListBoxOption(id));
         });
 
         it('should display the selectedDisplayValue if defined in the button for the selected item', () => {


### PR DESCRIPTION
Added props on the SingleSelect to add a clear button and a tooltip
Added unit tests
Fixed demo for single select and Menu

![image](https://user-images.githubusercontent.com/260007/53442030-4aaac180-39d6-11e9-8450-d676a59dd75a.png)
