### PR TITLE
Fix type error in Label

### DIFF
--- a/packages/react-vapor/src/components/input/Label.tsx
+++ b/packages/react-vapor/src/components/input/Label.tsx
@@ -8,7 +8,7 @@ export interface ILabelProps {
     invalidMessage?: string;
 }
 
-export class Label extends React.Component<ILabelProps & React.HTMLAttributes<HTMLLabelElement>, any> {
+export class Label extends React.Component<ILabelProps & React.HTMLProps<HTMLLabelElement>, any> {
     render() {
         const classes = classNames(this.props.classes);
         const {validMessage, invalidMessage, children, ...attributes} = this.props;


### PR DESCRIPTION
I had some error when compiling react-vapor

![image](https://user-images.githubusercontent.com/260007/63944348-589dd580-ca3f-11e9-8299-92626d6f0ffa.png)
