### PR TITLE
Fix adui 4499 truncate multiselect values

### DIFF
--- a/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/DraggableSelectedOption.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/DraggableSelectedOption.tsx
@@ -3,6 +3,7 @@ import {DragSource, DropTarget, IDragSource, IDropTarget} from 'react-dnd';
 import {findDOMNode} from 'react-dom';
 import {keys} from 'ts-transformer-keys';
 import * as _ from 'underscore';
+
 import {Svg} from '../../svg/Svg';
 import {ISelectedOptionProps, SelectedOption} from './SelectedOption';
 
@@ -88,22 +89,25 @@ const DraggableSelectedOptionPropsToOmit = keys<IDraggableSelectedOptionOwnProps
     isDragging: monitor.isDragging(),
 }),
 )
-export class DraggableSelectedOption extends React.Component<IDraggableSelectedOptionProps> {
+export class DraggableSelectedOption extends React.PureComponent<IDraggableSelectedOptionProps> {
     render() {
         const opacity = this.props.isDragging ? 0 : 1;
 
-        const content: React.ReactNode = [
-            this.props.connectDragSource(
-                <div className='move-option infline-flex cursor-move align-center'>
-                    <Svg svgName='drag-drop' svgClass='icon mod-small' />
-                </div>,
-            ),
-            this.props.label,
-        ];
         return this.props.connectDragPreview(
             this.props.connectDropTarget(
                 <div className='selected-option-wrapper' style={{opacity}}>
-                    <SelectedOption {..._.omit(this.props, DraggableSelectedOptionPropsToOmit)} label={content} />
+                    <SelectedOption {..._.omit(this.props, DraggableSelectedOptionPropsToOmit)}
+                        label={this.props.isDragging ? null : this.props.label}
+                    >
+                        <div className='inline-flex'>
+                            {this.props.connectDragSource(
+                                <div className='move-option infline-flex cursor-move align-center'>
+                                    <Svg svgName='drag-drop' svgClass='icon mod-small' />
+                                </div>,
+                            )}
+                            {this.props.label}
+                        </div>
+                    </SelectedOption>
                 </div>,
             ),
         );

--- a/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/SelectedOption.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/SelectedOption.tsx
@@ -1,30 +1,42 @@
 import * as React from 'react';
+import * as _ from 'underscore';
+import {callIfDefined} from '../../../utils/FalsyValuesUtils';
+import {TooltipPlacement} from '../../../utils/TooltipUtils';
 import {Svg} from '../../svg/Svg';
+import {Tooltip} from '../../tooltip/Tooltip';
 
 export interface ISelectedOptionProps {
     value: string;
     label: React.ReactNode;
     onRemoveClick?: (value: string) => void;
-    key: string;
 }
 
-export class SelectedOption extends React.Component<ISelectedOptionProps, any> {
-
-    handleOnRemove() {
-        if (this.props.onRemoveClick) {
-            this.props.onRemoveClick(this.props.value);
-        }
+export class SelectedOption extends React.PureComponent<ISelectedOptionProps> {
+    handleOnRemove = () => {
+        callIfDefined(this.props.onRemoveClick, this.props.value);
     }
 
     render() {
+        const tooltipContent = React.Children.count(this.props.children) > 0
+            ? this.props.children
+            : this.props.label;
+        const tooltipLabel = typeof this.props.label == 'string'
+            ? this.props.label
+            : '';
+
         return (
-            <div className='selected-option' >
+            <div className='selected-option' key={this.props.value}>
 
-                <div className='selected-option-value'>
-                    {this.props.label}
-                </div>
+                <Tooltip
+                    title={tooltipLabel}
+                    placement={TooltipPlacement.Top}
+                    className='selected-option-value'
+                    delayShow={300}
+                >
+                    {tooltipContent}
+                </Tooltip>
 
-                <div className='remove-option' onClick={() => this.handleOnRemove()} >
+                <div className='remove-option' onClick={this.handleOnRemove} >
                     <Svg svgName='clear' svgClass='icon fill-medium-blue mod-small' />
                 </div>
             </div>

--- a/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/SelectedOption.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/SelectedOption.tsx
@@ -20,7 +20,7 @@ export class SelectedOption extends React.PureComponent<ISelectedOptionProps> {
         const tooltipContent = React.Children.count(this.props.children) > 0
             ? this.props.children
             : this.props.label;
-        const tooltipLabel = typeof this.props.label == 'string'
+        const tooltipLabel = typeof this.props.label === 'string'
             ? this.props.label
             : '';
 

--- a/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/tests/DraggableSelectedOption.spec.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/tests/DraggableSelectedOption.spec.tsx
@@ -2,13 +2,10 @@ import {mount, ReactWrapper} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
 import {TestUtils} from '../../../../utils/tests/TestUtils';
-import {UUID} from '../../../../utils/UUID';
 import {DraggableSelectedOption, IDraggableSelectedOptionProps} from '../DraggableSelectedOption';
 
 describe('DraggableSelectedOption', () => {
-    const key: string = UUID.generate();
     const props: Partial<IDraggableSelectedOptionProps> = {
-        key,
         value: 'test',
         label: '',
         index: 0,

--- a/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/tests/DraggableSelectedOption.spec.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/tests/DraggableSelectedOption.spec.tsx
@@ -43,7 +43,7 @@ describe('DraggableSelectedOption', () => {
             const label: string = 'displayTest';
             mountOption({label});
 
-            expect(selectedOption.find('.selected-option-value').text()).toBe(label);
+            expect(selectedOption.find('.selected-option-value').first().text()).toBe(label);
         });
 
         it('should change the opacity when the element is dragged', () => {

--- a/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/tests/SelectedOption.spec.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/tests/SelectedOption.spec.tsx
@@ -35,7 +35,7 @@ describe('SelectedOption', () => {
                 const label: string = 'displayTest';
                 selectedOption.setProps({label});
 
-                expect(selectedOption.find('.selected-option-value').text()).toBe(label);
+                expect(selectedOption.find('.selected-option-value').first().text()).toBe(label);
             });
         });
 
@@ -55,7 +55,7 @@ describe('SelectedOption', () => {
 
                 selectedOption.simulate('click');
                 selectedOption.find('.selected-option').simulate('click');
-                selectedOption.find('.selected-option-value').simulate('click');
+                selectedOption.find('.selected-option-value').first().simulate('click');
 
                 expect(onRemoveOptionClick).not.toHaveBeenCalled();
             });

--- a/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/tests/SelectedOption.spec.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/tests/SelectedOption.spec.tsx
@@ -1,13 +1,10 @@
 import {mount, ReactWrapper} from 'enzyme';
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
-import {UUID} from '../../../../utils/UUID';
 import {ISelectedOptionProps, SelectedOption} from '../SelectedOption';
 
 describe('SelectedOption', () => {
-    const key: string = UUID.generate();
     const props: ISelectedOptionProps = {
-        key,
         value: 'test',
         label: '',
     };

--- a/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
@@ -109,12 +109,14 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps & React.ButtonHT
     }
 
     private renderOption(item: IItemBoxProps): JSX.Element {
-        return <SelectedOption
-            label={item.displayValue || item.value}
-            value={item.value}
-            key={item.value}
-            onRemoveClick={() => this.props.onRemoveClick(item)}
-        />;
+        return (
+            <SelectedOption
+                label={item.displayValue || item.value}
+                value={item.value}
+                key={item.value}
+                onRemoveClick={() => this.props.onRemoveClick(item)}
+            />
+        );
     }
 
     private renderDraggableOption(item: IItemBoxProps, index: number): JSX.Element {
@@ -149,7 +151,7 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps & React.ButtonHT
     private getRemoveAllSelectedOptionsButton(): JSX.Element {
         return this.getSelectedOptions().length > 1
             ? <Tooltip title={this.props.deselectAllTooltipText} placement='top' noSpanWrapper>
-                <div className='remove-all-selected-options' onClick={() => this.props.onRemoveAll()}>
+                <div className='remove-all-selected-options ml1' onClick={() => this.props.onRemoveAll()}>
                     <Svg svgName='clear' svgClass='icon fill-medium-blue' />
                 </div>
             </Tooltip>
@@ -166,8 +168,8 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps & React.ButtonHT
         return (
             <div className={classes} style={this.props.multiSelectStyle}>
                 {this.props.connectDropTarget(
-                    <div className='multiselect-selected flex flex-center flex-auto'>
-                        <div className='selected-options-container'>
+                    <div className='multiselect-selected flex flex-center flex-auto full-content'>
+                        <div className='selected-options-container truncate'>
                             {this.getSelectedOptionComponents()}
                         </div>
                         {this.getRemoveAllSelectedOptionsButton()}

--- a/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
@@ -109,24 +109,26 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps & React.ButtonHT
     }
 
     private renderOption(item: IItemBoxProps): JSX.Element {
+        const displayValue = item.displayValue || item.value;
         return (
             <SelectedOption
-                label={item.displayValue || item.value}
+                label={displayValue}
                 value={item.value}
                 key={item.value}
                 onRemoveClick={() => this.props.onRemoveClick(item)}
-            />
+            >
+                {displayValue}
+            </SelectedOption>
         );
     }
 
     private renderDraggableOption(item: IItemBoxProps, index: number): JSX.Element {
         return (
-            <div className='flex flex-row flex-center sortable-selected-option'>
+            <div className='flex flex-row flex-center sortable-selected-option' key={item.value}>
                 <span className='mr1 text-medium-grey'>{index + 1}</span>
                 <DraggableSelectedOption
                     label={item.displayValue || item.value}
                     value={item.value}
-                    key={item.value}
                     onRemoveClick={() => this.props.onRemoveClick(item)}
                     index={index}
                     move={(dragIndex: number, hoverIndex: number) => this.move(dragIndex, hoverIndex)}

--- a/packages/react-vapor/src/components/select/examples/MultiSelectExamples.tsx
+++ b/packages/react-vapor/src/components/select/examples/MultiSelectExamples.tsx
@@ -51,7 +51,7 @@ export class MultiSelectExamples extends React.Component<{}, IMultiSelectExample
 
     render() {
         return (
-            <div>
+            <div className='mb2'>
                 <h1>Multi Select</h1>
                 <div className='form-group'>
                     <label className='form-control-label'>A Simple Multi Select without items</label>

--- a/packages/react-vapor/src/components/select/examples/MultiSelectExamples.tsx
+++ b/packages/react-vapor/src/components/select/examples/MultiSelectExamples.tsx
@@ -153,6 +153,17 @@ export class MultiSelectExamples extends React.Component<{}, IMultiSelectExample
                         matchPredicate={(p: string, i: IItemBoxProps) => this.matchPredicate(p, i)}
                         customValues />
                 </div>
+                <div className='form-group'>
+                    <label className='form-control-label'>A Multi Select With Filter, default list and Custom
+                        Values </label>
+                    <br />
+                    <MultiSelectWithFilter
+                        id={UUID.generate()}
+                        defaultCustomValues={['b'.repeat(100)]}
+                        items={[{value: 'a'.repeat(100)}]}
+                        customValues
+                    />
+                </div>
             </div>
         );
     }

--- a/packages/react-vapor/src/components/tooltip/Tooltip.tsx
+++ b/packages/react-vapor/src/components/tooltip/Tooltip.tsx
@@ -24,7 +24,7 @@ export interface IOverlayTriggerProps {
 }
 
 export interface ITooltipProps extends IOverlayTriggerProps, React.ClassAttributes<Tooltip> {
-    title: string;
+    title: React.ReactNode;
     className?: string;
     arrowOffsetLeft?: React.ReactText;
     arrowOffsetTop?: React.ReactText;

--- a/packages/vapor/gulpfile.js
+++ b/packages/vapor/gulpfile.js
@@ -284,7 +284,7 @@ gulp.task('docs:copy', () => {
     return gulp.src('./dist/**/*').pipe(gulp.dest('./docs/dist'));
 });
 
-gulp.task('docs', gulp.series('clean', 'default', 'docs:external-libs', 'docs:copy'));
+gulp.task('docs', gulp.series('default', 'docs:external-libs', 'docs:copy'));
 
 gulp.task('watch', () => {
     gulp.watch(['./scss/**/*.scss', '!./scss/common/palette-map.scss', '!./scss/sprites.scss'], gulp.series('docs'));

--- a/packages/vapor/package.json
+++ b/packages/vapor/package.json
@@ -15,7 +15,7 @@
     "main": "dist/js/VaporSVG.js",
     "scripts": {
         "clean": "gulp clean",
-        "build": "gulp docs",
+        "build": "npm run clean && gulp docs",
         "buildpages": "bundle exec jekyll build",
         "start": "concurrently \"npm run build && bundle exec jekyll server --host=0.0.0.0\" \"gulp watch\"",
         "version": "gulp clean && npm run build",

--- a/packages/vapor/scss/components/selected-option.scss
+++ b/packages/vapor/scss/components/selected-option.scss
@@ -26,7 +26,6 @@
 }
 
 .selected-option-value {
-    display: inline-flex;
     margin-left: $dropdown-multiselect-items-margin;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
### Description

Selected values of multiselect components were not getting truncated:
![image](https://user-images.githubusercontent.com/35579930/59229080-73cb1880-8ba7-11e9-88a8-13f35f581076.png) 

### Proposed Changes

- Ajusted the style so that selected values get truncated:
![image](https://user-images.githubusercontent.com/35579930/59229142-9e1cd600-8ba7-11e9-8e25-deedc6a3c9a9.png)

### Potential Breaking Changes

I removed the `flex: inline-flex` rule on the `.select-option-value` class. It could potentially have an undesired impact on selected value that render a funky react-node, but I haven't found any way to produce such problem.

### Acceptance Criteria

- [ ] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
