### PR TITLE
Export redux thunk types

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,14 +58,15 @@ gulp.task('internalDefs', false, () =>
             '**/*Examples*',
             '**/*Example*',
             '**/*.spec.*',
-            'src/utils/tests/TestUtils.tsx',
+            'src/utils/tests/**/*',
         ],
     }));
 
 gulp.task('cleanDefs', false, () =>
     gulp.src('dist/react-vapor.d.ts')
         .pipe(optimizeDeclarations({
-            moduleName: 'ReactVapor',
+            libraryName: 'ReactVapor',
+            externalTypesToExport: ['redux-thunk'],
             internalImportPaths: ['src/'],
         }))
         .pipe(gulp.dest('dist'))

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "del": "3.0.0",
     "dnd-core": "2.5.1",
     "dts-generator": "3.0.0",
-    "dts-generator-optimizer": "1.0.0",
+    "dts-generator-optimizer": "2.0.0",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.7.1",
     "enzyme-redux": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "del": "3.0.0",
     "dnd-core": "2.5.1",
     "dts-generator": "3.0.0",
-    "dts-generator-optimizer": "0.0.2",
+    "dts-generator-optimizer": "1.0.0",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.7.1",
     "enzyme-redux": "0.2.1",

--- a/src/utils/ReduxUtils.ts
+++ b/src/utils/ReduxUtils.ts
@@ -5,8 +5,8 @@ import {extend} from 'underscore';
 
 import {IReactVaporState} from '../ReactVapor';
 
-export type IThunkAction<R = any, S extends IReactVaporState = IReactVaporState> = ThunkAction<R, S, any, Redux.Action>;
-export type IDispatch<S extends IReactVaporState = IReactVaporState> = ThunkDispatch<S, any, Redux.Action>;
+export type IThunkAction<R = any, S extends IReactVaporState = IReactVaporState> = ThunkAction<R, S, any, IReduxAction<any>>;
+export type IDispatch<S extends IReactVaporState = IReactVaporState> = ThunkDispatch<S, any, IReduxAction<any>>;
 
 export class ReduxUtils {
     static mergeProps(stateProps: any, dispatchProps: any, ownProps: any) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,21 @@
     "sourceMap": true,
     "target": "ES5",
     "plugins": [
-      {"transform": "ts-transformer-keys/transformer"}
+      {
+        "transform": "ts-transformer-keys/transformer"
+      }
     ],
-    "lib": ["es2015", "dom"]
+    "lib": [
+      "es2015",
+      "dom"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "*": [
+        "node_modules/@types/*",
+        "*"
+      ]
+    },
   },
   "include": [
     "src/**/*.tsx",
@@ -26,7 +38,7 @@
   ],
   "exclude": [
     "src/**/*.spec.*",
-      "src/utils/tests/TestUtils.tsx",
+    "src/utils/tests/TestUtils.tsx",
     "src/components/tables/tests/TableTestCommon.tsx"
   ]
 }


### PR DESCRIPTION
Export the redux-thunk types in the d.ts file because it breaks when using symlinks