### PR TITLE
actionTrigger now takes the confirmLabel Props in requiresConfirmation

### DIFF
--- a/packages/react-vapor/src/components/actions/Action.tsx
+++ b/packages/react-vapor/src/components/actions/Action.tsx
@@ -11,6 +11,7 @@ export interface IConfirmButtonLabel {
 
 export interface IConfirmData {
     confirmType: string;
+    confirmLabel?: string;
     buttonLabels?: IConfirmButtonLabel;
 }
 

--- a/packages/react-vapor/src/components/actions/TriggerAction.tsx
+++ b/packages/react-vapor/src/components/actions/TriggerAction.tsx
@@ -22,7 +22,8 @@ export class TriggerAction extends React.Component<ITriggerActionProps, any> {
     private onTriggerAction() {
         const confirmData: IConfirmData = this.props.action.requiresConfirmation;
         if (confirmData && this.props.onTriggerConfirm) {
-            const confirmLabel: string = this.props.action.requiresConfirmation.confirmLabel || CONFIRM_LABEL;
+            const confirmLabel: string =
+                this.props.confirmLabel || this.props.action.requiresConfirmation.confirmLabel || CONFIRM_LABEL;
             const icon: string = this.props.action.icon;
             this.props.onTriggerConfirm(
                 () => {

--- a/packages/react-vapor/src/components/actions/TriggerAction.tsx
+++ b/packages/react-vapor/src/components/actions/TriggerAction.tsx
@@ -21,11 +21,9 @@ export const CONFIRM_LABEL: string = 'Are you sure?';
 export class TriggerAction extends React.Component<ITriggerActionProps, any> {
     private onTriggerAction() {
         const confirmData: IConfirmData = this.props.action.requiresConfirmation;
-
         if (confirmData && this.props.onTriggerConfirm) {
-            const confirmLabel: string = this.props.confirmLabel || CONFIRM_LABEL;
+            const confirmLabel: string = this.props.action.requiresConfirmation.confirmLabel || CONFIRM_LABEL;
             const icon: string = this.props.action.icon;
-
             this.props.onTriggerConfirm(
                 () => {
                     if (this.props.action.trigger) {

--- a/packages/react-vapor/src/components/actions/examples/ActionBarConnectedExamples.tsx
+++ b/packages/react-vapor/src/components/actions/examples/ActionBarConnectedExamples.tsx
@@ -21,9 +21,27 @@ export class ActionBarConnectedExamples extends React.Component<any, any> {
             },
             ACTION_SEPARATOR,
             {
+                name: 'Confirm Me',
+                trigger: () => alert('You confirmed this action !'),
+                target: '_blank',
+                icon: 'disable',
+                primary: true,
+                enabled: true,
+                requiresConfirmation: {
+                    confirmLabel: 'Want to do this action ?',
+                    confirmType: 'danger',
+                    buttonLabels: {
+                        confirm: 'sure !',
+                        cancel: 'never !',
+                    },
+                },
+            },
+            ACTION_SEPARATOR,
+            {
                 name: 'Action 1',
                 trigger: () => alert('Action 1 was triggered'),
                 enabled: true,
+                icon: 'edit',
                 requiresConfirmation: {
                     confirmType: 'danger',
                     buttonLabels: {

--- a/packages/react-vapor/src/components/actions/tests/TriggerAction.spec.tsx
+++ b/packages/react-vapor/src/components/actions/tests/TriggerAction.spec.tsx
@@ -168,5 +168,19 @@ describe('Actions', () => {
             triggerAction.setProps({action: newAction, onTriggerConfirm: onTriggerConfirm});
             expect(() => triggerActionInstance['onTriggerAction'].call(triggerActionInstance)).not.toThrow();
         });
+
+        it('should use a custom prompt description when the confirmLabel is set', () => {
+            const newAction = _.extend({requiresConfirmation: {confirmLabel: 'custom label'}}, action);
+            triggerAction.setProps({action: newAction});
+
+            triggerAction
+                .find('.enabled')
+                .props()
+                .onClick('mouseEvent' as any);
+            expect(triggerSpy).toHaveBeenCalled();
+            expect(triggerSpy.calls.first().object.requiresConfirmation.confirmLabel).toEqual(
+                newAction.requiresConfirmation.confirmLabel
+            );
+        });
     });
 });

--- a/packages/react-vapor/src/components/inlinePrompt/InlinePrompt.tsx
+++ b/packages/react-vapor/src/components/inlinePrompt/InlinePrompt.tsx
@@ -41,7 +41,7 @@ export class InlinePrompt extends React.Component<IInlinePromptProps, any> {
         const icon: JSX.Element = this.props.options.userChoice.icon ? (
             <Svg
                 svgName={this.props.options.userChoice.icon}
-                className="prompt-icon"
+                className="prompt-icon mr1"
                 svgClass="icon mod-2x fill-medium-blue"
             />
         ) : null;


### PR DESCRIPTION
…ation objet, added an example in vapor

### Proposed Changes

The inline prompt that is triggered when a requiresConfirmation is set will now take a custom prompt description that will bypass de default 'are you sure ?' string.

### Potential Breaking Changes

Not used anywhere yet.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
