### PR TITLE
Fix bar chart with mono value

### DIFF
--- a/packages/react-vapor/src/components/chart/BarSeries.tsx
+++ b/packages/react-vapor/src/components/chart/BarSeries.tsx
@@ -12,7 +12,9 @@ export interface BarSeriesProps {
 export const BarSeries: React.FunctionComponent<BarSeriesProps> = ({barRatio = 0.8, children}) => {
     const {series, xScale, yScale, xDomain, yDomain, color, colorPattern} = React.useContext(XYChartContext);
     const xValues = ChartUtils.getXValues(series);
-    const barWidth = (xScale(xDomain[1]) - xScale(xDomain[0])) / (xValues.length - 1) / 2 * barRatio;
+    const barWidth = xValues.length > 1
+        ? (xScale(xDomain[1]) - xScale(xDomain[0])) / xValues.length / 2 * barRatio
+        : xScale(xDomain[0]) / 2 * barRatio;
 
     const innerXScale = d3.scale.ordinal<number, number>()
         .domain(d3.range(series.length))

--- a/packages/react-vapor/src/components/chart/ChartTooltip.tsx
+++ b/packages/react-vapor/src/components/chart/ChartTooltip.tsx
@@ -23,7 +23,9 @@ export const ChartTooltip: React.FunctionComponent<ChartTooltipProps> = ({sort =
     };
     const onMouseLeave = () => setPosition({...position, position: ''});
 
-    const barWidth = (xScale(xDomain[1]) - xScale(xDomain[0])) / (series[0].data.length - 1);
+    const barWidth = series[0].data.length > 1
+        ? (xScale(xDomain[1]) - xScale(xDomain[0])) / series[0].data.length
+        : xScale(xDomain[0]);
     const bars = series[0].data.map((point: XYPoint, index: number) => {
         const x = xScale(point.x);
         return (

--- a/packages/react-vapor/src/components/chart/examples/ChartExamples.tsx
+++ b/packages/react-vapor/src/components/chart/examples/ChartExamples.tsx
@@ -161,6 +161,29 @@ export const ChartExamples: React.FunctionComponent = () => {
                     )} />
                 </div>
             </div>
+            <div className='form-group'>
+                <label className='form-control-label'>Date Chart</label>
+                <div className='form-control' style={{height: '300px'}}>
+                    <ChartContainer renderChart={(width, height) => (
+                        <XYChart
+                            series={[
+                                {
+                                    label: 'First',
+                                    data: [{x: moment().startOf('day').unix(), y: 500}],
+                                },
+                            ]}
+                            height={height}
+                            width={width}
+                            xFormat={(value: number) => moment.unix(value).format('YYYY-MM-DD')}
+                        >
+                            <XYAxis x={{tickTextSize: 120}} y={{show: false}}>
+                                <BarSeries />
+                                <ChartTooltip sort />
+                            </XYAxis>
+                        </XYChart>
+                    )} />
+                </div>
+            </div>
         </div>
     );
 };

--- a/packages/react-vapor/src/components/chart/tests/BarSeries.spec.tsx
+++ b/packages/react-vapor/src/components/chart/tests/BarSeries.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import {BarSeries} from '../BarSeries';
 import {ChartUtils} from '../ChartUtils';
-import {XYChartContextMock} from './XYChartContextMock';
+import {XYChartContextMock, XYChartOnePointContextMock} from './XYChartContextMock';
 
 describe('<BarSeries />', () => {
     it('should not throw', () => {
@@ -25,5 +25,13 @@ describe('<BarSeries />', () => {
         const component = shallow(<BarSeries />);
 
         expect(component.find('rect').length).toBe(ChartUtils.getXValues(series).length * series.length);
+    });
+
+    it('should not throw when there is only one point in a serie', () => {
+        spyOn(React, 'useContext').and.returnValue(XYChartOnePointContextMock);
+
+        expect(() => {
+            shallow(<BarSeries />);
+        }).not.toThrow();
     });
 });

--- a/packages/react-vapor/src/components/chart/tests/ChartTooltip.spec.tsx
+++ b/packages/react-vapor/src/components/chart/tests/ChartTooltip.spec.tsx
@@ -6,11 +6,12 @@ import {DropPod} from '../../drop/DropPod';
 import {ChartTooltip} from '../ChartTooltip';
 import {ChartTooltipContent} from '../ChartTooltipContent';
 import {ChartUtils} from '../ChartUtils';
-import {XYChartContextMock} from './XYChartContextMock';
+import {XYChartContextMock, XYChartOnePointContextMock} from './XYChartContextMock';
 
 describe('<ChartTooltip />', () => {
+    let contextSpy: jasmine.Spy;
     beforeEach(() => {
-        spyOn(React, 'useContext').and.returnValue(XYChartContextMock);
+        contextSpy = spyOn(React, 'useContext').and.returnValue(XYChartContextMock);
     });
 
     it('should not throw', () => {
@@ -72,5 +73,13 @@ describe('<ChartTooltip />', () => {
         component.setProps({sort: false});
 
         expect(component.find('.chart-tooltip-line').exists()).toBe(false);
+    });
+
+    it('should not throw when there is only one point in a serie', () => {
+        contextSpy.and.returnValue(XYChartOnePointContextMock);
+
+        expect(() => {
+            shallow(<ChartTooltip />);
+        }).not.toThrow();
     });
 });

--- a/packages/react-vapor/src/components/chart/tests/XYChartContextMock.ts
+++ b/packages/react-vapor/src/components/chart/tests/XYChartContextMock.ts
@@ -34,10 +34,36 @@ export const XYChartContextMock: XYChartContextProps = {
     ],
     colorPattern: ['blue', 'green', 'yellow'],
     color: (serie: number, pattern: string[]) => pattern[serie],
-    xScale: d3.scale.ordinal<number, number>().domain([20, 30, 40, 50, 60]).range([0, 10]),
-    yScale: d3.scale.linear().domain([100, 0]).range([50, 0]),
+    xScale: d3.scale
+        .ordinal<number, number>()
+        .domain([20, 30, 40, 50, 60])
+        .range([0, 10]),
+    yScale: d3.scale
+        .linear()
+        .domain([100, 0])
+        .range([50, 0]),
     xFormat: _.identity,
     yFormat: _.identity,
     xTicksCount: 2,
     yTicksCount: 10,
+};
+
+export const XYChartOnePointContextMock = {
+    width: 341.5,
+    height: 240,
+    xDomain: [1559880000, 1559880000],
+    yDomain: [0, 500],
+    colorPattern: ['#0d80ef', '#26e8cc', '#4ed6ff', '#94a9bf'],
+    series: [{label: 'First', data: [{x: 1559880000, y: 500}]}],
+    xTicksCount: 0.5,
+    yTicksCount: 0.5,
+    color: (serie: number, pattern: string[]) => pattern[serie],
+    xScale: d3.scale
+        .ordinal<number, number>()
+        .domain([1559880000])
+        .range([0, 10]),
+    yScale: d3.scale
+        .linear()
+        .domain([500])
+        .range([50, 0]),
 };

--- a/packages/react-vapor/webpack.config.prod.js
+++ b/packages/react-vapor/webpack.config.prod.js
@@ -52,7 +52,7 @@ const config = {
                 loader: 'awesome-typescript-loader',
                 options: {
                     compiler: 'ttypescript',
-                    configFileName: 'tsconfig.build.json'
+                    configFileName: 'tsconfig.build.json',
                 },
             },
             {


### PR DESCRIPTION
### Description

 When calculating the bar width of a bar chart, we would end up with a division by 0 when the data series had only one value. Same problem existed in the ChartTooltip component.

### Proposed Changes

- Added a code branch that handles the case when there is only one value in a data series

### Potential Breaking Changes

None

### Acceptance Criteria

- [x] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
