### PR TITLE
Expose toast props in add toast action

### DIFF
--- a/src/components/toast/ToastActions.ts
+++ b/src/components/toast/ToastActions.ts
@@ -1,5 +1,7 @@
 import * as _ from 'underscore';
+
 import {IReduxAction} from '../../utils/ReduxUtils';
+import {IToastProps} from './Toast';
 
 export interface IToastContainerActionPayload {
     id: string;
@@ -17,16 +19,10 @@ export const ToastAction = {
     removeToastContainer: 'REMOVE_TOAST_CONTAINER',
 };
 
-export interface IToastAddOptionalPayload {
-    dismiss?: number;
-    dismissible?: boolean;
-    type?: string;
-    animate?: boolean;
-    content?: React.ReactNode;
-}
+export interface IToastAddOptionalPayload extends Partial<IToastProps> {}
 
 export interface IToastAddPayload extends IToastActionPayload, IToastAddOptionalPayload {
-    title: string;
+    title: React.ReactNode;
 }
 
 export const addToast = (containerId: string, title: string, optionals: IToastAddOptionalPayload = {}): IReduxAction<IToastAddPayload> => ({
@@ -35,11 +31,7 @@ export const addToast = (containerId: string, title: string, optionals: IToastAd
         title,
         containerId,
         id: _.uniqueId('toast'),
-        type: optionals.type,
-        dismiss: optionals.dismiss,
-        dismissible: optionals.dismissible,
-        animate: optionals.animate,
-        content: optionals.content,
+        ...optionals,
     },
 });
 

--- a/src/components/toast/ToastActions.ts
+++ b/src/components/toast/ToastActions.ts
@@ -9,7 +9,7 @@ export interface IToastContainerActionPayload {
 
 export interface IToastActionPayload {
     containerId: string;
-    id?: string;
+    id: string;
 }
 
 export const ToastAction = {
@@ -19,13 +19,15 @@ export const ToastAction = {
     removeToastContainer: 'REMOVE_TOAST_CONTAINER',
 };
 
-export interface IToastAddOptionalPayload extends Partial<IToastProps> {}
+export interface IToastAddOptionalPayload extends Partial<IToastProps> {
+    id: string;
+}
 
 export interface IToastAddPayload extends IToastActionPayload, IToastAddOptionalPayload {
     title: React.ReactNode;
 }
 
-export const addToast = (containerId: string, title: string, optionals: IToastAddOptionalPayload = {}): IReduxAction<IToastAddPayload> => ({
+export const addToast = (containerId: string, title: string, optionals: Partial<IToastProps> = {}): IReduxAction<IToastAddPayload> => ({
     type: ToastAction.addToast,
     payload: {
         title,

--- a/src/components/toast/ToastReducers.ts
+++ b/src/components/toast/ToastReducers.ts
@@ -10,12 +10,8 @@ export interface IToastsState {
 
 export interface IToastState {
     id: string;
-    title: string;
-    type?: string;
-    dismiss?: number;
-    dismissible?: boolean;
-    animate?: boolean;
-    content?: React.ReactNode;
+    title: React.ReactNode;
+    [toastProp: string]: any;
 }
 
 export const toastContainerInitialState: IToastsState = {

--- a/src/components/toast/ToastReducers.ts
+++ b/src/components/toast/ToastReducers.ts
@@ -50,15 +50,7 @@ export const toastContainerReducer = (
 const toastsReducer = (state: IToastState[], action: IReduxAction<IToastActionPayload>): IToastState[] => {
     if (action.type === ToastAction.addToast) {
         const payload = action.payload as IToastAddPayload;
-        return [...state, {
-            id: payload.id,
-            title: payload.title,
-            animate: payload.animate,
-            dismiss: payload.dismiss,
-            dismissible: payload.dismissible,
-            content: payload.content,
-            type: payload.type,
-        }];
+        return [...state, payload];
     } else {
         return _.reject(state, (toast: IToastState) => action.payload.id === toast.id);
     }

--- a/src/components/toast/ToastReducers.ts
+++ b/src/components/toast/ToastReducers.ts
@@ -1,6 +1,7 @@
 import * as _ from 'underscore';
+
 import {IReduxAction} from '../../utils/ReduxUtils';
-import {ToastType} from './Toast';
+import {IToastProps, ToastType} from './Toast';
 import {IToastActionPayload, IToastAddPayload, IToastContainerActionPayload, ToastAction} from './ToastActions';
 
 export interface IToastsState {
@@ -8,10 +9,9 @@ export interface IToastsState {
     toasts: IToastState[];
 }
 
-export interface IToastState {
+export interface IToastState extends IToastProps {
     id: string;
     title: React.ReactNode;
-    [toastProp: string]: any;
 }
 
 export const toastContainerInitialState: IToastsState = {

--- a/src/components/toast/examples/ToastConnectedExamples.tsx
+++ b/src/components/toast/examples/ToastConnectedExamples.tsx
@@ -1,23 +1,18 @@
 import * as React from 'react';
-import {IReduxAction, ReduxConnect} from '../../../utils/ReduxUtils';
+
+import {ReduxConnect} from '../../../utils/ReduxUtils';
 import {ToastType} from '../Toast';
-import {addToast, IToastActionPayload, IToastAddOptionalPayload} from '../ToastActions';
+import {addToast} from '../ToastActions';
 import {ToastContainerConnected} from '../ToastContainerConnected';
 import {ToastContentExample} from './ToastContentExample';
 
 export interface IToastConnectedExamplesProps {
-    addToast?: (id: string, title: string, optionals?: IToastAddOptionalPayload) => void;
+    addToast: typeof addToast;
 }
 
 const containerId = 'some-id';
 
-const mapStateToProps = () => ({});
-
-const mapDispatchToProps = (dispatch: (action: IReduxAction<IToastActionPayload>) => void): IToastConnectedExamplesProps => ({
-    addToast: (id: string, title: string, optionals: IToastAddOptionalPayload) => dispatch(addToast(id, title, optionals)),
-});
-
-@ReduxConnect(mapStateToProps, mapDispatchToProps)
+@ReduxConnect(null, {addToast})
 export class ToastConnectedExamples extends React.Component<IToastConnectedExamplesProps, {}> {
 
     render() {


### PR DESCRIPTION
I needed a way to pass down a class to the toast created with addToast action.