### PR TITLE
Better Performance in the SlideY and Svg Components

### DIFF
--- a/packages/react-vapor/docs/src/components/ComponentPage.tsx
+++ b/packages/react-vapor/docs/src/components/ComponentPage.tsx
@@ -31,7 +31,7 @@ const ComponentPage: React.FunctionComponent<ComponentPageProps> = (props) => {
         };
         const loadAll = () => {
             const mdFiles = require.context(
-                '!!raw-loader!../../../src/components/',
+                '!!raw-loader!../../../src/',
                 true,
                 /Examples?(\.\d+)?(\.\w+)?\.md$/i,
                 'lazy'
@@ -108,9 +108,7 @@ const DevelopmentTabContent: React.FunctionComponent<ComponentPageProps> = ({com
     const [code, setCode] = React.useState('');
     React.useEffect(() => {
         const doImport = async () => {
-            const res: {default: string} = await import(
-                '!!raw-loader!../../../src/components/' + path.replace('./', '')
-            );
+            const res: {default: string} = await import('!!raw-loader!../../../src/' + path.replace('./', ''));
             return chopDownSourceFile(res.default);
         };
         doImport().then(setCode);

--- a/packages/react-vapor/docs/src/components/index.tsx
+++ b/packages/react-vapor/docs/src/components/index.tsx
@@ -22,7 +22,7 @@ const Components: React.FunctionComponent<RouteComponentProps> = ({match}) => {
             return c;
         };
         const loadAll = () => {
-            const componentFiles = require.context('../../../src/components/', true, /Examples?\.tsx?$/i, 'lazy');
+            const componentFiles = require.context('../../../src/', true, /Examples?\.tsx?$/i, 'lazy');
             return Promise.all(componentFiles.keys().map((path) => load(path, componentFiles)));
         };
         loadAll().then((all) => setComponents(all.filter(Boolean)));

--- a/packages/react-vapor/src/animations/SlideY.tsx
+++ b/packages/react-vapor/src/animations/SlideY.tsx
@@ -29,15 +29,15 @@ export class SlideY extends React.PureComponent<SlideYProps> {
         }
     }
 
-    componentWillUpdate() {
-        this.el.style.height = this.getCurrentHeight();
-    }
+    componentDidUpdate(prevProps: SlideYProps) {
+        if (prevProps.in !== this.props.in) {
+            this.el.style.height = this.getCurrentHeight();
 
-    componentDidUpdate() {
-        if (this.props.in) {
-            this.onEntering();
-        } else {
-            this.onExiting();
+            if (this.props.in) {
+                this.onEntering();
+            } else {
+                this.onExiting();
+            }
         }
     }
 

--- a/packages/react-vapor/src/animations/examples/SlideYExamples.tsx
+++ b/packages/react-vapor/src/animations/examples/SlideYExamples.tsx
@@ -9,6 +9,9 @@ interface SlideYExamplesState {
 }
 
 export class SlideYExamples extends React.PureComponent<any, SlideYExamplesState> {
+    private first: string;
+    private second: string;
+
     constructor(props: any, state: SlideYExamplesState) {
         super(props, state);
 
@@ -16,6 +19,9 @@ export class SlideYExamples extends React.PureComponent<any, SlideYExamplesState
             first: false,
             second: false,
         };
+
+        this.first = loremIpsum({count: 20});
+        this.second = loremIpsum({count: 20});
     }
 
     render() {
@@ -30,7 +36,7 @@ export class SlideYExamples extends React.PureComponent<any, SlideYExamplesState
                             enabled
                         ></Button>
                         <SlideY in={this.state.first} timeout={500}>
-                            <div>{loremIpsum({count: 20})}</div>
+                            <div>{this.first}</div>
                         </SlideY>
                     </div>
                 </div>
@@ -43,7 +49,7 @@ export class SlideYExamples extends React.PureComponent<any, SlideYExamplesState
                             enabled
                         ></Button>
                         <SlideY in={this.state.second} timeout={500} duration={5000}>
-                            <div>{loremIpsum({count: 20})}</div>
+                            <div>{this.second}</div>
                         </SlideY>
                     </div>
                 </div>

--- a/packages/react-vapor/src/components/svg/Svg.tsx
+++ b/packages/react-vapor/src/components/svg/Svg.tsx
@@ -18,14 +18,9 @@ export class Svg extends React.Component<ISvgProps> {
         svgClass: '',
     };
 
-    private setSvgClass = (svgString: string, svgClass: string): string => {
-        const parser = document.createElement('div');
-        parser.innerHTML = svgString;
-
-        (parser.children[0] as SVGElement).setAttribute('class', svgClass);
-
-        return parser.innerHTML;
-    };
+    private setSvgClass(svgString: string, svgClass: string): string {
+        return svgString.replace('<svg ', `<svg class="${svgClass}" `);
+    }
 
     render() {
         const formattedSvgName: string = camelize(this.props.svgName);


### PR DESCRIPTION
### Proposed Changes

Don't re-calculate the SlideY on unmount
Use a string replace in Svg instead of creating and updating a DOM node

Load all exemples and not just those in the components folder


### Potential Breaking Changes

All the tests are still green and the examples are working so I expect everything to be good

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
