### PR TITLE
Remove Breadcrumb's margin-top for height consistency

### DIFF
--- a/packages/react-vapor/src/components/breadcrumbs/BreadcrumbLink.tsx
+++ b/packages/react-vapor/src/components/breadcrumbs/BreadcrumbLink.tsx
@@ -25,7 +25,7 @@ export class BreadcrumbLink extends React.Component<IBreadcrumbLinkProps, {}> {
         const linkClasses = classNames('link', this.props.classes);
         return (<li className='breadcrumb-title'>
             <a className={linkClasses} href={this.props.link} onClick={(e: React.MouseEvent<HTMLAnchorElement>) => this.handleOnClick(e)}>{this.props.name}</a>
-            <Svg svgName='arrow-right-rounded' svgClass='breadcrumb-arrow' />
+            <Svg svgName='arrow-right-rounded' className='breadcrumb-arrow' />
         </li>);
     }
 }

--- a/packages/vapor/scss/components/breadcrumbs.scss
+++ b/packages/vapor/scss/components/breadcrumbs.scss
@@ -6,8 +6,6 @@
 }
 
 .breadcrumb-arrow {
-    margin-top: $breadcrumb-icon-vertical-alignment;
-
     @extend .icon;
     @extend .mod-normal;
     fill: $medium-grey;

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -478,9 +478,6 @@ $list-box-border-radius: 0 0 2px 2px;
 $limit-box-width: 300px;
 $limit-progress-bar-height: 10px;
 
-// Breadcrumb
-$breadcrumb-icon-vertical-alignment: 7px;
-
 // Slider
 $slider-rail-height: 4px;
 $slider-rail-margin-top: 2px;


### PR DESCRIPTION
### Description

I noticed that when BreadcrumbHeader contained a breadcrumb, the height of the header was 38px instead of the usual 32px and I wanted to fix this.

I noticed the `margin-top: 7px` was the culprit, but then the header was badly aligned, *but only in react-vapor*. 

Once I removed the rule, *vapor* was properly aligned, with the only difference being that `breadcrumb-arrow` was being applied to the `<span>` container instead of directly on the `svg`.

It is kind of hard to see, so here is what it was before. Have a look at the description when I switch back and forth between the two pages:
![breadcrumbheader](https://user-images.githubusercontent.com/8355585/59445648-05b46a80-8dce-11e9-9af4-07ceb8ee9528.gif)

Here is the proposed change:

![breadcrumbheadercomparison](https://user-images.githubusercontent.com/8355585/59445689-14028680-8dce-11e9-8906-ea0e47bb9fde.png)

### Proposed Changes

- (vapor) Remove the `margin-top: 7px` that was used for alignment 
- (react-vapor) Put "breadcrumb-arrow" on the container instead of the svg, as specified in vapor.

### Potential Breaking Changes

None

### Acceptance Criteria

- [ ] The proposed changes are covered by unit tests
- [ ] The potential breaking changes are clearly identified
- [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
