### PR TITLE
Support withServerSideProcessing in SelectWithPredicate

### DIFF
--- a/packages/react-vapor/src/components/select/SelectComponents.tsx
+++ b/packages/react-vapor/src/components/select/SelectComponents.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import {IMultiSelectOwnProps, MultiSelectConnected} from './MultiSelectConnected';
 import {ISelectWithFilterProps, selectWithFilter} from './SelectWithFilter';
 import {ISelectWithPredicateProps, selectWithPredicate} from './SelectWithPredicate';
@@ -9,23 +10,23 @@ type ButtonHTMLAttributes = React.ButtonHTMLAttributes<HTMLButtonElement>;
 export interface ISelectWithPredicateAndFilterProps extends ISelectWithFilterProps, ISelectWithPredicateProps {}
 
 // Single Select
-export const SingleSelectWithFilter: React.ComponentClass<
+export const SingleSelectWithFilter: React.ComponentType<
     ISelectWithFilterProps & ISingleSelectOwnProps & ButtonHTMLAttributes
 > = selectWithFilter(SingleSelectConnected);
-export const SingleSelectWithPredicate: React.ComponentClass<
+export const SingleSelectWithPredicate: React.ComponentType<
     ISelectWithPredicateProps & ISingleSelectOwnProps & ButtonHTMLAttributes
 > = selectWithPredicate(SingleSelectConnected);
-export const SingleSelectWithPredicateAndFilter: React.ComponentClass<
+export const SingleSelectWithPredicateAndFilter: React.ComponentType<
     ISelectWithPredicateAndFilterProps & ISingleSelectOwnProps & ButtonHTMLAttributes
 > = selectWithPredicate(selectWithFilter(SingleSelectConnected));
 
 // Multi Select
-export const MultiSelectWithFilter: React.ComponentClass<
+export const MultiSelectWithFilter: React.ComponentType<
     ISelectWithFilterProps & IMultiSelectOwnProps & ButtonHTMLAttributes
 > = selectWithFilter(MultiSelectConnected);
-export const MultiSelectWithPredicate: React.ComponentClass<
+export const MultiSelectWithPredicate: React.ComponentType<
     ISelectWithPredicateProps & IMultiSelectOwnProps & ButtonHTMLAttributes
 > = selectWithPredicate(MultiSelectConnected);
-export const MultiSelectWithPredicateAndFilter: React.ComponentClass<
+export const MultiSelectWithPredicateAndFilter: React.ComponentType<
     ISelectWithPredicateAndFilterProps & IMultiSelectOwnProps & ButtonHTMLAttributes
 > = selectWithPredicate(selectWithFilter(MultiSelectConnected));

--- a/packages/react-vapor/src/components/select/SelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SelectConnected.tsx
@@ -32,6 +32,7 @@ export interface ISelectOwnProps {
     items?: IItemBoxProps[];
     hasFocusableChild?: boolean;
     disabled?: boolean;
+    onUpdate?: () => void;
 }
 
 export interface ISelectStateProps {

--- a/packages/react-vapor/src/components/select/SelectWithPredicate.tsx
+++ b/packages/react-vapor/src/components/select/SelectWithPredicate.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
+import {connect} from 'react-redux';
 import {keys} from 'ts-transformer-keys';
 import * as _ from 'underscore';
+
+import {WithServerSideProcessingProps} from '../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {IReactVaporState} from '../../ReactVapor';
-import {ReduxConnect} from '../../utils/ReduxUtils';
+import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {FlatSelectConnected} from '../flatSelect/FlatSelectConnected';
 import {IFlatSelectOptionProps} from '../flatSelect/FlatSelectOption';
+import {FlatSelectSelectors} from '../flatSelect/FlatSelectSelectors';
 import {IItemBoxProps} from '../itemBox/ItemBox';
 import {ISelectProps} from './SelectConnected';
 
@@ -13,44 +17,58 @@ export interface ISelectWithPredicateOwnProps {
     matchPredicate: (predicate: string, item: IItemBoxProps) => boolean;
 }
 const SelectWithPredicatePropsToOmit = keys<ISelectWithPredicateOwnProps>();
+interface SelectWithPredicateStateProps {
+    predicate: string;
+    items: IItemBoxProps[];
+}
 
-export interface ISelectWithPredicateProps extends ISelectWithPredicateOwnProps, ISelectProps {}
+export interface ISelectWithPredicateProps
+    extends ISelectWithPredicateOwnProps,
+        ISelectProps,
+        Partial<SelectWithPredicateStateProps>,
+        WithServerSideProcessingProps {}
 
 export const selectWithPredicate = (
-    Component: React.ComponentClass<ISelectProps> | React.StatelessComponent<ISelectProps>
-): React.ComponentClass<ISelectWithPredicateProps> => {
-    const mapStateToProps = (state: IReactVaporState, ownProps: ISelectWithPredicateProps): Partial<ISelectProps> => {
-        const flatSelect = _.findWhere(state.flatSelect, {id: ownProps.id});
-        const predicate = (flatSelect && flatSelect.selectedOptionId) || ownProps.options[0].id;
+    Component: React.ComponentType<ISelectProps>
+): React.ComponentType<ISelectWithPredicateProps> => {
+    const mapStateToProps = (
+        state: IReactVaporState,
+        ownProps: ISelectWithPredicateProps
+    ): SelectWithPredicateStateProps => {
+        const predicate = FlatSelectSelectors.getSelectedOptionId(state, {id: ownProps.id}) || ownProps.options[0].id;
 
-        const items = _.map(ownProps.items, (item: IItemBoxProps) => {
-            const visible = ownProps.matchPredicate(predicate, item);
+        const items = ownProps.isServer
+            ? ownProps.items
+            : _.map(ownProps.items, (item: IItemBoxProps) => {
+                  const visible = ownProps.matchPredicate(predicate, item);
 
-            return {...item, hidden: !visible || item.hidden};
-        });
+                  return {...item, hidden: !visible || item.hidden};
+              });
 
         return {
             items,
+            predicate,
         };
     };
 
-    @ReduxConnect(mapStateToProps)
-    class WrappedComponent extends React.Component<ISelectWithPredicateProps> {
-        render() {
-            return (
-                <Component {..._.omit(this.props, SelectWithPredicatePropsToOmit)}>
-                    <FlatSelectConnected
-                        id={this.props.id}
-                        classes={['full-content-x']}
-                        options={this.props.options}
-                        group
-                        optionPicker
-                    />
-                    {this.props.children}
-                </Component>
-            );
-        }
-    }
+    const WrappedComponent: React.FunctionComponent<ISelectWithPredicateProps> = (props) => {
+        React.useEffect(() => {
+            callIfDefined(props.onUpdate);
+        }, [props.predicate, props.onUpdate]);
 
-    return WrappedComponent;
+        return (
+            <Component {..._.omit(props, SelectWithPredicatePropsToOmit)}>
+                <FlatSelectConnected
+                    id={props.id}
+                    classes={['full-content-x']}
+                    options={props.options}
+                    group
+                    optionPicker
+                />
+                {props.children}
+            </Component>
+        );
+    };
+
+    return connect(mapStateToProps)(WrappedComponent);
 };

--- a/packages/react-vapor/src/components/select/SelectWithPredicate.tsx
+++ b/packages/react-vapor/src/components/select/SelectWithPredicate.tsx
@@ -70,5 +70,7 @@ export const selectWithPredicate = (
         );
     };
 
+    WrappedComponent.displayName = `withPredicate(${Component.displayName})`;
+
     return connect(mapStateToProps)(WrappedComponent);
 };

--- a/packages/react-vapor/src/components/select/SelectWithPredicate.tsx
+++ b/packages/react-vapor/src/components/select/SelectWithPredicate.tsx
@@ -31,26 +31,6 @@ export interface ISelectWithPredicateProps
 export const selectWithPredicate = (
     Component: React.ComponentType<ISelectProps>
 ): React.ComponentType<ISelectWithPredicateProps> => {
-    const mapStateToProps = (
-        state: IReactVaporState,
-        ownProps: ISelectWithPredicateProps
-    ): SelectWithPredicateStateProps => {
-        const predicate = FlatSelectSelectors.getSelectedOptionId(state, {id: ownProps.id}) || ownProps.options[0].id;
-
-        const items = ownProps.isServer
-            ? ownProps.items
-            : _.map(ownProps.items, (item: IItemBoxProps) => {
-                  const visible = ownProps.matchPredicate(predicate, item);
-
-                  return {...item, hidden: !visible || item.hidden};
-              });
-
-        return {
-            items,
-            predicate,
-        };
-    };
-
     const WrappedComponent: React.FunctionComponent<ISelectWithPredicateProps> = (props) => {
         React.useEffect(() => {
             callIfDefined(props.onUpdate);
@@ -74,3 +54,20 @@ export const selectWithPredicate = (
 
     return connect(mapStateToProps)(WrappedComponent);
 };
+
+function mapStateToProps(state: IReactVaporState, ownProps: ISelectWithPredicateProps): SelectWithPredicateStateProps {
+    const predicate = FlatSelectSelectors.getSelectedOptionId(state, {id: ownProps.id}) || ownProps.options[0].id;
+
+    const items = ownProps.isServer
+        ? ownProps.items
+        : _.map(ownProps.items, (item: IItemBoxProps) => {
+              const visible = ownProps.matchPredicate(predicate, item);
+
+              return {...item, hidden: !visible || item.hidden};
+          });
+
+    return {
+        items,
+        predicate,
+    };
+}

--- a/packages/react-vapor/src/components/select/tests/MultiSelectWithPredicate.spec.tsx
+++ b/packages/react-vapor/src/components/select/tests/MultiSelectWithPredicate.spec.tsx
@@ -59,7 +59,9 @@ describe('Select', () => {
 
         afterEach(() => {
             store.dispatch(clearState());
-            wrapper.detach();
+            if (wrapper && wrapper.exists()) {
+                wrapper.detach();
+            }
         });
 
         describe('mount and unmount', () => {
@@ -171,6 +173,22 @@ describe('Select', () => {
                     .dive()
                     .dive();
                 expect(component.props().items).toEqual(items);
+            });
+
+            it('should trigger the onUpdate prop when the selected predicate changes', () => {
+                const onUpdateSpy = jasmine.createSpy('onUpdate');
+                const component: ShallowWrapper<ISelectWithPredicateProps> = shallowWithStore(
+                    <ServerSideMultiSelectWithPredicates {...basicProps} onUpdate={onUpdateSpy} />,
+                    store
+                )
+                    .dive()
+                    .dive();
+
+                expect(onUpdateSpy).not.toHaveBeenCalled();
+
+                component.setProps({predicate: 'some-other-predicate'});
+
+                expect(onUpdateSpy).not.toHaveBeenCalledTimes(1);
             });
         });
     });

--- a/packages/react-vapor/src/components/select/tests/MultiSelectWithPredicate.spec.tsx
+++ b/packages/react-vapor/src/components/select/tests/MultiSelectWithPredicate.spec.tsx
@@ -21,7 +21,7 @@ import {MultiSelectWithPredicate} from '../SelectComponents';
 import {SelectConnected} from '../SelectConnected';
 import {ISelectWithPredicateProps, selectWithPredicate} from '../SelectWithPredicate';
 
-fdescribe('Select', () => {
+describe('Select', () => {
     describe('<MultiSelectWithPredicate />', () => {
         let wrapper: ReactWrapper<any, any>;
         let multiSelect: ReactWrapper<IMultiSelectProps, void>;

--- a/packages/react-vapor/src/components/select/tests/MultiSelectWithPredicate.spec.tsx
+++ b/packages/react-vapor/src/components/select/tests/MultiSelectWithPredicate.spec.tsx
@@ -1,8 +1,11 @@
-import {mount, ReactWrapper} from 'enzyme';
+import {mount, ReactWrapper, ShallowWrapper} from 'enzyme';
+import {shallowWithStore} from 'enzyme-redux';
 import * as React from 'react';
 import {Provider} from 'react-redux';
 import {Store} from 'redux';
+import * as _ from 'underscore';
 
+import {withServerSideProcessing} from '../../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {IReactVaporState} from '../../../ReactVapor';
 import {clearState} from '../../../utils/ReduxUtils';
 import {TestUtils} from '../../../utils/tests/TestUtils';
@@ -12,12 +15,13 @@ import {selectFlatSelect} from '../../flatSelect/FlatSelectActions';
 import {IFlatSelectOptionProps} from '../../flatSelect/FlatSelectOption';
 import {IItemBoxProps} from '../../itemBox/ItemBox';
 import {reorderListBoxOption, unselectListBoxOption} from '../../listBox/ListBoxActions';
-import {IMultiSelectProps} from '../MultiSelectConnected';
+import {IMultiSelectOwnProps, IMultiSelectProps} from '../MultiSelectConnected';
 import {toggleSelect} from '../SelectActions';
 import {MultiSelectWithPredicate} from '../SelectComponents';
 import {SelectConnected} from '../SelectConnected';
+import {ISelectWithPredicateProps, selectWithPredicate} from '../SelectWithPredicate';
 
-describe('Select', () => {
+fdescribe('Select', () => {
     describe('<MultiSelectWithPredicate />', () => {
         let wrapper: ReactWrapper<any, any>;
         let multiSelect: ReactWrapper<IMultiSelectProps, void>;
@@ -28,25 +32,21 @@ describe('Select', () => {
             {id: UUID.generate(), option: {content: 'All'}, selected: true},
             {id: UUID.generate(), option: {content: 'None'}},
         ];
-
         const matchPredicate = (predicate: string, item: IItemBoxProps) => {
             return predicate === defaultFlatSelectOptions[0].id;
         };
 
-        const mountMultiSelect = (
-            items: IItemBoxProps[] = [],
-            options: IFlatSelectOptionProps[] = defaultFlatSelectOptions,
-            sortable: boolean = false
-        ) => {
+        const basicProps: ISelectWithPredicateProps & IMultiSelectOwnProps = {
+            id,
+            items: [],
+            options: defaultFlatSelectOptions,
+            matchPredicate,
+        };
+
+        const mountMultiSelect = (props?: Partial<ISelectWithPredicateProps & IMultiSelectOwnProps>) => {
             wrapper = mount(
                 <Provider store={store}>
-                    <MultiSelectWithPredicate
-                        id={id}
-                        items={items}
-                        options={options}
-                        matchPredicate={matchPredicate}
-                        sortable={sortable}
-                    />
+                    <MultiSelectWithPredicate {...basicProps} {...props} />
                 </Provider>,
                 {attachTo: document.getElementById('App')}
             );
@@ -93,7 +93,7 @@ describe('Select', () => {
         it('should hide items when they do not match the predicates', () => {
             const items = [{value: 'a'}, {value: 'b', selected: true}, {value: 'c', selected: true}];
 
-            mountMultiSelect(items);
+            mountMultiSelect({items});
             store.dispatch(toggleSelect(id, true));
             store.dispatch(selectFlatSelect(id, defaultFlatSelectOptions[1].id));
             wrapper.update();
@@ -109,7 +109,7 @@ describe('Select', () => {
         it('should not show items that are already hidden', () => {
             const items = [{value: 'a', hidden: true}, {value: 'b', selected: true}, {value: 'c', selected: true}];
 
-            mountMultiSelect(items);
+            mountMultiSelect({items});
             store.dispatch(toggleSelect(id, true));
             store.dispatch(selectFlatSelect(id, defaultFlatSelectOptions[0].id));
             wrapper.update();
@@ -126,7 +126,7 @@ describe('Select', () => {
                 const spy = spyOn(store, 'dispatch').and.callThrough();
                 const items = [{value: 'a', hidden: true}, {value: 'b', selected: true}, {value: 'c', selected: true}];
 
-                mountMultiSelect(items, defaultFlatSelectOptions, true);
+                mountMultiSelect({items, sortable: true});
 
                 // Move b from 0 to 1
                 multiSelect
@@ -140,7 +140,7 @@ describe('Select', () => {
                 const spy = spyOn(store, 'dispatch').and.callThrough();
                 const items = [{value: 'a', hidden: true}, {value: 'b', selected: true}, {value: 'c', selected: true}];
 
-                mountMultiSelect(items, defaultFlatSelectOptions, true);
+                mountMultiSelect({items, sortable: true});
 
                 // Move b from 0 to 1
                 multiSelect
@@ -148,6 +148,29 @@ describe('Select', () => {
                     .first()
                     .prop('onRemoveClick')();
                 expect(spy).toHaveBeenCalledWith(unselectListBoxOption(id, items[1].value));
+            });
+        });
+
+        describe('when predicates are processed on the server side', () => {
+            const ServerSideMultiSelectWithPredicates = _.compose(
+                withServerSideProcessing,
+                selectWithPredicate
+            )(MultiSelectWithPredicate);
+
+            const items = [{value: 'a', hidden: true}, {value: 'b', selected: true}, {value: 'c', selected: true}];
+
+            it('should not filter the items based on any predicate because it is done on the server', () => {
+                const component: ShallowWrapper<ISelectWithPredicateProps> = shallowWithStore(
+                    <ServerSideMultiSelectWithPredicates
+                        {...basicProps}
+                        items={items}
+                        predicate={basicProps.options[1].id}
+                    />,
+                    store
+                )
+                    .dive()
+                    .dive();
+                expect(component.props().items).toEqual(items);
             });
         });
     });


### PR DESCRIPTION
### Proposed Changes

Added support for server side processing of predicate filtering in select components. Followed the same pattern we use in TableHOC withServerSideProcessing.

Basically, the idea is that when processing is done by the server, no filtering is applied on the UI side, so we pass down `ownProps.items` directly to the wrapped component. Also, when the predicate value changes, we trigger the `onUpdate` callback so that a call to the server can be sent.

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
