### PR TITLE
Generate tabs from markdown files

### DIFF
--- a/packages/react-vapor/docs/src/components/ComponentPage.tsx
+++ b/packages/react-vapor/docs/src/components/ComponentPage.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+
+import {TabConnected} from '../../../src/components/tab/TabConnected';
+import {TabContent} from '../../../src/components/tab/TabContent';
+import {TabNavigation} from '../../../src/components/tab/TabNavigation';
+import {TabPaneConnected} from '../../../src/components/tab/TabPaneConnected';
+import Code from '../demo-building-blocs/Code';
+import {IComponent, TabConfig} from './ComponentsInterface';
+
+type ComponentPageProps = Omit<IComponent, 'path'>;
+
+const ComponentPage: React.FunctionComponent<ComponentPageProps> = (props) => {
+    const getTabId = (tabName: string) => `${props.name}-${tabName}-tab`;
+
+    return props.tabs.length > 0 ? (
+        <>
+            <TabNavigation>
+                <TabConnected id={getTabId('development')} title="Develop" />
+                {props.tabs
+                    .sort((tabA, tabB) => tabA.order - tabB.order)
+                    .map(({tabName}: TabConfig) => (
+                        <TabConnected key={getTabId(tabName)} id={getTabId(tabName)} title={tabName} />
+                    ))}
+            </TabNavigation>
+            <TabContent className="mod-header-padding mod-form-top-bottom-padding">
+                <TabPaneConnected id={getTabId('development')}>
+                    <DevelopmentTabContent {...props} />
+                </TabPaneConnected>
+                {props.tabs.map(({tabName, markdown}: TabConfig) => (
+                    <TabPaneConnected key={getTabId(tabName)} id={getTabId(tabName)}>
+                        {markdown}
+                    </TabPaneConnected>
+                ))}
+            </TabContent>
+        </>
+    ) : (
+        <div className="mod-header-padding p2">
+            <DevelopmentTabContent {...props} />
+        </div>
+    );
+};
+
+const DevelopmentTabContent: React.FunctionComponent<ComponentPageProps> = ({component, code}) => (
+    <>
+        {React.createElement(component)}
+        <div className="mt2">
+            <Code language="tsx">{code}</Code>
+        </div>
+    </>
+);
+
+export default ComponentPage;

--- a/packages/react-vapor/docs/src/components/ComponentsInterface.tsx
+++ b/packages/react-vapor/docs/src/components/ComponentsInterface.tsx
@@ -2,6 +2,12 @@ export interface IComponent {
     path: string;
     name: string;
     code: string;
-    link: string;
     component: any;
+    tabs: TabConfig[];
+}
+
+export interface TabConfig {
+    tabName: string;
+    markdown: string;
+    order: number;
 }

--- a/packages/react-vapor/docs/src/components/index.tsx
+++ b/packages/react-vapor/docs/src/components/index.tsx
@@ -2,46 +2,50 @@ import * as React from 'react';
 import {Redirect, Route, RouteComponentProps, Switch} from 'react-router-dom';
 import * as _ from 'underscore';
 
-import Code from '../demo-building-blocs/Code';
-import {IComponent} from './ComponentsInterface';
+import ComponentPage from './ComponentPage';
+import {IComponent, TabConfig} from './ComponentsInterface';
 import SideMenu from './Menu';
 
-const Components: React.FunctionComponent<RouteComponentProps> = ({match}) => {
-    const req = require.context('../../../src/components/', true, /Examples?\.tsx?$/i);
-    const components: IComponent[] = req
-        .keys()
-        .map((path) => {
-            const component = req(path);
-            const code = require('!raw-loader!../../../src/components/' + path.replace('./', '')).default;
-            const name = _.keys(component)[0].replace(/Examples?/i, '');
-            const link = `${match.url}/${name}`;
-            const componentPrototype = _.values(component)[0];
-            return {name, link, code, path, component: componentPrototype};
-        })
-        .sort((a: IComponent, b: IComponent) => a.name.localeCompare(b.name));
+const markdownFiles = require.context('../../../src/components/', true, /Examples?(\.\d+)?(\.\w+)?\.md$/i);
+const tabsDict: Record<string, TabConfig[]> = markdownFiles.keys().reduce((memo: Record<string, TabConfig[]>, path) => {
+    const [, componentName, order, tabName] = /(\w+)Examples?(?:\.(\d+))?(?:\.(\w+))?\.md$/.exec(path);
+    if (componentName && tabName) {
+        const markdown = require('!raw-loader!../../../src/components/' + path.replace('./', '')).default;
+        memo[componentName] = [
+            ...(memo[componentName] || []),
+            {
+                tabName,
+                markdown,
+                order: parseInt(order, 10) || 0,
+            },
+        ];
+    }
+    return memo;
+}, {});
 
-    const routes = components.map(({path, link, code, component}: IComponent) => (
-        <Route
-            key={path}
-            path={link}
-            component={() => (
-                <>
-                    {React.createElement(component)}
-                    <div className="mt2">
-                        <Code language="tsx">{code}</Code>
-                    </div>
-                </>
-            )}
-        />
-    ));
+const componentFiles = require.context('../../../src/components/', true, /Examples?\.tsx?$/i);
+const components = componentFiles.keys().map((path) => {
+    const component = componentFiles(path);
+    const code = require('!raw-loader!../../../src/components/' + path.replace('./', '')).default;
+    const name = _.keys(component)[0].replace(/Examples?/i, '');
+    const componentPrototype = _.values(component)[0];
+    return {name, code, path, component: componentPrototype, tabs: tabsDict[name] || []};
+});
+
+const Components: React.FunctionComponent<RouteComponentProps> = ({match}) => {
+    const routes = components
+        .sort((a: IComponent, b: IComponent) => a.name.localeCompare(b.name))
+        .map(({path, ...rest}: IComponent) => (
+            <Route key={path} path={`${match.url}/${rest.name}`} component={() => <ComponentPage {...rest} />} />
+        ));
 
     return (
         <div className="coveo-form flex full-content">
             <SideMenu components={components} />
-            <div className="flex-auto mod-header-padding overflow-auto p2 relative">
+            <div className="flex-auto overflow-auto relative">
                 <Switch>
                     {routes}
-                    <Route path="/" component={() => <Redirect to={components[0].link} />} />
+                    <Route path="/" component={() => <Redirect to={`${match.url}/${components[0].name}`} />} />
                 </Switch>
             </div>
         </div>

--- a/packages/vapor/scss/components/markdown-documentation.scss
+++ b/packages/vapor/scss/components/markdown-documentation.scss
@@ -23,7 +23,7 @@
     ol,
     ul,
     figure {
-        padding-bottom: $default-line-height;
+        margin-bottom: $default-line-height;
     }
 
     .split-layout {
@@ -56,7 +56,15 @@
         ol,
         ul,
         figure {
-            padding-bottom: 0;
+            margin-bottom: 0;
         }
+    }
+
+    strong {
+        font-weight: bold;
+    }
+
+    em {
+        font-style: italic;
     }
 }

--- a/packages/vapor/scss/guide.scss
+++ b/packages/vapor/scss/guide.scss
@@ -82,7 +82,7 @@
     @import 'components/member';
     @import 'components/menu';
     @import 'components/tooltip';
-    @import 'components/popover-rich-documentation';
+    @import 'components/markdown-documentation';
     @import 'components/popover';
     @import 'components/modal';
     @import 'components/lightbox-search';


### PR DESCRIPTION
### Proposed Changes

Added some logic that generates tab navigation from markdown files name in the "Components" section of the demo.

#### Usage

To enable tab navigation for a component you need to add a markdown file somewhere named according to the following pattern: `<ComponentName>Examples.<order>.<tabName>.md`.

Say I want to add tabs `Salmon` and `Tuna` to section `Fish`, I would need to create the following files:
- `FishExamples.tsx`
- `FishExamples.1.salmon.md`
- `FishExamples.2.tuna.md`

To obtain

![image](https://user-images.githubusercontent.com/35579930/64642066-7eca5a80-d3db-11e9-984c-6d426635ebbb.png)

PS: the default first tab name is `'Develop'`.

### Potential Breaking Changes

None, it only affects the demo.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
