### PR TITLE
Remove useless and breaking styling from the demo

### DIFF
--- a/packages/react-vapor/docs/src/demo-styling/base/_base.scss
+++ b/packages/react-vapor/docs/src/demo-styling/base/_base.scss
@@ -24,13 +24,6 @@ figure {
 /**
  * Basic styling
  */
-body > div {
-    display: flex;
-    flex-flow: column nowrap;
-    height: 100%;
-    overflow: hidden;
-    background-color: $background-color;
-}
 
 .application-wrapper {
     height: 0;


### PR DESCRIPTION
### Proposed Changes

Tooltips are currently [broken in the demo](http://react-vapor.surge.sh/#/components/Tooltip). The changes made here is simply removing the css rules that breaks the positioning of the tooltips. 

### Potential Breaking Changes

None, the style which was breaking was only used for demo purposes.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
