### PR TITLE
Fixed Options Cycle can Only Display Strings

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -171,7 +171,6 @@ export class Calendar extends React.Component<ICalendarProps, any> {
     render() {
         const monthPickerProps: IOptionsCycleProps = {
             options: this.props.months,
-            startAt: this.props.startingMonth,
             isInline: true,
         };
 
@@ -179,7 +178,6 @@ export class Calendar extends React.Component<ICalendarProps, any> {
         const startingYear: number = this.props.startingYear || (startingYearIndex >= 0 ? startingYearIndex : Math.floor(this.props.years.length / 2));
         const yearPickerProps: IOptionsCycleProps = {
             options: this.props.years,
-            startAt: startingYear,
             isInline: true,
         };
 
@@ -191,12 +189,12 @@ export class Calendar extends React.Component<ICalendarProps, any> {
         const daysHeaderColumns: ITableHeaderCellProps[] = _.map(orderedDays, (day: string) => ({title: day}));
 
         const monthPicker = this.props.withReduxState
-            ? <OptionsCycleConnected id={this.props.id + MONTH_PICKER_ID} {...monthPickerProps} />
-            : <OptionsCycle {...monthPickerProps} />;
+            ? <OptionsCycleConnected id={this.props.id + MONTH_PICKER_ID} startAt={this.props.startingMonth} {...monthPickerProps} />
+            : <OptionsCycle currentOption={this.props.startingMonth} {...monthPickerProps} />;
 
         const yearPicker = this.props.withReduxState
-            ? <OptionsCycleConnected id={this.props.id + YEAR_PICKER_ID} {...yearPickerProps} />
-            : <OptionsCycle {...yearPickerProps} />;
+            ? <OptionsCycleConnected id={this.props.id + YEAR_PICKER_ID} startAt={startingYear} {...yearPickerProps} />
+            : <OptionsCycle currentOption={startingYear} {...yearPickerProps} />;
 
         const selectedYearOption = !_.isUndefined(this.props.selectedYear) ? this.props.selectedYear : startingYear;
         const year = parseInt(this.props.years[selectedYearOption], 10);

--- a/src/components/optionsCycle/OptionsCycle.tsx
+++ b/src/components/optionsCycle/OptionsCycle.tsx
@@ -1,27 +1,42 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
+
+import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {Svg} from '../svg/Svg';
 
-export interface IOptionsCycleOwnProps extends React.ClassAttributes<OptionsCycle> {
-    options: string[];
-    id?: string;
+export interface IOptionsCycleConnectedOwnProps {
+    id: string;
     startAt?: number;
+}
+
+export interface IOptionsCycleOwnProps {
+    options: React.ReactNode[];
     isInline?: boolean;
+    className?: string;
+    previousClassName?: string;
+    nextClassName?: string;
+    buttonClassName?: string;
 }
 
 export interface IOptionsCycleStateProps {
-    currentOption?: number;
+    currentOption: number;
 }
 
 export interface IOptionsCycleDispatchProps {
-    onRender?: (index: number) => void;
-    onDestroy?: () => void;
-    onChange?: (index: number) => void;
+    onRender: () => void;
+    onDestroy: () => void;
+    onChange: (index: number) => void;
 }
 
-export interface IOptionsCycleProps extends IOptionsCycleOwnProps, IOptionsCycleStateProps, IOptionsCycleDispatchProps {}
+export interface IOptionsCycleProps extends IOptionsCycleOwnProps,
+    Partial<IOptionsCycleStateProps>,
+    Partial<IOptionsCycleDispatchProps> {}
 
-export class OptionsCycle extends React.Component<IOptionsCycleProps, any> {
-    private selectedOption: string;
+export class OptionsCycle extends React.Component<IOptionsCycleProps> {
+
+    static defaultProps: Partial<IOptionsCycleProps> = {
+        currentOption: 0,
+    };
 
     private goToPreviousOption() {
         if (this.props.onChange) {
@@ -37,43 +52,23 @@ export class OptionsCycle extends React.Component<IOptionsCycleProps, any> {
         }
     }
 
-    private setSelectedOption(currentOption: number = 0) {
-        this.selectedOption = this.props.options[currentOption];
-    }
-
-    componentWillMount() {
-        if (this.props.onRender) {
-            this.props.onRender(this.props.startAt);
-            this.setSelectedOption(this.props.currentOption);
-        }
-        this.setSelectedOption(this.props.startAt);
+    componentDidMount() {
+        callIfDefined(this.props.onRender);
     }
 
     componentWillUnmount() {
-        if (this.props.onDestroy) {
-            this.props.onDestroy();
-        }
-    }
-
-    componentWillReceiveProps(nextProps: IOptionsCycleProps) {
-        this.setSelectedOption(nextProps.currentOption);
+        callIfDefined(this.props.onDestroy);
     }
 
     render() {
-        const optionsCycleClasses = ['options-cycle', 'text-medium-blue'];
-
-        if (this.props.isInline) {
-            optionsCycleClasses.push('mod-inline');
-        }
-
         return (
-            <div className={optionsCycleClasses.join(' ')}>
-                <button type='button' className='options-cycle-button previous-option' onClick={() => this.goToPreviousOption()}>
-                    <Svg svgName='arrow-left-rounded' svgClass='icon fill-dark-blue' />
+            <div className={classNames('options-cycle text-medium-blue', this.props.className, {'mod-inline': this.props.isInline})}>
+                <button type='button' className={classNames('options-cycle-button previous-option', this.props.previousClassName)} onClick={() => this.goToPreviousOption()}>
+                    <Svg svgName='arrow-left-rounded' svgClass='icon fill-dark-blue mod-16' />
                 </button>
-                <span className='options-cycle-option'>{this.selectedOption}</span>
-                <button type='button' className='options-cycle-button next-option' onClick={() => this.goToNextOption()}>
-                    <Svg svgName='arrow-right-rounded' svgClass='icon fill-dark-blue' />
+                <span className={classNames('options-cycle-option', this.props.buttonClassName)}>{this.props.options[this.props.currentOption]}</span>
+                <button type='button' className={classNames('options-cycle-button next-option', this.props.nextClassName)} onClick={() => this.goToNextOption()}>
+                    <Svg svgName='arrow-right-rounded' svgClass='icon fill-dark-blue mod-16' />
                 </button>
             </div>
         );

--- a/src/components/optionsCycle/OptionsCycleConnected.tsx
+++ b/src/components/optionsCycle/OptionsCycleConnected.tsx
@@ -4,30 +4,30 @@ import * as _ from 'underscore';
 import {IReactVaporState, IReduxActionsPayload} from '../../ReactVapor';
 import {IReduxAction, ReduxUtils} from '../../utils/ReduxUtils';
 import {
+    IOptionsCycleConnectedOwnProps,
     IOptionsCycleDispatchProps,
-    IOptionsCycleOwnProps,
     IOptionsCycleProps,
     IOptionsCycleStateProps,
     OptionsCycle,
 } from './OptionsCycle';
 import {addOptionsCycle, changeOptionsCycle, removeOptionsCycle} from './OptionsCycleActions';
 
-const mapStateToProps = (state: IReactVaporState, ownProps: IOptionsCycleOwnProps): IOptionsCycleStateProps => {
+const mapStateToProps = (state: IReactVaporState, ownProps: IOptionsCycleConnectedOwnProps): IOptionsCycleStateProps => {
     const cycle = _.findWhere(state.optionsCycles, {id: ownProps.id});
 
     return {
-        currentOption: cycle ? cycle.currentOption : 0,
+        currentOption: cycle ? cycle.currentOption : ownProps.startAt || 0,
     };
 };
 
 const mapDispatchToProps = (
     dispatch: (action: IReduxAction<IReduxActionsPayload>) => void,
-    ownProps: IOptionsCycleOwnProps,
+    ownProps: IOptionsCycleConnectedOwnProps,
 ): IOptionsCycleDispatchProps => ({
-    onRender: (index: number) => dispatch(addOptionsCycle(ownProps.id, index)),
+    onRender: () => dispatch(addOptionsCycle(ownProps.id, ownProps.startAt)),
     onDestroy: () => dispatch(removeOptionsCycle(ownProps.id)),
     onChange: (index: number) => dispatch(changeOptionsCycle(ownProps.id, index)),
 });
 
-export const OptionsCycleConnected: React.ComponentClass<IOptionsCycleProps> =
+export const OptionsCycleConnected: React.ComponentClass<IOptionsCycleProps & IOptionsCycleConnectedOwnProps> =
     connect(mapStateToProps, mapDispatchToProps, ReduxUtils.mergeProps)(OptionsCycle);

--- a/src/components/optionsCycle/examples/OptionsCycleConnectedExamples.tsx
+++ b/src/components/optionsCycle/examples/OptionsCycleConnectedExamples.tsx
@@ -10,7 +10,17 @@ export class OptionsCycleConnectedExamples extends React.Component<any, any> {
             <div className='mt2'>
                 <div className='form-group'>
                     <label className='form-control-label'>Options cycle</label>
-                    <OptionsCycleConnected options={OPTIONS} />
+                    <OptionsCycleConnected id='Cycle-1' options={OPTIONS} />
+                </div>
+
+                <div className='form-group'>
+                    <label className='form-control-label'>Options cycle at 2</label>
+                    <OptionsCycleConnected id='Cycle-2' options={OPTIONS} startAt={1} />
+                </div>
+
+                <div className='form-group'>
+                    <label className='form-control-label'>Options cycle like an action</label>
+                    <OptionsCycleConnected id='Cycle-3' options={OPTIONS} previousClassName='btn mod-border w4' buttonClassName='btn ml1' nextClassName='btn mod-border ml1 w4' />
                 </div>
             </div>
         );

--- a/src/components/optionsCycle/examples/OptionsCycleExamples.tsx
+++ b/src/components/optionsCycle/examples/OptionsCycleExamples.tsx
@@ -12,6 +12,11 @@ export class OptionsCycleExamples extends React.Component<any, any> {
                     <label className='form-control-label'>Options cycle</label>
                     <OptionsCycle options={OPTIONS} />
                 </div>
+
+                <div className='form-group'>
+                    <label className='form-control-label'>Options cycle at 2</label>
+                    <OptionsCycle options={OPTIONS} currentOption={1} />
+                </div>
             </div>
         );
     }

--- a/src/components/optionsCycle/tests/OptionsCycle.spec.tsx
+++ b/src/components/optionsCycle/tests/OptionsCycle.spec.tsx
@@ -42,7 +42,7 @@ describe('Options cycle', () => {
         it('should call prop onRender on mounting if set', () => {
             const renderSpy = jasmine.createSpy('onRender');
 
-            expect(() => optionsCycleInstance.componentWillMount()).not.toThrow();
+            expect(() => optionsCycleInstance.componentDidMount()).not.toThrow();
 
             optionsCycle.setProps({options: OPTIONS, onRender: renderSpy});
             optionsCycle.unmount();
@@ -67,6 +67,32 @@ describe('Options cycle', () => {
             optionsCycle.setProps({options: OPTIONS, currentOption: 2});
 
             expect(optionsCycle.html()).toContain(OPTIONS[2]);
+        });
+
+        it('should display the selected option even if it is not a string', () => {
+            const className = 'catch-me-if-you-can';
+            const options = [
+                <span className='something' />,
+                <span className={className} />,
+                <span className='something-else' />,
+            ];
+            optionsCycle.setProps({options, currentOption: 1});
+
+            expect(optionsCycle.find(`.${className}`).exists()).toBe(true);
+        });
+
+        it('should allow custom classes', () => {
+            const className = 'i-wonder';
+            const previousClassName = 'where-is';
+            const nextClassName = 'the-closest';
+            const buttonClassName = 'wonder-there-is';
+
+            optionsCycle.setProps({className, previousClassName, nextClassName, buttonClassName});
+
+            expect(optionsCycle.find(`.${className}`).exists()).toBe(true);
+            expect(optionsCycle.find(`.${previousClassName}`).exists()).toBe(true);
+            expect(optionsCycle.find(`.${nextClassName}`).exists()).toBe(true);
+            expect(optionsCycle.find(`.${buttonClassName}`).exists()).toBe(true);
         });
 
         it('should not throw on goToPreviousOption or goToNextOption when onChange prop is not defined', () => {
@@ -159,7 +185,7 @@ describe('Options cycle', () => {
 
             optionsCycle.unmount();
             optionsCycle = mount(
-                <OptionsCycle options={OPTIONS} startAt={startAt} />,
+                <OptionsCycle options={OPTIONS} currentOption={startAt} />,
                 {attachTo: document.getElementById('App')},
             );
 

--- a/src/components/optionsCycle/tests/OptionsCycleConnected.spec.tsx
+++ b/src/components/optionsCycle/tests/OptionsCycleConnected.spec.tsx
@@ -7,12 +7,12 @@ import * as _ from 'underscore';
 import {IReactVaporState} from '../../../ReactVapor';
 import {clearState} from '../../../utils/ReduxUtils';
 import {TestUtils} from '../../../utils/tests/TestUtils';
-import {IOptionsCycleProps, OptionsCycle} from '../OptionsCycle';
+import {IOptionsCycleConnectedOwnProps, IOptionsCycleProps, OptionsCycle} from '../OptionsCycle';
 import {changeOptionsCycle} from '../OptionsCycleActions';
 import {OptionsCycleConnected} from '../OptionsCycleConnected';
 
 describe('Options cycle', () => {
-    const optionsCycleBasicProps: IOptionsCycleProps = {
+    const optionsCycleBasicProps: IOptionsCycleProps & IOptionsCycleConnectedOwnProps = {
         id: 'options-cycle',
         options: ['option 1', 'option 2', 'option 3', 'option 4'],
     };
@@ -37,13 +37,6 @@ describe('Options cycle', () => {
         afterEach(() => {
             store.dispatch(clearState());
             wrapper.detach();
-        });
-
-        it('should get an id as a prop', () => {
-            const idProp = optionsCycle.props().id;
-
-            expect(idProp).toBeDefined();
-            expect(idProp).toBe(optionsCycleBasicProps.id);
         });
 
         it('should get the current option as a prop', () => {


### PR DESCRIPTION
Added possibility to render any React.ReactNode
Added examples
Removed props from OptionsCycle interface if they are only for the connected
Cleaned up OptionsCycle code
Added unit tests

Needs coveo/vapor#642

![image](https://user-images.githubusercontent.com/260007/53764463-5ba67780-3e9b-11e9-8424-15f6c72059fa.png)
