### PR TITLE
Fix unit test typings in vscode

### DIFF
--- a/packages/react-vapor/gulpfile.js
+++ b/packages/react-vapor/gulpfile.js
@@ -5,6 +5,7 @@ const colors = require('ansi-colors');
 const log = require('fancy-log');
 const parseArgs = require('minimist');
 const optimizeDeclarations = require('dts-generator-optimizer');
+const path = require('path');
 
 const argv = parseArgs(process.argv.slice(2), {boolean: 'all'});
 const cleanAll = argv.all;
@@ -48,7 +49,7 @@ gulp.task('clean', gulp.series(gulp.parallel('clean:dist', 'clean:docs', 'clean:
 // <editor-fold desc="Typescript d.ts generation">
 gulp.task('internalDefs', () =>
     dtsGenerator.default({
-        project: './',
+        project: 'tsconfig.build.json',
         out: 'dist/react-vapor.d.ts',
         exclude: [
             'node_modules/**/*.d.ts',

--- a/packages/react-vapor/gulpfile.js
+++ b/packages/react-vapor/gulpfile.js
@@ -5,7 +5,6 @@ const colors = require('ansi-colors');
 const log = require('fancy-log');
 const parseArgs = require('minimist');
 const optimizeDeclarations = require('dts-generator-optimizer');
-const path = require('path');
 
 const argv = parseArgs(process.argv.slice(2), {boolean: 'all'});
 const cleanAll = argv.all;

--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -158,7 +158,7 @@
     "tsjs": "0.7.2",
     "tslint-loader": "3.6.0",
     "ttypescript": "1.5.6",
-    "typescript": "3.4.5",
+    "typescript": "3.5.1",
     "typings-for-css-modules-loader": "1.7.0",
     "underscore": "1.9.1",
     "underscore.string": "3.3.5",

--- a/packages/react-vapor/tsconfig.build.json
+++ b/packages/react-vapor/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "./dist/split/",
+    "sourceMap": true,
+    "rootDir": ".",
+  },
+  "exclude": [
+    "src/**/*.spec.*",
+    "src/utils/tests/TestUtils.tsx",
+    "src/components/tables/tests/TableTestCommon.tsx"
+  ]
+}

--- a/packages/react-vapor/tsconfig.json
+++ b/packages/react-vapor/tsconfig.json
@@ -9,10 +9,8 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
-    "outDir": "./dist/split/",
     "removeComments": true,
     "skipLibCheck": true,
-    "sourceMap": true,
     "target": "ES5",
     "plugins": [
       {
@@ -24,14 +22,7 @@
       "dom"
     ],
   },
-  "include": [
-    "src/**/*.tsx",
-    "src/**/*.ts",
-    "types/**/*.d.ts"
-  ],
   "exclude": [
-    "src/**/*.spec.*",
-    "src/utils/tests/TestUtils.tsx",
-    "src/components/tables/tests/TableTestCommon.tsx"
+    "node_modules"
   ]
 }

--- a/packages/react-vapor/tsconfig.test.json
+++ b/packages/react-vapor/tsconfig.test.json
@@ -1,26 +1,7 @@
 {
+  "extends": "./tsconfig",
   "compilerOptions": {
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "downlevelIteration": true,
     "inlineSourceMap": true,
-    "jsx": "react",
-    "allowJs": true,
-    "module": "commonjs",
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "noUnusedLocals": true,
-    "skipLibCheck": true,
     "sourceMap": false,
-    "target": "ES5",
-    "plugins": [
-      {"transform": "ts-transformer-keys/transformer"}
-    ],
-    "lib": ["es2015", "dom"]
   },
-  "include": [
-    "src/**/*.tsx",
-    "src/**/*.ts",
-    "types/**/*.d.ts"
-  ]
 }

--- a/packages/react-vapor/webpack.config.js
+++ b/packages/react-vapor/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
                     loader: 'tslint-loader',
                     options: {
                         configFile: './node_modules/tsjs/tslint.json',
-                        tsConfigFile: './tsconfig.json',
+                        tsConfigFile: './tsconfig.build.json',
                         emitErrors: isTravis,
                         failOnHint: isTravis,
                     },
@@ -55,6 +55,7 @@ module.exports = {
                     useCache: true,
                     cacheDirectory: '.awcache',
                     compiler: 'ttypescript',
+                    configFileName: 'tsconfig.build.json',
                 },
             },
             {

--- a/packages/react-vapor/webpack.config.prod.js
+++ b/packages/react-vapor/webpack.config.prod.js
@@ -31,7 +31,7 @@ const config = {
                     loader: 'tslint-loader',
                     options: {
                         configFile: './node_modules/tsjs/tslint.json',
-                        tsConfigFile: './tsconfig.json',
+                        tsConfigFile: './tsconfig.build.json',
                         emitErrors: true,
                         failOnHint: isTravis,
                     },
@@ -52,6 +52,7 @@ const config = {
                 loader: 'awesome-typescript-loader',
                 options: {
                     compiler: 'ttypescript',
+                    configFileName: 'tsconfig.build.json'
                 },
             },
             {


### PR DESCRIPTION
### Description

vscode resolves a given file's typings by finding the nearest parent `tsconfig.json` file. When opening any `.spec` file, typings don't get resolved correctly, because all spec files are excluded in the `tsconfig.json` file. 

### Proposed Changes

- Removed all includes and excludes from `tsconfig.json`
- Added a `tsconfig.build.json` file which is now targeted by webpack and gulp for compilation and d.ts generation.

### Potential Breaking Changes

None

### Acceptance Criteria

- [x] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
