### PR TITLE
Add an InputSelector for the `valid ` attribute

### DIFF
--- a/src/components/input/InputSelectors.ts
+++ b/src/components/input/InputSelectors.ts
@@ -1,12 +1,23 @@
+import {createSelector} from 'reselect';
 import * as _ from 'underscore';
+
 import {IReactVaporState} from '../../ReactVapor';
 import {IInputState} from './InputReducers';
 
-const getInputValue = (state: Partial<IReactVaporState>, props: {id: string}): string => {
-    const input: IInputState = _.findWhere(state.inputs, {id: props.id});
-    return input && input.value;
-};
+const getInput = (state: IReactVaporState, props: {id: string}): IInputState =>
+    _.findWhere(state.inputs, {id: props.id});
+
+const getValue = createSelector(
+    getInput,
+    (input: IInputState): string => input && input.value,
+);
+
+const getIsValid = createSelector(
+    getInput,
+    (input: IInputState): boolean => !!input && input.valid,
+);
 
 export const InputSelectors = {
-    getValue: getInputValue,
+    getValue,
+    getIsValid,
 };

--- a/src/components/input/tests/InputSelectors.spec.ts
+++ b/src/components/input/tests/InputSelectors.spec.ts
@@ -1,22 +1,48 @@
 import {InputSelectors} from '../InputSelectors';
 
-describe('getContextValue', () => {
+fdescribe('InputSelectors', () => {
     const ownProps = {
         id: 'iron man',
     };
 
-    it('should return undefined if the input id is not in the state', () => {
-        expect(InputSelectors.getValue({inputs: [{id: 'ham man', value: 'man', valid: true, disabled: false}]}, ownProps))
-            .toBeUndefined();
+    describe('getValue', () => {
+        it('should return undefined if the input id is not in the state', () => {
+            expect(InputSelectors.getValue({
+                inputs: [{id: 'ham man', value: 'man', valid: true, disabled: false}],
+            }, ownProps)).toBeUndefined();
+        });
+
+        it('should return undefined if the input value is not defined', () => {
+            expect(InputSelectors.getValue({
+                inputs: [{id: ownProps.id, value: undefined, valid: true, disabled: false}],
+            }, ownProps)).toBeUndefined();
+        });
+
+        it('should return the value if the input is defined in the state', () => {
+            const expectedValue = 'bacon';
+            expect(InputSelectors.getValue({
+                inputs: [{id: ownProps.id, value: expectedValue, valid: true, disabled: false}],
+            }, ownProps)).toBe(expectedValue);
+        });
     });
 
-    it('should return undefined if the input value is not defined', () => {
-        expect(InputSelectors.getValue({inputs: [{id: ownProps.id, value: undefined, valid: true, disabled: false}]}, ownProps))
-            .toBeUndefined();
-    });
+    describe('getIsValid', () => {
+        it('should return false if the input id is not in the state', () => {
+            expect(InputSelectors.getIsValid({
+                inputs: [{id: 'ham man', value: 'man', valid: true, disabled: false}],
+            }, ownProps)).toBe(false);
+        });
 
-    it('should return the value if the input is defined in the state', () => {
-        expect(InputSelectors.getValue({inputs: [{id: ownProps.id, value: 'value', valid: true, disabled: false}]}, ownProps))
-            .toBe('value');
+        it('should return false if the input is not valid', () => {
+            expect(InputSelectors.getIsValid({
+                inputs: [{id: ownProps.id, value: 'bacon', valid: false, disabled: false}],
+            }, ownProps)).toBe(false);
+        });
+
+        it('should return true if the input is valid', () => {
+            expect(InputSelectors.getIsValid({
+                inputs: [{id: ownProps.id, value: 'bacon', valid: true, disabled: false}],
+            }, ownProps)).toBe(true);
+        });
     });
 });

--- a/src/components/input/tests/InputSelectors.spec.ts
+++ b/src/components/input/tests/InputSelectors.spec.ts
@@ -1,6 +1,6 @@
 import {InputSelectors} from '../InputSelectors';
 
-fdescribe('InputSelectors', () => {
+describe('InputSelectors', () => {
     const ownProps = {
         id: 'iron man',
     };


### PR DESCRIPTION
### Description

We had no selector for the `valid` attribute of the input states.

### Proposed Changes

- Added a `InputSelector` for the `valid` attribute that can be called like so:
```ts
InputSelectors.getIsValid(state, {id: 'the-input-id'});
```

### Potential Breaking Changes

None

### Acceptance Criteria

- [x] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
