### PR TITLE
Add Custom Classes for the Radio Select

### DIFF
--- a/packages/react-vapor/src/components/drop/tests/DropPod.spec.tsx
+++ b/packages/react-vapor/src/components/drop/tests/DropPod.spec.tsx
@@ -68,7 +68,7 @@ describe('DropPod', () => {
 
             expect(() => {
                 wrapper.unmount();
-            }).not.toThrow('umount');
+            }).not.toThrow('unmount');
         });
 
         describe('once mounted', () => {

--- a/packages/react-vapor/src/components/listBox/tests/ListBox.spec.tsx
+++ b/packages/react-vapor/src/components/listBox/tests/ListBox.spec.tsx
@@ -43,7 +43,7 @@ describe('ListBox', () => {
             expect(listBoxComponent.find(ItemBox).length).toBe(defaultProps.items.length);
         });
 
-        it('should not throw on umount', () => {
+        it('should not throw on unmount', () => {
             expect(() => listBoxComponent.unmount()).not.toThrow();
         });
     });

--- a/packages/react-vapor/src/components/radio/RadioSelect.tsx
+++ b/packages/react-vapor/src/components/radio/RadioSelect.tsx
@@ -12,7 +12,7 @@ export interface IRadioSelectOnChangeCallback {
 export interface IRadioSelectProps extends IRadioSelectOnChangeCallback {
     id?: string;
     name?: string;
-    classes?: string;
+    className?: string;
     value?: string;
     disabled?: boolean;
     disabledTooltip?: string;
@@ -64,7 +64,7 @@ export class RadioSelect extends React.PureComponent<IRadioSelectAllProps> {
             });
         });
 
-        return <div className={classNames('form-control radio-select', this.props.classes)}>{children}</div>;
+        return <div className={classNames('form-control radio-select', this.props.className)}>{children}</div>;
     }
 
     private handleToggle(value: string, e: React.MouseEvent<HTMLElement>) {

--- a/packages/react-vapor/src/components/radio/RadioSelect.tsx
+++ b/packages/react-vapor/src/components/radio/RadioSelect.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
 import {callIfDefined} from '../../utils/FalsyValuesUtils';
@@ -11,6 +12,7 @@ export interface IRadioSelectOnChangeCallback {
 export interface IRadioSelectProps extends IRadioSelectOnChangeCallback {
     id?: string;
     name?: string;
+    classes?: string;
     value?: string;
     disabled?: boolean;
     disabledTooltip?: string;
@@ -62,7 +64,7 @@ export class RadioSelect extends React.PureComponent<IRadioSelectAllProps> {
             });
         });
 
-        return <div className="form-control radio-select">{children}</div>;
+        return <div className={classNames('form-control radio-select', this.props.classes)}>{children}</div>;
     }
 
     private handleToggle(value: string, e: React.MouseEvent<HTMLElement>) {


### PR DESCRIPTION
Add classes prop for the RadioSelect button

### Proposed Changes

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
