### PR TITLE
Fix primary button disabled color

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -68,7 +68,8 @@ export class Button extends React.Component<IButtonProps & React.ButtonHTMLAttri
         return classNames('btn', {
             'mod-primary': this.props.primary,
             'mod-small': this.props.small,
-            'state-disabled disabled text-medium-grey': !this.props.enabled,
+            'state-disabled disabled': !this.props.enabled,
+            'text-medium-grey': !this.props.primary && !this.props.enabled,
         }, this.props.classes);
     }
 

--- a/src/components/button/examples/ButtonExamples.tsx
+++ b/src/components/button/examples/ButtonExamples.tsx
@@ -71,6 +71,12 @@ export class ButtonExamples extends React.Component<any, any> {
                     </div>
                 </div>
                 <div className='form-group'>
+                    <label className='form-control-label'>Disabled Primary Button</label>
+                    <div className='form-control'>
+                        <Button enabled={false} name='Disabled Button' primary />
+                    </div>
+                </div>
+                <div className='form-group'>
                     <label className='form-control-label'>Disabled Button with tooltip</label>
                     <div className='form-control'>
                         <Button enabled={false} name='Disabled Button with tooltip' tooltip='Tooltip test' />

--- a/src/components/button/tests/Button.spec.tsx
+++ b/src/components/button/tests/Button.spec.tsx
@@ -117,6 +117,18 @@ describe('Button', () => {
                 expect(buttonComponent.find('a').hasClass('text-medium-grey')).toBe(true);
             });
 
+            it('should not add the text-medium-grey if the button is disabled and primary', () => {
+                showButton({
+                    enabled: false,
+                    primary: true,
+                    link,
+                });
+
+                expect(buttonComponent.find('a').prop('disabled')).toBe(true);
+                expect(buttonComponent.find('a').hasClass('disabled')).toBe(true);
+                expect(buttonComponent.find('a').hasClass('text-medium-grey')).toBe(false);
+            });
+
             it('should add the link in a href', () => {
                 showButton({
                     link,


### PR DESCRIPTION
Don't add the text-medium-grey class if the button is primary
Add unit test
Add example

Before
![image](https://user-images.githubusercontent.com/260007/55084031-e46b9a00-507a-11e9-9aa4-fa0721b18adc.png)

After
![image](https://user-images.githubusercontent.com/260007/55083979-d0279d00-507a-11e9-8ba9-8f25f87c273a.png)

