### PR TITLE
Remove `react-modal` `afterClose` bug workaround

### DIFF
--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -44,7 +44,7 @@
         "react-bootstrap": "0.32.4",
         "react-codemirror2": "5.1.0",
         "react-infinite-scroll-component": "4.2.0",
-        "react-modal": "3.8.1",
+        "react-modal": "3.10.1",
         "react-tether": "1.0.4",
         "react-textarea-autosize": "7.1.0",
         "unidiff": "0.0.4"
@@ -81,7 +81,7 @@
         "@types/react-codemirror": "1.0.2",
         "@types/react-dom": "16.8.1",
         "@types/react-infinite-scroll-component": "4.2.3",
-        "@types/react-modal": "3.8.1",
+        "@types/react-modal": "3.8.2",
         "@types/react-redux": "6.0.10",
         "@types/react-router-dom": "4.3.4",
         "@types/react-syntax-highlighter": "10.2.1",

--- a/packages/react-vapor/src/components/modal/ModalComposite.tsx
+++ b/packages/react-vapor/src/components/modal/ModalComposite.tsx
@@ -94,7 +94,7 @@ export class ModalComposite extends React.PureComponent<
         callIfDefined(this.props.onDestroy);
     }
 
-    private onRequestClose = (e: MouseEvent | KeyboardEvent) => {
+    private onRequestClose = (e: React.MouseEvent | React.KeyboardEvent) => {
         e.preventDefault();
         e.stopPropagation();
 

--- a/packages/react-vapor/src/components/modal/ModalComposite.tsx
+++ b/packages/react-vapor/src/components/modal/ModalComposite.tsx
@@ -52,13 +52,6 @@ export class ModalComposite extends React.PureComponent<
         closeTimeout: Defaults.MODAL_TIMEOUT,
     };
 
-    private timeoutId: number;
-
-    constructor(props: IModalCompositeProps) {
-        super(props);
-        this.onRequestClose = this.onRequestClose.bind(this);
-    }
-
     render() {
         const reactModalprops: Partial<ReactModal.Props> = _.omit(this.props, modalPropsToOmit);
         return (
@@ -81,6 +74,7 @@ export class ModalComposite extends React.PureComponent<
                 closeTimeoutMS={this.props.closeTimeout}
                 contentRef={this.props.contentRef}
                 parentSelector={this.getParent}
+                onAfterClose={this.props.closeCallback}
                 {...reactModalprops}
             >
                 <div className="modal-content" id={this.props.id}>
@@ -92,26 +86,15 @@ export class ModalComposite extends React.PureComponent<
         );
     }
 
-    componentDidUpdate(prevProps: IModalCompositeProps) {
-        // Workaround for https://github.com/reactjs/react-modal/issues/745
-        if (prevProps.isOpened && !this.props.isOpened) {
-            window.clearTimeout(this.timeoutId);
-            this.timeoutId = window.setTimeout(() => {
-                callIfDefined(this.props.closeCallback);
-            }, this.props.closeTimeout);
-        }
-    }
-
     componentDidMount() {
         callIfDefined(this.props.onRender);
     }
 
     componentWillUnmount() {
         callIfDefined(this.props.onDestroy);
-        window.clearTimeout(this.timeoutId);
     }
 
-    private onRequestClose(e: MouseEvent | KeyboardEvent) {
+    private onRequestClose = (e: MouseEvent | KeyboardEvent) => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -122,7 +105,7 @@ export class ModalComposite extends React.PureComponent<
         } else {
             callIfDefined(this.props.onClose);
         }
-    }
+    };
 
     private getModalHeader() {
         const basicProps: IModalHeaderProps = {

--- a/packages/react-vapor/src/components/modal/examples/ModalCompositeConnectedExamples.tsx
+++ b/packages/react-vapor/src/components/modal/examples/ModalCompositeConnectedExamples.tsx
@@ -57,7 +57,7 @@ class ComponentWithPreventNavigateExample extends React.PureComponent<IWithDirty
     }
 }
 
-export const ComponentWithPreventNavigationHOC = modalWithPreventNavigation({id: 'modal-composite-2'})(
+const ComponentWithPreventNavigationHOC = modalWithPreventNavigation({id: 'modal-composite-2'})(
     ComponentWithPreventNavigateExample
 );
 

--- a/packages/react-vapor/src/components/modal/tests/ModalComposite.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/ModalComposite.spec.tsx
@@ -2,7 +2,6 @@ import {shallow} from 'enzyme';
 import * as React from 'react';
 import * as ReactModal from 'react-modal';
 
-import {Defaults} from '../../../Defaults';
 import {ModalBody} from '../ModalBody';
 import {ModalComposite} from '../ModalComposite';
 import {ModalFooter} from '../ModalFooter';
@@ -76,18 +75,12 @@ describe('ModalComposite', () => {
     });
 
     it('should call the closeCallback prop after the modal has closed', () => {
-        jasmine.clock().install();
         const closeCallbackSpy = jasmine.createSpy('closeCallback');
         const modalComposite = shallow(<ModalComposite closeCallback={closeCallbackSpy} />);
 
-        modalComposite.setProps({isOpened: true});
-        modalComposite.setProps({isOpened: false});
-        expect(closeCallbackSpy).not.toHaveBeenCalled();
-
-        jasmine.clock().tick(Defaults.MODAL_TIMEOUT);
+        modalComposite.prop('onAfterClose')();
 
         expect(closeCallbackSpy).toHaveBeenCalledTimes(1);
-        jasmine.clock().uninstall();
     });
 
     it('should add a "layer-x" class to the modal overlay where x equals the layer prop value', () => {

--- a/packages/react-vapor/src/components/modal/tests/ModalCompositeConnected.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/ModalCompositeConnected.spec.tsx
@@ -66,7 +66,7 @@ describe('<ModalCompositeConnected />', () => {
             store
         ).dive();
 
-        modalCompositeConnected.props().onRequestClose(new MouseEvent('fakeEvent'));
+        modalCompositeConnected.props().onRequestClose(new MouseEvent('fakeevent') as any);
 
         expect(store.getActions()).toContain(closeModal(basicProps.id));
     });


### PR DESCRIPTION
### Proposed Changes

Now that the `afterClose` prop bug has been closed (see https://github.com/reactjs/react-modal/pull/755) we can safely remove the workaround we made in the `ModalComposite` component.

### Potential Breaking Changes

Hopefully none.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
