### PR TITLE
Fix adui 4565 keyboard selection issue in permission filter

### DIFF
--- a/packages/react-vapor/src/components/listBox/ListBoxActions.ts
+++ b/packages/react-vapor/src/components/listBox/ListBoxActions.ts
@@ -20,9 +20,9 @@ export interface IListBoxPayload {
     diff?: number;
 }
 
-export const addListBox = (id: string, items: IItemBoxProps[]): IReduxAction<IListBoxPayload> => ({
+export const addListBox = (id: string, items: IItemBoxProps[], multi = false): IReduxAction<IListBoxPayload> => ({
     type: ListBoxActions.add,
-    payload: {id, items},
+    payload: {id, items, multi},
 });
 
 export const removeListBox = (id: string): IReduxAction<IListBoxPayload> => ({

--- a/packages/react-vapor/src/components/listBox/ListBoxConnected.tsx
+++ b/packages/react-vapor/src/components/listBox/ListBoxConnected.tsx
@@ -11,7 +11,6 @@ import {IListBoxState} from './ListBoxReducers';
 
 const mapStateToProps = (state: IReactVaporState, ownProps: IListBoxOwnProps): IListBoxStateProps => {
     const list: IListBoxState = _.findWhere(state.listBoxes, {id: ownProps.id});
-
     return {
         selected: list ? list.selected : [],
         active: list ? list.active : undefined,
@@ -19,7 +18,7 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IListBoxOwnProps): I
 };
 
 const mapDispatchToProps = (dispatch: IDispatch, ownProps: IListBoxOwnProps): IListBoxDispatchProps => ({
-    onRender: () => dispatch(addListBox(ownProps.id, ownProps.items)),
+    onRender: () => dispatch(addListBox(ownProps.id, ownProps.items, ownProps.multi)),
     onDestroy: () => dispatch(removeListBox(ownProps.id)),
     onOptionClick: (option: IItemBoxProps) => dispatch(selectListBoxOption(ownProps.id, ownProps.multi, option.value)),
 });

--- a/packages/react-vapor/src/components/listBox/ListBoxReducers.ts
+++ b/packages/react-vapor/src/components/listBox/ListBoxReducers.ts
@@ -40,6 +40,7 @@ export const listBoxReducer = (
                 selected: action.payload.multi
                     ? _.uniq([...state.selected, action.payload.value])
                     : [action.payload.value],
+                active: action.payload.multi ? null : state.active,
             };
         case AutocompleteActions.setValue:
             return {

--- a/packages/react-vapor/src/components/listBox/ListBoxReducers.ts
+++ b/packages/react-vapor/src/components/listBox/ListBoxReducers.ts
@@ -28,7 +28,7 @@ export const listBoxReducer = (
                 .pluck('value')
                 .value();
             let selectedIndex = _.findIndex(action.payload.items, (e) => e.selected);
-            selectedIndex = selectedIndex === -1 ? 0 : selectedIndex;
+            selectedIndex = selectedIndex === -1 || action.payload.multi ? 0 : selectedIndex;
             return {
                 id: action.payload.id,
                 selected: selected,
@@ -40,7 +40,6 @@ export const listBoxReducer = (
                 selected: action.payload.multi
                     ? _.uniq([...state.selected, action.payload.value])
                     : [action.payload.value],
-                active: null,
             };
         case AutocompleteActions.setValue:
             return {

--- a/packages/react-vapor/src/components/select/SelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SelectConnected.tsx
@@ -205,13 +205,9 @@ export class SelectConnected extends React.PureComponent<ISelectProps & ISelectS
             }
         } else if (_.contains([keyCode.enter, keyCode.downArrow, keyCode.upArrow], e.keyCode) && !this.props.isOpened) {
             this.onToggleDropdown(e);
-        }
-
-        if (keyCode.downArrow === e.keyCode) {
+        } else if (keyCode.downArrow === e.keyCode) {
             this.props.setActive(this.props.isOpened ? 1 : 0);
-        }
-
-        if (keyCode.upArrow === e.keyCode) {
+        } else if (keyCode.upArrow === e.keyCode) {
             this.props.setActive(this.props.isOpened ? -1 : 0);
         }
     }

--- a/packages/react-vapor/src/components/select/tests/SingleSelectWithFilter.spec.tsx
+++ b/packages/react-vapor/src/components/select/tests/SingleSelectWithFilter.spec.tsx
@@ -206,26 +206,23 @@ describe('Select', () => {
                 expect(dispatchSpy).toHaveBeenCalledWith(setActiveListBoxOption(id, -1));
             });
 
-            it('should dispatch a setActiveListBoxOption with 0 as the active parameter when the user press the up or down arrow but the dropdown is not open', () => {
-                expect(dispatchSpy).not.toHaveBeenCalledWith(setActiveListBoxOption(id, 0));
+            it('should dispatch a toggleSelect to open the Select when the user press the up or down arrow', () => {
                 singleSelect
                     .find('.dropdown-toggle')
                     .simulate('keydown', {keyCode: keyCode.downArrow})
                     .simulate('keyup', {keyCode: keyCode.downArrow});
-
-                expect(dispatchSpy).toHaveBeenCalledWith(setActiveListBoxOption(id, 0));
+                expect(dispatchSpy).toHaveBeenCalledWith(toggleSelect(id));
 
                 // Close the dropdown
                 store.dispatch(toggleSelect(id, false));
                 dispatchSpy.calls.reset();
 
-                expect(dispatchSpy).not.toHaveBeenCalledWith(setActiveListBoxOption(id, 0));
                 singleSelect
                     .find('.dropdown-toggle')
                     .simulate('keydown', {keyCode: keyCode.upArrow})
                     .simulate('keyup', {keyCode: keyCode.upArrow});
 
-                expect(dispatchSpy).toHaveBeenCalledWith(setActiveListBoxOption(id, 0));
+                expect(dispatchSpy).toHaveBeenCalledWith(toggleSelect(id));
             });
         });
 


### PR DESCRIPTION
### Proposed Changes

- Initial value of MultiSelect should be the first element even when using selected props
- Using arrows in Select should behave as expected

### Potential Breaking Changes

none

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
