### PR TITLE
Enable Split Points in Demo Build

### DIFF
--- a/packages/react-vapor/docs/index.html
+++ b/packages/react-vapor/docs/index.html
@@ -12,6 +12,6 @@
         <div id="App" class="full-content"></div>
         <div id="Modals"></div>
         <div id="Drops"></div>
-        <script src="assets/bundle.js"></script>
+        <script src="assets/main.bundle.js"></script>
     </body>
 </html>

--- a/packages/react-vapor/docs/src/OneDemoToRuleThemAll.tsx
+++ b/packages/react-vapor/docs/src/OneDemoToRuleThemAll.tsx
@@ -32,7 +32,7 @@ function Header() {
     );
 }
 
-const fallback = {fallback: <Loading />};
+const fallback = {fallback: <Loading fullContent />};
 const LoadableComponents = loadable(() => import(/* webpackChunkName: "components" */ './components'), fallback);
 const LoadableStyles = loadable(() => import(/* webpackChunkName: "styles" */ './styles'), fallback);
 

--- a/packages/react-vapor/docs/src/OneDemoToRuleThemAll.tsx
+++ b/packages/react-vapor/docs/src/OneDemoToRuleThemAll.tsx
@@ -1,10 +1,9 @@
 import './demo-styling/main.scss';
 
+import loadable from '@loadable/component';
 import * as React from 'react';
 import {HashRouter as Router, Link, Redirect, Route} from 'react-router-dom';
-
-import Components from './components';
-import Styles from './styles';
+import {Loading} from '../../src/components/loading/Loading';
 
 function TopNav() {
     return (
@@ -33,13 +32,17 @@ function Header() {
     );
 }
 
+const fallback = {fallback: <Loading />};
+const LoadableComponents = loadable(() => import(/* webpackChunkName: "components" */ './components'), fallback);
+const LoadableStyles = loadable(() => import(/* webpackChunkName: "styles" */ './styles'), fallback);
+
 function Demo() {
     return (
         <Router>
             <Header />
             <div className="container flex-auto overflow-auto" style={{height: 'calc(100% - 65px)'}}>
-                <Route path="/components" component={Components} />
-                <Route path="/styles" component={Styles} />
+                <Route path="/components" component={LoadableComponents} />
+                <Route path="/styles" component={LoadableStyles} />
                 <Route exact path="/" component={() => <Redirect to="/components" />} />
             </div>
         </Router>

--- a/packages/react-vapor/docs/src/components/ComponentPage.tsx
+++ b/packages/react-vapor/docs/src/components/ComponentPage.tsx
@@ -9,12 +9,38 @@ import Code from '../demo-building-blocs/Code';
 import {MarkdownOverrides} from '../demo-building-blocs/MarkdownOverrides';
 import {IComponent, TabConfig} from './ComponentsInterface';
 
-type ComponentPageProps = Omit<IComponent, 'path'>;
+type ComponentPageProps = IComponent;
 
 const buildTabIdTemplate = (componentName: string) => (tabName: string) => `${componentName}-${tabName}-tab`;
 
 const ComponentPage: React.FunctionComponent<ComponentPageProps> = (props) => {
-    const {name, tabs, component} = props;
+    const componentRootPath = props.path.substring(0, props.path.lastIndexOf('.'));
+    const [tabs, setTabs] = React.useState([]);
+    React.useEffect(() => {
+        const load = async (path: string, ctx: any) => {
+            if (path.includes(componentRootPath)) {
+                const [, order, tabName] = /\w+Examples?(?:\.(\d+))?(?:\.(\w+))?\.md$/.exec(path);
+                const {default: markdown} = await ctx(path);
+                const c: TabConfig = {
+                    tabName,
+                    markdown,
+                    order: parseInt(order, 10) || 0,
+                };
+                return c;
+            }
+        };
+        const loadAll = () => {
+            const mdFiles = require.context(
+                '!!raw-loader!../../../src/components/',
+                true,
+                /Examples?(\.\d+)?(\.\w+)?\.md$/i,
+                'lazy'
+            );
+            return Promise.all(mdFiles.keys().map((path) => load(path, mdFiles)));
+        };
+        loadAll().then((all) => setTabs(all.filter(Boolean)));
+    }, [componentRootPath]);
+    const {name, component} = props;
     const hasMarkdownTabs = tabs.length > 0;
     const getTabId = buildTabIdTemplate(name);
     const mapTabConfigToProps = ({tabName}: TabConfig): ITabProps => ({
@@ -31,12 +57,12 @@ const ComponentPage: React.FunctionComponent<ComponentPageProps> = (props) => {
     return (
         <>
             <BasicHeader title={{text: component.title || name}} description={component.description} tabs={tabProps} />
-            <PageLayout {...props} />
+            <PageLayout {...props} tabs={tabs} />
         </>
     );
 };
 
-const PageLayoutWithTabs: React.FunctionComponent<ComponentPageProps> = (props) => {
+const PageLayoutWithTabs: React.FunctionComponent<ComponentPageProps & {tabs: TabConfig[]}> = (props) => {
     const {name, tabs} = props;
     const getTabId = buildTabIdTemplate(name);
     return (
@@ -59,13 +85,46 @@ const PageLayoutWithoutTabs: React.FunctionComponent<ComponentPageProps> = (prop
     </div>
 );
 
-const DevelopmentTabContent: React.FunctionComponent<ComponentPageProps> = ({component, code}) => (
-    <>
-        {React.createElement(component)}
-        <div className="mt2">
-            <Code language="tsx">{code}</Code>
-        </div>
-    </>
-);
+const START_STOP = /\/\/ start-print\s*([\s\S]*)\/\/ stop-print/g;
+const START_END = /\/\/ start-print\s*([\s\S]*)$/g;
+const BEGIN_STOP = /^([\s\S]*)\/\/ stop-print/g;
+
+function chopDownSourceFile(wholeFile: string): string {
+    const hasStartDirective = wholeFile.indexOf('// start-print') >= 0;
+    const hasStopDirective = wholeFile.indexOf('// stop-print') >= 0;
+
+    if (hasStartDirective && hasStopDirective) {
+        return START_STOP.exec(wholeFile)[1];
+    } else if (hasStartDirective) {
+        return START_END.exec(wholeFile)[1];
+    } else if (hasStopDirective) {
+        return BEGIN_STOP.exec(wholeFile)[1];
+    } else {
+        return wholeFile;
+    }
+}
+
+const DevelopmentTabContent: React.FunctionComponent<ComponentPageProps> = ({component, path}) => {
+    const [code, setCode] = React.useState('');
+    React.useEffect(() => {
+        const doImport = async () => {
+            const res: {default: string} = await import(
+                '!!raw-loader!../../../src/components/' + path.replace('./', '')
+            );
+            return chopDownSourceFile(res.default);
+        };
+        doImport().then(setCode);
+    }, [path]);
+    return (
+        <>
+            {React.createElement(component)}
+            {code && (
+                <div className="mt2">
+                    <Code language="tsx">{code}</Code>
+                </div>
+            )}
+        </>
+    );
+};
 
 export default ComponentPage;

--- a/packages/react-vapor/docs/src/components/ComponentsInterface.tsx
+++ b/packages/react-vapor/docs/src/components/ComponentsInterface.tsx
@@ -3,9 +3,7 @@ import * as React from 'react';
 export interface IComponent {
     path: string;
     name: string;
-    code: string;
     component: ExampleComponent;
-    tabs: TabConfig[];
 }
 
 export type ExampleComponent = React.ComponentType & {

--- a/packages/react-vapor/docs/src/components/index.tsx
+++ b/packages/react-vapor/docs/src/components/index.tsx
@@ -37,7 +37,7 @@ const Components: React.FunctionComponent<RouteComponentProps> = ({match}) => {
             />
         ));
     if (components.length === 0) {
-        return <Loading />;
+        return <Loading fullContent />;
     }
 
     return (

--- a/packages/react-vapor/docs/src/demo-building-blocs/Code.tsx
+++ b/packages/react-vapor/docs/src/demo-building-blocs/Code.tsx
@@ -2,9 +2,13 @@ import * as html from 'prettier/parser-html';
 import * as prettier from 'prettier/standalone';
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
-import {Prism as SyntaxHighlighter} from 'react-syntax-highlighter';
+import {PrismLight as SyntaxHighlighter} from 'react-syntax-highlighter';
+// @ts-ignore
+import tsx from 'react-syntax-highlighter/dist/esm/languages/prism/tsx';
 // @ts-ignore
 import {prism as theme} from 'react-syntax-highlighter/dist/esm/styles/prism';
+
+SyntaxHighlighter.registerLanguage('tsx', tsx);
 
 export const Code: React.FunctionComponent<{language: string}> = ({language, children}) => {
     let formattedCode: React.ReactNode = children;

--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -21,7 +21,7 @@
     },
     "scripts": {
         "start": "webpack-dev-server --progress",
-        "docs": "webpack --devtool source-map",
+        "docs": "webpack",
         "compileTs": "webpack --config webpack.config.prod.js",
         "minify": "webpack --config webpack.config.prod.minify.js",
         "build": "gulp clean && concurrently \"npm run compileTs\" \"npm run minify\" \"gulp ts:definitions\"",
@@ -61,6 +61,7 @@
         "underscore.string": "^3.3.5"
     },
     "devDependencies": {
+        "@loadable/component": "5.10.2",
         "@types/chosen-js": "1.6.2",
         "@types/classnames": "2.2.6",
         "@types/codemirror": "0.0.62",
@@ -73,6 +74,7 @@
         "@types/faker": "4.1.5",
         "@types/jasmine": "3.3.1",
         "@types/jquery": "2.0.46",
+        "@types/loadable__component": "5.10.0",
         "@types/lorem-ipsum": "1.0.2",
         "@types/prettier": "^1.18.2",
         "@types/rc-slider": "8.6.0",
@@ -92,7 +94,7 @@
         "@types/redux-mock-store": "1.0.1",
         "@types/underscore": "1.8.10",
         "@types/underscore.string": "0.0.33",
-        "@types/webpack-env": "1.13.6",
+        "@types/webpack-env": "1.14.0",
         "ansi-colors": "3.2.4",
         "autoprefixer": "9.4.0",
         "awesome-typescript-loader": "5.2.1",
@@ -169,7 +171,7 @@
         "typings-for-css-modules-loader": "1.7.0",
         "underscore": "1.9.1",
         "underscore.string": "3.3.5",
-        "webpack": "4.26.1",
+        "webpack": "4.40.2",
         "webpack-bundle-analyzer": "3.0.3",
         "webpack-cli": "3.2.0",
         "webpack-dev-server": "3.1.11"

--- a/packages/react-vapor/src/components/calendar/Calendar.tsx
+++ b/packages/react-vapor/src/components/calendar/Calendar.tsx
@@ -1,4 +1,4 @@
-import classNames = require('classnames');
+import * as classNames from 'classnames';
 import * as moment from 'moment';
 import * as React from 'react';
 import * as _ from 'underscore';

--- a/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
@@ -1,4 +1,4 @@
-import classNames = require('classnames');
+import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
 import * as s from 'underscore.string';

--- a/packages/react-vapor/src/components/table-hoc/examples/TableHOCExamples.tsx
+++ b/packages/react-vapor/src/components/table-hoc/examples/TableHOCExamples.tsx
@@ -1,4 +1,4 @@
-import {helpers, seed} from 'faker';
+import {helpers, seed} from 'faker/locale/en';
 import * as moment from 'moment';
 import * as React from 'react';
 import * as _ from 'underscore';

--- a/packages/react-vapor/src/components/tables/tests/TableTestCommon.tsx
+++ b/packages/react-vapor/src/components/tables/tests/TableTestCommon.tsx
@@ -1,4 +1,4 @@
-import {date, internet} from 'faker';
+import {date, internet} from 'faker/locale/en';
 import * as moment from 'moment';
 import * as React from 'react';
 import * as _ from 'underscore';

--- a/packages/react-vapor/src/components/tables/tests/TableUtils.spec.ts
+++ b/packages/react-vapor/src/components/tables/tests/TableUtils.spec.ts
@@ -1,4 +1,4 @@
-import * as faker from 'faker';
+import * as faker from 'faker/locale/en';
 import * as _ from 'underscore';
 import {TableChildComponent, TableSortingOrder} from '../TableConstants';
 import {

--- a/packages/react-vapor/tsconfig.build.json
+++ b/packages/react-vapor/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
+        "module": "esnext",
+        "moduleResolution": "Node",
+        "removeComments": false,
         "outDir": "./dist/split/",
         "sourceMap": true,
         "rootDir": "."

--- a/packages/react-vapor/webpack.config.js
+++ b/packages/react-vapor/webpack.config.js
@@ -6,14 +6,17 @@ const isTravis = !!process.env.TRAVIS;
  * Config file for the documentation project
  */
 module.exports = {
-    entry: './docs/Index.tsx',
-    mode: 'development',
+    entry: {
+        main: './docs/Index.tsx',
+    },
+    mode: isTravis ? 'development' : 'production',
     output: {
         path: path.join(__dirname, '/docs/assets'),
         publicPath: 'assets/',
-        filename: 'bundle.js',
+        filename: '[name].bundle.js',
+        chunkFilename: '[name].bundle.js',
     },
-    devtool: 'eval-source-map',
+    devtool: isTravis ? 'source-map' : 'cheap-module-source-map',
     resolve: {
         extensions: ['.ts', '.tsx', '.js', '.jsx'],
     },
@@ -22,13 +25,14 @@ module.exports = {
             WEBPACK_DEFINED_VERSION: JSON.stringify(require('./package.json').version),
         }),
         new webpack.HotModuleReplacementPlugin(),
+        new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /en-ca/),
     ],
     module: {
         rules: [
             {
                 enforce: 'pre',
-                test: /\.ts(x?)$/i,
-                exclude: [/node_modules/],
+                test: /\.tsx?$/,
+                include: [path.resolve(__dirname, 'src'), path.resolve(__dirname, 'docs')],
                 use: {
                     loader: 'tslint-loader',
                     options: {
@@ -49,6 +53,7 @@ module.exports = {
             },
             {
                 test: /\.tsx?$/,
+                include: [path.resolve(__dirname, 'src'), path.resolve(__dirname, 'docs')],
                 loader: 'awesome-typescript-loader',
                 options: {
                     useCache: true,

--- a/packages/react-vapor/webpack.config.js
+++ b/packages/react-vapor/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     entry: {
         main: './docs/Index.tsx',
     },
-    mode: isTravis ? 'development' : 'production',
+    mode: isTravis ? 'production' : 'development',
     output: {
         path: path.join(__dirname, '/docs/assets'),
         publicPath: 'assets/',


### PR DESCRIPTION
### Proposed Changes

Split styles and components in two files
Dynamic imports of examples and markdown
Minify on Travis
Reduce bundle size by only using english in moment and faker
Reduce bundle size by only loading html and tsx in syntax highlighter

### Potential Breaking Changes

It only modify the demo for now, I might do another PR to modify the npm package

### Acceptance Criteria

-   [x] The potential breaking changes are clearly identified
