### PR TITLE
Fix PartialStringMatch for function components

### DIFF
--- a/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.spec.tsx
+++ b/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.spec.tsx
@@ -1,5 +1,6 @@
 import {shallow} from 'enzyme';
 import * as React from 'react';
+
 import {PartialStringMatch} from './PartialStringMatch';
 
 describe('PartialStringMatch', () => {
@@ -22,7 +23,7 @@ describe('PartialStringMatch', () => {
     it('should render the wholeString unchanged if partialMatch is not in the wholeString', () => {
         expect(
             shallow(<PartialStringMatch wholeString={testString} partialMatch="i am not in whole string" />).find(
-                'span.bold'
+                'Highlight'
             ).length
         ).toBe(0);
     });
@@ -30,16 +31,16 @@ describe('PartialStringMatch', () => {
     it('should render the wholeString unchanged if partialMatch is in the wholeString but with different casing (if case sensitive)', () => {
         expect(
             shallow(<PartialStringMatch wholeString={testString} partialMatch={testString.toUpperCase()} />).find(
-                'span.bold'
+                'Highlight'
             ).length
         ).toBe(0);
     });
 
-    it('should render a span with the partialString match in bold if contained in the wholeString', () => {
+    it('should highlight the partialString match in bold if contained in the wholeString', () => {
         const partialMatch = testString.substr(3, 5);
         const component = shallow(<PartialStringMatch wholeString={testString} partialMatch={partialMatch} />);
 
-        expect(component.find('span.bold').length).toBe(1);
+        expect(component.find('Highlight').length).toBe(1);
     });
 
     it('should escape partialString match if dangerous', () => {
@@ -47,28 +48,28 @@ describe('PartialStringMatch', () => {
         const wholeString = 'whole string <script>alert("I could be dangerous")</script> with scripting';
         const component = shallow(<PartialStringMatch wholeString={wholeString} partialMatch={partialMatch} />);
 
-        expect(component.find('span.bold').length).toBe(1);
+        expect(component.find('Highlight').length).toBe(1);
         expect(component.find('script').length).toBe(0); // it will still be a string
     });
 
-    it('should render a span with the partialString in bold regardless of casing, when caseInsensitive is passed as prop', () => {
+    it('should highlight the partialString in bold regardless of casing, when caseInsensitive is passed as prop', () => {
         const partialMatch = testString.substr(3, 5);
         const component = shallow(
             <PartialStringMatch wholeString={testString} partialMatch={partialMatch.toUpperCase()} caseInsensitive />
         );
 
-        expect(component.find('span.bold').length).toBe(1);
+        expect(component.find('Highlight').length).toBe(1);
     });
 
-    it('should wrap all matches in a string with a span.bold', () => {
+    it('should highlight all matches in a string', () => {
         const partialMatch = 'match';
         const multipleMatchString = 'match I have three match match';
         const component = shallow(<PartialStringMatch wholeString={multipleMatchString} partialMatch={partialMatch} />);
 
-        expect(component.find('span.bold').length).toBe(3);
+        expect(component.find('Highlight').length).toBe(3);
     });
 
-    it('should correctly wrap all matches in a string with a span.bold when there is multiple children', () => {
+    it('should highlight all matches in a string when there is multiple children', () => {
         const partialMatch = 'match';
         const component = shallow(
             <PartialStringMatch partialMatch={partialMatch}>
@@ -78,6 +79,31 @@ describe('PartialStringMatch', () => {
                 <div>Or they can be in a div, like this match</div>
             </PartialStringMatch>
         );
-        expect(component.find('span.bold').length).toBe(2);
+        expect(component.find('Highlight').length).toBe(2);
+    });
+
+    it('should highlight matches by rendering them in bold', () => {
+        const matcher = 'bacon';
+        const component = shallow(
+            <PartialStringMatch partialMatch={matcher}>bacon is my favorite vegetable</PartialStringMatch>
+        );
+        expect(
+            component
+                .find('Highlight')
+                .dive()
+                .hasClass('bold')
+        ).toBe(true);
+    });
+
+    it('should highlight all matches rendered throught a function component', () => {
+        const Porkchop: React.FunctionComponent = () => <span>porkchop is a chop of the pork</span>;
+        const matcher = 'chop';
+        const component = shallow(
+            <PartialStringMatch partialMatch={matcher}>
+                <Porkchop />
+            </PartialStringMatch>
+        );
+
+        expect(component.find('Highlight').length).toBe(2);
     });
 });


### PR DESCRIPTION
### Proposed Changes

`PartialStringMatch` was not highlighting matches rendered by functional components.

- Changed the `*deepReplaceStrings` method so that it picks-up children of functional components
- Simplified `*deepReplaceStrings` method my extracting 2 new methods: `lookupChildren` and `hightlightMatches`.

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
