### PR TITLE
Fix the demo link branch name hash

### DIFF
--- a/create-live-demo.sh
+++ b/create-live-demo.sh
@@ -5,7 +5,7 @@ git config user.email "$COMMIT_AUTHOR_EMAIL"
 
 REPO=`git config remote.origin.url`
 SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
-BRANCH_FOLDER_NAME=`$TRAVIS_PULL_REQUEST_BRANCH | md5sum | awk '{print $1}'`
+BRANCH_FOLDER_NAME=`echo "$TRAVIS_PULL_REQUEST_BRANCH" | md5sum | awk '{print $1}'`
 
 echo "Syncing with gh-pages from branch: $TRAVIS_PULL_REQUEST_BRANCH"
 git stash


### PR DESCRIPTION
The hash in the demo link should be different than `d41d8cd98f00b204e9800998ecf8427e`