### PR TITLE
Change name of action symbol to avoid conflicts

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableRowConnected.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableRowConnected.tsx
@@ -12,7 +12,7 @@ import {IActionOptions} from '../actions/Action';
 import {addActionsToActionBar} from '../actions/ActionBarActions';
 import {Collapsible} from '../collapsible/Collapsible';
 import {CollapsibleToggle} from '../collapsible/CollapsibleToggle';
-import {TableRowActions} from './actions/TableRowActions';
+import {TableHOCRowActions} from './actions/TableHOCRowActions';
 import {TableSelectors} from './TableSelectors';
 
 export interface CollapsibleRowProps {
@@ -70,28 +70,28 @@ const mapDispatchToProps = (
     const refreshActionBarActions = (isMulti: boolean) => {
         if (!_.isEmpty(ownProps.actions)) {
             dispatch(addActionsToActionBar(ownProps.tableId, ownProps.actions));
-            dispatch(TableRowActions.select(ownProps.id, isMulti));
+            dispatch(TableHOCRowActions.select(ownProps.id, isMulti));
         }
     };
 
     return ({
         onMount: () => {
-            dispatch(TableRowActions.add(ownProps.id, ownProps.tableId));
+            dispatch(TableHOCRowActions.add(ownProps.id, ownProps.tableId));
             if (isCollapsible(ownProps) && ownProps.collapsible.expandOnMount) {
-                dispatch(TableRowActions.toggleCollapsible(ownProps.id, true));
+                dispatch(TableHOCRowActions.toggleCollapsible(ownProps.id, true));
             }
         },
-        onUnmount: () => dispatch(TableRowActions.remove(ownProps.id)),
+        onUnmount: () => dispatch(TableHOCRowActions.remove(ownProps.id)),
         handleClick: (isMulti: boolean, isOpened: boolean) => {
             refreshActionBarActions(isMulti);
             if (isCollapsible(ownProps)) {
                 callIfDefined(ownProps.collapsible.onToggleCollapsible, !isOpened);
-                dispatch(TableRowActions.toggleCollapsible(ownProps.id));
+                dispatch(TableHOCRowActions.toggleCollapsible(ownProps.id));
             }
         },
         onUpdateToCollapsibleRow: () => {
             if (ownProps.collapsible.expandOnMount) {
-                dispatch(TableRowActions.toggleCollapsible(ownProps.id, true));
+                dispatch(TableHOCRowActions.toggleCollapsible(ownProps.id, true));
             }
         },
         onActionBarActionsChanged: () => refreshActionBarActions(false),

--- a/packages/react-vapor/src/components/table-hoc/actions/TableHOCRowActions.ts
+++ b/packages/react-vapor/src/components/table-hoc/actions/TableHOCRowActions.ts
@@ -1,6 +1,6 @@
 import {BasePayload, IReduxAction} from '../../../utils/ReduxUtils';
 
-export const TableRowActionsType = {
+export const TableHOCRowActionsType = {
     add: 'ADD_TABLE_ROW',
     remove: 'REMOVE_TABLE_ROW',
     select: 'SELECT_TABLE_ROW',
@@ -13,12 +13,12 @@ export interface ITableRowAddPayload extends BasePayload {
 }
 
 const addTableRow = (id: string, tableId: string): IReduxAction<ITableRowAddPayload> => ({
-    type: TableRowActionsType.add,
+    type: TableHOCRowActionsType.add,
     payload: {id, tableId},
 });
 
 const removeTableRow = (id: string): IReduxAction<BasePayload> => ({
-    type: TableRowActionsType.remove,
+    type: TableHOCRowActionsType.remove,
     payload: {id},
 });
 
@@ -27,12 +27,12 @@ export interface ITableRowSelectPayload extends BasePayload {
 }
 
 const selectRow = (id: string, isMulti: boolean = false): IReduxAction<ITableRowSelectPayload> => ({
-    type: TableRowActionsType.select,
+    type: TableHOCRowActionsType.select,
     payload: {id, isMulti},
 });
 
 const deselectAllRows = (id: string): IReduxAction<ITableRowSelectPayload> => ({
-    type: TableRowActionsType.deselectAll,
+    type: TableHOCRowActionsType.deselectAll,
     payload: {id},
 });
 
@@ -41,11 +41,11 @@ export interface ITableRowToggleCollapsiblePayload extends BasePayload {
 }
 
 const toggleCollapsibleRow = (id: string, opened?: boolean): IReduxAction<ITableRowToggleCollapsiblePayload> => ({
-    type: TableRowActionsType.toggleCollapsible,
+    type: TableHOCRowActionsType.toggleCollapsible,
     payload: {id, opened},
 });
 
-export const TableRowActions = {
+export const TableHOCRowActions = {
     add: addTableRow,
     remove: removeTableRow,
     select: selectRow,

--- a/packages/react-vapor/src/components/table-hoc/examples/TableHOCExamples.tsx
+++ b/packages/react-vapor/src/components/table-hoc/examples/TableHOCExamples.tsx
@@ -8,7 +8,7 @@ import {UUID} from '../../../utils/UUID';
 import {Button} from '../../button/Button';
 import {SELECTION_BOX, SELECTION_BOXES_LONG} from '../../datePicker/examples/DatePickerExamplesCommon';
 import {SingleSelectConnected} from '../../select/SingleSelectConnected';
-import {TableRowActions} from '../actions/TableRowActions';
+import {TableHOCRowActions} from '../actions/TableHOCRowActions';
 import {TableHeaderWithSort} from '../TableHeaderWithSort';
 import {TableHOC} from '../TableHOC';
 import {TableRowConnected} from '../TableRowConnected';
@@ -111,7 +111,7 @@ const TableWithSortFilterAndPagination = _.compose(
 )(TableHOC);
 
 const mapDispatchToProps = (dispatch: IDispatch) => ({
-    unselectActions: () => dispatch(TableRowActions.deselectAll('table-with-unselect-all')),
+    unselectActions: () => dispatch(TableHOCRowActions.deselectAll('table-with-unselect-all')),
 });
 
 @ReduxConnect(null, mapDispatchToProps)

--- a/packages/react-vapor/src/components/table-hoc/reducers/TableRowReducers.ts
+++ b/packages/react-vapor/src/components/table-hoc/reducers/TableRowReducers.ts
@@ -7,8 +7,8 @@ import {
     ITableRowAddPayload,
     ITableRowSelectPayload,
     ITableRowToggleCollapsiblePayload,
-    TableRowActionsType,
-} from '../actions/TableRowActions';
+    TableHOCRowActionsType,
+} from '../actions/TableHOCRowActions';
 import {TableHOCUtils} from '../TableHOCUtils';
 
 export interface ITableRowState {
@@ -79,11 +79,11 @@ const deselectTableRowReducer = (state: ITableRowState[], action: IReduxAction<I
 };
 
 const TableRowActionReducers: {[key: string]: (...args: any[]) => any} = {
-    [TableRowActionsType.add]: addTableRowReducer,
-    [TableRowActionsType.remove]: removeTableRowReducer,
-    [TableRowActionsType.select]: selectTableRowReducer,
-    [TableRowActionsType.deselectAll]: deselectTableRowReducer,
-    [TableRowActionsType.toggleCollapsible]: toggleCollasibleTableRowReducer,
+    [TableHOCRowActionsType.add]: addTableRowReducer,
+    [TableHOCRowActionsType.remove]: removeTableRowReducer,
+    [TableHOCRowActionsType.select]: selectTableRowReducer,
+    [TableHOCRowActionsType.deselectAll]: deselectTableRowReducer,
+    [TableHOCRowActionsType.toggleCollapsible]: toggleCollasibleTableRowReducer,
     [PerPageActions.change]: deselectTableRowReducer,
     [PaginationActions.changePage]: deselectTableRowReducer,
 };

--- a/packages/react-vapor/src/components/table-hoc/tests/TableRowConnected.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableRowConnected.spec.tsx
@@ -6,7 +6,7 @@ import {createMockStore, mockStore} from 'redux-test-utils';
 import {IReactVaporState} from '../../../ReactVapor';
 import {addActionsToActionBar} from '../../actions/ActionBarActions';
 import {CollapsibleToggle} from '../../collapsible/CollapsibleToggle';
-import {TableRowActions} from '../actions/TableRowActions';
+import {TableHOCRowActions} from '../actions/TableHOCRowActions';
 import {ITableRowConnectedProps, TableRowConnected} from '../TableRowConnected';
 import {TableSelectors} from '../TableSelectors';
 
@@ -66,16 +66,16 @@ describe('Table HOC', () => {
             expect(wrapper.find('tr').hasClass('selected')).toBe(false);
         });
 
-        it('should dispatch a TableRowActions.add on componentDidMount', () => {
-            const expectedAction = TableRowActions.add(defaultProps.id, defaultProps.tableId);
+        it('should dispatch a TableHOCRowActions.add on componentDidMount', () => {
+            const expectedAction = TableHOCRowActions.add(defaultProps.id, defaultProps.tableId);
 
             shallowWithStore(<TableRowConnected {...defaultProps} />, store).dive();
 
             expect(store.isActionDispatched(expectedAction)).toBe(true);
         });
 
-        it('should dispatch an TableRowActions.remove on componentWillUnmount', () => {
-            const expectedAction = TableRowActions.remove(defaultProps.id);
+        it('should dispatch an TableHOCRowActions.remove on componentWillUnmount', () => {
+            const expectedAction = TableHOCRowActions.remove(defaultProps.id);
 
             const wrapper = shallowWithStore(<TableRowConnected {...defaultProps} />, store).dive();
             wrapper.unmount();
@@ -93,8 +93,8 @@ describe('Table HOC', () => {
             expect(store.isActionDispatched(expectedAction)).toBe(true);
         });
 
-        it('should dispatch a TableRowActions.select action on click when actions is not empty', () => {
-            const expectedAction = TableRowActions.select(defaultProps.id, false);
+        it('should dispatch a TableHOCRowActions.select action on click when actions is not empty', () => {
+            const expectedAction = TableHOCRowActions.select(defaultProps.id, false);
 
             const wrapper = shallowWithStore(<TableRowConnected {...defaultProps} actions={[{enabled: true, name: 'action'}]} />, store).dive();
             wrapper.find('tr').simulate('click', {});
@@ -114,10 +114,10 @@ describe('Table HOC', () => {
             expect(store.isActionDispatched(expectedAction)).toBe(true);
         });
 
-        it('should dispatch a TableRowActions.select action when the action change and the row was selected', () => {
+        it('should dispatch a TableHOCRowActions.select action when the action change and the row was selected', () => {
             const actions = [{name: 'name', enabled: false}];
             const newActions = [{name: 'name', enabled: true}];
-            const expectedAction = TableRowActions.select(defaultProps.id, false);
+            const expectedAction = TableHOCRowActions.select(defaultProps.id, false);
             spyOn(TableSelectors, 'getTableRow').and.returnValue({selected: true, opened: false});
 
             const wrapper = shallowWithStore(<TableRowConnected {...defaultProps} actions={actions} />, store).dive();
@@ -126,8 +126,8 @@ describe('Table HOC', () => {
             expect(store.isActionDispatched(expectedAction)).toBe(true);
         });
 
-        it('should not dispatch a TableRowActions.select action on click when actions is empty', () => {
-            const actionNotExpected = TableRowActions.select(defaultProps.id, false);
+        it('should not dispatch a TableHOCRowActions.select action on click when actions is empty', () => {
+            const actionNotExpected = TableHOCRowActions.select(defaultProps.id, false);
 
             const wrapper = shallowWithStore(<TableRowConnected {...defaultProps} />, store).dive();
             wrapper.find('tr').simulate('click', {});
@@ -135,8 +135,8 @@ describe('Table HOC', () => {
             expect(store.isActionDispatched(actionNotExpected)).toBe(false);
         });
 
-        it('should not dispatch a TableRowActions.select action on click when clicking inside an underlying dropdown', () => {
-            const actionNotExpected = TableRowActions.select(defaultProps.id, false);
+        it('should not dispatch a TableHOCRowActions.select action on click when clicking inside an underlying dropdown', () => {
+            const actionNotExpected = TableHOCRowActions.select(defaultProps.id, false);
 
             // We must mount the component here because simulated events don't propagate throughout ShallowWrappers
             const wrapper = mountWithStore(
@@ -153,9 +153,9 @@ describe('Table HOC', () => {
             expect(store.isActionDispatched(actionNotExpected)).toBe(false);
         });
 
-        it('should dispatch an TableRowActions.select on click and handle multi-select', () => {
-            const expectedActionWithMulti = TableRowActions.select(defaultProps.id, true);
-            const expectedActionWithoutMulti = TableRowActions.select(defaultProps.id, false);
+        it('should dispatch an TableHOCRowActions.select on click and handle multi-select', () => {
+            const expectedActionWithMulti = TableHOCRowActions.select(defaultProps.id, true);
+            const expectedActionWithoutMulti = TableHOCRowActions.select(defaultProps.id, false);
 
             const wrapper = shallowWithStore(
                 <TableRowConnected
@@ -256,7 +256,7 @@ describe('Table HOC', () => {
             });
 
             it('should dispatch a toggleCollapsible action when clicking on a collapsible heading-row', () => {
-                const expectedAction = TableRowActions.toggleCollapsible(defaultProps.id);
+                const expectedAction = TableHOCRowActions.toggleCollapsible(defaultProps.id);
 
                 wrapper.find('tr.heading-row').simulate('click', {});
 
@@ -265,7 +265,7 @@ describe('Table HOC', () => {
         });
 
         it('should dispatch a toggleCollapsible action with opened:true on mount when expandOnMount is set to true', () => {
-            const expectedAction = TableRowActions.toggleCollapsible(defaultProps.id, true);
+            const expectedAction = TableHOCRowActions.toggleCollapsible(defaultProps.id, true);
 
             store = createMockStore({
                 tableHOCRow: [{
@@ -292,7 +292,7 @@ describe('Table HOC', () => {
         });
 
         it('should dispatch a toggleCollapsible action with opened:true when changing from a non-collapsible to a collapsible row', () => {
-            const expectedAction = TableRowActions.toggleCollapsible(defaultProps.id, true);
+            const expectedAction = TableHOCRowActions.toggleCollapsible(defaultProps.id, true);
 
             store = createMockStore({
                 tableHOCRow: [{
@@ -323,7 +323,7 @@ describe('Table HOC', () => {
         });
 
         it('should not dispatch a toggleCollapsible action when changing from a non-collapsible to a collapsible row if expandOnMount is false', () => {
-            const actionNotExpected = TableRowActions.toggleCollapsible(defaultProps.id, true);
+            const actionNotExpected = TableHOCRowActions.toggleCollapsible(defaultProps.id, true);
 
             store = createMockStore({
                 tableHOCRow: [{

--- a/packages/react-vapor/src/components/table-hoc/tests/TableRowReducers.spec.ts
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableRowReducers.spec.ts
@@ -3,7 +3,7 @@ import * as _ from 'underscore';
 import {IReduxAction} from '../../../utils/ReduxUtils';
 import {changePage} from '../../navigation/pagination/NavigationPaginationActions';
 import {changePerPage} from '../../navigation/perPage/NavigationPerPageActions';
-import {ITableRowAddPayload, TableRowActions} from '../actions/TableRowActions';
+import {ITableRowAddPayload, TableHOCRowActions} from '../actions/TableHOCRowActions';
 import {ITableRowState, TableRowReducers} from '../reducers/TableRowReducers';
 
 describe('Table HOC', () => {
@@ -35,7 +35,7 @@ describe('Table HOC', () => {
                 {id: 'a', tableId: 'b', selected: true},
                 {id: 'ab', tableId: 'b', selected: true},
             ];
-            const action = TableRowActions.deselectAll('b');
+            const action = TableHOCRowActions.deselectAll('b');
 
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
 
@@ -43,11 +43,11 @@ describe('Table HOC', () => {
             expect(tableHeadersState).toEqual(newState);
         });
 
-        it('should return the old state with one more ITableRowState when the action is "TableRowActions.addTableRow"', () => {
+        it('should return the old state with one more ITableRowState when the action is "TableHOCRowActions.addTableRow"', () => {
             const expectedId = 'a';
             const expectedTableId = 'b';
             const expectedSelected = false;
-            const action = TableRowActions.add(expectedId, expectedTableId);
+            const action = TableHOCRowActions.add(expectedId, expectedTableId);
 
             const oldState: ITableRowState[] = [];
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
@@ -61,7 +61,7 @@ describe('Table HOC', () => {
             expect(headerState.selected).toBe(expectedSelected);
         });
 
-        it('should return the old state without the ITableRowState when the action is "TableRowActions.removeTableRow"', () => {
+        it('should return the old state without the ITableRowState when the action is "TableHOCRowActions.removeTableRow"', () => {
             const oldState: ITableRowState[] = [
                 {
                     id: 'some-table-header-1',
@@ -77,14 +77,14 @@ describe('Table HOC', () => {
                     selected: true,
                 },
             ];
-            const action = TableRowActions.remove(oldState[1].id);
+            const action = TableHOCRowActions.remove(oldState[1].id);
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
 
             expect(tableHeadersState.length).toBe(oldState.length - 1);
             expect(_.findWhere(tableHeadersState, {id: action.payload.id})).toBeUndefined();
         });
 
-        it('should set the selected on the table row when the action is "TableRowActions.selectRow"', () => {
+        it('should set the selected on the table row when the action is "TableHOCRowActions.selectRow"', () => {
             const oldState: ITableRowState[] = [
                 {
                     id: 'some-table-header-1',
@@ -97,7 +97,7 @@ describe('Table HOC', () => {
                 },
             ];
 
-            const action = TableRowActions.select(oldState[0].id, false);
+            const action = TableHOCRowActions.select(oldState[0].id, false);
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
 
             expect(tableHeadersState.length).toBe(oldState.length);
@@ -105,7 +105,7 @@ describe('Table HOC', () => {
             expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).selected).toBe(false);
         });
 
-        it('should set opened on the table row when the action is "TableRowActions.toggleCollapsible"', () => {
+        it('should set opened on the table row when the action is "TableHOCRowActions.toggleCollapsible"', () => {
             const oldState: ITableRowState[] = [
                 {
                     id: 'some-table-header-1',
@@ -118,7 +118,7 @@ describe('Table HOC', () => {
                 },
             ];
 
-            const action = TableRowActions.toggleCollapsible(oldState[0].id, true);
+            const action = TableHOCRowActions.toggleCollapsible(oldState[0].id, true);
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
 
             expect(tableHeadersState.length).toBe(oldState.length);
@@ -126,7 +126,7 @@ describe('Table HOC', () => {
             expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).opened).toBe(false);
         });
 
-        it('should toggle opened the row when the action is "TableRowActions.toggleCollapsible" and no opened payload is specified', () => {
+        it('should toggle opened the row when the action is "TableHOCRowActions.toggleCollapsible" and no opened payload is specified', () => {
             const oldState: ITableRowState[] = [
                 {
                     id: 'some-table-header-1',
@@ -139,7 +139,7 @@ describe('Table HOC', () => {
                 },
             ];
 
-            const action = TableRowActions.toggleCollapsible(oldState[0].id);
+            const action = TableHOCRowActions.toggleCollapsible(oldState[0].id);
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
 
             expect(tableHeadersState.length).toBe(oldState.length);
@@ -147,7 +147,7 @@ describe('Table HOC', () => {
             expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).opened).toBe(false);
         });
 
-        it('should collapse other rows of the same table row when the action is "TableRowActions.toggleCollapsible"', () => {
+        it('should collapse other rows of the same table row when the action is "TableHOCRowActions.toggleCollapsible"', () => {
             const oldState: ITableRowState[] = [
                 {
                     id: 'some-table-header-1',
@@ -162,7 +162,7 @@ describe('Table HOC', () => {
                 },
             ];
 
-            const action = TableRowActions.toggleCollapsible(oldState[1].id);
+            const action = TableHOCRowActions.toggleCollapsible(oldState[1].id);
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
 
             expect(tableHeadersState.length).toBe(oldState.length);
@@ -170,7 +170,7 @@ describe('Table HOC', () => {
             expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).opened).toBe(true);
         });
 
-        it('should not deselect other rows of the same table row when the action is "TableRowActions.selectRow" and multi is true', () => {
+        it('should not deselect other rows of the same table row when the action is "TableHOCRowActions.selectRow" and multi is true', () => {
             const oldState: ITableRowState[] = [
                 {
                     id: 'some-table-header-1',
@@ -183,7 +183,7 @@ describe('Table HOC', () => {
                 },
             ];
 
-            const action = TableRowActions.select(oldState[0].id, true);
+            const action = TableHOCRowActions.select(oldState[0].id, true);
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
 
             expect(tableHeadersState.length).toBe(oldState.length);
@@ -191,7 +191,7 @@ describe('Table HOC', () => {
             expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).selected).toBe(true);
         });
 
-        it('should not collapse other rows of the same table row when the action is "TableRowActions.toggleCollapsibel"', () => {
+        it('should not collapse other rows of the same table row when the action is "TableHOCRowActions.toggleCollapsibel"', () => {
             const oldState: ITableRowState[] = [
                 {
                     id: 'some-table-header-1',
@@ -206,14 +206,14 @@ describe('Table HOC', () => {
                 },
             ];
 
-            const action = TableRowActions.toggleCollapsible(oldState[0].id);
+            const action = TableHOCRowActions.toggleCollapsible(oldState[0].id);
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
 
             expect(tableHeadersState.length).toBe(oldState.length);
             expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).opened).toBe(true);
         });
 
-        it('should not modify the selected for the other tables when the action is "TableRowActions.selectRow"', () => {
+        it('should not modify the selected for the other tables when the action is "TableHOCRowActions.selectRow"', () => {
             const oldState: ITableRowState[] = [
                 {
                     id: 'some-table-header',
@@ -226,21 +226,21 @@ describe('Table HOC', () => {
                 },
             ];
 
-            const action = TableRowActions.select(oldState[0].id);
+            const action = TableHOCRowActions.select(oldState[0].id);
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
             expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).selected).toBe(oldState[1].selected);
         });
 
         it('should not throw on toggleCollapsible if the table row does not exists', () => {
             const oldState: ITableRowState[] = [];
-            const action = TableRowActions.toggleCollapsible('To toggle or not to toggle');
+            const action = TableHOCRowActions.toggleCollapsible('To toggle or not to toggle');
 
             expect(() => TableRowReducers(oldState, action)).not.toThrow();
         });
 
         it('should not throw on select if the table row does not exists', () => {
             const oldState: ITableRowState[] = [];
-            const action = TableRowActions.select('To be or not to be');
+            const action = TableHOCRowActions.select('To be or not to be');
 
             expect(() => TableRowReducers(oldState, action)).not.toThrow();
         });


### PR DESCRIPTION
`TableRowActions` is defined in both Table and Table HOC, and this causes great confusion downstream. Or at least I think :)