### PR TITLE
Fix Style When the Element is a Child of the input-field

### DIFF
--- a/packages/vapor/scss/controls/input-field.scss
+++ b/packages/vapor/scss/controls/input-field.scss
@@ -59,6 +59,8 @@
 
     > label,
     > span,
+    .input-wrapper > label,
+    .input-wrapper > span,
     &.input-wrapper > label,
     &.input-wrapper > span {
         position: absolute;


### PR DESCRIPTION
A [change had some side effect](https://github.com/coveo/react-vapor/pull/1238/files#diff-48a7d6baa8f7bd7c15486dff810ecc17L57) in the UI. I kept the change but added a selector for the rule

![image](https://user-images.githubusercontent.com/260007/64988421-6e155b00-d899-11e9-8547-9ae71244975a.png)

@salvarez07 Do you think it can have more unexpected effects?
