### PR TITLE
Handle modal layers

### DIFF
--- a/src/components/modal/ModalComposite.tsx
+++ b/src/components/modal/ModalComposite.tsx
@@ -24,7 +24,9 @@ export interface IModalCompositeOwnProps extends IModalOwnProps, IModalHeaderOwn
     isPrompt?: boolean;
 }
 
-export interface IModalCompositeStateProps extends IReduxStatePossibleProps, IModalStateProps {}
+export interface IModalCompositeStateProps extends IReduxStatePossibleProps, IModalStateProps {
+    layer: number;
+}
 
 export interface IModalCompositeDispatchProps extends IModalDispatchProps, IModalHeaderDispatchProps {}
 
@@ -41,12 +43,18 @@ export class ModalComposite extends React.PureComponent<IModalCompositeProps> {
                 key={this.props.id}
                 isOpen={this.props.isOpened}
                 className={{
-                    base: classNames('modal-container --react-modal', this.props.classes),
+                    base: classNames(
+                        'modal-container --react-modal',
+                        this.props.classes,
+                    ),
                     afterOpen: 'opened',
                     beforeClose: 'closed',
                 }}
                 overlayClassName={{
-                    base: 'modal-backdrop --react-modal',
+                    base: classNames(
+                        'modal-backdrop --react-modal',
+                        {[`layer-${this.props.layer}`]: this.props.layer > 0},
+                    ),
                     afterOpen: 'opened',
                     beforeClose: 'clear',
                 }}

--- a/src/components/modal/ModalCompositeConnected.tsx
+++ b/src/components/modal/ModalCompositeConnected.tsx
@@ -14,6 +14,7 @@ import {
 const mapStateToProps = (state: IReactVaporState, ownProps: IModalCompositeOwnProps): IModalCompositeStateProps => ({
     withReduxState: true,
     isOpened: state.modals && state.modals.some((modal) => modal.id === ownProps.id && modal.isOpened),
+    layer: state.openModals ? state.openModals.indexOf(ownProps.id) + 1 : 0,
 });
 
 const mapDispatchToProps = (dispatch: IDispatch, ownProps: IModalCompositeOwnProps): IModalCompositeDispatchProps => ({

--- a/src/components/modal/tests/ModalComposite.spec.tsx
+++ b/src/components/modal/tests/ModalComposite.spec.tsx
@@ -75,4 +75,18 @@ describe('ModalComposite', () => {
 
         expect(closeCallbackSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('should add a "layer-x" class to the modal overlay where x equals the layer prop value', () => {
+        const modalComposite = shallow(<ModalComposite isOpened layer={3} />);
+        const overlayClasses = modalComposite.find(ReactModal).props().overlayClassName as ReactModal.Classes;
+
+        expect(overlayClasses.base).toContain('layer-3');
+    });
+
+    it('should not add any "layer-x" class to the modal overlay when the layer is smaller than 1', () => {
+        const modalComposite = shallow(<ModalComposite isOpened layer={0} />);
+        const overlayClasses = modalComposite.find(ReactModal).props().overlayClassName as ReactModal.Classes;
+
+        expect(overlayClasses.base).not.toContain('layer-0');
+    });
 });

--- a/src/components/modal/tests/ModalCompositeConnected.spec.tsx
+++ b/src/components/modal/tests/ModalCompositeConnected.spec.tsx
@@ -35,6 +35,13 @@ describe('<ModalCompositeConnected />', () => {
         expect(modalCompositeConnected.props().isOpened).toBe(true);
     });
 
+    it('should have the layer prop set to the position of the current modal in opened modal stack + 1', () => {
+        mockstore = createMockStore({openModals: ['meeeeehhh-I-m-a-sheep', basicProps.id, 'mooooohhh-I-m-a-cow']});
+        const modalCompositeConnected = shallowWithStore(<ModalCompositeConnected {...basicProps} />, mockstore);
+
+        expect(modalCompositeConnected.props().layer).toBe(2);
+    });
+
     it('should dispatch an "ADD_MODAL" action when it mounts', () => {
         shallowWithStore(<ModalCompositeConnected {...basicProps} />, mockstore).dive();
 


### PR DESCRIPTION
Added the `layer-x` classes to modal overlays so that they all stack properly.

The layer number of a given modal equals its position in the `openModals` array in the store + 1.