### PR TITLE
fix added Nocursor function in CodeEditor when in Readonly [ADUI4507]

### DIFF
--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -93,9 +93,8 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
     }
 
     private removeCursorWhenEditorIsReadOnly(isItReadOnly: boolean) {
-        return isItReadOnly === true ? "nocursor" : false;
+        return isItReadOnly === true ? 'nocursor' : false;
     }
-
 
     private handleChange(code: string) {
         callIfDefined(this.props.onChange, code);

--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -18,7 +18,7 @@ import {CodeMirrorGutters} from './EditorConstants';
 
 export interface ICodeEditorProps {
     value: string;
-    readOnly?: any;
+    readOnly?: boolean;
     onChange?: (code: string) => void;
     onMount?: (codemirror: ReactCodeMirror.Controlled) => void;
     errorMessage?: string;
@@ -93,7 +93,7 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
     }
 
     private removeCursorWhenEditorIsReadOnly(isItReadOnly: boolean) {
-        return isItReadOnly === true ? 'nocursor' : false;
+        return isItReadOnly === true ? 'nocursor' : this.props.readOnly;
     }
 
     private handleChange(code: string) {

--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -86,14 +86,14 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
                 }}
                 value={this.state.value}
                 onChange={(editor, data, value: string) => this.handleChange(value)}
-                options={_.extend({}, CodeEditor.Options, {readOnly: this.removeCursorWhenEditorIsReadOnly(this.props.readOnly), mode: this.props.mode})}
+                options={_.extend({}, CodeEditor.Options, {readOnly: this.removeCursorWhenEditorIsReadOnly(), mode: this.props.mode})}
                 className={this.props.className}
             />
         );
     }
 
-    private removeCursorWhenEditorIsReadOnly(isItReadOnly: boolean) {
-        return isItReadOnly === true ? 'nocursor' : this.props.readOnly;
+    private removeCursorWhenEditorIsReadOnly() {
+        return this.props.readOnly ? 'nocursor' : this.props.readOnly;
     }
 
     private handleChange(code: string) {

--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -18,7 +18,7 @@ import {CodeMirrorGutters} from './EditorConstants';
 
 export interface ICodeEditorProps {
     value: string;
-    readOnly?: boolean;
+    readOnly?: any;
     onChange?: (code: string) => void;
     onMount?: (codemirror: ReactCodeMirror.Controlled) => void;
     errorMessage?: string;
@@ -86,11 +86,16 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
                 }}
                 value={this.state.value}
                 onChange={(editor, data, value: string) => this.handleChange(value)}
-                options={_.extend({}, CodeEditor.Options, {readOnly: this.props.readOnly, mode: this.props.mode})}
+                options={_.extend({}, CodeEditor.Options, {readOnly: this.removeCursorWhenEditorIsReadOnly(this.props.readOnly), mode: this.props.mode})}
                 className={this.props.className}
             />
         );
     }
+
+    private removeCursorWhenEditorIsReadOnly(isItReadOnly: boolean) {
+        return isItReadOnly === true ? "nocursor" : false;
+    }
+
 
     private handleChange(code: string) {
         callIfDefined(this.props.onChange, code);

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -19,7 +19,7 @@ describe('CodeEditor', () => {
         }).not.toThrow();
     });
 
-    describe('<CodeEditor />', () => {
+    fdescribe('<CodeEditor />', () => {
         let codeEditor: ReactWrapper<ICodeEditorProps, CodeEditorState>;
         let codeEditorInstance: CodeEditor;
 
@@ -53,7 +53,7 @@ describe('CodeEditor', () => {
             expect(readOnlyProp).toBe(true);
         });
 
-        it('should set readOnly to \'nocursor\' when receiving true from props, else keep props', () => {
+        it('should set readOnly to `nocursor` when receiving true from props, else keep props', () => {
             mountWithProps({readOnly: true});
             expect((codeEditorInstance as any)
                 .removeCursorWhenEditorIsReadOnly(codeEditor.props().readOnly))

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -19,7 +19,7 @@ describe('CodeEditor', () => {
         }).not.toThrow();
     });
 
-    fdescribe('<CodeEditor />', () => {
+    describe('<CodeEditor />', () => {
         let codeEditor: ReactWrapper<ICodeEditorProps, CodeEditorState>;
         let codeEditorInstance: CodeEditor;
 

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -7,7 +7,7 @@ import * as _ from 'underscore';
 import {CodeEditor, CodeEditorState, ICodeEditorProps} from '../CodeEditor';
 import {CodeMirrorModes} from '../EditorConstants';
 
-fdescribe('CodeEditor', () => {
+describe('CodeEditor', () => {
     const basicProps: ICodeEditorProps = {
         value: 'any string',
         mode: CodeMirrorModes.Python,

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -54,7 +54,7 @@ describe('CodeEditor', () => {
         });
 
         it('should set readOnly to \'nocursor\' when receiving true from props, else keep props', () => {
-            mountWithProps({readOnly: true})
+            mountWithProps({readOnly: true});
             expect((codeEditorInstance as any)
                 .removeCursorWhenEditorIsReadOnly(codeEditor.props().readOnly))
                 .toBe('nocursor');
@@ -63,7 +63,7 @@ describe('CodeEditor', () => {
             expect((codeEditorInstance as any)
                 .removeCursorWhenEditorIsReadOnly(codeEditor.props().readOnly))
                 .toBe(codeEditor.props().readOnly);
-        })
+        });
 
         it('should get what to do on change state as a prop if set', () => {
             let onChangeProp: (json: string) => void = codeEditor.props().onChange;

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -7,7 +7,7 @@ import * as _ from 'underscore';
 import {CodeEditor, CodeEditorState, ICodeEditorProps} from '../CodeEditor';
 import {CodeMirrorModes} from '../EditorConstants';
 
-describe('CodeEditor', () => {
+fdescribe('CodeEditor', () => {
     const basicProps: ICodeEditorProps = {
         value: 'any string',
         mode: CodeMirrorModes.Python,
@@ -52,6 +52,18 @@ describe('CodeEditor', () => {
 
             expect(readOnlyProp).toBe(true);
         });
+
+        it('should set readOnly to \'nocursor\' when receiving true from props, else keep props', () => {
+            mountWithProps({readOnly: true})
+            expect((codeEditorInstance as any)
+                .removeCursorWhenEditorIsReadOnly(codeEditor.props().readOnly))
+                .toBe('nocursor');
+
+            codeEditor.setProps({readOnly: false});
+            expect((codeEditorInstance as any)
+                .removeCursorWhenEditorIsReadOnly(codeEditor.props().readOnly))
+                .toBe(codeEditor.props().readOnly);
+        })
 
         it('should get what to do on change state as a prop if set', () => {
             let onChangeProp: (json: string) => void = codeEditor.props().onChange;


### PR DESCRIPTION
Added a function in the root component that grab the true value and switch it to "nocursor". Thus giving us the functionalities that we want.