### PR TITLE
Fix "Cannot read property 'classList' of null" error

### DIFF
--- a/src/utils/EventUtils.spec.tsx
+++ b/src/utils/EventUtils.spec.tsx
@@ -64,5 +64,9 @@ describe('EventUtils', () => {
 
                 wrapper.find('.div2').simulate('click');
             });
+
+        it('should not throw and return false when the event target is null', () => {
+            expect(EventUtils.isClickingInsideElementWithClassname({target: null, currentTarget: {}} as React.MouseEvent, 'whatever')).toBe(false);
+        });
     });
 });

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -6,7 +6,7 @@ export class EventUtils {
         let currentTarget: HTMLElement = e && (e.target as HTMLElement);
         let isClickingInside = false;
 
-        while (e && !isEmpty(classname) && currentTarget !== e.currentTarget && !isClickingInside) {
+        while (e && !isEmpty(classname) && currentTarget && currentTarget !== e.currentTarget && !isClickingInside) {
             isClickingInside = currentTarget.classList.contains(classname);
             currentTarget = currentTarget.parentElement;
         }


### PR DESCRIPTION
@fblais

`isClickingInsideElementWithClassname` util was throwing "Cannot read property 'classList' of null" errors. It seems to happen when the event target is null. Not sure how this can happen though.