### PR TITLE
Fix adui 4009 unbalanced collapsible info box margins in react vapor

### DIFF
--- a/src/components/collapsible/Collapsible.tsx
+++ b/src/components/collapsible/Collapsible.tsx
@@ -55,7 +55,7 @@ export class Collapsible extends React.Component<CollapsibleProps> {
                     <CollapsibleToggle
                         expanded={this.props.expanded}
                         svgClassName={this.props.toggleIconClassName}
-                        className='mr3'
+                        className='mr2'
                     />
                 </div>
                 <SlideY id={this.props.id} in={this.props.expanded} timeout={Collapsible.TIMEOUT} duration={Collapsible.TIMEOUT}>

--- a/src/components/collapsible/CollapsibleContainer.tsx
+++ b/src/components/collapsible/CollapsibleContainer.tsx
@@ -44,7 +44,7 @@ export class CollapsibleContainer extends React.Component<ICollapsibleContainerP
                 headerContent={this.getHeader()}
                 expandedOnMount={this.props.expandedOnMount}
                 headerClasses={classNames(styles.header, this.props.expanded ? 'bg-light-grey' : 'bg-white')}
-                toggleIconClassName='fill-medium-blue mr3'
+                toggleIconClassName='fill-medium-blue mr4'
                 withBorders
             >
                 <div className={contentClasses}>

--- a/src/components/collapsible/CollapsibleInfoBox.tsx
+++ b/src/components/collapsible/CollapsibleInfoBox.tsx
@@ -21,7 +21,7 @@ export class CollapsibleInfoBox extends React.PureComponent<CollapsibleInfoBoxPr
             <CollapsibleConnected
                 id={this.props.id}
                 className={classNames(styles.container, 'text-grey-9 mod-rounded-border-2')}
-                headerClasses='p1'
+                headerClasses='p1 pr0'
                 toggleIconClassName='fill-medium-blue'
                 headerContent={this.getHeader()}
                 expandedOnMount={this.props.expandedOnMount}

--- a/src/components/collapsible/CollapsibleInfoBox.tsx
+++ b/src/components/collapsible/CollapsibleInfoBox.tsx
@@ -26,7 +26,7 @@ export class CollapsibleInfoBox extends React.PureComponent<CollapsibleInfoBoxPr
                 headerContent={this.getHeader()}
                 expandedOnMount={this.props.expandedOnMount}
             >
-                <div className={classNames(styles.alignWithIcon, 'px1 pb1 mr3')}>
+                <div className={classNames(styles.alignWithIcon, styles.pbBox, 'px1 mr3')}>
                     {this.props.children}
                 </div>
             </CollapsibleConnected>

--- a/src/components/collapsible/styles/CollapsibleInfoBox.scss
+++ b/src/components/collapsible/styles/CollapsibleInfoBox.scss
@@ -13,3 +13,7 @@ $collapsible-timeout: 150ms;
 .alignWithIcon {
     margin-left: calc(1rem + #{$collapsible-infobox-icon-size});
 }
+
+.pbBox {
+    padding-bottom: 0.7rem;
+}

--- a/src/components/collapsible/styles/CollapsibleInfoBox.scss.d.ts
+++ b/src/components/collapsible/styles/CollapsibleInfoBox.scss.d.ts
@@ -1,2 +1,3 @@
 export const container: string;
 export const alignWithIcon: string;
+export const pbBox: string;


### PR DESCRIPTION
- correction margin arrow icon for collapsible
- set bottom padding to 0.7 rem of collapsed text

https://coveord.atlassian.net/secure/RapidBoard.jspa?rapidView=569&modal=detail&selectedIssue=ADUI-4009&assignee=nanani
