### PR TITLE
Fix drop bottom right postion

### DIFF
--- a/packages/react-vapor/src/components/drop/DomPositionCalculator.ts
+++ b/packages/react-vapor/src/components/drop/DomPositionCalculator.ts
@@ -70,7 +70,7 @@ export const DomPositionCalculator: {
                 return {
                     style: {
                         top: buttonOffset.bottom,
-                        left: buttonOffset.left + buttonOffset.width,
+                        left: buttonOffset.right - dropOffset.width,
                     },
                     lastPosition: {
                         position: DropPodPosition.bottom,

--- a/packages/react-vapor/src/components/drop/DomPositionCalculator.ts
+++ b/packages/react-vapor/src/components/drop/DomPositionCalculator.ts
@@ -69,7 +69,7 @@ export const DomPositionCalculator: {
             ) {
                 return {
                     style: {
-                        top: buttonOffset.top,
+                        top: buttonOffset.bottom,
                         left: buttonOffset.left + buttonOffset.width,
                     },
                     lastPosition: {

--- a/packages/react-vapor/src/components/drop/DropPod.tsx
+++ b/packages/react-vapor/src/components/drop/DropPod.tsx
@@ -194,6 +194,7 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
             if (this.props.hasSameWidth) {
                 newDomPosition.style = {
                     ...style,
+                    left: buttonOffset.left,
                     width: buttonOffset.width,
                 };
             }

--- a/packages/react-vapor/src/components/drop/examples/DropExamples.tsx
+++ b/packages/react-vapor/src/components/drop/examples/DropExamples.tsx
@@ -156,6 +156,38 @@ export class DropExamples extends React.PureComponent<any> {
                     </div>
                 </div>
                 <div className="form-group">
+                    <label className="form-control-label">Drop with an item with a long text</label>
+                    <div className="form-control flex center-align">
+                        <Drop
+                            id={UUID.generate()}
+                            parentSelector={'body'}
+                            selector={'#App'}
+                            positions={[DropPodPosition.bottom]}
+                            buttonContainerProps={{
+                                className: 'inline-block',
+                            }}
+                            renderOpenButton={(onClick: () => void) => (
+                                <Button
+                                    name={'Text'}
+                                    enabled={true}
+                                    onClick={() => onClick()}
+                                    style={{width: '300px'}}
+                                />
+                            )}
+                        >
+                            <ListBox
+                                items={[
+                                    ...defaultItems,
+                                    {
+                                        value:
+                                            'this is a long storyyyyyyyyyyyyyyyyyyyy!!!!!!!!! and more ....... more ..... more ..... more .... more ..... more',
+                                    },
+                                ]}
+                            />
+                        </Drop>
+                    </div>
+                </div>
+                <div className="form-group">
                     <label className="form-control-label">Drop inside a modal</label>
                     <div className="form-control">
                         <button className="btn" onClick={() => this.openModal(modalId)}>
@@ -237,7 +269,7 @@ export class DropExamples extends React.PureComponent<any> {
                                         <Drop
                                             id={UUID.generate()}
                                             selector={'#App'}
-                                            positions={[DropPodPosition.top]}
+                                            positions={[DropPodPosition.bottom]}
                                             buttonContainerProps={{
                                                 className: 'inline-block relative',
                                             }}

--- a/packages/react-vapor/src/components/drop/examples/DropExamples.tsx
+++ b/packages/react-vapor/src/components/drop/examples/DropExamples.tsx
@@ -269,7 +269,7 @@ export class DropExamples extends React.PureComponent<any> {
                                         <Drop
                                             id={UUID.generate()}
                                             selector={'#App'}
-                                            positions={[DropPodPosition.bottom]}
+                                            positions={[DropPodPosition.top]}
                                             buttonContainerProps={{
                                                 className: 'inline-block relative',
                                             }}

--- a/packages/react-vapor/src/components/drop/tests/DomPositionCalculator.spec.ts
+++ b/packages/react-vapor/src/components/drop/tests/DomPositionCalculator.spec.ts
@@ -41,7 +41,7 @@ describe('DomPositionCalculator', () => {
             });
         });
 
-        it('should return button offset top and left + width position if the drop can render on bottom with right orientation', () => {
+        it('should return button offset top and right - width position if the drop can render on bottom with right orientation', () => {
             expect(
                 validator(
                     {bottom: 100, left: 100, right: 110, top: 90, width: 10, height: 10} as any,
@@ -50,8 +50,8 @@ describe('DomPositionCalculator', () => {
                     defaultLastPosition
                 ).style
             ).toEqual({
-                top: 90,
-                left: 110,
+                top: 100,
+                left: 100,
             });
         });
 


### PR DESCRIPTION
### Proposed Changes

Set the width if we use the sameWidth
Set the position if the drop position bottom-right is rendered

### Potential Breaking Changes

change the drop bottom-right position

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
