### PR TITLE
Add TooltipContainer to TooltipUtils

### DIFF
--- a/packages/react-vapor/src/Defaults.ts
+++ b/packages/react-vapor/src/Defaults.ts
@@ -6,6 +6,8 @@ export abstract class Defaults {
 
     static DROP_ROOT: string = 'body';
 
+    static TOOLTIP_ROOT: string = 'body';
+
     static set APP_ELEMENT(appElement: string | HTMLElement) {
         ReactModal.setAppElement(appElement);
     }

--- a/packages/react-vapor/src/utils/TooltipUtils.ts
+++ b/packages/react-vapor/src/utils/TooltipUtils.ts
@@ -4,7 +4,3 @@ export enum TooltipPlacement {
     Left = 'left',
     Right = 'right',
 }
-
-export enum TooltipContainer {
-    Body = 'body',
-}

--- a/packages/react-vapor/src/utils/TooltipUtils.ts
+++ b/packages/react-vapor/src/utils/TooltipUtils.ts
@@ -4,3 +4,7 @@ export enum TooltipPlacement {
     Left = 'left',
     Right = 'right',
 }
+
+export enum TooltipContainer {
+    Body = 'body',
+}


### PR DESCRIPTION
### Proposed Changes

We start to using a lot the variable `container: 'body'` in table header during refactor tables with React. 

### Potential Breaking Changes

no

### Acceptance Criteria

-   [x ] The proposed changes are covered by unit tests
-   [x ] The potential breaking changes are clearly identified
-   [x ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
