### PR TITLE
fix - removed the border radius in .btn when also collapsible[ADUI-4004]

### DIFF
--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -183,6 +183,10 @@
             display: none;
         }
     }
+
+    &.collapsible-header {
+        border-radius: 0;
+    }
 }
 
 .btn-container {


### PR DESCRIPTION
added a styling rule to .btn when also collapsible to remove the all mighty border-radius.