### PR TITLE
Fix adui 4535 connect react vapor input to selector

### DIFF
--- a/packages/react-vapor/src/components/datePicker/DatePickerSelectors.ts
+++ b/packages/react-vapor/src/components/datePicker/DatePickerSelectors.ts
@@ -1,8 +1,10 @@
+import {createSelector} from 'reselect';
 import * as _ from 'underscore';
+
 import {IReactVaporState} from '../../ReactVapor';
 import {IDatePickerState} from './DatePickerReducers';
 
-const getDatePicker = (state: IReactVaporState, props: {id: string}): IDatePickerState => {
+const getPicker = (state: IReactVaporState, props: {id: string}): IDatePickerState => {
     const datePickers: IDatePickerState[] = _.map(state.datePickers || [], (datePicker: IDatePickerState) => {
         if (datePicker.id.indexOf(props.id) === 0) {
             return datePicker;
@@ -11,10 +13,20 @@ const getDatePicker = (state: IReactVaporState, props: {id: string}): IDatePicke
     return (datePickers && datePickers[0]) || null;
 };
 
-const getDatePickerLimits = (state: IReactVaporState, props: {id: string}): [Date, Date?] => {
+const getLimits = (state: IReactVaporState, props: {id: string}): [Date, Date?] => {
     const picker = DatePickerSelectors.getDatePicker(state, props);
     return picker ? [picker.appliedLowerLimit, picker.appliedUpperLimit] : [null, null];
 };
+
+const getDatePicker = createSelector(
+    getPicker,
+    (picker: IDatePickerState) => picker
+);
+
+const getDatePickerLimits = createSelector(
+    getLimits,
+    (limit: [Date, Date?]) => limit
+);
 
 export const DatePickerSelectors = {
     getDatePicker,

--- a/packages/react-vapor/src/components/input/InputConnected.tsx
+++ b/packages/react-vapor/src/components/input/InputConnected.tsx
@@ -1,12 +1,14 @@
 import {connect} from 'react-redux';
-import {findWhere} from 'underscore';
+
 import {IReactVaporState} from '../../ReactVapor';
 import {IDispatch, ReduxUtils} from '../../utils/ReduxUtils';
 import {IInputDispatchProps, IInputOwnProps, IInputProps, IInputStateProps, Input} from './Input';
 import {addInput, changeInputValue, removeInput} from './InputActions';
+import {IInputState} from './InputReducers';
+import {InputSelectors} from './InputSelectors';
 
 const mapStateToProps = (state: IReactVaporState, ownProps: IInputOwnProps): IInputStateProps => {
-    const input = findWhere(state.inputs, {id: ownProps.id});
+    const input: IInputState = InputSelectors.getInput(state, {id: ownProps.id});
     return {
         valid: input && input.valid,
         value: input && input.value,

--- a/packages/react-vapor/src/components/input/InputSelectors.ts
+++ b/packages/react-vapor/src/components/input/InputSelectors.ts
@@ -4,20 +4,25 @@ import * as _ from 'underscore';
 import {IReactVaporState} from '../../ReactVapor';
 import {IInputState} from './InputReducers';
 
-const getInput = (state: IReactVaporState, props: {id: string}): IInputState =>
-    _.findWhere(state.inputs, {id: props.id});
+const get = (state: IReactVaporState, props: {id: string}): IInputState => _.findWhere(state.inputs, {id: props.id});
+
+const getInput = createSelector(
+    get,
+    (input: IInputState) => input
+);
 
 const getValue = createSelector(
-    getInput,
+    get,
     (input: IInputState): string => input && input.value
 );
 
 const getIsValid = createSelector(
-    getInput,
+    get,
     (input: IInputState): boolean => !!input && input.valid
 );
 
 export const InputSelectors = {
+    getInput,
     getValue,
     getIsValid,
 };

--- a/packages/react-vapor/src/components/optionPicker/OptionPickerConnected.tsx
+++ b/packages/react-vapor/src/components/optionPicker/OptionPickerConnected.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {connect} from 'react-redux';
-import * as _ from 'underscore';
+
 import {IReactVaporState, IReduxActionsPayload} from '../../ReactVapor';
 import {IReduxAction, ReduxUtils} from '../../utils/ReduxUtils';
 import {
@@ -12,9 +12,10 @@ import {
 } from './OptionPicker';
 import {addOptionPicker, changeOptionPicker, removeOptionPicker} from './OptionPickerActions';
 import {IOptionPickerState} from './OptionPickerReducers';
+import {OptionPickerSelectors} from './OptionPickerSelectors';
 
 const mapStateToProps = (state: IReactVaporState, ownProps: IOptionPickerOwnProps): IOptionPickerStateProps => {
-    const item: IOptionPickerState = _.findWhere(state.optionPickers, {id: ownProps.id});
+    const item: IOptionPickerState = OptionPickerSelectors.getOptionPicker(state, {id: ownProps.id});
 
     return {
         activeLabel: item ? item.selectedLabel : '',

--- a/packages/react-vapor/src/components/optionPicker/OptionPickerSelectors.ts
+++ b/packages/react-vapor/src/components/optionPicker/OptionPickerSelectors.ts
@@ -1,0 +1,18 @@
+import {createSelector} from 'reselect';
+import * as _ from 'underscore';
+
+import {IReactVaporState} from '../../ReactVapor';
+import {IOptionPickerState, optionPickerInitialState} from './OptionPickerReducers';
+
+const get = (state: IReactVaporState, props: {id: string}): IOptionPickerState =>
+    _.findWhere(state.optionPickers, {id: props.id}) || optionPickerInitialState;
+
+const getOptionPicker = createSelector(
+    get,
+    (optionPicker: IOptionPickerState) => optionPicker
+);
+
+export const OptionPickerSelectors = {
+    get,
+    getOptionPicker,
+};

--- a/packages/react-vapor/src/components/optionPicker/tests/OptionPickerSelectors.spec.ts
+++ b/packages/react-vapor/src/components/optionPicker/tests/OptionPickerSelectors.spec.ts
@@ -1,0 +1,46 @@
+import {IOptionPickerState, optionPickerInitialState} from '../OptionPickerReducers';
+import {OptionPickerSelectors} from '../OptionPickerSelectors';
+
+describe('OptionPickerSelector', () => {
+    const expectedOptionPicker: IOptionPickerState = {
+        id: 'option-picker-id',
+        selectedLabel: 'selected-label',
+        selectedValue: 'selected-value',
+    };
+
+    describe('get', () => {
+        it('should return the optionPickerInitialState when the option picker does not exist in the state', () => {
+            const optionPicker: IOptionPickerState = OptionPickerSelectors.get(
+                {datePickers: []},
+                {id: 'I aint in the state'}
+            );
+            expect(optionPicker).toEqual(optionPickerInitialState);
+        });
+
+        it('should return the right option picker for the specified Id', () => {
+            const optionPickerSelected = OptionPickerSelectors.get(
+                {optionPickers: [expectedOptionPicker]},
+                {id: expectedOptionPicker.id}
+            );
+            expect(optionPickerSelected).toEqual(expectedOptionPicker);
+        });
+
+        describe('getOptionPicker', () => {
+            it('should return the optionPickerInitialState when the option picker does not exist in the state', () => {
+                const optionpicker = OptionPickerSelectors.getOptionPicker(
+                    {optionPickers: []},
+                    {id: 'I aint in the state'}
+                );
+                expect(optionpicker).toEqual(optionPickerInitialState);
+            });
+
+            it('should return the right option picker from the state', () => {
+                const selectedOptionPicker = OptionPickerSelectors.getOptionPicker(
+                    {optionPickers: [expectedOptionPicker]},
+                    {id: expectedOptionPicker.id}
+                );
+                expect(selectedOptionPicker).toEqual(expectedOptionPicker);
+            });
+        });
+    });
+});

--- a/packages/react-vapor/src/components/radio/RadioSelectConnected.tsx
+++ b/packages/react-vapor/src/components/radio/RadioSelectConnected.tsx
@@ -1,5 +1,5 @@
 import {connect} from 'react-redux';
-import * as _ from 'underscore';
+
 import {IReactVaporState} from '../../ReactVapor';
 import {IDispatch, ReduxUtils} from '../../utils/ReduxUtils';
 import {
@@ -10,9 +10,10 @@ import {
     RadioSelect,
 } from './RadioSelect';
 import {removeRadioSelect, setRadioSelect} from './RadioSelectActions';
+import {RadioSelectSelectors} from './RadioSelectSelectors';
 
 const mapStateToProps = (state: IReactVaporState, ownProps: IRadioSelectProps): IRadioSelectStateProps => {
-    const radioSelect = _.findWhere(state.radioSelects, {id: ownProps.id});
+    const radioSelect = RadioSelectSelectors.getRadioSelect(state, {id: ownProps.id});
 
     return {
         value: radioSelect && radioSelect.value,

--- a/packages/react-vapor/src/components/radio/RadioSelectSelectors.ts
+++ b/packages/react-vapor/src/components/radio/RadioSelectSelectors.ts
@@ -8,6 +8,11 @@ const get = (state: IReactVaporState, {id}: {id: string}): IRadioSelectState => 
     return _.findWhere(state.radioSelects, {id}) || radioSelectInitialState;
 };
 
+const getRadioSelect = createSelector(
+    get,
+    (radioSelect: IRadioSelectState) => radioSelect && radioSelect
+);
+
 const getValue = createSelector(
     get,
     (radioSelect: IRadioSelectState) => radioSelect && radioSelect.value
@@ -16,4 +21,5 @@ const getValue = createSelector(
 export const RadioSelectSelectors = {
     get,
     getValue,
+    getRadioSelect,
 };

--- a/packages/react-vapor/src/components/radio/tests/RadioSelectSelectors.spec.ts
+++ b/packages/react-vapor/src/components/radio/tests/RadioSelectSelectors.spec.ts
@@ -41,4 +41,14 @@ describe('RadioSelectSelectors', () => {
             expect(selectedValue).toBe(expectedRadioSelect.value);
         });
     });
+
+    describe('getRadioSelect', () => {
+        it('should return RadioSelectInitialState when the radio select does not exist in the state', () => {
+            const radioSelect = RadioSelectSelectors.getRadioSelect(
+                {radioSelects: []},
+                {id: 'I-do-not-exist-in-the-state'}
+            );
+            expect(radioSelect).toEqual(radioSelectInitialState);
+        });
+    });
 });


### PR DESCRIPTION
### Proposed Changes

Wired all the input to their selector, since some of the input had coded selector but was not wired to them.
Small refactor of the selector for future reusability

### Potential Breaking Changes

Inputs are used as part of other components. The modifications where tested but still, I could break the more complex components

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
