### PR TITLE
add valid js for ie 11 in svgWrapper file

### DIFF
--- a/packages/vapor/gulpfile.js
+++ b/packages/vapor/gulpfile.js
@@ -125,7 +125,7 @@ const svgTemplate = (key, svgString) => `
     ${key}: {
         name: "${key}",
         svgString: ${svgString},
-        render: (...args) => svgWrapper(svg.${key}.svgString, ...args)
+        render: function(svgClass, spanClass, title, attr){ return svgWrapper(svg.${key}.svgString, svgClass, spanClass, title, attr)},
     },`;
 
 function Dictionary(from) {

--- a/packages/vapor/svgWrapper.js
+++ b/packages/vapor/svgWrapper.js
@@ -27,17 +27,23 @@ function renderSvg(svgString, svgClass, attr) {
     return '<svg class="' + svgClass + '"></svg>';
 }
 
-export function svgWrapper(svgString, svgClass = '', spanClass = '', title = '', attr = {}) {
+export function svgWrapper(svgString, svgClass, spanClass, title, attr) {
     if (svgString.indexOf('#coveo-icon-') !== -1) {
         const svgNameFormatted = formatSvgName(svgString.replace('#coveo-icon-', ''));
         if (!_.isUndefined(svgEnum[svgNameFormatted])) {
-            return svgEnum[svgNameFormatted].render(svgClass, spanClass, title, attr);
+            return svgEnum[svgNameFormatted].render(svgClass || '', spanClass || '', title || '', attr || '');
         }
     }
 
     const titleToDisplay = title ? 'title="' + title + '"' : '';
     const spanClassAttribute = spanClass ? 'class="' + spanClass + '"' : '';
     return (
-        '<span ' + spanClassAttribute + ' ' + titleToDisplay + '>' + renderSvg(svgString, svgClass, attr) + '</span>'
+        '<span ' +
+        spanClassAttribute +
+        ' ' +
+        titleToDisplay +
+        '>' +
+        renderSvg(svgString || '', svgClass || '', attr || '') +
+        '</span>'
     );
 }


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->

### Potential Breaking Changes
- spread syntax is not available with ie 11 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Browser_compatibility
- default parameter is not available with ie 11
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters#Browser_compatibility

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
