### PR TITLE
Better reflect actual callIfDefined signature

### DIFF
--- a/packages/react-vapor/src/utils/FalsyValuesUtils.spec.tsx
+++ b/packages/react-vapor/src/utils/FalsyValuesUtils.spec.tsx
@@ -39,7 +39,7 @@ describe('callIfDefined', () => {
     });
 
     it('should not throw errors when calling with undefined values', () => {
-        const someDeclaredButNotAssignedCallback: () => any = undefined;
+        const someDeclaredButNotAssignedCallback: any = undefined;
 
         expect(() => callIfDefined(undefined)).not.toThrow();
         expect(() => callIfDefined(null)).not.toThrow();

--- a/packages/react-vapor/src/utils/FalsyValuesUtils.ts
+++ b/packages/react-vapor/src/utils/FalsyValuesUtils.ts
@@ -3,7 +3,7 @@ import * as _ from 'underscore';
 export const convertUndefinedAndNullToEmptyString = (value: any) =>
     _.isUndefined(value) || _.isNull(value) ? '' : value;
 
-export const callIfDefined = <T>(callback: (...params: any[]) => T, ...args: any[]): T => {
+export const callIfDefined = <T>(callback?: ((...params: any[]) => T) | null, ...args: any[]): T | undefined => {
     if (_.isFunction(callback)) {
         return callback(...args);
     }


### PR DESCRIPTION
### Proposed Changes

We tried using `callIfDefined` with `strictNullCheck: true` and the method is failing because it does not actually accept `null` and `undefined` values!

Since its purpose is to validate whether it is defined, I think it makes sense to allow passing those values :P

What I have done here is activate `strictNullCheck` temporarily and tested that the unit tests did not return an error. Since `someDeclaredButNotAssignedCallback` was also invalid (assigning `undefined` to a callback type), I instead put `any`.

### Potential Breaking Changes

None, it is more permissive now.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
