### PR TITLE
Add props filterPlaceholder to FilterBoxConnected

### DIFF
--- a/packages/react-vapor/src/components/select/SelectWithFilter.tsx
+++ b/packages/react-vapor/src/components/select/SelectWithFilter.tsx
@@ -28,6 +28,7 @@ export interface ISelectWithFilterOwnProps {
     noItemsText?: string;
     filterButton?: IButtonProps;
     filter?: IFilterBoxOwnProps;
+    filterPlaceholder?: string;
 }
 
 export interface ISelectWithFilterStateProps {
@@ -205,6 +206,7 @@ export const selectWithFilter = (
                         onKeyDown={(this.props as any).onKeyDown}
                         onKeyUp={(this.props as any).onKeyUp}
                         className={filterBoxClassNames}
+                        filterPlaceholder={this.props.filterPlaceholder}
                         isAutoFocus
                     >
                         {this.getAddValueButton()}


### PR DESCRIPTION
### Proposed Changes

Add props filterPlaceholder to FilterBoxConnected in order to changing the default text of filter box in drop down menu

Before:
![before](https://user-images.githubusercontent.com/52677246/61474968-ba0a5900-a957-11e9-94cf-d2f8d3681097.JPG)

After:
![after](https://user-images.githubusercontent.com/52677246/61474986-c4c4ee00-a957-11e9-9d83-21191864c9c3.JPG)

