### PR TITLE
Remove HTML entities in getTextContent util

### DIFF
--- a/packages/react-vapor/src/utils/JSXUtils.spec.tsx
+++ b/packages/react-vapor/src/utils/JSXUtils.spec.tsx
@@ -17,12 +17,12 @@ describe('JSXUtils', () => {
                     <div>
                         {'Hello there!    '}
                         <span>
-                            {' Can you see me? '}
+                            {" Can't you see me? "}
                             <span>I can.</span>
                         </span>
                     </div>
                 )
-            ).toBe('Hello there! Can you see me? I can.');
+            ).toBe("Hello there! Can't you see me? I can.");
         });
     });
 });

--- a/packages/react-vapor/src/utils/JSXUtils.tsx
+++ b/packages/react-vapor/src/utils/JSXUtils.tsx
@@ -3,11 +3,14 @@ import {renderToStaticMarkup} from 'react-dom/server';
 import * as _ from 'underscore';
 import * as s from 'underscore.string';
 
+import {decodeHtml} from './InputUtils';
+
 export type JSXRenderable = JSX.Element | JSX.Element[] | string | number;
 
 export const getReactNodeTextContent = (node: React.ReactNode): string => {
     return _.compose(
         s.clean,
+        decodeHtml,
         s.stripTags
     )(renderToStaticMarkup(<div>{node}</div>));
 };


### PR DESCRIPTION
### Proposed Changes

Remove HTML entities generated by renderToStaticMarkup function, because we were getting display issues with `'`: 
```
Expected 'Hello there! Can&#x27;t you see me? I can.' to be 'Hello there! Can't you see me? I can.'
```

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
