### PR TITLE
Drop improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test": "karma start",
     "test:compile": "webpack --display-error-details --config webpack.config.test.js",
     "test:watch": "node --max-old-space-size=2048 node_modules/karma/bin/karma start --no-single-run",
+    "test:browser": "karma start --browsers Chrome",
     "posttest": "npm run coverage",
     "coverage": "npm run coverage:remap && npm run coverage:report",
     "coverage:remap": "remap-istanbul -i coverage/coverage.json -o coverage/coverage.json -t json -e node_modules,karma.entry.ts",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "compileTs": "webpack --config webpack.config.prod.js",
     "minify": "webpack --config webpack.config.prod.minify.js",
     "build": "gulp clean && npm run compileTs && npm run minify && gulp ts:definitions",
+    "build:dev": "gulp clean && npm run compileTs && gulp ts:definitions",
     "pretest": "gulp clean:tests",
     "test": "karma start",
     "test:compile": "webpack --display-error-details --config webpack.config.test.js",

--- a/src/components/drop/Drop.tsx
+++ b/src/components/drop/Drop.tsx
@@ -59,13 +59,15 @@ export class Drop extends React.PureComponent<IDropProps> {
         this.removeEventOnClickOnDocument();
     }
 
-    render() {
-        if (this.props.isOpen) {
+    componentDidUpdate(prevProps: Readonly<IDropProps>) {
+        if (!prevProps.isOpen && this.props.isOpen) {
             this.setEventOnClickOnDocument();
-        } else {
+        } else if (prevProps.isOpen && !this.props.isOpen) {
             this.removeEventOnClickOnDocument();
         }
+    }
 
+    render() {
         return (
             <>
                 <div

--- a/src/components/drop/Drop.tsx
+++ b/src/components/drop/Drop.tsx
@@ -97,6 +97,7 @@ export class Drop extends React.PureComponent<IDropProps> {
                 minHeight={this.props.minHeight}
                 minWidth={this.props.minWidth}
                 hasSameWidth={this.props.hasSameWidth}
+                parentSelector={this.props.parentSelector}
                 renderDrop={(style: React.CSSProperties, dropRef: React.RefObject<HTMLDivElement>): React.ReactNode => (
                     // Use dropRef as a reference of the drop element because we need to calculate later if the click is inside or not the drop container
                     <div style={style} ref={this.dropRef = dropRef} className={classNames('show-on-top', this.props.listContainerProps.className)} {...this.props.listContainerProps} >

--- a/src/components/drop/Drop.tsx
+++ b/src/components/drop/Drop.tsx
@@ -52,17 +52,20 @@ export class Drop extends React.PureComponent<IDropProps> {
 
         this.button = React.createRef();
         this.handleDocumentClick = this.handleDocumentClick.bind(this);
-    }
-
-    componentWillMount() {
-        document.addEventListener('mousedown', this.handleDocumentClick);
+        this.onClick = this.onClick.bind(this);
     }
 
     componentWillUnmount() {
-        document.removeEventListener('mousedown', this.handleDocumentClick);
+        this.removeEventOnClickOnDocument();
     }
 
     render() {
+        if (this.props.isOpen) {
+            this.setEventOnClickOnDocument();
+        } else {
+            this.removeEventOnClickOnDocument();
+        }
+
         return (
             <>
                 <div
@@ -76,6 +79,14 @@ export class Drop extends React.PureComponent<IDropProps> {
         );
     }
 
+    private setEventOnClickOnDocument() {
+        document.addEventListener('click', this.handleDocumentClick);
+    }
+
+    private removeEventOnClickOnDocument() {
+        document.removeEventListener('click', this.handleDocumentClick);
+    }
+
     private createPortalMenu() {
         return (
             <DropPod
@@ -85,6 +96,7 @@ export class Drop extends React.PureComponent<IDropProps> {
                 selector={this.props.selector}
                 minHeight={this.props.minHeight}
                 minWidth={this.props.minWidth}
+                hasSameWidth={this.props.hasSameWidth}
                 renderDrop={(style: React.CSSProperties, dropRef: React.RefObject<HTMLDivElement>): React.ReactNode => (
                     // Use dropRef as a reference of the drop element because we need to calculate later if the click is inside or not the drop container
                     <div style={style} ref={this.dropRef = dropRef} className={classNames('show-on-top', this.props.listContainerProps.className)} {...this.props.listContainerProps} >
@@ -95,11 +107,11 @@ export class Drop extends React.PureComponent<IDropProps> {
         );
     }
 
-    private onClick = () => {
+    private onClick() {
         this.props.toggle(true);
     }
 
-    private onClickOutside() {
+    private onClickOutside(e: MouseEvent) {
         this.props.toggle(false);
     }
 
@@ -109,10 +121,10 @@ export class Drop extends React.PureComponent<IDropProps> {
 
             if (this.dropRef.current.contains(e.target as Node)) {
                 if (this.props.closeOnClickDrop) {
-                    this.onClickOutside();
+                    this.onClickOutside(e);
                 }
             } else if (!button.contains(e.target as Node) && this.props.closeOnClickOutside) {
-                this.onClickOutside();
+                this.onClickOutside(e);
             }
         }
     }
@@ -125,4 +137,5 @@ Drop.defaultProps = {
     listContainerProps: {},
     minHeight: 0,
     minWidth: 0,
+    hasSameWidth: false,
 };

--- a/src/components/drop/Drop.tsx
+++ b/src/components/drop/Drop.tsx
@@ -55,6 +55,12 @@ export class Drop extends React.PureComponent<IDropProps> {
         this.onClick = this.onClick.bind(this);
     }
 
+    componentWillMount() {
+        if (this.props.isOpen) {
+            this.setEventOnClickOnDocument();
+        }
+    }
+
     componentWillUnmount() {
         this.removeEventOnClickOnDocument();
     }

--- a/src/components/drop/Drop.tsx
+++ b/src/components/drop/Drop.tsx
@@ -111,7 +111,7 @@ export class Drop extends React.PureComponent<IDropProps> {
         this.props.toggle(true);
     }
 
-    private onClickOutside(e: MouseEvent) {
+    private onClickOutside() {
         this.props.toggle(false);
     }
 

--- a/src/components/drop/Drop.tsx
+++ b/src/components/drop/Drop.tsx
@@ -121,10 +121,10 @@ export class Drop extends React.PureComponent<IDropProps> {
 
             if (this.dropRef.current.contains(e.target as Node)) {
                 if (this.props.closeOnClickDrop) {
-                    this.onClickOutside(e);
+                    this.onClickOutside();
                 }
             } else if (!button.contains(e.target as Node) && this.props.closeOnClickOutside) {
-                this.onClickOutside(e);
+                this.onClickOutside();
             }
         }
     }

--- a/src/components/drop/DropPod.tsx
+++ b/src/components/drop/DropPod.tsx
@@ -3,6 +3,7 @@ import * as ReactDOM from 'react-dom';
 import * as _ from 'underscore';
 import {Defaults} from '../../Defaults';
 import {DomPositionVisibilityValidator, IBoundingLimit} from './DomPositionVisibilityValidator';
+import {IDropProps} from './Drop';
 
 export const DropPodPosition = {
     bottom: 'bottom',
@@ -60,6 +61,14 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
 
     componentWillUnmount() {
         this.removeEventsOnDocument();
+    }
+
+    componentDidUpdate(prevProps: Readonly<IDropProps>) {
+        if (!prevProps.isOpen && this.props.isOpen) {
+            this.setEventsOnDocument();
+        } else if (prevProps.isOpen && !this.props.isOpen) {
+            this.removeEventsOnDocument();
+        }
     }
 
     private setEventsOnDocument() {
@@ -154,12 +163,6 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
     }
 
     render() {
-        if (this.props.isOpen) {
-            this.setEventsOnDocument();
-        } else {
-            this.removeEventsOnDocument();
-        }
-
         this.calculateStyleOffset();
 
         const selector: any = this.props.selector || Defaults.DROP_ROOT;

--- a/src/components/drop/DropPod.tsx
+++ b/src/components/drop/DropPod.tsx
@@ -16,6 +16,7 @@ export interface IDropPodProps {
     positions?: string[];
     renderDrop: (style: React.CSSProperties, dropRef: React.RefObject<HTMLElement>) => React.ReactNode;
     selector?: string;
+    parentSelector?: string;
     minWidth?: number;
     minHeight?: number;
     hasSameWidth?: boolean;
@@ -86,8 +87,7 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
     private calculateStyleOffset() {
         let style: React.CSSProperties = {};
         if (this.canRenderDrop()) {
-            const buttonOffset: ClientRect | DOMRect = this.state && this.state.offset ||
-                this.props.buttonRef.current.getBoundingClientRect();
+            const buttonOffset: ClientRect | DOMRect = this.props.buttonRef.current && this.props.buttonRef.current.getBoundingClientRect() || this.state.offset;
             let dropOffset: ClientRect | DOMRect = this.dropRef.current.getBoundingClientRect();
             if (this.props.hasSameWidth) {
                 dropOffset = {
@@ -96,7 +96,7 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
                 };
             }
 
-            const parentOffset = this.props.buttonRef.current.offsetParent.getBoundingClientRect();
+            const parentOffset = this.props.parentSelector ? this.props.buttonRef.current.closest(this.props.parentSelector).getBoundingClientRect() : this.props.buttonRef.current.offsetParent.getBoundingClientRect();
             const boundingLimit: IBoundingLimit = {
                 maxY: Math.min(parentOffset.bottom, window.innerHeight),
                 minY: Math.max(parentOffset.top, 0),
@@ -118,7 +118,8 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
                 index += 1;
             }
 
-            // Map each side of drop if the button offset is outside of the bounding limit
+            // Resize the button with the last position before the out of the box
+
             if (buttonOffset.top <= boundingLimit.minY) {
                 style.top = boundingLimit.minY;
             }

--- a/src/components/drop/DropPod.tsx
+++ b/src/components/drop/DropPod.tsx
@@ -59,6 +59,12 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
         this.updateOffset = this.updateOffset.bind(this);
     }
 
+    componentWillMount() {
+        if (this.props.isOpen) {
+            this.setEventsOnDocument();
+        }
+    }
+
     componentWillUnmount() {
         this.removeEventsOnDocument();
     }

--- a/src/components/drop/tests/Drop.spec.tsx
+++ b/src/components/drop/tests/Drop.spec.tsx
@@ -132,6 +132,18 @@ describe('Drop', () => {
                 expect(store.isActionDispatched(DropActions.toggle(id, DefaultGroupIds.default, false))).toBe(true);
             });
 
+            it('should not dispatch an action to toggle drop isOpen if drop is close', () => {
+                const store = RTestUtils.buildMockStore(defaultStore(false));
+                mountDropWithStore({},
+                    store,
+                    <div id={'Drop'} className={'drop'}></div>,
+                );
+
+                RTestUtils.clickOnElement(document.getElementById('Drop'));
+
+                expect(store.isActionDispatched(DropActions.toggle(id, DefaultGroupIds.default, false))).toBe(false);
+            });
+
             it('should not dispatch an action to toggle drop isOpen if the element target is in the body and inside the drop element if closeOnClickDrop is false',
                 () => {
                     const store = RTestUtils.buildMockStore(defaultStore(true));

--- a/src/components/drop/tests/Drop.spec.tsx
+++ b/src/components/drop/tests/Drop.spec.tsx
@@ -1,3 +1,4 @@
+import {ReactWrapper, ShallowWrapper} from 'enzyme';
 import {mountWithStore, shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
 import {mockStore} from 'redux-test-utils';
@@ -48,7 +49,7 @@ describe('Drop', () => {
 
             const id = 'DropId';
 
-            let wrapper: any;
+            let wrapper: ReactWrapper<IDropProps>;
             const defaultStore = (isOpen: boolean) => ({
                 drop: {
                     [DefaultGroupIds.default]: {
@@ -61,7 +62,7 @@ describe('Drop', () => {
             beforeEach(() => RTestUtils.addHTMLElementWithId());
 
             afterEach(() => {
-                if (wrapper) {
+                if (wrapper.length) {
                     wrapper.unmount();
                 }
                 RTestUtils.removeHTMLElementWithId();
@@ -101,6 +102,8 @@ describe('Drop', () => {
                 const store = RTestUtils.buildMockStore(defaultStore(true));
                 mountDropWithStore({}, store);
 
+                store.dispatch(DropActions.toggle(id, DefaultGroupIds.default));
+
                 RTestUtils.clickOnElement();
 
                 expect(store.isActionDispatched(DropActions.toggle(id, DefaultGroupIds.default, false))).toBe(true);
@@ -108,7 +111,7 @@ describe('Drop', () => {
 
             it('should not dispatch an action to toggle drop isOpen if the element target is in the body but not inside the button if closeOnClickOutside is false',
                 () => {
-                    const store = RTestUtils.buildMockStore(defaultStore(true));
+                    const store = RTestUtils.buildMockStore(defaultStore(false));
                     mountDropWithStore({
                         closeOnClickOutside: false,
                     },
@@ -127,6 +130,8 @@ describe('Drop', () => {
                     <div id={'Drop'} className={'drop'}></div>,
                 );
 
+                store.dispatch(DropActions.toggle(id, DefaultGroupIds.default));
+
                 RTestUtils.clickOnElement(document.getElementById('Drop'));
 
                 expect(store.isActionDispatched(DropActions.toggle(id, DefaultGroupIds.default, false))).toBe(true);
@@ -138,6 +143,8 @@ describe('Drop', () => {
                     store,
                     <div id={'Drop'} className={'drop'}></div>,
                 );
+
+                store.dispatch(DropActions.toggle(id, DefaultGroupIds.default));
 
                 RTestUtils.clickOnElement(document.getElementById('Drop'));
 
@@ -159,21 +166,57 @@ describe('Drop', () => {
                     expect(store.isActionDispatched(DropActions.toggle(id, DefaultGroupIds.default, false))).toBe(false);
                 });
 
-            it('should dispatch a toggle event when we call onClick sent with renderOpenButton',
-                () => {
-                    const store = RTestUtils.buildMockStore(defaultStore(false));
-                    mountDropWithStore({
-                        renderOpenButton: (onClick: () => void) => {
-                            onClick();
-                            return <div></div>;
-                        },
+            it('should dispatch a toggle event when we call onClick sent with renderOpenButton', () => {
+                const store = RTestUtils.buildMockStore(defaultStore(false));
+                mountDropWithStore({
+                    renderOpenButton: (onClick: () => void) => {
+                        onClick();
+                        return <div></div>;
                     },
-                        store,
-                        <div id={'Drop'} className={'drop'}></div>,
-                    );
+                },
+                    store,
+                    <div id={'Drop'} className={'drop'}></div>,
+                );
 
-                    expect(store.isActionDispatched(DropActions.toggle(id, DefaultGroupIds.default, true))).toBe(true);
-                });
+                expect(store.isActionDispatched(DropActions.toggle(id, DefaultGroupIds.default, true))).toBe(true);
+            });
+
+            it('should add the event on click if the drop is opening', () => {
+                const spy = spyOn(document, 'addEventListener');
+                let shallowWrapper: ShallowWrapper;
+
+                shallowWrapper = shallowWithState(
+                    <Drop
+                        id={'test'}
+                        renderOpenButton={() => defaultButton}
+                    />,
+                    {},
+                ).dive();
+
+                expect(spy).toHaveBeenCalledTimes(0);
+
+                shallowWrapper.setProps({isOpen: true});
+
+                expect(spy).toHaveBeenCalledTimes(1);
+            });
+
+            it('should remove the event on click if the drop is closing', () => {
+                const spy = spyOn(document, 'removeEventListener');
+                let shallowWrapper: ShallowWrapper;
+
+                shallowWrapper = shallowWithState(
+                    <Drop
+                        id={'test'}
+                        renderOpenButton={() => defaultButton}
+                    />,
+                    {},
+                ).dive();
+
+                shallowWrapper.setProps({isOpen: true});
+                shallowWrapper.setProps({isOpen: false});
+
+                expect(spy).toHaveBeenCalledTimes(1);
+            });
         });
     });
 });

--- a/src/components/drop/tests/DropPod.spec.tsx
+++ b/src/components/drop/tests/DropPod.spec.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import {DomPositionVisibilityValidator} from '../DomPositionVisibilityValidator';
 import {defaultDropPodPosition, DropPod, DropPodPosition, IDropPodProps} from '../DropPod';
 
-fdescribe('DropPod', () => {
+describe('DropPod', () => {
 
     const defaultDrop: any = null;
 
@@ -409,7 +409,7 @@ fdescribe('DropPod', () => {
 
                     let RWrapper: ShallowWrapper;
 
-                        it('should add events if the dropPod is open', () => {
+                    it('should add events if the dropPod is open', () => {
                         const spy = spyOn(window, 'addEventListener');
 
                         shallowWithState(

--- a/src/components/drop/tests/DropPod.spec.tsx
+++ b/src/components/drop/tests/DropPod.spec.tsx
@@ -1,6 +1,7 @@
 import {shallow, ShallowWrapper} from 'enzyme';
 import {shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
+import * as _ from 'underscore';
 import {DomPositionVisibilityValidator} from '../DomPositionVisibilityValidator';
 import {defaultDropPodPosition, DropPod, DropPodPosition, IDropPodProps} from '../DropPod';
 
@@ -349,6 +350,26 @@ describe('DropPod', () => {
 
                         expect(styleRendered.top).toBeUndefined();
                         expect(styleRendered.left).toBeUndefined();
+                    });
+
+                    it('should return a style with the width equal than the button width if the prop hasSameWidth is set to true', () => {
+                        setupReference({
+                            left: 0,
+                            right: 1000,
+                        },
+                            {
+                                width: 100,
+                            },
+                            {
+                                width: 40,
+                                toJSON: () => ({}),
+                            });
+                        shallowDropPodForStyle({
+                            positions: [DropPodPosition.bottom],
+                            hasSameWidth: true,
+                        });
+
+                        expect(styleRendered.width).toBe(100);
                     });
 
                     describe('DomPositionVisibilityValidator', () => {

--- a/src/components/drop/tests/DropPod.spec.tsx
+++ b/src/components/drop/tests/DropPod.spec.tsx
@@ -1,11 +1,10 @@
 import {shallow, ShallowWrapper} from 'enzyme';
 import {shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
-import * as _ from 'underscore';
 import {DomPositionVisibilityValidator} from '../DomPositionVisibilityValidator';
 import {defaultDropPodPosition, DropPod, DropPodPosition, IDropPodProps} from '../DropPod';
 
-describe('DropPod', () => {
+fdescribe('DropPod', () => {
 
     const defaultDrop: any = null;
 
@@ -403,6 +402,94 @@ describe('DropPod', () => {
                                 minX: 10,
                             });
                         });
+                    });
+                });
+
+                describe('events', () => {
+
+                    let RWrapper: ShallowWrapper;
+
+                        it('should add events if the dropPod is open', () => {
+                        const spy = spyOn(window, 'addEventListener');
+
+                        shallowWithState(
+                            <DropPod
+                                renderDrop={() => defaultDrop}
+                                isOpen={true}
+                            />, {}).dive();
+
+                        expect(spy).toHaveBeenCalledTimes(2);
+                    });
+
+                    it('should not add events if the dropPod is close', () => {
+                        const spy = spyOn(window, 'addEventListener');
+
+                        shallowWithState(
+                            <DropPod
+                                renderDrop={() => defaultDrop}
+                                isOpen={false}
+                            />, {}).dive();
+
+                        expect(spy).toHaveBeenCalledTimes(0);
+                    });
+
+                    it('should remove events on unmount', () => {
+                        const spy = spyOn(window, 'removeEventListener');
+
+                        RWrapper = shallowWithState(
+                            <DropPod
+                                renderDrop={() => defaultDrop}
+                                isOpen={false}
+                            />, {}).dive();
+
+                        RWrapper.unmount();
+
+                        expect(spy).toHaveBeenCalledTimes(2);
+                    });
+
+                    it('should add events if the prop isOpen change to true on update', () => {
+                        const spy = spyOn(window, 'addEventListener');
+
+                        RWrapper = shallowWithState(
+                            <DropPod
+                                renderDrop={() => defaultDrop}
+                                isOpen={false}
+                            />, {}).dive();
+
+                        RWrapper.setProps({isOpen: true});
+                        RWrapper.update();
+
+                        expect(spy).toHaveBeenCalledTimes(2);
+                    });
+
+                    it('should not add events if the prop isOpen do not change on update', () => {
+                        const spy = spyOn(window, 'addEventListener');
+
+                        RWrapper = shallowWithState(
+                            <DropPod
+                                renderDrop={() => defaultDrop}
+                                isOpen={false}
+                            />, {}).dive();
+
+                        RWrapper.setProps({isOpen: false});
+                        RWrapper.update();
+
+                        expect(spy).toHaveBeenCalledTimes(0);
+                    });
+
+                    it('should remove events if the prop isOpen change to false on update', () => {
+                        const spy = spyOn(window, 'removeEventListener');
+
+                        RWrapper = shallowWithState(
+                            <DropPod
+                                renderDrop={() => defaultDrop}
+                                isOpen={true}
+                            />, {}).dive();
+
+                        RWrapper.setProps({isOpen: false});
+                        RWrapper.update();
+
+                        expect(spy).toHaveBeenCalledTimes(2);
                     });
                 });
             });

--- a/src/utils/tests/RTestUtils.tsx
+++ b/src/utils/tests/RTestUtils.tsx
@@ -60,7 +60,7 @@ const removeHTMLElementWithId = (id: string = defaultId) => {
     document.getElementById(id).remove();
 };
 
-const clickOnElement = (el: Element = document.getElementById(defaultId), event: string = 'mousedown') => {
+const clickOnElement = (el: Element = document.getElementById(defaultId), event: string = 'click') => {
     const evt = new MouseEvent(event, {
         view: window,
         bubbles: true,


### PR DESCRIPTION
Improvement on event handling, no more event when the drop is not open to avoid useless process on the other on the page
Add new props to set the same width for the drop than the button
add little task to create a js file not minified to test in local with link
fix a little miss variable where the number was sent instead of a boolean ( work too because a number is true but fixed now )
Add uts
Fix uts with the old event system
