### PR TITLE
Fix active state in SingleSelect when clicking or using key navigation

### DIFF
--- a/packages/react-vapor/src/components/itemBox/ItemBox.tsx
+++ b/packages/react-vapor/src/components/itemBox/ItemBox.tsx
@@ -18,7 +18,7 @@ export interface IItemBoxProps {
     classes?: string[];
     prepend?: IContentProps;
     append?: IContentProps;
-    onOptionClick?: (option?: IItemBoxProps) => void;
+    onOptionClick?: (option?: IItemBoxProps, index?: number) => void;
     selectedDisplayValue?: string;
 }
 

--- a/packages/react-vapor/src/components/listBox/ListBox.tsx
+++ b/packages/react-vapor/src/components/listBox/ListBox.tsx
@@ -6,6 +6,11 @@ import {mod} from '../../utils/DataStructuresUtils';
 import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {IItemBoxProps, ItemBox} from '../itemBox/ItemBox';
 
+export interface IITemBoxPropsWithIndex {
+    index?: number;
+    item: IItemBoxProps;
+}
+
 export interface IListBoxOwnProps {
     noResultItem?: IItemBoxProps;
     classes?: string[];
@@ -23,7 +28,7 @@ export interface IListBoxStateProps {
 export interface IListBoxDispatchProps {
     onRender?: () => void;
     onDestroy?: () => void;
-    onOptionClick?: (option: IItemBoxProps) => void;
+    onOptionClick?: (option: IItemBoxProps, index?: number) => void;
 }
 
 export interface IListBoxProps extends IListBoxOwnProps, IListBoxStateProps, IListBoxDispatchProps {}
@@ -54,39 +59,45 @@ export class ListBox extends React.Component<IListBoxProps, {}> {
         const visibleLength = _.filter(this.props.items, (item: IItemBoxProps) => shouldShow(item) && !item.disabled)
             .length;
 
-        let index = 0;
+        let realIndex = 0;
         let activeSet = false;
         const items = _.chain(this.props.items)
             .filter(shouldShow)
             .map((item: IItemBoxProps) => {
                 let active = false;
+                const itemWithIndex: IITemBoxPropsWithIndex = {item: {...item}};
                 if (!item.disabled) {
                     if (this.props.active === null) {
                         active = _.contains(this.props.selected, item.value);
                     } else {
-                        active = mod(this.props.active, visibleLength) === index;
+                        active = mod(this.props.active, visibleLength) === realIndex;
                     }
                     activeSet = active || activeSet;
-                    index++;
+
+                    itemWithIndex.index = realIndex;
+                    itemWithIndex.item.active = active;
+                    realIndex++;
                 }
-                return {...item, active};
+                return itemWithIndex;
             })
-            .map((item: IItemBoxProps) => {
+            .map(({item, index}: IITemBoxPropsWithIndex) => {
                 let active = item.active;
                 if (!item.disabled && activeSet === false) {
                     active = true;
                     activeSet = true;
                 }
-                return {...item, active};
+                return {item: {...item, active}, index};
             })
-            .map((item: IItemBoxProps) => (
-                <ItemBox
-                    key={item.value}
-                    {...item}
-                    onOptionClick={(option: IItemBoxProps) => this.onSelectItem(item)}
-                    selected={_.contains(this.props.selected, item.value)}
-                />
-            ))
+            .map(({item, index}: IITemBoxPropsWithIndex) => {
+                return (
+                    <ItemBox
+                        key={item.value}
+                        {...item}
+                        onOptionClick={(option: IItemBoxProps) => this.onSelectItem(item, index)}
+                        selected={_.contains(this.props.selected, item.value)}
+                    />
+                );
+            })
             .value();
 
         const emptyItem = (
@@ -107,10 +118,10 @@ export class ListBox extends React.Component<IListBoxProps, {}> {
         );
     }
 
-    private onSelectItem(item: IItemBoxProps) {
+    private onSelectItem(item: IItemBoxProps, index?: number) {
         if (!item.disabled) {
-            callIfDefined(this.props.onOptionClick, item);
-            callIfDefined(item.onOptionClick, item);
+            callIfDefined(this.props.onOptionClick, item, index);
+            callIfDefined(item.onOptionClick, item, index);
         }
     }
 }

--- a/packages/react-vapor/src/components/listBox/ListBoxActions.ts
+++ b/packages/react-vapor/src/components/listBox/ListBoxActions.ts
@@ -18,6 +18,7 @@ export interface IListBoxPayload {
     values?: string[];
     items?: IItemBoxProps[];
     diff?: number;
+    index?: number;
 }
 
 export const addListBox = (id: string, items: IItemBoxProps[], multi = false): IReduxAction<IListBoxPayload> => ({
@@ -30,9 +31,14 @@ export const removeListBox = (id: string): IReduxAction<IListBoxPayload> => ({
     payload: {id},
 });
 
-export const selectListBoxOption = (id: string, multi: boolean, value: string): IReduxAction<IListBoxPayload> => ({
+export const selectListBoxOption = (
+    id: string,
+    multi: boolean,
+    value: string,
+    index?: number
+): IReduxAction<IListBoxPayload> => ({
     type: ListBoxActions.select,
-    payload: {id, multi, value},
+    payload: {id, multi, value, index},
 });
 
 export const unselectListBoxOption = (id: string, value: string): IReduxAction<IListBoxPayload> => ({

--- a/packages/react-vapor/src/components/listBox/ListBoxConnected.tsx
+++ b/packages/react-vapor/src/components/listBox/ListBoxConnected.tsx
@@ -20,7 +20,8 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IListBoxOwnProps): I
 const mapDispatchToProps = (dispatch: IDispatch, ownProps: IListBoxOwnProps): IListBoxDispatchProps => ({
     onRender: () => dispatch(addListBox(ownProps.id, ownProps.items, ownProps.multi)),
     onDestroy: () => dispatch(removeListBox(ownProps.id)),
-    onOptionClick: (option: IItemBoxProps) => dispatch(selectListBoxOption(ownProps.id, ownProps.multi, option.value)),
+    onOptionClick: (option: IItemBoxProps, index?: number) =>
+        dispatch(selectListBoxOption(ownProps.id, ownProps.multi, option.value, index)),
 });
 
 export const ListBoxConnected: React.ComponentClass<IListBoxProps> = connect(

--- a/packages/react-vapor/src/components/listBox/ListBoxReducers.ts
+++ b/packages/react-vapor/src/components/listBox/ListBoxReducers.ts
@@ -21,6 +21,7 @@ export const listBoxReducer = (
         return state;
     }
 
+    const {payload} = action;
     switch (action.type) {
         case ListBoxActions.add:
             const selected = _.chain(action.payload.items)
@@ -37,30 +38,28 @@ export const listBoxReducer = (
         case ListBoxActions.select:
             return {
                 ...state,
-                selected: action.payload.multi
-                    ? _.uniq([...state.selected, action.payload.value])
-                    : [action.payload.value],
-                active: action.payload.multi ? null : state.active,
+                selected: payload.multi ? _.uniq([...state.selected, payload.value]) : [payload.value],
+                active: payload.multi ? null : typeof payload.index !== undefined ? payload.index : state.active,
             };
         case AutocompleteActions.setValue:
             return {
                 ...state,
-                selected: [action.payload.value],
+                selected: [payload.value],
             };
         case ListBoxActions.unselect:
             return {
                 ...state,
-                selected: _.without(state.selected, action.payload.value),
+                selected: _.without(state.selected, payload.value),
             };
         case ListBoxActions.reorder:
             return {
                 ...state,
-                selected: action.payload.values,
+                selected: payload.values,
             };
         case ListBoxActions.setActive:
-            let active = state.active + action.payload.diff;
+            let active = state.active + payload.diff;
             if (_.isUndefined(state.active)) {
-                active = action.payload.diff === 1 ? 0 : -1;
+                active = payload.diff === 1 ? 0 : -1;
             }
 
             return {...state, active};

--- a/packages/react-vapor/src/components/listBox/tests/ListBoxReducers.spec.ts
+++ b/packages/react-vapor/src/components/listBox/tests/ListBoxReducers.spec.ts
@@ -122,7 +122,13 @@ describe('ListBox', () => {
 
         describe('SELECT_ITEM_LIST_BOX', () => {
             const id = 'list-box-id';
-            const items = [{value: 'a'}, {value: 'b', selected: true}];
+            const items = [
+                {value: 'a'},
+                {value: 'b', selected: true},
+                {value: 'c'},
+                {value: 'd', disabled: true},
+                {value: 'e'},
+            ];
             const selected = _.chain(items)
                 .where({selected: true})
                 .pluck('value')
@@ -158,6 +164,38 @@ describe('ListBox', () => {
 
                 expect(newState[0].selected.length).toBe(2, 'length');
                 expect(newState[0].selected).toEqual([items[1].value, newValue]);
+            });
+
+            it('should activate the new item when the list box is not multi', () => {
+                const expectedValue = items[2].value;
+                const oldState: IListBoxState[] = defaultState;
+                const newState: IListBoxState[] = listBoxesReducer(
+                    oldState,
+                    selectListBoxOption(id, false, expectedValue, 2)
+                );
+
+                expect(newState.length).toBe(oldState.length);
+                expect(newState[0].id).toBe(id);
+
+                expect(newState[0].selected.length).toBe(1);
+                expect(newState[0].selected[0]).toBe(expectedValue);
+                expect(newState[0].active).toBe(2);
+            });
+
+            it('should not activate the new item (and the old one) when the list box is multi', () => {
+                const newValue = items[2].value;
+                const oldState: IListBoxState[] = defaultState;
+                const newState: IListBoxState[] = listBoxesReducer(
+                    oldState,
+                    selectListBoxOption(id, true, newValue, 2)
+                );
+
+                expect(newState.length).toBe(oldState.length);
+                expect(newState[0].id).toBe(id);
+
+                expect(newState[0].selected.length).toBe(2, 'length');
+                expect(newState[0].selected).toEqual([items[1].value, newValue]);
+                expect(newState[0].active).toBe(null);
             });
 
             it('should not modify the old state', () => {

--- a/packages/react-vapor/src/components/select/SelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SelectConnected.tsx
@@ -13,7 +13,7 @@ import {Content} from '../content/Content';
 import {DropPodPosition} from '../drop/DomPositionCalculator';
 import {Drop} from '../drop/Drop';
 import {IItemBoxProps} from '../itemBox/ItemBox';
-import {IListBoxOwnProps} from '../listBox/ListBox';
+import {IITemBoxPropsWithIndex, IListBoxOwnProps} from '../listBox/ListBox';
 import {selectListBoxOption, setActiveListBoxOption} from '../listBox/ListBoxActions';
 import {ListBoxConnected} from '../listBox/ListBoxConnected';
 import {addSelect, removeSelect, toggleSelect} from './SelectActions';
@@ -70,8 +70,8 @@ const mapDispatchToProps = (
     onRender: () => dispatch(addSelect(ownProps.id)),
     onDestroy: () => dispatch(removeSelect(ownProps.id)),
     onToggleDropdown: () => dispatch(toggleSelect(ownProps.id)),
-    onSelectValue: (value: string, isMulti: boolean) => {
-        dispatch(selectListBoxOption(ownProps.id, isMulti, value));
+    onSelectValue: (value: string, isMulti: boolean, index?: number) => {
+        dispatch(selectListBoxOption(ownProps.id, isMulti, value, index));
     },
     setActive: (diff: number) => dispatch(setActiveListBoxOption(ownProps.id, diff)),
 });
@@ -186,19 +186,22 @@ export class SelectConnected extends React.PureComponent<ISelectProps & ISelectS
         if (keyCode.escape === e.keyCode && this.props.isOpened) {
             this.onToggleDropdown(e);
         }
-
+        let realIndex = 0;
         if (_.contains([keyCode.enter, keyCode.tab], e.keyCode) && this.props.isOpened) {
-            const actives = _.chain(this.props.items)
+            const actives: IITemBoxPropsWithIndex[] = _.chain(this.props.items)
                 .filter(
                     (item: IItemBoxProps) =>
                         !item.hidden &&
                         (!this.props.multi || !_.contains(this.props.selectedValues, item.value)) &&
                         !item.disabled
                 )
+                .map((item: IItemBoxProps) => {
+                    return {item, index: realIndex++};
+                })
                 .value();
             const active = actives[mod(this.props.active, actives.length)];
             if (active) {
-                this.props.onSelectValue(active.value, this.props.multi);
+                this.props.onSelectValue(active.item.value, this.props.multi, active.index);
             }
         } else if (_.contains([keyCode.enter, keyCode.downArrow, keyCode.upArrow], e.keyCode) && !this.props.isOpened) {
             this.onToggleDropdown(e);

--- a/packages/react-vapor/src/components/select/hoc/tests/SingleSelectWithFilter.spec.tsx
+++ b/packages/react-vapor/src/components/select/hoc/tests/SingleSelectWithFilter.spec.tsx
@@ -186,7 +186,7 @@ describe('Select', () => {
                     .simulate('keydown', {keyCode: keyCode.enter})
                     .simulate('keyup', {keyCode: keyCode.enter});
 
-                expect(dispatchSpy).toHaveBeenCalledWith(selectListBoxOption(id, undefined, items[1].value));
+                expect(dispatchSpy).toHaveBeenCalledWith(selectListBoxOption(id, undefined, items[1].value, 1));
             });
 
             it('should dispatch a setActiveListBoxOption when the user press the up or down arrow', () => {


### PR DESCRIPTION
### Proposed Changes

The active items in a SingleSelect was not working properly when changing selection.

When selecting an item by clicking or entering enter on it, it set the item as active.

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
