### PR TITLE
Fix the getReactNodeTextContent util

### DIFF
--- a/packages/react-vapor/src/utils/JSXUtils.spec.tsx
+++ b/packages/react-vapor/src/utils/JSXUtils.spec.tsx
@@ -17,7 +17,7 @@ describe('JSXUtils', () => {
                     <div>
                         {'Hello there!    '}
                         <span>
-                            {'Can you see me? '}
+                            {' Can you see me? '}
                             <span>I can.</span>
                         </span>
                     </div>

--- a/packages/react-vapor/src/utils/JSXUtils.tsx
+++ b/packages/react-vapor/src/utils/JSXUtils.tsx
@@ -7,7 +7,7 @@ export type JSXRenderable = JSX.Element | JSX.Element[] | string | number;
 
 export const getReactNodeTextContent = (node: React.ReactNode): string => {
     return _.compose(
-        s.stripTags,
-        s.clean
+        s.clean,
+        s.stripTags
     )(renderToStaticMarkup(<div>{node}</div>));
 };


### PR DESCRIPTION
### Proposed Changes

`getReactNodeTextContent` was not stripping consecutive whitespaces on different nodes, because of the order of the functions inside the `_.compose`

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
