### PR TITLE
Refactor unMount method

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableRowConnected.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableRowConnected.tsx
@@ -39,7 +39,7 @@ export interface ITableRowStateProps {
 
 export interface ITableRowDispatchProps {
     onMount: () => void;
-    onUnmount: () => void;
+    onUnmount: (isSelected: boolean) => void;
     handleClick: (isMulti: boolean, isOpened: boolean) => void;
     onUpdateToCollapsibleRow: () => void;
     onActionBarActionsChanged: () => void;
@@ -78,9 +78,11 @@ const mapDispatchToProps = (dispatch: IDispatch, ownProps: ITableRowOwnProps): I
                 dispatch(TableHOCRowActions.toggleCollapsible(ownProps.id, true));
             }
         },
-        onUnmount: () => {
+        onUnmount: (isSelected?: boolean) => {
             dispatch(TableHOCRowActions.remove(ownProps.id));
-            dispatch(TableHOCRowActions.deselectAll(ownProps.tableId));
+            if (isSelected) {
+                dispatch(addActionsToActionBar(ownProps.tableId, []));
+            }
         },
         handleClick: (isMulti: boolean, isOpened: boolean) => {
             refreshActionBarActions(isMulti);
@@ -119,7 +121,7 @@ class TableRowConnected extends React.PureComponent<
     }
 
     componentWillUnmount() {
-        this.props.onUnmount();
+        this.props.onUnmount(this.props.selected);
     }
 
     render() {


### PR DESCRIPTION
### Proposed Changes

- At first, I've tried replace deselectAll with dispatching deselect a single row, but it didn't work. Because the ActionBarReducer has no knowledge about the current selection. Also it may cause unexpected effect. 
- In a nutshell, IMO the safest solution till now is dispatching addActionsToActionBar without action on unMount if a row is selected, in another word, remove existing actions.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
