### PR TITLE
Fix adui 4702 input connected have a way

### DIFF
--- a/packages/react-vapor/src/components/input/Input.tsx
+++ b/packages/react-vapor/src/components/input/Input.tsx
@@ -23,7 +23,7 @@ export interface IInputAdditionalOwnProps {
     classes?: IClassName;
     innerInputClasses?: IClassName;
     validate?: (value: any) => boolean;
-    labelTitle?: string;
+    labelTitle?: React.ReactNode;
     labelProps?: ILabelProps;
     validateOnChange?: boolean;
     disabledOnMount?: boolean;
@@ -151,11 +151,15 @@ export class Input extends React.Component<IInputProps, IInputComponentState> {
 
     private getLabel(): JSX.Element {
         const {labelProps, labelTitle} = this.props;
-        return labelTitle || this.props.validate ? (
-            <Label key={this.props.id + 'label'} htmlFor={this.props.id} {...labelProps}>
-                {labelTitle}
-            </Label>
-        ) : null;
+        if (labelTitle instanceof Tooltip) {
+            return <> {labelTitle} </>;
+        } else {
+            return labelTitle || this.props.validate ? (
+                <Label key={this.props.id + 'label'} htmlFor={this.props.id} {...labelProps}>
+                    {labelTitle}
+                </Label>
+            ) : null;
+        }
     }
 
     render() {

--- a/packages/react-vapor/src/components/input/Input.tsx
+++ b/packages/react-vapor/src/components/input/Input.tsx
@@ -149,7 +149,7 @@ export class Input extends React.Component<IInputProps, IInputComponentState> {
         }
     }
 
-    private getLabel(): JSX.Element {
+    private getLabel(): React.ReactNode {
         const {labelProps, labelTitle} = this.props;
         if (typeof labelTitle === 'string') {
             return labelTitle || this.props.validate ? (
@@ -158,7 +158,7 @@ export class Input extends React.Component<IInputProps, IInputComponentState> {
                 </Label>
             ) : null;
         } else {
-            return <> {labelTitle} </>;
+            return labelTitle;
         }
     }
 

--- a/packages/react-vapor/src/components/input/Input.tsx
+++ b/packages/react-vapor/src/components/input/Input.tsx
@@ -151,14 +151,14 @@ export class Input extends React.Component<IInputProps, IInputComponentState> {
 
     private getLabel(): JSX.Element {
         const {labelProps, labelTitle} = this.props;
-        if (labelTitle instanceof Tooltip) {
-            return <> {labelTitle} </>;
-        } else {
+        if (typeof labelTitle === 'string') {
             return labelTitle || this.props.validate ? (
                 <Label key={this.props.id + 'label'} htmlFor={this.props.id} {...labelProps}>
                     {labelTitle}
                 </Label>
             ) : null;
+        } else {
+            return <> {labelTitle} </>;
         }
     }
 

--- a/packages/react-vapor/src/components/input/examples/InputConnectedExamples.tsx
+++ b/packages/react-vapor/src/components/input/examples/InputConnectedExamples.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import {findWhere} from 'underscore';
 import {ReactVaporStore} from '../../../../docs/ReactVaporStore';
 import {UUID} from '../../../utils/UUID';
+import {Tooltip} from '../../tooltip/Tooltip';
 import {setDisabledInput, validateInputValue} from '../InputActions';
 import {InputConnected} from '../InputConnected';
+import {Label} from '../Label';
 
 const validate = (value: any) => !!value;
 
@@ -83,6 +85,39 @@ export const InputConnectedExamples = (): JSX.Element => (
                 labelProps={{invalidMessage: 'not empty'}}
                 defaultValue="valid only on change"
                 validateOnChange
+            />
+        </div>
+
+        <div className="form-group">
+            <button
+                className="mb2"
+                onClick={() => {
+                    ReactVaporStore.dispatch(
+                        setDisabledInput(
+                            'super-input-5',
+                            !findWhere(ReactVaporStore.getState().inputs, {id: 'super-input-5'}).disabled
+                        )
+                    );
+                }}
+            >
+                Toggle disabled state
+            </button>
+            <InputConnected
+                id="super-input-5"
+                validate={validate}
+                labelTitle={
+                    <Tooltip title="I am a tooltip!" placement={'top'}>
+                        <Label
+                            key={'super-input-5-label'}
+                            htmlFor={'super-input-5'}
+                            invalidMessage={'Do not leave me empty'}
+                        >
+                            {'I am a disabled connected input WITH a Tooltip'}
+                        </Label>
+                    </Tooltip>
+                }
+                labelProps={{invalidMessage: 'Do not leave me empty'}}
+                defaultValue="awesome disabled feature"
             />
         </div>
     </div>

--- a/packages/vapor/scss/controls/input-field.scss
+++ b/packages/vapor/scss/controls/input-field.scss
@@ -27,7 +27,8 @@
 
             @include placeholder();
 
-            & + label {
+            & + label,
+            & + span {
                 @extend .active;
             }
 
@@ -54,18 +55,17 @@
     }
 
     > label,
-    .input-wrapper > label {
+    > span,
+    &.input-wrapper > label {
         position: absolute;
         top: 10px;
         left: 0;
         display: flex; // Used for inline-help-tooltip placement
 
         box-sizing: content-box;
-        height: 100%;
         color: $medium-grey;
         font-size: $input-font-size;
         transition: $input-transition;
-        pointer-events: none;
 
         &.active {
             top: -1 * $input-margin-top;

--- a/packages/vapor/scss/controls/input-field.scss
+++ b/packages/vapor/scss/controls/input-field.scss
@@ -8,7 +8,7 @@
     > textarea,
     .input-wrapper > input {
         position: relative;
-        z-index: 10;
+        z-index: 1;
         width: 100%;
         height: $input-height;
         padding: $input-padding;
@@ -37,7 +37,8 @@
             &:focus:not([readonly]) {
                 border-bottom-color: $azure;
 
-                & + label {
+                & + label,
+                & + span {
                     color: $azure;
                 }
             }
@@ -58,10 +59,12 @@
 
     > label,
     > span,
-    &.input-wrapper > label {
+    &.input-wrapper > label,
+    &.input-wrapper > span {
         position: absolute;
         top: 10px;
         left: 0;
+        z-index: 0;
         display: flex; // Used for inline-help-tooltip placement
         box-sizing: content-box;
         height: 100%;

--- a/packages/vapor/scss/controls/input-field.scss
+++ b/packages/vapor/scss/controls/input-field.scss
@@ -7,6 +7,8 @@
     > input,
     > textarea,
     .input-wrapper > input {
+        position: relative;
+        z-index: 10;
         width: 100%;
         height: $input-height;
         padding: $input-padding;
@@ -61,8 +63,8 @@
         top: 10px;
         left: 0;
         display: flex; // Used for inline-help-tooltip placement
-
         box-sizing: content-box;
+        height: 100%;
         color: $medium-grey;
         font-size: $input-font-size;
         transition: $input-transition;


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->

Change value type of labelTitle from 'string' to 'ReactNode' in order to accept any element. Added css for the span that Tooltip creates and added new example.

### Potential Breaking Changes

Removed 'pointer-events: none' on the label. I can't for-see any breaking changes, but might be worth mentioning.

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
