### PR TITLE
Show readable source files when debugging UTs in the browser

### DIFF
--- a/packages/react-vapor/karma.conf.js
+++ b/packages/react-vapor/karma.conf.js
@@ -1,7 +1,8 @@
-const webpackConfig = require('./webpack.config.test.js');
+const webpackConfig = require('./webpack.config.test.js')();
+const skipCoverageProcessing = process.env.npm_lifecycle_script.indexOf('--no-single-run') !== -1;
 
 module.exports = (config) => {
-    config.set({
+    const configuration = {
         frameworks: ['jasmine', 'source-map-support'],
 
         files: ['./karma.entry.ts'],
@@ -20,15 +21,10 @@ module.exports = (config) => {
             noInfo: true,
         },
 
-        reporters: ['nyan', 'coverage'],
+        reporters: ['nyan'],
 
         nyanReporter: {
             renderOnRunCompleteOnly: !!process.env.TRAVIS,
-        },
-
-        coverageReporter: {
-            dir: 'coverage',
-            reporters: [{type: 'json', subdir: '.', file: 'coverage.json'}, {type: 'text-summary'}],
         },
 
         client: {
@@ -52,5 +48,15 @@ module.exports = (config) => {
         singleRun: true,
 
         browserNoActivityTimeout: 30000,
-    });
+    };
+
+    if (!skipCoverageProcessing) {
+        configuration.reporters.push('coverage');
+        configuration.coverageReporter = {
+            dir: 'coverage',
+            reporters: [{type: 'json', subdir: '.', file: 'coverage.json'}, {type: 'text-summary'}],
+        };
+    }
+
+    config.set(configuration);
 };

--- a/packages/react-vapor/karma.conf.js
+++ b/packages/react-vapor/karma.conf.js
@@ -1,5 +1,5 @@
 const webpackConfig = require('./webpack.config.test.js')();
-const skipCoverageProcessing = process.env.npm_lifecycle_script.indexOf('--no-single-run') !== -1;
+const skipCoverageProcessing = process.env.npm_lifecycle_script.indexOf('--browsers Chrome') !== -1;
 
 module.exports = (config) => {
     const configuration = {

--- a/packages/react-vapor/webpack.config.test.js
+++ b/packages/react-vapor/webpack.config.test.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const isTravis = process.env.TRAVIS;
-const skipCoverageProcessing = process.env.npm_lifecycle_script.indexOf('--no-single-run') !== -1;
+const skipCoverageProcessing = process.env.npm_lifecycle_script.indexOf('--browsers Chrome') !== -1;
 
 module.exports = function(options) {
     const config = {

--- a/packages/react-vapor/webpack.config.test.js
+++ b/packages/react-vapor/webpack.config.test.js
@@ -1,107 +1,116 @@
 const path = require('path');
 const webpack = require('webpack');
 const isTravis = process.env.TRAVIS;
+const skipCoverageProcessing = process.env.npm_lifecycle_script.indexOf('--no-single-run') !== -1;
 
-module.exports = {
-    mode: 'development',
-    entry: './karma.entry.ts',
-    devtool: 'cheap-source-map',
-    resolve: {
-        extensions: ['.ts', '.tsx', '.js'],
-    },
-    module: {
-        rules: [
-            {
-                enforce: 'pre',
-                test: /\.ts(x?)$/i,
-                exclude: [/node_modules/],
-                use: {
-                    loader: 'tslint-loader',
-                    options: {
-                        configFile: '../../tslint.json',
-                        tsConfigFile: './tsconfig.test.json',
-                        emitErrors: true,
-                        failOnHint: isTravis,
-                    },
-                },
-            },
-            {
-                /**
-                 *  Transform let and const to var in js files below to make them ES5 compatible
-                 *  Target only problematic files to prevent compilation from hanging
-                 */
-                include: [path.resolve(__dirname, 'node_modules/unidiff/hunk.js')],
-                loader: 'awesome-typescript-loader',
-            },
-            {
-                test: /\.tsx?$/,
-                loader: 'awesome-typescript-loader',
-                options: {
-                    useCache: true,
-                    cacheDirectory: '.awcache',
-                    configFileName: 'tsconfig.test.json',
-                    compiler: 'ttypescript',
-                },
-            },
-            {
-                enforce: 'post',
-                test: /src\/(?:(?!Examples)(?!spec)(?!tests)(?!Utils).)*\.(?!scss).+$/i,
-                exclude: /(node_modules)/,
-                loader: 'istanbul-instrumenter-loader',
-            },
-            {
-                test: /\.css$/,
-                exclude: path.join(__dirname, 'src/components'),
-                use: [
-                    {
-                        loader: 'style-loader',
-                    },
-                    {
-                        loader: 'css-loader',
-                    },
-                ],
-            },
-            {
-                test: /\.scss$/,
-                include: path.join(__dirname, 'src/components'),
-                use: [
-                    {
-                        loader: 'style-loader',
-                    },
-                    {
-                        loader: 'typings-for-css-modules-loader',
+module.exports = function(options) {
+    const config = {
+        mode: 'development',
+        entry: './karma.entry.ts',
+        devtool: 'cheap-source-map',
+        resolve: {
+            extensions: ['.ts', '.tsx', '.js'],
+        },
+        module: {
+            rules: [
+                {
+                    enforce: 'pre',
+                    test: /\.ts(x?)$/i,
+                    exclude: [/node_modules/],
+                    use: {
+                        loader: 'tslint-loader',
                         options: {
-                            modules: true,
-                            scss: true,
-                            namedExport: true,
-                            localIdentName: '[name]-[local]-[hash:base64]',
+                            configFile: '../../tslint.json',
+                            tsConfigFile: './tsconfig.test.json',
+                            emitErrors: true,
+                            failOnHint: isTravis,
                         },
                     },
-                    {
-                        loader: 'postcss-loader',
+                },
+                {
+                    /**
+                     *  Transform let and const to var in js files below to make them ES5 compatible
+                     *  Target only problematic files to prevent compilation from hanging
+                     */
+                    include: [path.resolve(__dirname, 'node_modules/unidiff/hunk.js')],
+                    loader: 'awesome-typescript-loader',
+                },
+                {
+                    test: /\.tsx?$/,
+                    loader: 'awesome-typescript-loader',
+                    options: {
+                        useCache: true,
+                        cacheDirectory: '.awcache',
+                        configFileName: 'tsconfig.test.json',
+                        compiler: 'ttypescript',
                     },
-                    {
-                        loader: 'sass-loader',
-                    },
-                ],
-            },
+                },
+
+                {
+                    test: /\.css$/,
+                    exclude: path.join(__dirname, 'src/components'),
+                    use: [
+                        {
+                            loader: 'style-loader',
+                        },
+                        {
+                            loader: 'css-loader',
+                        },
+                    ],
+                },
+                {
+                    test: /\.scss$/,
+                    include: path.join(__dirname, 'src/components'),
+                    use: [
+                        {
+                            loader: 'style-loader',
+                        },
+                        {
+                            loader: 'typings-for-css-modules-loader',
+                            options: {
+                                modules: true,
+                                scss: true,
+                                namedExport: true,
+                                localIdentName: '[name]-[local]-[hash:base64]',
+                            },
+                        },
+                        {
+                            loader: 'postcss-loader',
+                        },
+                        {
+                            loader: 'sass-loader',
+                        },
+                    ],
+                },
+            ],
+        },
+        plugins: [
+            new webpack.DefinePlugin({
+                WEBPACK_DEFINED_VERSION: JSON.stringify(require('./package.json').version),
+                'process.env.NODE_ENV': JSON.stringify('test'),
+            }),
+            new webpack.ProvidePlugin({
+                React: 'react',
+                $: 'jquery',
+                jQuery: 'jquery', // Required for chosen-js, otherwise, it won't work.
+            }),
         ],
-    },
-    plugins: [
-        new webpack.DefinePlugin({
-            WEBPACK_DEFINED_VERSION: JSON.stringify(require('./package.json').version),
-            'process.env.NODE_ENV': JSON.stringify('test'),
-        }),
-        new webpack.ProvidePlugin({
-            React: 'react',
-            $: 'jquery',
-            jQuery: 'jquery', // Required for chosen-js, otherwise, it won't work.
-        }),
-    ],
-    externals: {
-        cheerio: 'window',
-        'react/addons': true,
-        'react/lib/ExecutionEnvironment': true,
-        'react/lib/ReactContext': true,
-    },
+        externals: {
+            cheerio: 'window',
+            'react/addons': true,
+            'react/lib/ExecutionEnvironment': true,
+            'react/lib/ReactContext': true,
+        },
+    };
+
+    if (!skipCoverageProcessing) {
+        config.module.rules.push({
+            enforce: 'post',
+            test: /src\/(?:(?!Examples)(?!spec)(?!tests)(?!Utils).)*\.(?!scss).+$/i,
+            exclude: /(node_modules)/,
+            loader: 'istanbul-instrumenter-loader',
+        });
+    }
+
+    return config;
 };


### PR DESCRIPTION
### Proposed Changes

In karma's build process, the coverage reporter is doing some processing on the source files behind the scenes before handling them to karma server. This becomes a problem when running unit tests in the browser while placing `debugger;` in the code, because it is barely readable.

The solution I implemented checks if `--browsers Chrome` is an argument to `karma start` command. If so, it does not compute any coverage, allowing us to debug properly. 

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
