### PR TITLE
Filter out the separators when they should not be shown

### DIFF
--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -29,7 +29,7 @@
         "pretest": "gulp clean:tests",
         "test": "karma start",
         "test:compile": "webpack --display-error-details --config webpack.config.test.js",
-        "test:watch": "node --max-old-space-size=2048 node_modules/karma/bin/karma start --no-single-run",
+        "test:watch": "node --max-old-space-size=2048 node_modules/karma/bin/karma start --no-single-run --auto-watch",
         "test:browser": "karma start --browsers Chrome --no-single-run",
         "posttest": "npm run coverage",
         "coverage": "npm run coverage:remap && npm run coverage:report",

--- a/packages/react-vapor/src/components/actions/ActionConstants.tsx
+++ b/packages/react-vapor/src/components/actions/ActionConstants.tsx
@@ -1,0 +1,6 @@
+import {IActionOptions} from './Action';
+
+export const ACTION_SEPARATOR: IActionOptions = {
+    separator: true,
+    enabled: true,
+};

--- a/packages/react-vapor/src/components/actions/ActionDropdownItem.tsx
+++ b/packages/react-vapor/src/components/actions/ActionDropdownItem.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {IActionOptions} from './Action';
+import {LinkAction} from './LinkAction';
+import {TriggerAction} from './TriggerAction';
+import {TriggerActionConnected} from './TriggerActionConnected';
+
+export interface IActionDropdownItemProps {
+    action: IActionOptions;
+    withReduxState: boolean;
+    parentId?: string;
+}
+
+export const ActionDropdownItem: React.FunctionComponent<IActionDropdownItemProps> = ({
+    parentId,
+    action,
+    withReduxState,
+}) => {
+    if (action.separator) {
+        return <li className="divider" />;
+    }
+
+    if (action.link) {
+        return (
+            <li>
+                <LinkAction action={action} simple={true} />
+            </li>
+        );
+    }
+
+    if (withReduxState) {
+        return (
+            <li>
+                <TriggerActionConnected action={action} simple={true} parentId={parentId} />
+            </li>
+        );
+    }
+    return (
+        <li>
+            <TriggerAction action={action} simple={true} />
+        </li>
+    );
+};

--- a/packages/react-vapor/src/components/actions/ActionsDropdown.tsx
+++ b/packages/react-vapor/src/components/actions/ActionsDropdown.tsx
@@ -5,9 +5,7 @@ import {Dropdown} from '../dropdown/Dropdown';
 import {DropdownConnected} from '../dropdown/DropdownConnected';
 import {Svg} from '../svg/Svg';
 import {IActionOptions} from './Action';
-import {LinkAction} from './LinkAction';
-import {TriggerAction} from './TriggerAction';
-import {TriggerActionConnected} from './TriggerActionConnected';
+import {ActionDropdownItem} from './ActionDropdownItem';
 
 export interface IActionsDropdownOwnProps extends React.ClassAttributes<ActionsDropdown> {
     actions: IActionOptions[];
@@ -42,35 +40,14 @@ export class ActionsDropdown extends React.Component<IActionsDropdownProps, any>
             .filter((action: IActionOptions, index: number, filteredActions: IActionOptions[]) => {
                 return index < filteredActions.length - 1 || !action.separator;
             })
-            .map(
-                (action: IActionOptions, index: number): JSX.Element => {
-                    const actionKey: string = 'action-' + index;
-                    if (action.separator) {
-                        return <li className="divider" key={actionKey}></li>;
-                    }
-
-                    if (action.link) {
-                        return (
-                            <li key={actionKey}>
-                                <LinkAction action={action} simple={true} />
-                            </li>
-                        );
-                    }
-
-                    if (this.props.withReduxState) {
-                        return (
-                            <li key={actionKey}>
-                                <TriggerActionConnected action={action} simple={true} parentId={this.props.id} />
-                            </li>
-                        );
-                    }
-                    return (
-                        <li key={actionKey}>
-                            <TriggerAction action={action} simple={true} />
-                        </li>
-                    );
-                }
-            )
+            .map((action: IActionOptions, index: number) => (
+                <ActionDropdownItem
+                    key={`action-${action.id || index}`}
+                    action={action}
+                    parentId={this.props.id}
+                    withReduxState={this.props.withReduxState}
+                />
+            ))
             .value();
         const toggleContent: JSX.Element[] = [
             <Svg

--- a/packages/react-vapor/src/components/actions/examples/ActionBarConnectedExamples.tsx
+++ b/packages/react-vapor/src/components/actions/examples/ActionBarConnectedExamples.tsx
@@ -3,16 +3,14 @@ import {ReactVaporStore} from '../../../../docs/ReactVaporStore';
 import {IActionOptions} from '../Action';
 import {addActionsToActionBar} from '../ActionBarActions';
 import {ActionBarConnected} from '../ActionBarConnected';
+import {ACTION_SEPARATOR} from '../ActionConstants';
 
 const actionBarId = 'action-bar-connected';
 
 export class ActionBarConnectedExamples extends React.Component<any, any> {
     componentDidMount() {
         const actions: IActionOptions[] = [
-            {
-                separator: true,
-                enabled: true,
-            },
+            ACTION_SEPARATOR,
             {
                 name: 'Link to Coveo',
                 link: 'http://coveo.com',
@@ -21,10 +19,7 @@ export class ActionBarConnectedExamples extends React.Component<any, any> {
                 primary: true,
                 enabled: true,
             },
-            {
-                separator: true,
-                enabled: true,
-            },
+            ACTION_SEPARATOR,
             {
                 name: 'Action 1',
                 trigger: () => alert('Action 1 was triggered'),
@@ -37,14 +32,8 @@ export class ActionBarConnectedExamples extends React.Component<any, any> {
                     },
                 },
             },
-            {
-                separator: true,
-                enabled: true,
-            },
-            {
-                separator: true,
-                enabled: true,
-            },
+            ACTION_SEPARATOR,
+            ACTION_SEPARATOR,
             {
                 name: 'Action 2',
                 trigger: () => alert('Action 2 was triggered'),
@@ -62,10 +51,7 @@ export class ActionBarConnectedExamples extends React.Component<any, any> {
                 trigger: () => alert('Action 4 was triggered'),
                 enabled: true,
             },
-            {
-                separator: true,
-                enabled: true,
-            },
+            ACTION_SEPARATOR,
             {
                 name: 'Link to Coveo (disabled)',
                 link: 'http://coveo.com',
@@ -83,10 +69,7 @@ export class ActionBarConnectedExamples extends React.Component<any, any> {
                 enabled: false,
                 hideDisabled: false,
             },
-            {
-                separator: true,
-                enabled: true,
-            },
+            ACTION_SEPARATOR,
         ];
         setTimeout(() => {
             ReactVaporStore.dispatch(addActionsToActionBar(actionBarId, actions));

--- a/packages/react-vapor/src/components/actions/examples/ActionBarConnectedExamples.tsx
+++ b/packages/react-vapor/src/components/actions/examples/ActionBarConnectedExamples.tsx
@@ -10,11 +10,19 @@ export class ActionBarConnectedExamples extends React.Component<any, any> {
     componentDidMount() {
         const actions: IActionOptions[] = [
             {
+                separator: true,
+                enabled: true,
+            },
+            {
                 name: 'Link to Coveo',
                 link: 'http://coveo.com',
                 target: '_blank',
                 icon: 'edit',
                 primary: true,
+                enabled: true,
+            },
+            {
+                separator: true,
                 enabled: true,
             },
             {
@@ -34,6 +42,10 @@ export class ActionBarConnectedExamples extends React.Component<any, any> {
                 enabled: true,
             },
             {
+                separator: true,
+                enabled: true,
+            },
+            {
                 name: 'Action 2',
                 trigger: () => alert('Action 2 was triggered'),
                 enabled: true,
@@ -44,6 +56,15 @@ export class ActionBarConnectedExamples extends React.Component<any, any> {
                         cancel: 'Cancel',
                     },
                 },
+            },
+            {
+                name: 'Action 4',
+                trigger: () => alert('Action 4 was triggered'),
+                enabled: true,
+            },
+            {
+                separator: true,
+                enabled: true,
             },
             {
                 name: 'Link to Coveo (disabled)',
@@ -61,6 +82,10 @@ export class ActionBarConnectedExamples extends React.Component<any, any> {
                 primary: true,
                 enabled: false,
                 hideDisabled: false,
+            },
+            {
+                separator: true,
+                enabled: true,
             },
         ];
         setTimeout(() => {

--- a/packages/react-vapor/src/components/actions/examples/ActionBarExamples.tsx
+++ b/packages/react-vapor/src/components/actions/examples/ActionBarExamples.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {IActionOptions} from '../Action';
 import {ActionBar} from '../ActionBar';
+import {ACTION_SEPARATOR} from '../ActionConstants';
 
 export class ActionBarExamples extends React.Component<any, any> {
     render() {
@@ -18,10 +19,7 @@ export class ActionBarExamples extends React.Component<any, any> {
                 trigger: () => alert('Action 1 was triggered'),
                 enabled: true,
             },
-            {
-                separator: true,
-                enabled: true,
-            },
+            ACTION_SEPARATOR,
             {
                 name: 'action2',
                 trigger: () => alert('Action 2 was triggered'),

--- a/packages/react-vapor/src/components/actions/tests/ActionsDropdown.spec.tsx
+++ b/packages/react-vapor/src/components/actions/tests/ActionsDropdown.spec.tsx
@@ -1,7 +1,7 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
-// tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
 import * as _ from 'underscore';
+import {Dropdown} from '../../dropdown/Dropdown';
 import {IActionOptions} from '../Action';
 import {ActionsDropdown, IActionsDropdownProps} from '../ActionsDropdown';
 
@@ -9,23 +9,22 @@ describe('Actions', () => {
     const actionLink: string = 'http://coveo.com';
     const actionTrigger: jasmine.Spy = jasmine.createSpy('methodTrigger');
 
-    const actions: IActionOptions[] = [
-        {
-            name: 'action',
-            link: actionLink,
-            target: '_blank',
-            enabled: true,
-        },
-        {
-            separator: true,
-            enabled: true,
-        },
-        {
-            name: 'action2',
-            trigger: actionTrigger,
-            enabled: true,
-        },
-    ];
+    const simpleLinkAction: IActionOptions = {
+        name: 'action',
+        link: actionLink,
+        target: '_blank',
+        enabled: true,
+    };
+    const simpleAction: IActionOptions = {
+        name: 'action2',
+        trigger: actionTrigger,
+        enabled: true,
+    };
+    const separator: IActionOptions = {
+        separator: true,
+        enabled: true,
+    };
+    const actions: IActionOptions[] = [simpleLinkAction, separator, simpleAction];
 
     describe('<ActionsDropdown />', () => {
         it('should render without errors', () => {
@@ -89,6 +88,92 @@ describe('Actions', () => {
             });
             actionsDropdown.setProps({actions: newActions});
             expect(actionsDropdown.find('TriggerAction').length).toBe(triggerActionsLength - 1);
+        });
+    });
+
+    describe('separators', () => {
+        const shallowAndGetActions = (actionsList: IActionOptions[]) => {
+            const wrapper = shallow(<ActionsDropdown actions={actionsList} />);
+            return shallow(<div>{wrapper.find(Dropdown).prop('dropdownItems')}</div>).children();
+        };
+
+        it('should remove a separator if followed by another separator', () => {
+            const withTwoSeparators: IActionOptions[] = [simpleLinkAction, separator, separator, simpleAction];
+
+            const filteredActions = shallowAndGetActions(withTwoSeparators);
+            expect(filteredActions.length).toBe(3);
+            expect(filteredActions.find('.divider').length).toBe(1);
+        });
+
+        it('should remove the separator if it is the last action', () => {
+            const withSeparatorAtEnd: IActionOptions[] = [simpleLinkAction, simpleAction, separator];
+
+            const filteredActions = shallowAndGetActions(withSeparatorAtEnd);
+            expect(filteredActions.length).toBe(2);
+            expect(filteredActions.find('.divider').length).toBe(0);
+        });
+
+        it('should remove the separator if it is the first action', () => {
+            const withSeparatorAtStart: IActionOptions[] = [separator, simpleLinkAction, simpleAction];
+
+            const filteredActions = shallowAndGetActions(withSeparatorAtStart);
+            expect(filteredActions.length).toBe(2);
+            expect(filteredActions.find('.divider').length).toBe(0);
+        });
+
+        it('should remove the useless separators', () => {
+            const withSeparatorAtStart: IActionOptions[] = [
+                separator,
+                separator,
+                simpleLinkAction,
+                separator,
+                separator,
+                simpleAction,
+                separator,
+                separator,
+            ];
+
+            const filteredActions = shallowAndGetActions(withSeparatorAtStart);
+            expect(filteredActions.length).toBe(3); // Action separator Action
+            expect(filteredActions.find('.divider').length).toBe(1);
+        });
+
+        it('should remove the separator if it is between disabled actions', () => {
+            const withSeparatorAtStart: IActionOptions[] = [
+                {...simpleLinkAction, enabled: false},
+                separator,
+                {...simpleAction, enabled: false},
+            ];
+
+            const filteredActions = shallowAndGetActions(withSeparatorAtStart);
+            expect(filteredActions.length).toBe(0);
+            expect(filteredActions.find('.divider').length).toBe(0);
+        });
+
+        it('should not remove the separator if it is between disabled actions but they are still shown', () => {
+            const withSeparatorAtStart: IActionOptions[] = [
+                {...simpleLinkAction, enabled: false, hideDisabled: false},
+                separator,
+                {...simpleAction, enabled: false, hideDisabled: false},
+            ];
+
+            const filteredActions = shallowAndGetActions(withSeparatorAtStart);
+            expect(filteredActions.length).toBe(3);
+            expect(filteredActions.find('.divider').length).toBe(1);
+        });
+
+        it('should not remove the separator if it is between disabled actions but there are other actions around', () => {
+            const withSeparatorAtStart: IActionOptions[] = [
+                simpleLinkAction,
+                {...simpleLinkAction, enabled: false},
+                separator,
+                {...simpleAction, enabled: false},
+                simpleAction,
+            ];
+
+            const filteredActions = shallowAndGetActions(withSeparatorAtStart);
+            expect(filteredActions.length).toBe(3);
+            expect(filteredActions.find('.divider').length).toBe(1);
         });
     });
 });

--- a/packages/react-vapor/src/components/actions/tests/ActionsDropdown.spec.tsx
+++ b/packages/react-vapor/src/components/actions/tests/ActionsDropdown.spec.tsx
@@ -1,8 +1,10 @@
-import {mount, ReactWrapper, shallow} from 'enzyme';
+import {mount, ReactWrapper, shallow, ShallowWrapper} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
 import {Dropdown} from '../../dropdown/Dropdown';
 import {IActionOptions} from '../Action';
+import {ACTION_SEPARATOR} from '../ActionConstants';
+import {IActionDropdownItemProps} from '../ActionDropdownItem';
 import {ActionsDropdown, IActionsDropdownProps} from '../ActionsDropdown';
 
 describe('Actions', () => {
@@ -20,11 +22,7 @@ describe('Actions', () => {
         trigger: actionTrigger,
         enabled: true,
     };
-    const separator: IActionOptions = {
-        separator: true,
-        enabled: true,
-    };
-    const actions: IActionOptions[] = [simpleLinkAction, separator, simpleAction];
+    const actions: IActionOptions[] = [simpleLinkAction, ACTION_SEPARATOR, simpleAction];
 
     describe('<ActionsDropdown />', () => {
         it('should render without errors', () => {
@@ -97,83 +95,91 @@ describe('Actions', () => {
             return shallow(<div>{wrapper.find(Dropdown).prop('dropdownItems')}</div>).children();
         };
 
+        const isDivider = (content: ShallowWrapper<IActionDropdownItemProps>) =>
+            content.prop('action').separator === true;
+
         it('should remove a separator if followed by another separator', () => {
-            const withTwoSeparators: IActionOptions[] = [simpleLinkAction, separator, separator, simpleAction];
+            const withTwoSeparators: IActionOptions[] = [
+                simpleLinkAction,
+                ACTION_SEPARATOR,
+                ACTION_SEPARATOR,
+                simpleAction,
+            ];
 
             const filteredActions = shallowAndGetActions(withTwoSeparators);
             expect(filteredActions.length).toBe(3);
-            expect(filteredActions.find('.divider').length).toBe(1);
+            expect(filteredActions.findWhere(isDivider).length).toBe(1);
         });
 
         it('should remove the separator if it is the last action', () => {
-            const withSeparatorAtEnd: IActionOptions[] = [simpleLinkAction, simpleAction, separator];
+            const withSeparatorAtEnd: IActionOptions[] = [simpleLinkAction, simpleAction, ACTION_SEPARATOR];
 
             const filteredActions = shallowAndGetActions(withSeparatorAtEnd);
             expect(filteredActions.length).toBe(2);
-            expect(filteredActions.find('.divider').length).toBe(0);
+            expect(filteredActions.findWhere(isDivider).length).toBe(0);
         });
 
         it('should remove the separator if it is the first action', () => {
-            const withSeparatorAtStart: IActionOptions[] = [separator, simpleLinkAction, simpleAction];
+            const withSeparatorAtStart: IActionOptions[] = [ACTION_SEPARATOR, simpleLinkAction, simpleAction];
 
             const filteredActions = shallowAndGetActions(withSeparatorAtStart);
             expect(filteredActions.length).toBe(2);
-            expect(filteredActions.find('.divider').length).toBe(0);
+            expect(filteredActions.findWhere(isDivider).length).toBe(0);
         });
 
         it('should remove the useless separators', () => {
             const withSeparatorAtStart: IActionOptions[] = [
-                separator,
-                separator,
+                ACTION_SEPARATOR,
+                ACTION_SEPARATOR,
                 simpleLinkAction,
-                separator,
-                separator,
+                ACTION_SEPARATOR,
+                ACTION_SEPARATOR,
                 simpleAction,
-                separator,
-                separator,
+                ACTION_SEPARATOR,
+                ACTION_SEPARATOR,
             ];
 
             const filteredActions = shallowAndGetActions(withSeparatorAtStart);
-            expect(filteredActions.length).toBe(3); // Action separator Action
-            expect(filteredActions.find('.divider').length).toBe(1);
+            expect(filteredActions.length).toBe(3); // Action ACTION_SEPARATOR Action
+            expect(filteredActions.findWhere(isDivider).length).toBe(1);
         });
 
         it('should remove the separator if it is between disabled actions', () => {
             const withSeparatorAtStart: IActionOptions[] = [
                 {...simpleLinkAction, enabled: false},
-                separator,
+                ACTION_SEPARATOR,
                 {...simpleAction, enabled: false},
             ];
 
             const filteredActions = shallowAndGetActions(withSeparatorAtStart);
             expect(filteredActions.length).toBe(0);
-            expect(filteredActions.find('.divider').length).toBe(0);
+            expect(filteredActions.findWhere(isDivider).length).toBe(0);
         });
 
         it('should not remove the separator if it is between disabled actions but they are still shown', () => {
             const withSeparatorAtStart: IActionOptions[] = [
                 {...simpleLinkAction, enabled: false, hideDisabled: false},
-                separator,
+                ACTION_SEPARATOR,
                 {...simpleAction, enabled: false, hideDisabled: false},
             ];
 
             const filteredActions = shallowAndGetActions(withSeparatorAtStart);
             expect(filteredActions.length).toBe(3);
-            expect(filteredActions.find('.divider').length).toBe(1);
+            expect(filteredActions.findWhere(isDivider).length).toBe(1);
         });
 
         it('should not remove the separator if it is between disabled actions but there are other actions around', () => {
             const withSeparatorAtStart: IActionOptions[] = [
                 simpleLinkAction,
                 {...simpleLinkAction, enabled: false},
-                separator,
+                ACTION_SEPARATOR,
                 {...simpleAction, enabled: false},
                 simpleAction,
             ];
 
             const filteredActions = shallowAndGetActions(withSeparatorAtStart);
             expect(filteredActions.length).toBe(3);
-            expect(filteredActions.find('.divider').length).toBe(1);
+            expect(filteredActions.findWhere(isDivider).length).toBe(1);
         });
     });
 });

--- a/packages/react-vapor/src/components/actions/tests/SecondaryActions.spec.tsx
+++ b/packages/react-vapor/src/components/actions/tests/SecondaryActions.spec.tsx
@@ -2,6 +2,7 @@ import {mount, ReactWrapper, shallow} from 'enzyme';
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
 import {IActionOptions} from '../Action';
+import {ACTION_SEPARATOR} from '../ActionConstants';
 import {ISecondaryActionsProps, SecondaryActions} from '../SecondaryActions';
 
 describe('Actions', () => {
@@ -12,10 +13,7 @@ describe('Actions', () => {
             target: '_blank',
             enabled: true,
         },
-        {
-            separator: true,
-            enabled: true,
-        },
+        ACTION_SEPARATOR,
         {
             name: 'action2',
             trigger: jasmine.createSpy('triggerMethod'),

--- a/packages/react-vapor/src/components/actions/tests/SecondaryActionsConnected.spec.tsx
+++ b/packages/react-vapor/src/components/actions/tests/SecondaryActionsConnected.spec.tsx
@@ -6,6 +6,7 @@ import {Store} from 'redux';
 import {IReactVaporState} from '../../../ReactVapor';
 import {TestUtils} from '../../../utils/tests/TestUtils';
 import {IActionOptions} from '../Action';
+import {ACTION_SEPARATOR} from '../ActionConstants';
 import {ActionsDropdownConnected} from '../ActionsDropdownConnected';
 import {PrimaryActionConnected} from '../PrimaryActionConnected';
 import {ISecondaryActionsProps, SecondaryActions} from '../SecondaryActions';
@@ -20,10 +21,7 @@ describe('Actions', () => {
             target: '_blank',
             enabled: true,
         },
-        {
-            separator: true,
-            enabled: true,
-        },
+        ACTION_SEPARATOR,
         {
             name: 'action2',
             trigger: jasmine.createSpy('triggerMethod'),

--- a/packages/react-vapor/src/components/tables/examples/TableExamples.tsx
+++ b/packages/react-vapor/src/components/tables/examples/TableExamples.tsx
@@ -7,6 +7,7 @@ import * as _ from 'underscore';
 import {ReactVaporStore} from '../../../../docs/ReactVaporStore';
 import {IDispatch, IThunkAction} from '../../../utils/ReduxUtils';
 import {triggerAlertFunction} from '../../../utils/tests/TestUtils';
+import {ACTION_SEPARATOR} from '../../actions/ActionConstants';
 import {Breadcrumb} from '../../breadcrumbs/Breadcrumb';
 import {Button} from '../../button/Button';
 import {Checkbox} from '../../checkbox/Checkbox';
@@ -629,10 +630,7 @@ export class TableExamples extends React.Component<any, any> {
                                 enabled: true,
                                 callOnDoubleClick: true,
                             },
-                            {
-                                separator: true,
-                                enabled: true,
-                            },
+                            ACTION_SEPARATOR,
                             {
                                 name: 'action3',
                                 trigger: () => alert('another action'),


### PR DESCRIPTION
Lots of tests

### Proposed Changes

I was baffled by all the logic required in the sources to make the separator appear where they need to be so I implemented the filtering logic here

### Potential Breaking Changes

The logic should be better then before (and covered by tests)

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
