### PR TITLE
Better check for action changes on table row

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ after_success:
  - npm run report-coverage
 
 after_script:
- - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; ./create-live-demo.sh; fi' # run this line on pull request builds only
+ - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then ./create-live-demo.sh; fi' # run this line on pull request builds only
 
 before_install:
   - eval "$(ssh-agent -s)" #start the ssh agent

--- a/src/components/table-hoc/TableRowConnected.tsx
+++ b/src/components/table-hoc/TableRowConnected.tsx
@@ -13,7 +13,6 @@ import {addActionsToActionBar} from '../actions/ActionBarActions';
 import {Collapsible} from '../collapsible/Collapsible';
 import {CollapsibleToggle} from '../collapsible/CollapsibleToggle';
 import {TableRowActions} from './actions/TableRowActions';
-import {ITableRowState} from './reducers/TableRowReducers';
 import {TableSelectors} from './TableSelectors';
 
 export interface CollapsibleRowProps {
@@ -56,10 +55,10 @@ const isCollapsible = (props: ITableRowOwnProps): boolean => props.collapsible
     && (React.isValidElement(props.collapsible.content) || _.isString(props.collapsible.content));
 
 const mapStateToProps = (state: IReactVaporState, ownProps: ITableRowOwnProps) => {
-    const row: ITableRowState = TableSelectors.getTableRow(state, {id: ownProps.id});
+    const {selected, opened} = TableSelectors.getTableRow(state, {id: ownProps.id}) || {selected: false, opened: false};
     return {
-        selected: row && row.selected,
-        opened: row && row.opened,
+        selected,
+        opened,
     };
 };
 
@@ -106,7 +105,7 @@ class TableRowConnected extends React.PureComponent<ITableRowConnectedProps & Re
             this.props.onUpdateToCollapsibleRow();
         }
 
-        if (!_.isEqual(prevProps.actions, this.props.actions)) {
+        if (JSON.stringify(prevProps.actions) !== JSON.stringify(this.props.actions) && this.props.selected) {
             this.props.onActionBarActionsChanged();
         }
     }

--- a/src/components/table-hoc/tests/TableRowConnected.spec.tsx
+++ b/src/components/table-hoc/tests/TableRowConnected.spec.tsx
@@ -8,6 +8,7 @@ import {addActionsToActionBar} from '../../actions/ActionBarActions';
 import {CollapsibleToggle} from '../../collapsible/CollapsibleToggle';
 import {TableRowActions} from '../actions/TableRowActions';
 import {ITableRowConnectedProps, TableRowConnected} from '../TableRowConnected';
+import {TableSelectors} from '../TableSelectors';
 
 describe('Table HOC', () => {
     describe('TableRowConnected', () => {
@@ -101,10 +102,11 @@ describe('Table HOC', () => {
             expect(store.isActionDispatched(expectedAction)).toBe(true);
         });
 
-        it('should dispatch an addActionsToActionBar when the actions change', () => {
+        it('should dispatch an addActionsToActionBar when the actions change and the row was selected', () => {
             const actions = [{name: 'name', enabled: false}];
             const newActions = [{name: 'name', enabled: true}];
             const expectedAction = addActionsToActionBar(defaultProps.tableId, actions);
+            spyOn(TableSelectors, 'getTableRow').and.returnValue({selected: true, opened: false});
 
             const wrapper = shallowWithStore(<TableRowConnected {...defaultProps} actions={actions} />, store).dive();
             wrapper.setProps({actions: newActions});
@@ -112,10 +114,11 @@ describe('Table HOC', () => {
             expect(store.isActionDispatched(expectedAction)).toBe(true);
         });
 
-        it('should dispatch a TableRowActions.select action when the action change', () => {
+        it('should dispatch a TableRowActions.select action when the action change and the row was selected', () => {
             const actions = [{name: 'name', enabled: false}];
             const newActions = [{name: 'name', enabled: true}];
             const expectedAction = TableRowActions.select(defaultProps.id, false);
+            spyOn(TableSelectors, 'getTableRow').and.returnValue({selected: true, opened: false});
 
             const wrapper = shallowWithStore(<TableRowConnected {...defaultProps} actions={actions} />, store).dive();
             wrapper.setProps({actions: newActions});


### PR DESCRIPTION
Action bar was refreshing to much often.

- Stringifying the actions before the check seems to have fixed it.
- Added a check to only refresh the action bar actions when the row was selected.
