### PR TITLE
Fix perPageNumbers config in tableWithPagination

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableWithPagination.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithPagination.tsx
@@ -39,8 +39,7 @@ export interface ITableWithPaginationProps
         ITableHOCOwnProps,
         WithServerSideProcessingProps {}
 
-const TableWithPaginationPropsToOmit = keys<ITableWithPaginationStateProps>();
-const TableWithPaginationConfigToOmit = keys<ITableWithPaginationConfig>();
+const TableWithPaginationProps = keys<ITableWithPaginationStateProps>();
 
 const sliceData = (data: any[], startingIndex: number, endingIndex: number) => data.slice(startingIndex, endingIndex);
 
@@ -101,14 +100,14 @@ export const tableWithPagination = (supplier: ConfigSupplier<ITableWithPaginatio
         }
 
         render() {
-            const newProps = _.omit(this.props, [...TableWithPaginationPropsToOmit]);
+            const newProps = _.omit(this.props, [...TableWithPaginationProps]);
             return (
                 <Component {...newProps}>
                     <NavigationConnected
                         id={this.props.id}
-                        {..._.pick(this.props, TableWithPaginationPropsToOmit)}
-                        {..._.omit(config, [...TableWithPaginationConfigToOmit])}
                         loadingIds={[this.props.id]}
+                        {...config}
+                        {..._.pick(this.props, TableWithPaginationProps)}
                     />
                     {this.props.children}
                 </Component>

--- a/packages/react-vapor/src/components/table-hoc/examples/TableHOCExamples.tsx
+++ b/packages/react-vapor/src/components/table-hoc/examples/TableHOCExamples.tsx
@@ -74,7 +74,7 @@ const TableWithFilterAndPagination = _.compose(
     tableWithBlankSlate({title: 'No data caused the table to be empty'}),
     tableWithFilter(),
     tableWithBlankSlate({title: 'Filter caused the table to be empty'}),
-    tableWithPagination({perPageNumbers: [3, 5, 10]})
+    tableWithPagination()
 )(TableHOC);
 
 const TableWithSortFilterAndPagination = _.compose(

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithPagination.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithPagination.spec.tsx
@@ -9,7 +9,7 @@ import {NavigationConnected} from '../../navigation/NavigationConnected';
 import {TableWithPaginationActions} from '../actions/TableWithPaginationActions';
 import {ITableHOCProps, TableHOC} from '../TableHOC';
 import {TableHOCUtils} from '../TableHOCUtils';
-import {tableWithPagination} from '../TableWithPagination';
+import {ITableWithPaginationProps, tableWithPagination} from '../TableWithPagination';
 
 describe('Table HOC', () => {
     describe('TableWithPagination', () => {
@@ -73,6 +73,16 @@ describe('Table HOC', () => {
             wrapper.unmount();
 
             expect(store.getActions()).toContain(expectedAction);
+        });
+
+        it('should slice the data according to the perPageNumbers specified in the HOC config', () => {
+            const expectedPerPageNumbers = [2, 3, 4];
+            const MyTable: React.ComponentType<ITableWithPaginationProps> = _.compose(
+                tableWithPagination({perPageNumbers: expectedPerPageNumbers})
+            )(TableHOC);
+            const table = shallowWithStore(<MyTable {...defaultProps} />, getStoreMock()).dive();
+
+            expect(table.find(NavigationConnected).prop('perPageNumbers')).toEqual(expectedPerPageNumbers);
         });
 
         describe('with store data', () => {


### PR DESCRIPTION
### Proposed Changes

When specifying perPageNumbers in the tableWithPagination HOC config (say 3, 5, 10), it was getting ignored and the default perPageNumbers were used instead (10, 20, 30). Now it will use the perPageNumbers defined in the config if specified, else it will fallback to the default perPageNumbers as it should.

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
