### PR TITLE
Fix add dangerously set description in the blank slate component

### DIFF
--- a/packages/react-vapor/src/components/blankSlate/BlankSlate.tsx
+++ b/packages/react-vapor/src/components/blankSlate/BlankSlate.tsx
@@ -7,7 +7,7 @@ import {Svg} from '../svg/Svg';
 
 export interface IBlankSlateProps extends React.ClassAttributes<BlankSlate> {
     title?: string;
-    description?: string;
+    description?: React.ReactNode;
     buttons?: IBaseActionOptions[];
     withModal?: boolean;
     classes?: string[];

--- a/packages/react-vapor/src/components/blankSlate/examples/BlankSlateExample.tsx
+++ b/packages/react-vapor/src/components/blankSlate/examples/BlankSlateExample.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import {BlankSlate} from '../BlankSlate';
 
 export class BlankSlateExample extends React.Component<any, any> {

--- a/packages/react-vapor/src/components/blankSlate/examples/BlankSlateExample.tsx
+++ b/packages/react-vapor/src/components/blankSlate/examples/BlankSlateExample.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import {BlankSlate} from '../BlankSlate';
 
 export class BlankSlateExample extends React.Component<any, any> {
@@ -21,6 +22,17 @@ export class BlankSlateExample extends React.Component<any, any> {
                 <div className="form-group">
                     <label className="form-control-label">BlankSlate with title and description</label>
                     <BlankSlate title="title test" description="description test" />
+                </div>
+                <div className="form-group">
+                    <label className="form-control-label">BlankSlate with title and description with a link</label>
+                    <BlankSlate
+                        title="title test"
+                        description={
+                            <span>
+                                this is a description with a link to <a href="https//www.google.com">this website</a>
+                            </span>
+                        }
+                    />
                 </div>
                 <div className="form-group">
                     <label className="form-control-label">BlankSlate to fit in a modal</label>

--- a/packages/react-vapor/src/components/blankSlate/tests/BlankSlate.spec.tsx
+++ b/packages/react-vapor/src/components/blankSlate/tests/BlankSlate.spec.tsx
@@ -5,7 +5,7 @@ import * as _ from 'underscore';
 import {Svg} from '../../svg/Svg';
 import {BlankSlate, IBlankSlateProps} from '../BlankSlate';
 
-fdescribe('BlankSlate', () => {
+describe('BlankSlate', () => {
     let blankSlateComponent: ReactWrapper<IBlankSlateProps, any>;
 
     it('should render without errors', () => {

--- a/packages/react-vapor/src/components/blankSlate/tests/BlankSlate.spec.tsx
+++ b/packages/react-vapor/src/components/blankSlate/tests/BlankSlate.spec.tsx
@@ -1,10 +1,11 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
+
 import {Svg} from '../../svg/Svg';
 import {BlankSlate, IBlankSlateProps} from '../BlankSlate';
 
-describe('BlankSlate', () => {
+fdescribe('BlankSlate', () => {
     let blankSlateComponent: ReactWrapper<IBlankSlateProps, any>;
 
     it('should render without errors', () => {
@@ -38,7 +39,7 @@ describe('BlankSlate', () => {
     describe('<Blankslate /> with custom props', () => {
         const customProps = {
             title: 'title',
-            description: 'description test',
+            // description: 'description test',
             buttons: [
                 {
                     name: 'test',
@@ -69,9 +70,22 @@ describe('BlankSlate', () => {
         });
 
         it('should render the custom description', () => {
-            renderBlankSlate();
+            const expectedDescription = 'description test';
+            renderBlankSlate({description: expectedDescription});
             expect(blankSlateComponent.find('p').length).toBe(1);
-            expect(blankSlateComponent.find('p').text()).toEqual(customProps.description);
+            expect(blankSlateComponent.find('p').text()).toEqual(expectedDescription);
+        });
+
+        it('should render the custom description with a link', () => {
+            renderBlankSlate({
+                description: (
+                    <span>
+                        This is a description with a link to <a href="https://www.google.com"></a>this website.
+                    </span>
+                ),
+            });
+
+            expect(blankSlateComponent.find('p').text()).toEqual('This is a description with a link to this website.');
         });
 
         it('should render the button', () => {

--- a/packages/react-vapor/src/components/blankSlate/tests/BlankSlate.spec.tsx
+++ b/packages/react-vapor/src/components/blankSlate/tests/BlankSlate.spec.tsx
@@ -39,7 +39,7 @@ describe('BlankSlate', () => {
     describe('<Blankslate /> with custom props', () => {
         const customProps = {
             title: 'title',
-            // description: 'description test',
+            description: 'description test',
             buttons: [
                 {
                     name: 'test',
@@ -70,10 +70,9 @@ describe('BlankSlate', () => {
         });
 
         it('should render the custom description', () => {
-            const expectedDescription = 'description test';
-            renderBlankSlate({description: expectedDescription});
+            renderBlankSlate();
             expect(blankSlateComponent.find('p').length).toBe(1);
-            expect(blankSlateComponent.find('p').text()).toEqual(expectedDescription);
+            expect(blankSlateComponent.find('p').text()).toEqual(customProps.description);
         });
 
         it('should render the custom description with a link', () => {


### PR DESCRIPTION
### Proposed Changes

Added a dangerouslySetDescription in the BlankSlate props

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ x ] The proposed changes are covered by unit tests
-   [ x ] The potential breaking changes are clearly identified
-   [ - ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
