### PR TITLE
Hide SingleSelect clear button when disabled

### DIFF
--- a/src/components/listBox/ListBox.tsx
+++ b/src/components/listBox/ListBox.tsx
@@ -1,6 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
+
 import {mod} from '../../utils/DataStructuresUtils';
 import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {IItemBoxProps, ItemBox} from '../itemBox/ItemBox';
@@ -83,9 +84,14 @@ export class ListBox extends React.Component<IListBoxProps, {}> {
             />)
             .value();
 
-        return items.length
-            ? items
-            : <ItemBox {...{...this.props.noResultItem, classes: ['multi-line']}} />;
+        const emptyItem = (
+            <ItemBox
+                {...this.props.noResultItem}
+                classes={[classNames('multi-line', this.props.noResultItem.classes)]}
+            />
+        );
+
+        return _.isEmpty(items) ? emptyItem : items;
     }
 
     render() {

--- a/src/components/select/SingleSelectConnected.tsx
+++ b/src/components/select/SingleSelectConnected.tsx
@@ -75,7 +75,7 @@ export class SingleSelectConnected extends React.Component<ISingleSelectProps & 
 
     private getButton = (props: ISelectButtonProps): JSX.Element => {
         const option = _.findWhere(this.props.items, {value: this.props.selectedOption});
-        const showClear = !!option && this.props.canClear;
+        const showClear = !!option && this.props.canClear && !this.props.disabled;
         const buttonClasses = classNames('btn dropdown-toggle', this.props.toggleClasses, {
             'dropdown-toggle-placeholder': !option,
             [styles.singleSelectFixedWidth]: !this.props.noFixedWidth,
@@ -121,10 +121,16 @@ export class SingleSelectConnected extends React.Component<ISingleSelectProps & 
 
     private getDeselectOptionButton(): React.ReactNode {
         return (
-            <Tooltip title={this.props.deselectTooltipText} placement='top' noSpanWrapper onClick={this.props.deselect}>
+            <Tooltip title={this.props.deselectTooltipText} placement='top' noSpanWrapper onClick={this.handleDeselect}>
                 <Svg svgName={VaporSVG.svg.clear.name} svgClass='icon mod-12' className='btn-append center-align' />
             </Tooltip>
         );
+    }
+
+    private handleDeselect = () => {
+        if (!this.props.disabled) {
+            this.props.deselect();
+        }
     }
 }
 

--- a/src/components/select/SingleSelectConnected.tsx
+++ b/src/components/select/SingleSelectConnected.tsx
@@ -1,6 +1,7 @@
 import * as classNames from 'classnames';
 import * as VaporSVG from 'coveo-styleguide';
 import * as React from 'react';
+import {keys} from 'ts-transformer-keys';
 import * as _ from 'underscore';
 
 import {IReactVaporState} from '../../ReactVapor';
@@ -11,7 +12,7 @@ import {IItemBoxProps} from '../itemBox/ItemBox';
 import {clearListBoxOption} from '../listBox/ListBoxActions';
 import {Svg} from '../svg/Svg';
 import {Tooltip} from '../tooltip/Tooltip';
-import {ISelectButtonProps, ISelectProps, SelectConnected} from './SelectConnected';
+import {ISelectButtonProps, ISelectOwnProps, ISelectProps, SelectConnected} from './SelectConnected';
 import {SelectSelector} from './SelectSelector';
 import * as styles from './styles/SingleSelect.scss';
 
@@ -25,6 +26,8 @@ export interface ISingleSelectOwnProps extends ISelectProps {
     canClear?: boolean;
     deselectTooltipText?: string;
 }
+
+const selectPropsKeys = keys<ISelectOwnProps>();
 
 export interface ISingleSelectStateProps {
     selectedOption: string;
@@ -62,11 +65,8 @@ export class SingleSelectConnected extends React.Component<ISingleSelectProps & 
     render() {
         return (
             <SelectConnected
-                id={this.props.id}
+                {..._.pick(this.props, selectPropsKeys)}
                 button={this.getButton}
-                items={this.props.items}
-                selectClasses={this.props.selectClasses}
-                hasFocusableChild={this.props.hasFocusableChild}
             >
                 {this.props.children}
             </SelectConnected>

--- a/src/components/select/tests/SingleSelectConnected.spec.tsx
+++ b/src/components/select/tests/SingleSelectConnected.spec.tsx
@@ -20,7 +20,7 @@ describe('Select', () => {
 
         const id: string = 'list-box-connected';
 
-        const mountSingleSelect = (items: IItemBoxProps[] = [], props: Partial<ISingleSelectProps> = {}) => {
+        const mountSingleSelect = (items: IItemBoxProps[] = [], props: Partial<ISingleSelectProps & React.ButtonHTMLAttributes<HTMLButtonElement>> = {}) => {
             singleSelect = mount(
                 <SingleSelectConnected id={id} items={items} {...props} />,
                 {
@@ -162,6 +162,13 @@ describe('Select', () => {
 
         it('should not have a clear icon when no value is selected and canClear is true', () => {
             mountSingleSelect([{value: 'a', selected: false}], {canClear: true});
+
+            expect(select.find('.dropdown-toggle').hasClass('mod-append')).toBe(false);
+            expect(select.find('.btn-append').exists()).toBe(false);
+        });
+
+        it('should not have a clear icon when disabled is true even if canClear is true', () => {
+            mountSingleSelect([{value: 'a', selected: false}], {canClear: true, disabled: true});
 
             expect(select.find('.dropdown-toggle').hasClass('mod-append')).toBe(false);
             expect(select.find('.btn-append').exists()).toBe(false);


### PR DESCRIPTION
The clear button was shown and was also effective even when the SingleSelect was disabled.

What I did:
- Prevented the clear button from showing when the SingleSelect is disabled
- Prevented the clear single select value action to be dispatched onclick when the SingleSelect is disabled