### PR TITLE
Add valid Content in Content Component

### DIFF
--- a/packages/react-vapor/src/components/content/Content.tsx
+++ b/packages/react-vapor/src/components/content/Content.tsx
@@ -18,10 +18,16 @@ export class Content extends React.Component<IContentProps, {}> {
         tag: 'span',
     };
 
-    private getContent(): JSX.Element | string {
-        return _.isString(this.props.content)
-            ? this.props.content
-            : React.createElement(this.props.content as React.ComponentClass, this.props.componentProps);
+    private getContent(): JSX.Element | string | React.ReactNode {
+        if (
+            _.isString(this.props.content) ||
+            _.isNumber(this.props.content) ||
+            React.isValidElement(this.props.content)
+        ) {
+            return this.props.content;
+        }
+
+        return React.createElement(this.props.content as React.ComponentClass, this.props.componentProps);
     }
 
     render() {

--- a/packages/react-vapor/src/components/content/Content.tsx
+++ b/packages/react-vapor/src/components/content/Content.tsx
@@ -18,7 +18,7 @@ export class Content extends React.Component<IContentProps, {}> {
         tag: 'span',
     };
 
-    private getContent(): JSX.Element | string | React.ReactNode {
+    private getContent(): React.ReactNode {
         if (
             _.isString(this.props.content) ||
             _.isNumber(this.props.content) ||

--- a/packages/react-vapor/src/components/content/tests/Content.spec.tsx
+++ b/packages/react-vapor/src/components/content/tests/Content.spec.tsx
@@ -1,15 +1,10 @@
-import {mount, ReactWrapper, shallow} from 'enzyme';
+import {shallow, ShallowWrapper} from 'enzyme';
 import * as React from 'react';
 import {Loading} from '../../loading/Loading';
-import {ISvgProps, Svg} from '../../svg/Svg';
 import {Content, IContentProps} from '../Content';
 
 describe('Content', () => {
-    let contentComponent: ReactWrapper<IContentProps, any>;
-    const svg: ISvgProps = {
-        svgName: 'domain-google',
-        svgClass: 'icon',
-    };
+    let contentComponent: ShallowWrapper<IContentProps, any>;
 
     it('should render without errors', () => {
         expect(() => {
@@ -19,7 +14,7 @@ describe('Content', () => {
 
     describe('<BoxItem /> with custom props', () => {
         const renderContent = (props: IContentProps) => {
-            contentComponent = mount(<Content {...props} />, {attachTo: document.getElementById('App')});
+            contentComponent = shallow(<Content {...props} />);
         };
 
         it('should render with a string', () => {
@@ -27,13 +22,6 @@ describe('Content', () => {
                 content: 'test',
             });
             expect(contentComponent.find('span').text()).toBe('test');
-        });
-
-        it('should render with a function that returns <Svg/>', () => {
-            renderContent({
-                content: () => <Svg {...svg} />,
-            });
-            expect(contentComponent.find(Svg).length).toBe(1);
         });
 
         it('should render with a component <Loading/>', () => {
@@ -49,6 +37,20 @@ describe('Content', () => {
                 tag: 'div',
             });
             expect(contentComponent.find('div').text()).toBe('test');
+        });
+
+        it('should render with a ReactNode', () => {
+            renderContent({
+                content: <div>React.ion</div>,
+            });
+            expect(contentComponent.find('div').text()).toBe('React.ion');
+        });
+
+        it('should render with a number', () => {
+            renderContent({
+                content: 420,
+            });
+            expect(contentComponent.find('span').text()).toBe('420');
         });
     });
 });

--- a/packages/react-vapor/src/components/headers/examples/BreadcrumbHeaderExample.tsx
+++ b/packages/react-vapor/src/components/headers/examples/BreadcrumbHeaderExample.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import {Button} from '../../button/Button';
+import {Svg} from '../../svg/Svg';
 import {BreadcrumbHeader} from '../BreadcrumbHeader';
 import {actions, defaultBreadcrumb, defaultBreadcrumbLongTitle, defaultTabs} from './ExamplesUtils';
 
@@ -70,6 +72,38 @@ export class BreadcrumbHeaderExample extends React.Component<any, any> {
                             description="Simple description for the title"
                             actions={actions}
                             tabs={defaultTabs}
+                        />
+                    </div>
+                </div>
+                <div className="form-group">
+                    <label className="form-control-label">Breadcrumb with a node as action</label>
+                    <div className="form-control">
+                        <BreadcrumbHeader
+                            breadcrumb={defaultBreadcrumbLongTitle}
+                            description="Simple description for the title"
+                            actions={[
+                                {
+                                    content: (
+                                        <Button>
+                                            <Svg svgName={'add'} svgClass={'icon'} />
+                                        </Button>
+                                    ),
+                                },
+                            ]}
+                        />
+                    </div>
+                </div>
+                <div className="form-group">
+                    <label className="form-control-label">Breadcrumb with a number as action</label>
+                    <div className="form-control">
+                        <BreadcrumbHeader
+                            breadcrumb={defaultBreadcrumbLongTitle}
+                            description="Simple description for the title"
+                            actions={[
+                                {
+                                    content: 1,
+                                },
+                            ]}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
add validation to allowed reactNode and number as content for the Content Comonent
add 2 examples

### Proposed Changes

I change the condition to return the ReactNode  or the number instead of throwing an error

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
