### PR TITLE
Allow to use StickyFooter outside of the project

### DIFF
--- a/src/components/stickyFooter/StickyFooter.tsx
+++ b/src/components/stickyFooter/StickyFooter.tsx
@@ -1,17 +1,25 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as styles from './StickyFooter.scss';
+import { IClassName } from 'src/utils/ClassNameUtils';
 
 export interface IStickyFooterProps {
-    className?: string;
+    id?: string;
+    className?: IClassName;
+    isOpened: boolean;
 }
 
 export class StickyFooter extends React.Component<IStickyFooterProps> {
     static ID = 'StickyFooter';
 
     render() {
+        const { id, className, isOpened } = this.props;
         return (
-            <div id={StickyFooter.ID} className={classNames(styles.stickyFooter, this.props.className)}>
+            <div id={id || StickyFooter.ID} className={
+                classNames({
+                    [styles.stickyFooterOpened]: isOpened,
+                    [styles.stickyFooter]: true
+                }, className)}>
                 {this.props.children}
             </div>
         );

--- a/src/components/stickyFooter/StickyFooter.tsx
+++ b/src/components/stickyFooter/StickyFooter.tsx
@@ -10,11 +10,14 @@ export interface IStickyFooterProps {
 
 export class StickyFooter extends React.Component<IStickyFooterProps> {
     static ID = 'StickyFooter';
+    static defaultProps: Partial<IStickyFooterProps> = {
+        id: StickyFooter.ID
+    }
 
     render() {
         const {id, className, isOpened} = this.props;
         return (
-            <div id={id || StickyFooter.ID} className={classNames(styles.stickyFooter, {[styles.stickyFooterOpened]: isOpened}, className)}>
+            <div id={id} className={classNames(styles.stickyFooter, {[styles.stickyFooterOpened]: isOpened}, className)}>
                 {this.props.children}
             </div>
         );

--- a/src/components/stickyFooter/StickyFooter.tsx
+++ b/src/components/stickyFooter/StickyFooter.tsx
@@ -1,25 +1,20 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as styles from './StickyFooter.scss';
-import { IClassName } from 'src/utils/ClassNameUtils';
 
 export interface IStickyFooterProps {
-    id?: string;
-    className?: IClassName;
     isOpened: boolean;
+    id?: string;
+    className?: string;
 }
 
 export class StickyFooter extends React.Component<IStickyFooterProps> {
     static ID = 'StickyFooter';
 
     render() {
-        const { id, className, isOpened } = this.props;
+        const {id, className, isOpened} = this.props;
         return (
-            <div id={id || StickyFooter.ID} className={
-                classNames({
-                    [styles.stickyFooterOpened]: isOpened,
-                    [styles.stickyFooter]: true
-                }, className)}>
+            <div id={id || StickyFooter.ID} className={classNames(styles.stickyFooter, {[styles.stickyFooterOpened]: isOpened}, className)}>
                 {this.props.children}
             </div>
         );

--- a/src/components/stickyFooter/examples/StickyFooterExamples.tsx
+++ b/src/components/stickyFooter/examples/StickyFooterExamples.tsx
@@ -3,7 +3,6 @@ import * as loremIpsum from 'lorem-ipsum';
 import * as React from 'react';
 import {Button} from '../../button/Button';
 import {StickyFooter} from '../../stickyFooter/StickyFooter';
-import * as styles from '../../stickyFooter/StickyFooter.scss';
 
 const lorem = loremIpsum({count: 200});
 
@@ -21,7 +20,7 @@ export class StickyFooterExamples extends React.Component<{}, {isOpened: boolean
             <div className='mt2'>
                 <Button name='toggle footer' onClick={() => this.setState({isOpened: !this.state.isOpened})} />
                 <div className='mt2'>{lorem}</div>
-                <StickyFooter className={classNames('sticky-footer-mod-header', {[styles.stickyFooterOpened]: this.state.isOpened})}>
+                <StickyFooter className={'sticky-footer-mod-header'} isOpened={this.state.isOpened} >
                     <Button primary name='Save' />
                 </StickyFooter>
             </div>

--- a/src/components/stickyFooter/examples/StickyFooterExamples.tsx
+++ b/src/components/stickyFooter/examples/StickyFooterExamples.tsx
@@ -1,4 +1,3 @@
-import * as classNames from 'classnames';
 import * as loremIpsum from 'lorem-ipsum';
 import * as React from 'react';
 import {Button} from '../../button/Button';
@@ -20,7 +19,7 @@ export class StickyFooterExamples extends React.Component<{}, {isOpened: boolean
             <div className='mt2'>
                 <Button name='toggle footer' onClick={() => this.setState({isOpened: !this.state.isOpened})} />
                 <div className='mt2'>{lorem}</div>
-                <StickyFooter className={'sticky-footer-mod-header'} isOpened={this.state.isOpened} >
+                <StickyFooter className='sticky-footer-mod-header' isOpened={this.state.isOpened} >
                     <Button primary name='Save' />
                 </StickyFooter>
             </div>

--- a/src/components/stickyFooter/tests/StickyFooter.spec.tsx
+++ b/src/components/stickyFooter/tests/StickyFooter.spec.tsx
@@ -1,16 +1,34 @@
 import {shallow} from 'enzyme';
 import * as React from 'react';
 import {StickyFooter} from '../StickyFooter';
+import * as styles from '../StickyFooter.scss';
 
 describe('StickyFooter', () => {
     it('should render without error', () => {
-        expect(() => shallow(<StickyFooter />)).not.toThrow();
-        expect(() => shallow(<StickyFooter className='someclass' />)).not.toThrow();
+        expect(() => shallow(<StickyFooter isOpened={true} />)).not.toThrow();
+        expect(() => shallow(<StickyFooter className='someclass' isOpened={true} />)).not.toThrow();
+        expect(() => shallow(<StickyFooter id='oyeah' isOpened={true} />)).not.toThrow();
     });
 
     it('should render with extra classes on container if classes is passed as prop', () => {
         const classes = 'some classes';
-        const component = shallow(<StickyFooter className={classes} />);
+        const component = shallow(<StickyFooter className={classes} isOpened={true} />);
         expect(component.find('.some.classes').exists()).toBe(true);
+    });
+
+    it('should render with id if passed as prop', () => {
+        const id = 'someid';
+        const component = shallow(<StickyFooter id={id} isOpened={true} />);
+        expect(component.find(`#${id}`).exists()).toBe(true);
+    });
+
+    it('should render opened class if it is opened', () => {
+        const component = shallow(<StickyFooter isOpened={true} />);
+        expect(component.find('#StickyFooter').hasClass(styles.stickyFooterOpened)).toBe(true);
+    });
+
+    it('should not render opened class if it is closed', () => {
+        const component = shallow(<StickyFooter isOpened={false} />);
+        expect(component.find('#StickyFooter').hasClass(styles.stickyFooterOpened)).toBe(false);
     });
 });

--- a/src/components/stickyFooter/tests/StickyFooter.spec.tsx
+++ b/src/components/stickyFooter/tests/StickyFooter.spec.tsx
@@ -6,6 +6,7 @@ import * as styles from '../StickyFooter.scss';
 describe('StickyFooter', () => {
     it('should render without error', () => {
         expect(() => shallow(<StickyFooter isOpened={true} />)).not.toThrow();
+        expect(() => shallow(<StickyFooter isOpened={false} />)).not.toThrow();
         expect(() => shallow(<StickyFooter className='someclass' isOpened={true} />)).not.toThrow();
         expect(() => shallow(<StickyFooter id='oyeah' isOpened={true} />)).not.toThrow();
     });

--- a/src/hoc/withEditing/withEditing.tsx
+++ b/src/hoc/withEditing/withEditing.tsx
@@ -1,4 +1,3 @@
-import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
 import {StickyFooter} from '../../components/stickyFooter/StickyFooter';

--- a/src/hoc/withEditing/withEditing.tsx
+++ b/src/hoc/withEditing/withEditing.tsx
@@ -2,7 +2,6 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
 import {StickyFooter} from '../../components/stickyFooter/StickyFooter';
-import * as styles from '../../components/stickyFooter/StickyFooter.scss';
 import {IReactVaporState} from '../../ReactVapor';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
 import {toggleDirtyComponent} from './withEditingActions';
@@ -52,7 +51,7 @@ export const withEditing = <T, R = any>(config: IWithEditing) =>
                             {this.props.children}
                         </Component>
                         {config.footerChildren && (
-                            <StickyFooter className={classNames({[styles.stickyFooterOpened]: this.props.isDirty}, config.footerClassName)}>
+                            <StickyFooter className={config.footerClassName} isOpened={this.props.isDirty}>
                                 {config.footerChildren}
                             </StickyFooter>
                         )}


### PR DESCRIPTION
`.stickyFooterOpened` was compiled, so there was no direct way to use this class.

Furthermore, the component was *closed* by default, meaning that the only way we could use the component was by replicating the `stickyFooterOpened` into our project and applying it at all times.

I instead fronted a simple property to add this class when required.