### PR TITLE
Refactor title component + button style fix

### DIFF
--- a/packages/react-vapor/src/components/headers/BasicHeader.tsx
+++ b/packages/react-vapor/src/components/headers/BasicHeader.tsx
@@ -21,7 +21,7 @@ export class BasicHeader extends React.Component<IBasicHeaderProps, {}> {
     render() {
         return (
             <HeaderWrapper {..._.omit(this.props, 'title')}>
-                <Title {...this.props.title} />
+                <Title {...this.props.title}>{this.props.children}</Title>
             </HeaderWrapper>
         );
     }

--- a/packages/react-vapor/src/components/title/Title.tsx
+++ b/packages/react-vapor/src/components/title/Title.tsx
@@ -5,7 +5,7 @@ import * as _ from 'underscore';
 import {ILinkSvgProps, LinkSvg} from '../svg/LinkSvg';
 import {Tooltip} from '../tooltip/Tooltip';
 
-export interface ITitleProps extends React.ClassAttributes<Title> {
+export interface ITitleProps {
     prefix?: string;
     text: string;
     withTitleTooltip?: boolean;
@@ -13,45 +13,33 @@ export interface ITitleProps extends React.ClassAttributes<Title> {
     classes?: string[];
 }
 
-export class Title extends React.Component<ITitleProps, {}> {
-    static defaultProps: Partial<ITitleProps> = {
-        prefix: '',
-        withTitleTooltip: false,
-    };
+export const Title: React.FunctionComponent<ITitleProps> = (props) => {
+    const linkClasses = classNames('inline-doc-link', props.documentationLink && props.documentationLink.linkClasses);
+    const titleClasses: string = classNames('bold', 'text-medium-blue', 'mr1', 'truncate', props.classes);
+    const prefixClasses: string = classNames({mr1: !_.isEmpty(props.prefix)});
 
-    private getLinkIcon(): JSX.Element {
-        if (!this.props.documentationLink) {
-            return null;
-        }
+    const linkIcon = props.documentationLink && <LinkSvg {...props.documentationLink} linkClasses={[linkClasses]} />;
+    const title = props.withTitleTooltip ? (
+        <Tooltip title={props.text} placement="left">
+            {props.text}
+        </Tooltip>
+    ) : (
+        props.text
+    );
 
-        const linkClasses = classNames('inline-doc-link', this.props.documentationLink.linkClasses).split(' ');
+    return (
+        <div className="flex flex-center full-content-x">
+            <h1 className={titleClasses}>
+                <span className={prefixClasses}>{props.prefix}</span>
+                {title}
+            </h1>
+            {linkIcon}
+            {props.children}
+        </div>
+    );
+};
 
-        return <LinkSvg {...this.props.documentationLink} linkClasses={linkClasses} />;
-    }
-
-    render() {
-        const prefixClasses: string = classNames({
-            mr1: !_.isEmpty(this.props.prefix),
-        });
-
-        const titleClasses: string = classNames('bold', 'text-medium-blue', 'mr1', 'truncate', this.props.classes);
-
-        const title = this.props.withTitleTooltip ? (
-            <Tooltip title={this.props.text} placement="left">
-                {this.props.text}
-            </Tooltip>
-        ) : (
-            this.props.text
-        );
-
-        return (
-            <div className="flex flex-center full-content-x">
-                <h1 className={titleClasses}>
-                    <span className={prefixClasses}>{this.props.prefix}</span>
-                    {title}
-                </h1>
-                {this.getLinkIcon()}
-            </div>
-        );
-    }
-}
+Title.defaultProps = {
+    prefix: '',
+    withTitleTooltip: false,
+};

--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -72,7 +72,7 @@
 
     &.mod-small {
         height: $button-small-height;
-        padding: 0 $button-small-padding-x;
+        padding: $button-small-padding-y $button-small-padding-x;
         font-size: $button-small-font-size;
         line-height: $button-small-line-height;
     }

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -56,6 +56,7 @@ $button-margin-width: 10px;
 $button-small-font-size: 11px;
 $button-small-line-height: 14px;
 $button-small-padding-x: 10px;
+$button-small-padding-y: 4px;
 $button-small-height: 24px;
 $button-large-height: 50px;
 $button-confirm-icon-width: 15px;


### PR DESCRIPTION
### Proposed Changes

- Enable to pass down children to `Title` component
- Fix the `Button` mod-small padding when using as link:
Before: 
![image](https://user-images.githubusercontent.com/35579930/60685655-44d85780-9e72-11e9-8d01-2f14092f4196.png)
After: 
![image](https://user-images.githubusercontent.com/35579930/60685664-54f03700-9e72-11e9-9511-c1aff52ce2ab.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
