### PR TITLE
remove flex-grow on the h1 tag in the modal header

### DIFF
--- a/packages/vapor/scss/components/modal.scss
+++ b/packages/vapor/scss/components/modal.scss
@@ -197,8 +197,6 @@ $icon-size: (4em / 3);
     }
 
     h1 {
-        flex-grow: 1;
-
         overflow: hidden;
         color: $medium-blue;
         line-height: 30px;


### PR DESCRIPTION
this avoid a big space if the description is longer than the title

### Proposed Changes

<!-- Explain what are your changes. -->
Remove flex-grow, the bug is caused by this property who set the title text with the same with than the description. Its wrong because we want to have the docs icon next to the title text.

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->
I dont know where the flex-grow property is useful. can break something but I dont understand how...

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
