### PR TITLE
Support withServerSideProcessing in SelectWithFilter

### DIFF
--- a/packages/react-vapor/karma.conf.js
+++ b/packages/react-vapor/karma.conf.js
@@ -1,7 +1,8 @@
-const webpackConfig = require('./webpack.config.test.js');
+const webpackConfig = require('./webpack.config.test.js')();
+const skipCoverageProcessing = process.env.npm_lifecycle_script.indexOf('--no-single-run') !== -1;
 
 module.exports = (config) => {
-    config.set({
+    const configuration = {
         frameworks: ['jasmine', 'source-map-support'],
 
         files: ['./karma.entry.ts'],
@@ -20,15 +21,10 @@ module.exports = (config) => {
             noInfo: true,
         },
 
-        reporters: ['nyan', 'coverage'],
+        reporters: ['nyan'],
 
         nyanReporter: {
             renderOnRunCompleteOnly: !!process.env.TRAVIS,
-        },
-
-        coverageReporter: {
-            dir: 'coverage',
-            reporters: [{type: 'json', subdir: '.', file: 'coverage.json'}, {type: 'text-summary'}],
         },
 
         client: {
@@ -52,5 +48,15 @@ module.exports = (config) => {
         singleRun: true,
 
         browserNoActivityTimeout: 30000,
-    });
+    };
+
+    if (!skipCoverageProcessing) {
+        configuration.reporters.push('coverage');
+        configuration.coverageReporter = {
+            dir: 'coverage',
+            reporters: [{type: 'json', subdir: '.', file: 'coverage.json'}, {type: 'text-summary'}],
+        };
+    }
+
+    config.set(configuration);
 };

--- a/packages/react-vapor/src/components/select/SelectSelector.ts
+++ b/packages/react-vapor/src/components/select/SelectSelector.ts
@@ -55,6 +55,12 @@ const getCustomItemsWithFilter: (state: IReactVaporState, ownProps: ISelectProps
     (filteredItems: IItemBoxProps[], customItems: IItemBoxProps[]) => [...filteredItems, ...customItems]
 );
 
+const getServerFilteredItems = createSelector(
+    getItems,
+    getCustomItems,
+    (serverSideProcessedItems, customValuesFiltered) => [...serverSideProcessedItems, ...customValuesFiltered]
+);
+
 const listBoxSelectedCombiner = (listBox: IListBoxState): string[] =>
     listBox && listBox.selected ? listBox.selected : [];
 
@@ -89,6 +95,7 @@ export const SelectSelector = {
     getSelectOpened,
     getCustomItemsWithFilter,
     getMultiSelectSelectedValues,
+    getServerFilteredItems,
 };
 
 export const SelectCombiners = {

--- a/packages/react-vapor/src/components/select/SelectWithFilter.tsx
+++ b/packages/react-vapor/src/components/select/SelectWithFilter.tsx
@@ -76,7 +76,7 @@ export const selectWithFilter = (
 
     @ReduxConnect(makeMapStateToProps, mapDispatchToProps)
     class WrappedComponent extends React.Component<ISelectWithFilterProps> {
-        static displayName = `${Component.displayName}WithFilter`;
+        static displayName = `withFilter(${Component.displayName})`;
         static defaultProps: Partial<ISelectWithFilterProps> = {
             duplicateText: 'Cannot add a duplicate value',
             noResultFilterText: (filterText: string) => `No results match "${filterText}"`,

--- a/packages/react-vapor/src/components/select/SelectWithFilter.tsx
+++ b/packages/react-vapor/src/components/select/SelectWithFilter.tsx
@@ -4,8 +4,10 @@ import {createStructuredSelector} from 'reselect';
 import {keys} from 'ts-transformer-keys';
 import * as _ from 'underscore';
 
+import {WithServerSideProcessingProps} from '../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {IReactVaporState} from '../../ReactVapor';
 import {addStringList, addValueStringList, removeStringList} from '../../reusableState/customList/StringListActions';
+import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {MatchFilter} from '../../utils/FilterUtils';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
 import {UUID} from '../../utils/UUID';
@@ -48,21 +50,20 @@ export interface ISelectWithFilterProps
     extends ISelectWithFilterOwnProps,
         Partial<ISelectWithFilterStateProps>,
         Partial<ISelectWithFilterDispatchProps>,
+        WithServerSideProcessingProps,
         ISelectOwnProps {}
 
 export const selectWithFilter = (
-    Component: React.ComponentClass<ISelectWithFilterProps> | React.StatelessComponent<ISelectWithFilterProps>
-): React.ComponentClass<ISelectWithFilterProps> => {
-    const makeMapStateToProps = () => {
-        const getStateProps = createStructuredSelector({
+    Component: React.ComponentType<ISelectWithFilterProps>
+): React.ComponentType<ISelectWithFilterProps> => {
+    const makeMapStateToProps = (initialState: IReactVaporState, initialOwnProps: ISelectWithFilterProps) =>
+        createStructuredSelector({
             filterValue: FilterBoxSelectors.getFilterText,
-            items: SelectSelector.getCustomItemsWithFilter,
+            items: initialOwnProps.isServer
+                ? SelectSelector.getServerFilteredItems
+                : SelectSelector.getCustomItemsWithFilter,
             selected: SelectSelector.getListBoxSelected,
         });
-
-        return (state: IReactVaporState, ownProps: ISelectWithFilterProps): ISelectWithFilterStateProps =>
-            getStateProps(state, ownProps);
-    };
 
     const mapDispatchToProps = (
         dispatch: IDispatch,
@@ -75,6 +76,7 @@ export const selectWithFilter = (
 
     @ReduxConnect(makeMapStateToProps, mapDispatchToProps)
     class WrappedComponent extends React.Component<ISelectWithFilterProps> {
+        static displayName = `${Component.displayName}WithFilter`;
         static defaultProps: Partial<ISelectWithFilterProps> = {
             duplicateText: 'Cannot add a duplicate value',
             noResultFilterText: (filterText: string) => `No results match "${filterText}"`,
@@ -92,6 +94,12 @@ export const selectWithFilter = (
 
         componentWillMount() {
             this.props.onRenderFilter(this.props.defaultCustomValues);
+        }
+
+        componentDidUpdate(prevProps: ISelectWithFilterProps) {
+            if (prevProps.filterValue !== this.props.filterValue) {
+                callIfDefined(this.props.onUpdate);
+            }
         }
 
         componentWillUnmount() {

--- a/packages/react-vapor/src/hoc/withServerSideProcessing/withServerSideProcessing.tsx
+++ b/packages/react-vapor/src/hoc/withServerSideProcessing/withServerSideProcessing.tsx
@@ -8,6 +8,6 @@ export function withServerSideProcessing<T extends {}>(
     Component: React.ComponentType<T>
 ): React.ComponentType<T & WithServerSideProcessingProps> {
     const WrappedComponent: React.FunctionComponent<T> = (props) => <Component {...props} isServer />;
-    WrappedComponent.displayName = `ServerSide${Component.displayName}`;
+    WrappedComponent.displayName = `withServerSideProcessing(${Component.displayName})`;
     return WrappedComponent;
 }

--- a/packages/react-vapor/src/hoc/withServerSideProcessing/withServerSideProcessing.tsx
+++ b/packages/react-vapor/src/hoc/withServerSideProcessing/withServerSideProcessing.tsx
@@ -5,7 +5,9 @@ export interface WithServerSideProcessingProps {
 }
 
 export function withServerSideProcessing<T extends {}>(
-    WrappedComponent: React.ComponentType<T>
+    Component: React.ComponentType<T>
 ): React.ComponentType<T & WithServerSideProcessingProps> {
-    return (props: T) => <WrappedComponent {...props} isServer />;
+    const WrappedComponent: React.FunctionComponent<T> = (props) => <Component {...props} isServer />;
+    WrappedComponent.displayName = `ServerSide${Component.displayName}`;
+    return WrappedComponent;
 }

--- a/packages/react-vapor/webpack.config.test.js
+++ b/packages/react-vapor/webpack.config.test.js
@@ -1,107 +1,115 @@
 const path = require('path');
 const webpack = require('webpack');
 const isTravis = process.env.TRAVIS;
+const skipCoverageProcessing = process.env.npm_lifecycle_script.indexOf('--no-single-run') !== -1;
 
-module.exports = {
-    mode: 'development',
-    entry: './karma.entry.ts',
-    devtool: 'cheap-source-map',
-    resolve: {
-        extensions: ['.ts', '.tsx', '.js'],
-    },
-    module: {
-        rules: [
-            {
-                enforce: 'pre',
-                test: /\.ts(x?)$/i,
-                exclude: [/node_modules/],
-                use: {
-                    loader: 'tslint-loader',
-                    options: {
-                        configFile: '../../tslint.json',
-                        tsConfigFile: './tsconfig.test.json',
-                        emitErrors: true,
-                        failOnHint: isTravis,
-                    },
-                },
-            },
-            {
-                /**
-                 *  Transform let and const to var in js files below to make them ES5 compatible
-                 *  Target only problematic files to prevent compilation from hanging
-                 */
-                include: [path.resolve(__dirname, 'node_modules/unidiff/hunk.js')],
-                loader: 'awesome-typescript-loader',
-            },
-            {
-                test: /\.tsx?$/,
-                loader: 'awesome-typescript-loader',
-                options: {
-                    useCache: true,
-                    cacheDirectory: '.awcache',
-                    configFileName: 'tsconfig.test.json',
-                    compiler: 'ttypescript',
-                },
-            },
-            {
-                enforce: 'post',
-                test: /src\/(?:(?!Examples)(?!spec)(?!tests)(?!Utils).)*\.(?!scss).+$/i,
-                exclude: /(node_modules)/,
-                loader: 'istanbul-instrumenter-loader',
-            },
-            {
-                test: /\.css$/,
-                exclude: path.join(__dirname, 'src/components'),
-                use: [
-                    {
-                        loader: 'style-loader',
-                    },
-                    {
-                        loader: 'css-loader',
-                    },
-                ],
-            },
-            {
-                test: /\.scss$/,
-                include: path.join(__dirname, 'src/components'),
-                use: [
-                    {
-                        loader: 'style-loader',
-                    },
-                    {
-                        loader: 'typings-for-css-modules-loader',
+module.exports = function(options) {
+    const config = {
+        mode: 'development',
+        entry: './karma.entry.ts',
+        devtool: 'cheap-source-map',
+        resolve: {
+            extensions: ['.ts', '.tsx', '.js'],
+        },
+        module: {
+            rules: [
+                {
+                    enforce: 'pre',
+                    test: /\.ts(x?)$/i,
+                    exclude: [/node_modules/],
+                    use: {
+                        loader: 'tslint-loader',
                         options: {
-                            modules: true,
-                            scss: true,
-                            namedExport: true,
-                            localIdentName: '[name]-[local]-[hash:base64]',
+                            configFile: '../../tslint.json',
+                            tsConfigFile: './tsconfig.test.json',
+                            emitErrors: true,
+                            failOnHint: isTravis,
                         },
                     },
-                    {
-                        loader: 'postcss-loader',
+                },
+                {
+                    /**
+                     *  Transform let and const to var in js files below to make them ES5 compatible
+                     *  Target only problematic files to prevent compilation from hanging
+                     */
+                    include: [path.resolve(__dirname, 'node_modules/unidiff/hunk.js')],
+                    loader: 'awesome-typescript-loader',
+                },
+                {
+                    test: /\.tsx?$/,
+                    loader: 'awesome-typescript-loader',
+                    options: {
+                        useCache: true,
+                        cacheDirectory: '.awcache',
+                        configFileName: 'tsconfig.test.json',
+                        compiler: 'ttypescript',
                     },
-                    {
-                        loader: 'sass-loader',
-                    },
-                ],
-            },
+                },
+                {
+                    test: /\.css$/,
+                    exclude: path.join(__dirname, 'src/components'),
+                    use: [
+                        {
+                            loader: 'style-loader',
+                        },
+                        {
+                            loader: 'css-loader',
+                        },
+                    ],
+                },
+                {
+                    test: /\.scss$/,
+                    include: path.join(__dirname, 'src/components'),
+                    use: [
+                        {
+                            loader: 'style-loader',
+                        },
+                        {
+                            loader: 'typings-for-css-modules-loader',
+                            options: {
+                                modules: true,
+                                scss: true,
+                                namedExport: true,
+                                localIdentName: '[name]-[local]-[hash:base64]',
+                            },
+                        },
+                        {
+                            loader: 'postcss-loader',
+                        },
+                        {
+                            loader: 'sass-loader',
+                        },
+                    ],
+                },
+            ],
+        },
+        plugins: [
+            new webpack.DefinePlugin({
+                WEBPACK_DEFINED_VERSION: JSON.stringify(require('./package.json').version),
+                'process.env.NODE_ENV': JSON.stringify('test'),
+            }),
+            new webpack.ProvidePlugin({
+                React: 'react',
+                $: 'jquery',
+                jQuery: 'jquery', // Required for chosen-js, otherwise, it won't work.
+            }),
         ],
-    },
-    plugins: [
-        new webpack.DefinePlugin({
-            WEBPACK_DEFINED_VERSION: JSON.stringify(require('./package.json').version),
-            'process.env.NODE_ENV': JSON.stringify('test'),
-        }),
-        new webpack.ProvidePlugin({
-            React: 'react',
-            $: 'jquery',
-            jQuery: 'jquery', // Required for chosen-js, otherwise, it won't work.
-        }),
-    ],
-    externals: {
-        cheerio: 'window',
-        'react/addons': true,
-        'react/lib/ExecutionEnvironment': true,
-        'react/lib/ReactContext': true,
-    },
+        externals: {
+            cheerio: 'window',
+            'react/addons': true,
+            'react/lib/ExecutionEnvironment': true,
+            'react/lib/ReactContext': true,
+        },
+    };
+
+    if (!skipCoverageProcessing) {
+        config.module.push({
+            enforce: 'post',
+            test: /src\/(?:(?!Examples)(?!spec)(?!tests)(?!Utils).)*\.(?!scss).+$/i,
+            exclude: /(node_modules)/,
+            loader: 'istanbul-instrumenter-loader',
+        });
+    }
+
+    return config;
 };


### PR DESCRIPTION
### Proposed Changes

Added support for server side processing of filtering items of select components. Followed the same pattern we use in TableHOC withServerSideProcessing.

Basically, the idea is that when processing is done by the server, no filtering is applied on the UI side, so we pass down ownProps.items directly to the wrapped component. Also, when the filter input value changes, we trigger the onUpdate callback so that a call to the server can be sent.

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
