### PR TITLE
Add class name to children util

### DIFF
--- a/packages/react-vapor/karma.conf.js
+++ b/packages/react-vapor/karma.conf.js
@@ -46,8 +46,6 @@ module.exports = (config) => {
 
         autoWatch: true,
         singleRun: true,
-
-        browserNoActivityTimeout: 30000,
     };
 
     if (!skipCoverageProcessing) {

--- a/packages/react-vapor/src/utils/JSXUtils.spec.tsx
+++ b/packages/react-vapor/src/utils/JSXUtils.spec.tsx
@@ -1,7 +1,9 @@
+import {shallow} from 'enzyme';
 import * as React from 'react';
-import {getReactNodeTextContent} from './JSXUtils';
 
-describe('JSXUtils', () => {
+import {addClassNameToChildren, getReactNodeTextContent} from './JSXUtils';
+
+fdescribe('JSXUtils', () => {
     describe('getReactNodeTextContent', () => {
         it('should return an empty string when receiving falsy values as react node', () => {
             expect(getReactNodeTextContent(null)).toBe('');
@@ -23,6 +25,23 @@ describe('JSXUtils', () => {
                     </div>
                 )
             ).toBe("Hello there! Can't you see me? I can.");
+        });
+    });
+
+    describe('addClassNameToChildren', () => {
+        it('should not add any class if the children is not a react element', () => {
+            const myElement = 'a string is not a react element';
+            expect(addClassNameToChildren(myElement, 'new-class')).toContain(myElement);
+        });
+
+        it('should add the new className to existing ones if the children a react element', () => {
+            const resultingChildren = addClassNameToChildren(
+                <span className="old-class">Hello react-vapor!</span>,
+                'new-class'
+            );
+            const component = shallow(resultingChildren[0] as React.ReactElement);
+            expect(component.hasClass('old-class')).toBe(true);
+            expect(component.hasClass('new-class')).toBe(true);
         });
     });
 });

--- a/packages/react-vapor/src/utils/JSXUtils.spec.tsx
+++ b/packages/react-vapor/src/utils/JSXUtils.spec.tsx
@@ -29,9 +29,12 @@ describe('JSXUtils', () => {
     });
 
     describe('addClassNameToChildren', () => {
-        it('should not add any class if the children is not a react element', () => {
-            const myElement = 'a string is not a react element';
-            expect(addClassNameToChildren(myElement, 'new-class')).toContain(myElement);
+        it('should wrap the child with a span that has the classname if the children is not a react element', () => {
+            const resultingChildren = addClassNameToChildren('a string is not a react element', 'new-class');
+            const component = shallow(resultingChildren[0] as React.ReactElement);
+
+            expect(component.type()).toBe('span');
+            expect(component.hasClass('new-class')).toBe(true);
         });
 
         it('should add the new className to existing ones if the children a react element', () => {

--- a/packages/react-vapor/src/utils/JSXUtils.spec.tsx
+++ b/packages/react-vapor/src/utils/JSXUtils.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import {addClassNameToChildren, getReactNodeTextContent} from './JSXUtils';
 
-fdescribe('JSXUtils', () => {
+describe('JSXUtils', () => {
     describe('getReactNodeTextContent', () => {
         it('should return an empty string when receiving falsy values as react node', () => {
             expect(getReactNodeTextContent(null)).toBe('');

--- a/packages/react-vapor/src/utils/JSXUtils.tsx
+++ b/packages/react-vapor/src/utils/JSXUtils.tsx
@@ -18,7 +18,9 @@ export const getReactNodeTextContent = (node: React.ReactNode): string => {
 
 export const addClassNameToChildren = (children: React.ReactNode, className: string) =>
     React.Children.map(children, (child) =>
-        React.isValidElement(child)
-            ? React.cloneElement(child, {className: classNames(child.props.className, className)})
-            : child
+        React.isValidElement(child) ? (
+            React.cloneElement(child, {className: classNames(child.props.className, className)})
+        ) : (
+            <span className={className}>{child}</span>
+        )
     );

--- a/packages/react-vapor/src/utils/JSXUtils.tsx
+++ b/packages/react-vapor/src/utils/JSXUtils.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
 import {renderToStaticMarkup} from 'react-dom/server';
 import * as _ from 'underscore';
@@ -14,3 +15,10 @@ export const getReactNodeTextContent = (node: React.ReactNode): string => {
         s.stripTags
     )(renderToStaticMarkup(<div>{node}</div>));
 };
+
+export const addClassNameToChildren = (children: React.ReactNode, className: string) =>
+    React.Children.map(children, (child) =>
+        React.isValidElement(child)
+            ? React.cloneElement(child, {className: classNames(child.props.className, className)})
+            : child
+    );


### PR DESCRIPTION
### Proposed Changes

Implemented a small util that adds className to children (or any react node).

```tsx
// node
<span className="old-class">Hello react-vapor!</span>;

const newNode = addClassNameToChildren(node, 'new-class');

// newNode
<span className="old-class new-class">Hello react-vapor!</span>
```

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
