### PR TITLE
Fix issue with defaultMatchFilter when value is undefined

### DIFF
--- a/packages/react-vapor/src/utils/FilterUtils.spec.ts
+++ b/packages/react-vapor/src/utils/FilterUtils.spec.ts
@@ -11,6 +11,12 @@ describe('FilterUtils', () => {
             expect(defaultMatchFilter('', defaultItemBox)).toBe(true);
         });
 
+        it('should not throw for falsy values', () => {
+            expect(() => defaultMatchFilter(null, defaultItemBox)).not.toThrow();
+            expect(() => defaultMatchFilter(undefined, defaultItemBox)).not.toThrow();
+            expect(() => defaultMatchFilter('', defaultItemBox)).not.toThrow();
+        });
+
         it('should not throw errors when the filterValue contains special characters', () => {
             expect(() => {
                 defaultMatchFilter('(', defaultItemBox);

--- a/packages/react-vapor/src/utils/FilterUtils.ts
+++ b/packages/react-vapor/src/utils/FilterUtils.ts
@@ -6,7 +6,7 @@ import {getReactNodeTextContent} from './JSXUtils';
 export type MatchFilter = (filterValue: string, item: IItemBoxProps) => boolean;
 
 export const defaultMatchFilter = (filterValue: string, item: IItemBoxProps) => {
-    const escapedFilterValue = escapeRegExp(filterValue);
+    const escapedFilterValue = escapeRegExp(filterValue || '');
     if (escapedFilterValue === '') {
         return true;
     }


### PR DESCRIPTION
### Proposed Changes

The library that we use throws an error when the value is undefined

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
