### PR TITLE
withServerSideProcessing HOC

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
@@ -1,10 +1,13 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
+
+import {WithServerSideProcessingProps} from '../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {ActionBarConnected} from '../actions/ActionBarConnected';
 
-export interface IMaybeServerConfig {
-    isServer?: boolean;
-}
+/**
+ * @deprecated Use WithServerSideProcessingProps directly instead
+ */
+export type IMaybeServerConfig = WithServerSideProcessingProps;
 
 export interface ITableHOCOwnProps {
     id: string;

--- a/packages/react-vapor/src/components/table-hoc/examples/TableHOCServerExamples.tsx
+++ b/packages/react-vapor/src/components/table-hoc/examples/TableHOCServerExamples.tsx
@@ -2,6 +2,7 @@ import * as moment from 'moment';
 import * as React from 'react';
 import * as _ from 'underscore';
 
+import {withServerSideProcessing} from '../../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {DateUtils} from '../../../utils/DateUtils';
 import {IDispatch, ReduxConnect} from '../../../utils/ReduxUtils';
 import {IReactVaporTestState} from '../../../utils/tests/TestUtils';
@@ -22,22 +23,20 @@ import {tableWithSort} from '../TableWithSort';
 import {IExampleRowData, TableHOCServerActions} from './TableHOCServerExampleReducer';
 
 const ServerTable = _.compose(
+    withServerSideProcessing,
     tableWithBlankSlate({title: 'No data caused the table to be empty'}),
     tableWithPredicate({
         id: 'address.city',
         prepend: <span className="mr1 text-medium-grey">City:</span>,
-        isServer: true,
         values: [{displayValue: 'All', value: '', selected: true}, {displayValue: 'Lebsackbury', value: 'Lebsackbury'}],
     }),
     tableWithPredicate({
         id: 'username',
         prepend: <span className="mr1 text-medium-grey">Username:</span>,
-        isServer: true,
         values: [{displayValue: 'All', value: '', selected: true}, {displayValue: 'bret', value: 'Bret'}],
     }),
-    tableWithFilter({isServer: true}),
+    tableWithFilter(),
     tableWithDatePicker({
-        isServer: true,
         datesSelectionBoxes: SELECTION_BOXES_LONG,
         years: [...DateUtils.getPreviousYears(25), DateUtils.currentYear.toString()],
         initialDateRange: [
@@ -48,8 +47,8 @@ const ServerTable = _.compose(
         ],
     }),
     tableWithBlankSlate({title: 'Filter caused the table to be empty'}),
-    tableWithSort({isServer: true}),
-    tableWithPagination({isServer: true, perPageNumbers: [3, 5, 10]}),
+    tableWithSort(),
+    tableWithPagination({perPageNumbers: [3, 5, 10]}),
     tableWithActions()
 )(TableHOC);
 

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithDatePicker.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithDatePicker.spec.tsx
@@ -3,6 +3,7 @@ import * as moment from 'moment';
 import * as React from 'react';
 import * as _ from 'underscore';
 
+import {withServerSideProcessing} from '../../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {ITableHOCProps, TableHOC} from '../TableHOC';
 import {FilterableTableComponent, tableWithDatePicker} from '../TableWithDatePicker';
 
@@ -92,13 +93,18 @@ describe('Table HOC', () => {
         });
 
         describe('when server side', () => {
-            const TableWithDatePickerServer = _.compose(tableWithDatePicker({isServer: true}))(TableHOC);
+            const TableWithDatePickerServer = _.compose(
+                withServerSideProcessing,
+                tableWithDatePicker()
+            )(TableHOC);
 
             it('should not filter out elements if the date picker is server side', () => {
                 const wrapper = shallowWithState(
                     <TableWithDatePickerServer {...defaultProps} />,
                     getStateWithDatePicker(new Date())
-                ).dive();
+                )
+                    .dive()
+                    .dive();
 
                 const tableData = wrapper.find(TableHOC).prop('data');
 
@@ -113,7 +119,9 @@ describe('Table HOC', () => {
                 const wrapper = shallowWithState(
                     <TableWithDatePickerServer {...defaultProps} onUpdate={updateSpy} />,
                     getStateWithDatePicker(lowerLimit)
-                ).dive();
+                )
+                    .dive()
+                    .dive();
 
                 wrapper.setProps({lowerLimit: new Date()});
                 wrapper.update();
@@ -132,7 +140,9 @@ describe('Table HOC', () => {
                 const wrapper = shallowWithState(
                     <TableWithDatePickerServer {...defaultProps} onUpdate={updateSpy} />,
                     getStateWithDatePicker(lowerLimit, upperLimit)
-                ).dive();
+                )
+                    .dive()
+                    .dive();
 
                 wrapper.setProps({upperLimit: new Date()});
                 wrapper.update();
@@ -148,7 +158,9 @@ describe('Table HOC', () => {
                 const wrapper = shallowWithState(
                     <TableWithDatePickerServer {...defaultProps} onUpdate={updateSpy} />,
                     getStateWithDatePicker(lowerLimit, new Date())
-                ).dive();
+                )
+                    .dive()
+                    .dive();
 
                 wrapper.setProps({ignore: true});
                 wrapper.update();

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithFilter.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithFilter.spec.tsx
@@ -1,6 +1,8 @@
 import {shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
 import * as _ from 'underscore';
+
+import {withServerSideProcessing} from '../../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {ITableHOCProps, TableHOC} from '../TableHOC';
 import {tableWithFilter} from '../TableWithFilter';
 
@@ -40,14 +42,19 @@ describe('Table HOC', () => {
         });
 
         describe('when server side', () => {
-            const TableWithFilterServer = _.compose(tableWithFilter({isServer: true}))(TableHOC);
+            const TableWithFilterServer = _.compose(
+                withServerSideProcessing,
+                tableWithFilter()
+            )(TableHOC);
 
             it('should not filter out elements if the filter is server side', () => {
                 const filterText = 'b';
                 const wrapper = shallowWithState(
                     <TableWithFilterServer {...defaultProps} />,
                     getStateWithFilter(filterText)
-                ).dive();
+                )
+                    .dive()
+                    .dive();
 
                 const tableData = wrapper.find(TableHOC).prop('data');
 
@@ -60,7 +67,9 @@ describe('Table HOC', () => {
                 const wrapper = shallowWithState(
                     <TableWithFilterServer {...defaultProps} onUpdate={updateSpy} />,
                     getStateWithFilter(filterText)
-                ).dive();
+                )
+                    .dive()
+                    .dive();
 
                 wrapper.setProps({filter: 'a'});
                 wrapper.update();
@@ -74,7 +83,9 @@ describe('Table HOC', () => {
                 const wrapper = shallowWithState(
                     <TableWithFilterServer {...defaultProps} onUpdate={updateSpy} />,
                     getStateWithFilter(filterText)
-                ).dive();
+                )
+                    .dive()
+                    .dive();
 
                 wrapper.setProps({ignore: true});
                 wrapper.update();

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithPagination.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithPagination.spec.tsx
@@ -2,6 +2,8 @@ import {shallowWithStore} from 'enzyme-redux';
 import * as React from 'react';
 import {createMockStore, mockStore} from 'redux-test-utils';
 import * as _ from 'underscore';
+
+import {withServerSideProcessing} from '../../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {IReactVaporState} from '../../../ReactVapor';
 import {turnOffLoading} from '../../loading/LoadingActions';
 import {NavigationConnected} from '../../navigation/NavigationConnected';
@@ -101,14 +103,19 @@ describe('Table HOC', () => {
             });
 
             describe('when server side', () => {
-                const TableWithPaginationServer = _.compose(tableWithPagination({isServer: true}))(TableHOC);
+                const TableWithPaginationServer = _.compose(
+                    withServerSideProcessing,
+                    tableWithPagination()
+                )(TableHOC);
 
                 it('should not slice data', () => {
                     const perPage = 3;
                     const page = 2;
 
                     store = getStoreWithPage(page, perPage);
-                    const wrapper = shallowWithStore(<TableWithPaginationServer {...defaultProps} />, store).dive();
+                    const wrapper = shallowWithStore(<TableWithPaginationServer {...defaultProps} />, store)
+                        .dive()
+                        .dive();
                     const tableData = wrapper.find(TableHOC).prop('data');
                     expect(tableData).toEqual(defaultProps.data);
                 });
@@ -122,7 +129,9 @@ describe('Table HOC', () => {
                     const wrapper = shallowWithStore(
                         <TableWithPaginationServer {...defaultProps} onUpdate={updateSpy} />,
                         store
-                    ).dive();
+                    )
+                        .dive()
+                        .dive();
 
                     wrapper.setProps({pageNb: initialPage + 1});
                     wrapper.update();
@@ -142,7 +151,9 @@ describe('Table HOC', () => {
                     const wrapper = shallowWithStore(
                         <TableWithPaginationServer {...defaultProps} onUpdate={updateSpy} />,
                         store
-                    ).dive();
+                    )
+                        .dive()
+                        .dive();
 
                     wrapper.setProps({ignore: true});
                     wrapper.update();

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithPredicate.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithPredicate.spec.tsx
@@ -1,6 +1,8 @@
 import {shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
 import * as _ from 'underscore';
+
+import {withServerSideProcessing} from '../../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {ITableHOCProps, TableHOC} from '../TableHOC';
 import {TableHOCUtils} from '../TableHOCUtils';
 import {tableWithPredicate} from '../TableWithPredicate';
@@ -56,7 +58,8 @@ describe('Table HOC', () => {
 
         describe('when server side', () => {
             const TableWithPredicateServer = _.compose(
-                tableWithPredicate({id: predicateId, isServer: true, values: predicateValues})
+                withServerSideProcessing,
+                tableWithPredicate({id: predicateId, values: predicateValues})
             )(TableHOC);
 
             it('should not filter out elements', () => {
@@ -64,7 +67,9 @@ describe('Table HOC', () => {
                 const wrapper = shallowWithState(
                     <TableWithPredicateServer {...defaultProps} />,
                     getStateWithPredicate(predicate)
-                ).dive();
+                )
+                    .dive()
+                    .dive();
 
                 const tableData = wrapper.find(TableHOC).prop('data');
 
@@ -77,7 +82,9 @@ describe('Table HOC', () => {
                 const wrapper = shallowWithState(
                     <TableWithPredicateServer {...defaultProps} onUpdate={updateSpy} />,
                     getStateWithPredicate(predicate)
-                ).dive();
+                )
+                    .dive()
+                    .dive();
 
                 wrapper.setProps({predicate: predicateValues[0].value});
                 wrapper.update();
@@ -91,7 +98,9 @@ describe('Table HOC', () => {
                 const wrapper = shallowWithState(
                     <TableWithPredicateServer {...defaultProps} onUpdate={updateSpy} />,
                     getStateWithPredicate(predicate)
-                ).dive();
+                )
+                    .dive()
+                    .dive();
 
                 wrapper.setProps({ignore: true});
                 wrapper.update();

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithSort.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithSort.spec.tsx
@@ -1,6 +1,7 @@
 import {shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
 import * as _ from 'underscore';
+import {withServerSideProcessing} from '../../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {ITableHOCProps, TableHOC} from '../TableHOC';
 import {tableWithSort} from '../TableWithSort';
 
@@ -55,13 +56,18 @@ describe('Table HOC', () => {
         });
 
         describe('when server side', () => {
-            const TableWithPredicateServer = _.compose(tableWithSort({isServer: true}))(TableHOC);
+            const TableWithPredicateServer = _.compose(
+                withServerSideProcessing,
+                tableWithSort()
+            )(TableHOC);
 
             it('should not sort elements', () => {
                 const wrapper = shallowWithState(
                     <TableWithPredicateServer {...defaultProps} />,
                     getStateWithSort(true, 'value')
-                ).dive();
+                )
+                    .dive()
+                    .dive();
 
                 const tableData = wrapper.find(TableHOC).prop('data');
 
@@ -73,7 +79,9 @@ describe('Table HOC', () => {
                 const wrapper = shallowWithState(
                     <TableWithPredicateServer {...defaultProps} onUpdate={updateSpy} />,
                     getStateWithSort(true, 'value')
-                ).dive();
+                )
+                    .dive()
+                    .dive();
 
                 wrapper.setProps({isAsc: false});
                 wrapper.update();
@@ -86,7 +94,9 @@ describe('Table HOC', () => {
                 const wrapper = shallowWithState(
                     <TableWithPredicateServer {...defaultProps} onUpdate={updateSpy} />,
                     getStateWithSort(true, 'value')
-                ).dive();
+                )
+                    .dive()
+                    .dive();
 
                 wrapper.setProps({ignore: true});
                 wrapper.update();

--- a/packages/react-vapor/src/hoc/withServerSideProcessing/withServerSideProcessing.spec.tsx
+++ b/packages/react-vapor/src/hoc/withServerSideProcessing/withServerSideProcessing.spec.tsx
@@ -1,0 +1,28 @@
+import {shallow} from 'enzyme';
+import * as React from 'react';
+
+import {withServerSideProcessing} from './withServerSideProcessing';
+
+describe('withServerSideProcessing', () => {
+    const Component = () => <div>I am a component</div>;
+
+    it('should not throw when creating the HOC component', () => {
+        expect(() => {
+            withServerSideProcessing(Component);
+        }).not.toThrow();
+    });
+
+    it('should not throw when rendering the HOC component', () => {
+        expect(() => {
+            const ComponentWithServerSideProcessing = withServerSideProcessing(Component);
+            shallow(<ComponentWithServerSideProcessing />);
+        }).not.toThrow();
+    });
+
+    it('should set the "isServer" prop to true on the wrapped component', () => {
+        const ComponentWithServerSideProcessing = withServerSideProcessing(Component);
+        const wrapper = shallow(<ComponentWithServerSideProcessing />);
+
+        expect(wrapper.props().isServer).toBe(true);
+    });
+});

--- a/packages/react-vapor/src/hoc/withServerSideProcessing/withServerSideProcessing.tsx
+++ b/packages/react-vapor/src/hoc/withServerSideProcessing/withServerSideProcessing.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export interface WithServerSideProcessingProps {
+    isServer?: boolean;
+}
+
+export function withServerSideProcessing<T extends {}>(
+    WrappedComponent: React.ComponentType<T>
+): React.ComponentType<T & WithServerSideProcessingProps> {
+    return (props: T) => <WrappedComponent {...props} isServer />;
+}


### PR DESCRIPTION
### Proposed Changes

Implemented the `withServerSideProcessing` HOC. It removes the need to specify `{isServer: true}` in every subsequent HOC configs.

See [TableHOCServerExamples.tsx](https://github.com/coveo/react-vapor/pull/1194/files#diff-63800e89d7e668fdf8d0bcd1e917c234) for an example of what I'm talking about.

### Potential Breaking Changes

None, I made this change fully retro-compatible with the old way of doing things.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
