### PR TITLE
Adui 4690/refactor side navigation

### DIFF
--- a/packages/react-vapor/src/components/sideNavigation/SideNavigation.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigation.tsx
@@ -1,5 +1,6 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
+
 import {JSXRenderable} from '../../utils/JSXUtils';
 import {IReduxStatePossibleProps} from '../../utils/ReduxUtils';
 
@@ -14,17 +15,15 @@ export class SideNavigation extends React.Component<ISideNavProps> {
 
     render() {
         return (
-            <nav className={this.getClasses()}>
+            <nav
+                className={classNames(this.props.className, 'navigation', {
+                    'navigation-opened': !this.props.withReduxState || this.props.opened,
+                })}
+            >
                 <div className="navigation-menu">
                     <div className="navigation-menu-sections">{this.props.children}</div>
                 </div>
             </nav>
         );
-    }
-
-    private getClasses(): string {
-        return classNames(this.props.className, 'navigation', {
-            'navigation-opened': this.props.withReduxState ? this.props.opened : true,
-        });
     }
 }

--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationHeader.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationHeader.tsx
@@ -1,37 +1,40 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
+
 import {Svg} from '../svg/Svg';
 
+/**
+ * @deprecated Use SideNavigationHeaderProps instead
+ */
 export interface ISideNavigationHeaderProps {
-    title: string;
+    title?: string;
     svgName?: string;
     svgClass?: string;
-    onClick?: () => void;
+    onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 }
 
-export class SideNavigationHeader extends React.Component<ISideNavigationHeaderProps> {
-    private handleClick() {
-        if (this.props.onClick) {
-            this.props.onClick();
-        }
-    }
+/**
+ * @deprecated Will be removed in version 5
+ */
+export const SideNavigationHeader: React.FunctionComponent<ISideNavigationHeaderProps> = ({
+    onClick,
+    svgClass,
+    svgName,
+    children,
+}) => {
+    const icon = svgName ? (
+        <Svg
+            svgName={svgName}
+            svgClass={classNames('navigation-menu-section-header-icon icon mod-lg transparency-3', svgClass)}
+        />
+    ) : (
+        <span className="navigation-menu-section-header-icon" />
+    );
 
-    render() {
-        const svgClass = classNames(
-            'navigation-menu-section-header-icon icon mod-lg transparency-3',
-            this.props.svgClass
-        );
-        const icon = this.props.svgName ? (
-            <Svg svgName={this.props.svgName} svgClass={svgClass} />
-        ) : (
-            <span className="navigation-menu-section-header-icon" />
-        );
-        return (
-            <div className="navigation-menu-section-header text-white" onClick={() => this.handleClick()}>
-                {icon}
-                {this.props.title}
-                {this.props.children}
-            </div>
-        );
-    }
-}
+    return (
+        <div className="navigation-menu-section-header text-white" onClick={onClick}>
+            {icon}
+            {children}
+        </div>
+    );
+};

--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationHeader.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationHeader.tsx
@@ -7,34 +7,38 @@ import {Svg} from '../svg/Svg';
  * @deprecated Use SideNavigationHeaderProps instead
  */
 export interface ISideNavigationHeaderProps {
-    title?: string;
+    title: string;
     svgName?: string;
     svgClass?: string;
-    onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+    onClick?: () => void;
 }
 
 /**
  * @deprecated Will be removed in version 5
  */
-export const SideNavigationHeader: React.FunctionComponent<ISideNavigationHeaderProps> = ({
-    onClick,
-    svgClass,
-    svgName,
-    children,
-}) => {
-    const icon = svgName ? (
-        <Svg
-            svgName={svgName}
-            svgClass={classNames('navigation-menu-section-header-icon icon mod-lg transparency-3', svgClass)}
-        />
-    ) : (
-        <span className="navigation-menu-section-header-icon" />
-    );
+export class SideNavigationHeader extends React.Component<ISideNavigationHeaderProps> {
+    private handleClick() {
+        if (this.props.onClick) {
+            this.props.onClick();
+        }
+    }
 
-    return (
-        <div className="navigation-menu-section-header text-white" onClick={onClick}>
-            {icon}
-            {children}
-        </div>
-    );
-};
+    render() {
+        const svgClass = classNames(
+            'navigation-menu-section-header-icon icon mod-lg transparency-3',
+            this.props.svgClass
+        );
+        const icon = this.props.svgName ? (
+            <Svg svgName={this.props.svgName} svgClass={svgClass} />
+        ) : (
+            <span className="navigation-menu-section-header-icon" />
+        );
+        return (
+            <div className="navigation-menu-section-header text-white" onClick={() => this.handleClick()}>
+                {icon}
+                {this.props.title}
+                {this.props.children}
+            </div>
+        );
+    }
+}

--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationItem.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationItem.tsx
@@ -29,6 +29,7 @@ export const SideNavigationItem: React.FunctionComponent<SideNavigationItemProps
 
     const itemClasses = classNames('navigation-menu-section-item', {'state-active': isActive});
 
+    // Rendering an anchor tag from href and title support for retrocompatibility
     return href && title ? (
         <a className={classNames('block', itemClasses)} href={href} target={target} ref={ref}>
             <span className="navigation-menu-section-item-link">{title}</span>

--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationItem.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationItem.tsx
@@ -1,13 +1,22 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
 
-export interface ISideNavigationItemProps {
-    href: string;
-    title: string;
-    target?: string;
+export interface SideNavigationItemProps {
+    isActive?: boolean;
 }
 
-export const SideNavigationItem = (props: ISideNavigationItemProps) => (
-    <a className="block navigation-menu-section-item" href={props.href} target={props.target}>
-        <span className="navigation-menu-section-item-link">{props.title}</span>
-    </a>
-);
+export const SideNavigationItem: React.FunctionComponent<SideNavigationItemProps> = ({isActive, children}) => {
+    const ref = React.useRef(null);
+
+    React.useEffect(() => {
+        if (isActive && ref.current) {
+            ref.current.scrollIntoView({behavior: 'instant', block: 'nearest'});
+        }
+    }, [isActive]);
+
+    return (
+        <div className={classNames('navigation-menu-section-item', {'state-active': isActive})} ref={ref}>
+            {children}
+        </div>
+    );
+};

--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationItem.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationItem.tsx
@@ -1,5 +1,6 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
+import {addClassNameToChildren} from '../../utils/JSXUtils';
 
 export interface ISideNavigationItemProps {
     href: string;
@@ -26,17 +27,15 @@ export const SideNavigationItem: React.FunctionComponent<SideNavigationItemProps
         }
     }, [isActive]);
 
+    const itemClasses = classNames('navigation-menu-section-item', {'state-active': isActive});
+
     return href && title ? (
-        <a
-            className={classNames('block navigation-menu-section-item', {'state-active': isActive})}
-            href={href}
-            target={target}
-        >
+        <a className={classNames('block', itemClasses)} href={href} target={target}>
             <span className="navigation-menu-section-item-link">{title}</span>
         </a>
     ) : (
-        <div className={classNames('navigation-menu-section-item', {'state-active': isActive})} ref={ref}>
-            {children}
+        <div className={itemClasses} ref={ref}>
+            {addClassNameToChildren(children, 'navigation-menu-section-item-link')}
         </div>
     );
 };

--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationItem.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationItem.tsx
@@ -1,11 +1,23 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 
-export interface SideNavigationItemProps {
+export interface ISideNavigationItemProps {
+    href: string;
+    title: string;
+    target?: string;
+}
+
+export interface SideNavigationItemProps extends Partial<ISideNavigationItemProps> {
     isActive?: boolean;
 }
 
-export const SideNavigationItem: React.FunctionComponent<SideNavigationItemProps> = ({isActive, children}) => {
+export const SideNavigationItem: React.FunctionComponent<SideNavigationItemProps> = ({
+    isActive,
+    href,
+    title,
+    children,
+    target,
+}) => {
     const ref = React.useRef(null);
 
     React.useEffect(() => {
@@ -14,7 +26,15 @@ export const SideNavigationItem: React.FunctionComponent<SideNavigationItemProps
         }
     }, [isActive]);
 
-    return (
+    return href && title ? (
+        <a
+            className={classNames('block navigation-menu-section-item', {'state-active': isActive})}
+            href={href}
+            target={target}
+        >
+            <span className="navigation-menu-section-item-link">{title}</span>
+        </a>
+    ) : (
         <div className={classNames('navigation-menu-section-item', {'state-active': isActive})} ref={ref}>
             {children}
         </div>

--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationItem.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationItem.tsx
@@ -30,7 +30,7 @@ export const SideNavigationItem: React.FunctionComponent<SideNavigationItemProps
     const itemClasses = classNames('navigation-menu-section-item', {'state-active': isActive});
 
     return href && title ? (
-        <a className={classNames('block', itemClasses)} href={href} target={target}>
+        <a className={classNames('block', itemClasses)} href={href} target={target} ref={ref}>
             <span className="navigation-menu-section-item-link">{title}</span>
         </a>
     ) : (

--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationMenuSection.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationMenuSection.tsx
@@ -6,6 +6,13 @@ import {Collapsible} from '../collapsible/Collapsible';
 import {Svg} from '../svg/Svg';
 import {ISideNavigationHeaderProps} from './SideNavigationHeader';
 
+export interface SideNavigationHeaderProps {
+    title?: React.ReactNode;
+    svgName?: string;
+    svgClass?: string;
+    customIcon?: React.ReactNode;
+    onClick?: (event: React.MouseEvent) => void;
+}
 export interface ISideNavigationSectionProps extends SideNavigationHeaderProps {
     /**
      * @deprecated pass those in props directly
@@ -14,14 +21,6 @@ export interface ISideNavigationSectionProps extends SideNavigationHeaderProps {
     expandable?: boolean;
     expanded?: boolean;
     onClick?: () => void;
-}
-
-export interface SideNavigationHeaderProps {
-    title?: React.ReactNode;
-    svgName?: string;
-    svgClass?: string;
-    customIcon?: React.ReactNode;
-    onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 }
 
 const HeaderIcon: React.FunctionComponent<SideNavigationHeaderProps> = ({svgName, svgClass}) =>

--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationMenuSection.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationMenuSection.tsx
@@ -42,12 +42,12 @@ const SideNavigationHeader: React.FunctionComponent<SideNavigationHeaderProps> =
         icon = <span className="navigation-menu-section-header-icon" />;
     }
 
-    return !_.isEmpty(React.Children.map(props.children, _.identity)) ? (
+    return (
         <div className="navigation-menu-section-header text-white" onClick={props.onClick}>
             {icon}
             {props.children}
         </div>
-    ) : null;
+    );
 };
 
 export const SideNavigationMenuSection: React.FunctionComponent<ISideNavigationSectionProps> = ({
@@ -59,9 +59,10 @@ export const SideNavigationMenuSection: React.FunctionComponent<ISideNavigationS
     title,
     ...headerProps
 }) => {
-    const sectionHeader = (
+    const headerTitle = title || (header && header.title);
+    const sectionHeader = headerTitle && (
         <SideNavigationHeader {..._.extend({}, header, headerProps)} onClick={expandable ? _.noop : onClick}>
-            {title || (header && header.title)}
+            {headerTitle}
         </SideNavigationHeader>
     );
     const items = <div className="navigation-menu-section-items">{children}</div>;

--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationMenuSection.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationMenuSection.tsx
@@ -1,63 +1,86 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
-import {SlideY} from '../../animations/SlideY';
-import {Svg} from '../svg/Svg';
-import {ISideNavigationHeaderProps, SideNavigationHeader} from './SideNavigationHeader';
-import {SideNavigationLoadingHeader} from './SideNavigationLoadingHeader';
+import * as _ from 'underscore';
 
-export interface ISideNavigationSectionOwnProps {
+import {Collapsible} from '../collapsible/Collapsible';
+import {Svg} from '../svg/Svg';
+import {ISideNavigationHeaderProps} from './SideNavigationHeader';
+
+export interface ISideNavigationSectionProps extends SideNavigationHeaderProps {
+    /**
+     * @deprecated pass those in props directly
+     */
     header?: ISideNavigationHeaderProps;
     expandable?: boolean;
-}
-
-export interface ISideNavigationSectionStateProps {
     expanded?: boolean;
-}
-
-export interface ISideNavigationSectionDispatchProps {
     onClick?: () => void;
 }
 
-export interface ISideNavigationSectionProps
-    extends ISideNavigationSectionOwnProps,
-        ISideNavigationSectionStateProps,
-        ISideNavigationSectionDispatchProps {}
-
-const arrowClassName = 'collapsible-arrow icon fill-white transparency-4';
-
-export class SideNavigationMenuSection extends React.Component<ISideNavigationSectionProps> {
-    private handleClick() {
-        if (this.props.onClick) {
-            this.props.onClick();
-        }
-    }
-
-    render() {
-        return (
-            <div className="block navigation-menu-section">
-                {this.buildHeader()}
-                <SlideY in={!(this.props.expandable && !this.props.expanded)} timeout={350}>
-                    <div className="navigation-menu-section-items">{this.props.children}</div>
-                </SlideY>
-            </div>
-        );
-    }
-
-    private buildHeader(): JSX.Element {
-        if (this.props.header) {
-            let arrow = null;
-            if (this.props.expandable) {
-                arrow = this.props.expanded ? (
-                    <Svg svgName="arrow-top-rounded" className={arrowClassName} />
-                ) : (
-                    <Svg svgName="arrow-bottom-rounded" className={arrowClassName} />
-                );
-            }
-            return (
-                <SideNavigationHeader {...this.props.header} onClick={() => this.handleClick()}>
-                    {arrow}
-                </SideNavigationHeader>
-            );
-        }
-        return <SideNavigationLoadingHeader />;
-    }
+export interface SideNavigationHeaderProps {
+    title?: React.ReactNode;
+    svgName?: string;
+    svgClass?: string;
+    customIcon?: React.ReactNode;
+    onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 }
+
+const SideNavigationHeader: React.FunctionComponent<SideNavigationHeaderProps> = (props) => {
+    let icon: React.ReactNode = null;
+    if (props.customIcon) {
+        icon = props.customIcon;
+    } else if (props.svgName) {
+        icon = (
+            <Svg
+                svgName={props.svgName}
+                svgClass={classNames(
+                    'navigation-menu-section-header-icon icon mod-lg transparency-3 fill-white',
+                    props.svgClass
+                )}
+            />
+        );
+    } else {
+        icon = <span className="navigation-menu-section-header-icon" />;
+    }
+
+    return !_.isEmpty(React.Children.map(props.children, _.identity)) ? (
+        <div className="navigation-menu-section-header text-white" onClick={props.onClick}>
+            {icon}
+            {props.children}
+        </div>
+    ) : null;
+};
+
+export const SideNavigationMenuSection: React.FunctionComponent<ISideNavigationSectionProps> = ({
+    expandable,
+    expanded,
+    onClick,
+    header,
+    children,
+    title,
+    ...headerProps
+}) => {
+    const sectionHeader = (
+        <SideNavigationHeader {..._.extend({}, header, headerProps)} onClick={expandable ? _.noop : onClick}>
+            {title || (header && header.title)}
+        </SideNavigationHeader>
+    );
+    const items = <div className="navigation-menu-section-items">{children}</div>;
+
+    return expandable ? (
+        <Collapsible
+            className="navigation-menu-section"
+            id={_.uniqueId('nav-section')}
+            headerContent={sectionHeader}
+            toggleIconClassName="fill-white transparency-3"
+            onToggleExpandedState={onClick}
+            expanded={expanded}
+        >
+            {items}
+        </Collapsible>
+    ) : (
+        <div className="navigation-menu-section">
+            {sectionHeader}
+            {items}
+        </div>
+    );
+};

--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationMenuSection.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationMenuSection.tsx
@@ -73,7 +73,7 @@ export const SideNavigationMenuSection: React.FunctionComponent<ISideNavigationS
             headerContent={sectionHeader}
             toggleIconClassName="fill-white transparency-3"
             onToggleExpandedState={onClick}
-            expanded={expanded}
+            expanded={!!expanded}
         >
             {items}
         </Collapsible>

--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationMenuSection.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationMenuSection.tsx
@@ -24,39 +24,35 @@ export interface SideNavigationHeaderProps {
     onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 }
 
-const SideNavigationHeader: React.FunctionComponent<SideNavigationHeaderProps> = (props) => {
-    let icon: React.ReactNode = null;
-    if (props.customIcon) {
-        icon = props.customIcon;
-    } else if (props.svgName) {
-        icon = (
-            <Svg
-                svgName={props.svgName}
-                svgClass={classNames(
-                    'navigation-menu-section-header-icon icon mod-lg transparency-3 fill-white',
-                    props.svgClass
-                )}
-            />
-        );
-    } else {
-        icon = <span className="navigation-menu-section-header-icon" />;
-    }
-
-    return (
-        <div className="navigation-menu-section-header text-white" onClick={props.onClick}>
-            {icon}
-            {props.children}
-        </div>
+const HeaderIcon: React.FunctionComponent<SideNavigationHeaderProps> = ({svgName, svgClass}) =>
+    svgName ? (
+        <Svg
+            svgName={svgName}
+            svgClass={classNames('navigation-menu-section-header-icon icon mod-lg transparency-3 fill-white', svgClass)}
+        />
+    ) : (
+        <span className="navigation-menu-section-header-icon" />
     );
-};
+
+const SideNavigationHeader: React.FunctionComponent<SideNavigationHeaderProps> = ({
+    customIcon,
+    onClick,
+    children,
+    ...iconProps
+}) => (
+    <div className="navigation-menu-section-header text-white" onClick={onClick}>
+        {customIcon || <HeaderIcon {...iconProps} />}
+        {children}
+    </div>
+);
 
 export const SideNavigationMenuSection: React.FunctionComponent<ISideNavigationSectionProps> = ({
     expandable,
     expanded,
+    title,
     onClick,
     header,
     children,
-    title,
     ...headerProps
 }) => {
     const headerTitle = title || (header && header.title);

--- a/packages/react-vapor/src/components/sideNavigation/examples/SideNavigationExample.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/examples/SideNavigationExample.tsx
@@ -27,24 +27,8 @@ export class SideNavigationExample extends React.Component<any, any> {
                 <div className="flex flex-row flex-stretch">
                     <SideNavigation>
                         <SideNavigationMenuSection title="Section 1" svgName="identity-user">
-                            <SideNavigationItem isActive>
-                                <a
-                                    href="http://coveo.com"
-                                    title="Link to Coveo"
-                                    className="navigation-menu-section-item-link"
-                                >
-                                    Link to Coveo
-                                </a>
-                            </SideNavigationItem>
-                            <SideNavigationItem>
-                                <a
-                                    href="http://coveo.com"
-                                    title="Link to Coveo"
-                                    className="navigation-menu-section-item-link"
-                                >
-                                    Another link to Coveo
-                                </a>
-                            </SideNavigationItem>
+                            <SideNavigationItem isActive href="http://coveo.com" title="Link to Coveo" />
+                            <SideNavigationItem href="http://coveo.com" title="Another link to Coveo" />
                         </SideNavigationMenuSection>
                         <SideNavigationMenuSection title="Section 2">
                             <SideNavigationLoadingItem className="mod-width-30" />

--- a/packages/react-vapor/src/components/sideNavigation/examples/SideNavigationExample.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/examples/SideNavigationExample.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import {SideNavigation} from '../SideNavigation';
 import {SideNavigationItem} from '../SideNavigationItem';
 import {SideNavigationLoadingItem} from '../SideNavigationLoadingItem';
@@ -25,23 +26,56 @@ export class SideNavigationExample extends React.Component<any, any> {
                 <label className="form-control-label">Side Navigation</label>
                 <div className="flex flex-row flex-stretch">
                     <SideNavigation>
-                        <SideNavigationMenuSection header={{title: 'Section 1', svgName: 'identity-user'}}>
-                            <SideNavigationItem href="http://coveo.com" title="Link to Coveo" />
-                            <SideNavigationItem href="http://coveo.com" title="Another link to Coveo" />
+                        <SideNavigationMenuSection title="Section 1" svgName="identity-user">
+                            <SideNavigationItem isActive>
+                                <a
+                                    href="http://coveo.com"
+                                    title="Link to Coveo"
+                                    className="navigation-menu-section-item-link"
+                                >
+                                    Link to Coveo
+                                </a>
+                            </SideNavigationItem>
+                            <SideNavigationItem>
+                                <a
+                                    href="http://coveo.com"
+                                    title="Link to Coveo"
+                                    className="navigation-menu-section-item-link"
+                                >
+                                    Another link to Coveo
+                                </a>
+                            </SideNavigationItem>
                         </SideNavigationMenuSection>
-                        <SideNavigationMenuSection header={{title: 'Section 2'}}>
+                        <SideNavigationMenuSection title="Section 2">
                             <SideNavigationLoadingItem className="mod-width-30" />
                             <SideNavigationLoadingItem className="mod-width-50" />
                             <SideNavigationLoadingItem className="mod-width-40" />
                         </SideNavigationMenuSection>
                         <SideNavigationMenuSection
-                            header={{title: 'Section 3', svgName: 'menu-content'}}
+                            title="Collapsible Section"
+                            svgName="menu-content"
                             expandable
                             expanded={this.state.expanded}
                             onClick={() => this.click()}
                         >
-                            <SideNavigationItem href="http://coveo.com" target="_blank" title="Link to Coveo" />
-                            <SideNavigationItem href="http://coveo.com" title="Another link to Coveo" />
+                            <SideNavigationItem>
+                                <a
+                                    href="http://coveo.com"
+                                    title="Link to Coveo"
+                                    className="navigation-menu-section-item-link"
+                                >
+                                    Link to Coveo
+                                </a>
+                            </SideNavigationItem>
+                            <SideNavigationItem>
+                                <a
+                                    href="http://coveo.com"
+                                    title="Link to Coveo"
+                                    className="navigation-menu-section-item-link"
+                                >
+                                    Another link to Coveo
+                                </a>
+                            </SideNavigationItem>
                         </SideNavigationMenuSection>
                     </SideNavigation>
                 </div>

--- a/packages/react-vapor/src/components/sideNavigation/examples/SideNavigationExample.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/examples/SideNavigationExample.tsx
@@ -43,20 +43,12 @@ export class SideNavigationExample extends React.Component<any, any> {
                             onClick={() => this.click()}
                         >
                             <SideNavigationItem>
-                                <a
-                                    href="http://coveo.com"
-                                    title="Link to Coveo"
-                                    className="navigation-menu-section-item-link"
-                                >
+                                <a href="http://coveo.com" title="Link to Coveo">
                                     Link to Coveo
                                 </a>
                             </SideNavigationItem>
                             <SideNavigationItem>
-                                <a
-                                    href="http://coveo.com"
-                                    title="Link to Coveo"
-                                    className="navigation-menu-section-item-link"
-                                >
+                                <a href="http://coveo.com" title="Link to Coveo">
                                     Another link to Coveo
                                 </a>
                             </SideNavigationItem>

--- a/packages/react-vapor/src/components/sideNavigation/tests/SideNavigationItem.spec.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/tests/SideNavigationItem.spec.tsx
@@ -23,4 +23,20 @@ describe('SideNavigationItem', () => {
         item = shallow(<SideNavigationItem isActive />);
         expect(item.hasClass('state-active')).toBe(true);
     });
+
+    it('should render an anchor tag if the "href" and "title" props are specified', () => {
+        item = shallow(<SideNavigationItem href="http://www.perdu.com" title="Perdu ?" />);
+
+        expect(item.type()).toBe('a');
+    });
+
+    it('should render a div tag if the "href" and "title" props are not specified', () => {
+        item = shallow(
+            <SideNavigationItem>
+                <a href="http://www.perdu.com">Perdu ?</a>
+            </SideNavigationItem>
+        );
+
+        expect(item.type()).toBe('div');
+    });
 });

--- a/packages/react-vapor/src/components/sideNavigation/tests/SideNavigationItem.spec.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/tests/SideNavigationItem.spec.tsx
@@ -1,11 +1,26 @@
-import {shallow} from 'enzyme';
+import {shallow, ShallowWrapper} from 'enzyme';
 import * as React from 'react';
-import {SideNavigationItem} from '../SideNavigationItem';
 
-describe('<SideNavigationItem />', () => {
-    it('should render without errors', () => {
+import {SideNavigationItem, SideNavigationItemProps} from '../SideNavigationItem';
+
+describe('SideNavigationItem', () => {
+    let item: ShallowWrapper<SideNavigationItemProps>;
+
+    afterEach(() => {
+        if (item && item.exists()) {
+            item.unmount();
+        }
+    });
+
+    it('should render and unmount without errors', () => {
         expect(() => {
-            shallow(<SideNavigationItem title="link to Coveo" href="http://coveo.com" />);
+            item = shallow(<SideNavigationItem />);
+            item.unmount();
         }).not.toThrow();
+    });
+
+    it('should have the .state-active class when "isActive" prop is set to true', () => {
+        item = shallow(<SideNavigationItem isActive />);
+        expect(item.hasClass('state-active')).toBe(true);
     });
 });

--- a/packages/react-vapor/src/components/sideNavigation/tests/SideNavigationMenuSection.spec.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/tests/SideNavigationMenuSection.spec.tsx
@@ -3,12 +3,12 @@ import * as React from 'react';
 import {SlideY} from '../../../animations/SlideY';
 import {SideNavigationHeader} from '../SideNavigationHeader';
 import {SideNavigationLoadingHeader} from '../SideNavigationLoadingHeader';
-import {ISideNavigationSectionProps, SideNavigationMenuSection} from '../SideNavigationMenuSection';
+import {ISideNavigationSectionProps, SideNavigationSection} from '../SideNavigationMenuSection';
 
 describe('<SideNavigationMenuSection />', () => {
     it('should render without errors', () => {
         expect(() => {
-            shallow(<SideNavigationMenuSection />);
+            shallow(<SideNavigationSection />);
         }).not.toThrow();
     });
 });
@@ -18,7 +18,7 @@ describe('<SideNavigationMenuSection />', () => {
     let wrapper: ReactWrapper<ISideNavigationSectionProps, any>;
 
     beforeEach(() => {
-        wrapper = mount(<SideNavigationMenuSection />, {attachTo: document.getElementById('App')});
+        wrapper = mount(<SideNavigationSection />, {attachTo: document.getElementById('App')});
     });
 
     afterEach(() => {

--- a/packages/react-vapor/src/components/sideNavigation/tests/SideNavigationMenuSection.spec.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/tests/SideNavigationMenuSection.spec.tsx
@@ -1,68 +1,79 @@
-import {mount, ReactWrapper, shallow} from 'enzyme';
+import {shallow, ShallowWrapper} from 'enzyme';
 import * as React from 'react';
-import {SlideY} from '../../../animations/SlideY';
-import {SideNavigationHeader} from '../SideNavigationHeader';
-import {SideNavigationLoadingHeader} from '../SideNavigationLoadingHeader';
-import {ISideNavigationSectionProps, SideNavigationSection} from '../SideNavigationMenuSection';
 
-describe('<SideNavigationMenuSection />', () => {
-    it('should render without errors', () => {
-        expect(() => {
-            shallow(<SideNavigationSection />);
-        }).not.toThrow();
-    });
-});
+import {Collapsible} from '../../collapsible/Collapsible';
+import {ISideNavigationSectionProps, SideNavigationMenuSection} from '../SideNavigationMenuSection';
 
-describe('<SideNavigationMenuSection />', () => {
-    const title = 'qwerty';
-    let wrapper: ReactWrapper<ISideNavigationSectionProps, any>;
-
-    beforeEach(() => {
-        wrapper = mount(<SideNavigationSection />, {attachTo: document.getElementById('App')});
-    });
+describe('SideNavigationMenuSection', () => {
+    let section: ShallowWrapper<ISideNavigationSectionProps>;
+    const header = {
+        title: 'title is comming from the header prop',
+        svgName: 'some-name',
+        svgClass: 'some-class',
+    };
 
     afterEach(() => {
-        wrapper.detach();
+        if (section && section.exists()) {
+            section.unmount();
+        }
     });
 
-    it('should render loading header when no header is specified.', () => {
-        const header = wrapper.find(SideNavigationLoadingHeader).first();
-
-        expect(header).toBeDefined();
+    it('should render and unmount without errors', () => {
+        expect(() => {
+            section = shallow(<SideNavigationMenuSection />);
+            section.unmount();
+        }).not.toThrow();
     });
 
-    it('should render normal header when header prop is specified.', () => {
-        wrapper.setProps({header: {title}});
-        wrapper.mount();
+    it('should setup the section header using the "header" prop', () => {
+        section = shallow(<SideNavigationMenuSection header={header} />);
+        expect(section.find('SideNavigationHeader').exists()).toBe(true);
 
-        const header = wrapper.find(SideNavigationHeader).first();
+        const sectionHeader = section.find('SideNavigationHeader');
+        expect(sectionHeader.children().contains(header.title)).toBe(true);
+        expect(sectionHeader.prop('svgName')).toBe(header.svgName);
+        expect(sectionHeader.prop('svgClass')).toBe(header.svgClass);
+    });
 
-        expect(header).toBeDefined();
+    it('should setup the section header directly using the props', () => {
+        section = shallow(<SideNavigationMenuSection {...header} />);
+        expect(section.find('SideNavigationHeader').exists()).toBe(true);
+
+        const sectionHeader = section.find('SideNavigationHeader');
+        expect(sectionHeader.children().contains(header.title)).toBe(true);
+        expect(sectionHeader.prop('svgName')).toBe(header.svgName);
+        expect(sectionHeader.prop('svgClass')).toBe(header.svgClass);
     });
 
     it('should hide children when expandable prop is true and expanded prop is false.', () => {
-        wrapper.setProps({header: {title}, expandable: true});
-        wrapper.mount();
+        section = shallow(<SideNavigationMenuSection {...header} expandable />);
 
-        expect(wrapper.find(SlideY).prop('in')).toBeDefined(false);
+        expect(section.find(Collapsible).prop('expanded')).toBe(false);
     });
 
     it('should not hide children when expandable prop is true and expanded prop is true.', () => {
-        wrapper.setProps({header: {title}, expandable: true, expanded: true});
-        wrapper.mount();
+        section = shallow(<SideNavigationMenuSection {...header} expandable expanded />);
 
-        expect(wrapper.find(SlideY).prop('in')).toBeDefined(true);
+        expect(section.find(Collapsible).prop('expanded')).toBe(true);
     });
 
-    it('should call onClick prop when header clicked and onClick prop is specified', () => {
+    it('should call onClick prop when clicking on the header', () => {
         const onClickSpy = jasmine.createSpy('click');
-        wrapper.setProps({header: {title}, onClick: onClickSpy});
-        wrapper.mount();
-        wrapper
-            .find(SideNavigationHeader)
-            .first()
-            .simulate('click');
+        section = shallow(<SideNavigationMenuSection {...header} onClick={onClickSpy} />);
+        section.find('SideNavigationHeader').prop('onClick')(null);
 
         expect(onClickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should render the navigation items inside the .navigation-menu-section-items class', () => {
+        section = shallow(
+            <SideNavigationMenuSection {...header}>
+                <div>Item 1</div>
+                <div>Item 2</div>
+                <div>Item 3</div>
+            </SideNavigationMenuSection>
+        );
+
+        expect(section.find('.navigation-menu-section-items').children().length).toBe(3);
     });
 });

--- a/packages/vapor/scss/components/navigation.scss
+++ b/packages/vapor/scss/components/navigation.scss
@@ -11,7 +11,8 @@
 }
 
 .navigation {
-    width: $navigation-width;
+    min-width: $navigation-width;
+    max-width: $navigation-width;
     overflow-x: auto;
     overflow-y: overlay;
     background-color: $navigation-background-color;


### PR DESCRIPTION
### Proposed Changes

#### Refactored the `SideNavigationMenuSection` component

Now the `SideNavigationMenuSection` supports passing down the header props directly on the SideNavigationMenuSection (backwards compatibility has been preserved):

```tsx
// Before
<SideNavigationMenuSection
    header={{
        title: 'the title',
        svgName: 'theIcon',
        svgClass: 'theClasses',
        onClick: doSomething,
    }}
    {...otherProps}
/>

// After (you can still use the header prop although it its deprecated)
<SideNavigationMenuSection 
    title='the title' 
    svgName='theIcon' 
    svgClass='theClasses' 
    onClick={doSomething}
    {...otherProps}
/>
```

#### Refactored the `SideNavigationItem` component
Made the `SideNavigationItem` more generic while preserving backwards compatibility.

```tsx
// Before
<SideNavigationItem href="http://coveo.com" title="Link to Coveo" />

// After (you can still use the old way)
<SideNavigationItem>
    <a
        href="http://coveo.com"
        title="Link to Coveo"
        className="navigation-menu-section-item-link"
    >
        Link to Coveo
    </a>
</SideNavigationItem>
```

#### Deprecate `SideNavigationHeader` component. 

Now it is embedded directly inside `SideNavigationMenuSection`'s implementation because it doesn't make sense to use such header outside a side navigation section.

### Potention breaking changes

None.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
