### PR TITLE
fix: print source directives and prettier config

### DIFF
--- a/create-live-demo.js
+++ b/create-live-demo.js
@@ -4,7 +4,7 @@ const branchName = process.env.BRANCH_FOLDER_NAME;
 const prNumber = process.env.TRAVIS_PULL_REQUEST;
 const userpassword = process.env.GITUSRPWD;
 const APIEndpointWithAuthentication = `https://${userpassword}@api.github.com/repos/coveo/react-vapor/pulls/${prNumber}/reviews`;
-const liveDemoMessage = `[Live demo available here](https://coveo.github.io/react-vapor/${branchName}/).`;
+const liveDemoMessage = `[Live demo available here](https://coveo.github.io/react-vapor/${branchName}/index.html).`;
 
 console.log('Posting demo in GitHub Pull Request...\n');
 const handleError = (e) => {

--- a/create-live-demo.sh
+++ b/create-live-demo.sh
@@ -9,7 +9,7 @@ BRANCH_FOLDER_NAME=`echo "$TRAVIS_PULL_REQUEST_BRANCH" | md5sum | awk '{print $1
 
 echo "Syncing with gh-pages from branch: $TRAVIS_PULL_REQUEST_BRANCH"
 git stash
-git pull --no-edit --strategy-option ours "$SSH_REPO" gh-pages
+git pull --no-edit --quiet --strategy-option ours "$SSH_REPO" gh-pages
 git rm "$BRANCH_FOLDER_NAME" -r
 git commit -m "Clean old build" --no-verify
 git stash pop

--- a/create-live-demo.sh
+++ b/create-live-demo.sh
@@ -10,15 +10,15 @@ BRANCH_FOLDER_NAME=`echo "$TRAVIS_PULL_REQUEST_BRANCH" | md5sum | awk '{print $1
 echo "Syncing with gh-pages from branch: $TRAVIS_PULL_REQUEST_BRANCH"
 git stash
 git pull --no-edit --quiet --strategy-option ours "$SSH_REPO" gh-pages
-git rm "$BRANCH_FOLDER_NAME" -r
-git commit -m "Clean old build" --no-verify
+git rm --quiet "$BRANCH_FOLDER_NAME" -r
+git commit --quiet -m "Clean old build" --no-verify
 git stash pop
 
 echo "Creating live demo for branch: $TRAVIS_PULL_REQUEST_BRANCH";
 cp -R packages/react-vapor/docs "$BRANCH_FOLDER_NAME"
 
 git add "$BRANCH_FOLDER_NAME"
-git commit -m "live demo at https://coveo.github.io/react-vapor/$BRANCH_FOLDER_NAME/" --no-verify
+git commit --quiet -m "live demo at https://coveo.github.io/react-vapor/$BRANCH_FOLDER_NAME/" --no-verify
 echo "Deploying demo at https://coveo.github.io/react-vapor/$BRANCH_FOLDER_NAME/"
 
 SHA=`git rev-parse --verify HEAD`

--- a/packages/react-vapor/docs/src/components/ComponentPage.tsx
+++ b/packages/react-vapor/docs/src/components/ComponentPage.tsx
@@ -85,20 +85,20 @@ const PageLayoutWithoutTabs: React.FunctionComponent<ComponentPageProps> = (prop
     </div>
 );
 
-const START_STOP = /\/\/ start-print\s*([\s\S]*)\/\/ stop-print/g;
-const START_END = /\/\/ start-print\s*([\s\S]*)$/g;
-const BEGIN_STOP = /^([\s\S]*)\/\/ stop-print/g;
+const START_STOP = /\/\/ start-print\s*([\s\S]*)\/\/ stop-print/;
+const START_END = /\/\/ start-print\s*([\s\S]*)$/;
+const BEGIN_STOP = /^([\s\S]*)\/\/ stop-print/;
 
 function chopDownSourceFile(wholeFile: string): string {
     const hasStartDirective = wholeFile.indexOf('// start-print') >= 0;
     const hasStopDirective = wholeFile.indexOf('// stop-print') >= 0;
 
     if (hasStartDirective && hasStopDirective) {
-        return START_STOP.exec(wholeFile)[1];
+        return wholeFile.match(START_STOP)[1];
     } else if (hasStartDirective) {
-        return START_END.exec(wholeFile)[1];
+        return wholeFile.match(START_END)[1];
     } else if (hasStopDirective) {
-        return BEGIN_STOP.exec(wholeFile)[1];
+        return wholeFile.match(BEGIN_STOP)[1];
     } else {
         return wholeFile;
     }

--- a/packages/react-vapor/docs/src/demo-building-blocs/Code.tsx
+++ b/packages/react-vapor/docs/src/demo-building-blocs/Code.tsx
@@ -1,12 +1,16 @@
 import * as html from 'prettier/parser-html';
+import * as typescript from 'prettier/parser-typescript';
 import * as prettier from 'prettier/standalone';
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 import {PrismLight as SyntaxHighlighter} from 'react-syntax-highlighter';
+
 // @ts-ignore
 import tsx from 'react-syntax-highlighter/dist/esm/languages/prism/tsx';
 // @ts-ignore
 import {prism as theme} from 'react-syntax-highlighter/dist/esm/styles/prism';
+// tslint:disable-next-line
+const prettierConfig = require('tsjs/prettier-config');
 
 SyntaxHighlighter.registerLanguage('tsx', tsx);
 
@@ -15,10 +19,16 @@ export const Code: React.FunctionComponent<{language: string}> = ({language, chi
     if (language === 'html') {
         const HTMLString = ReactDOMServer.renderToStaticMarkup(children as React.ReactElement);
         formattedCode = prettier.format(HTMLString, {
+            ...prettierConfig,
             plugins: [html],
             parser: 'html',
             htmlWhitespaceSensitivity: 'ignore',
-            tabWidth: 4,
+        });
+    } else if (language === 'tsx') {
+        formattedCode = prettier.format(children as string, {
+            ...prettierConfig,
+            plugins: [typescript],
+            parser: 'typescript',
         });
     }
 

--- a/packages/react-vapor/webpack.config.js
+++ b/packages/react-vapor/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
         new webpack.HotModuleReplacementPlugin(),
         new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /en-ca/),
     ],
+    stats: 'minimal',
     module: {
         rules: [
             {


### PR DESCRIPTION
### Proposed Changes

Examples source code print directives were throwing an error when loading an example for the first time.

- Make the print directives regex work on first load
- Prettify the examples source code based on [the prettier config from tsjs](https://github.com/coveord/tsjs/blob/master/prettier-config.js)

Before: [notice the example source code at the bottom is not rendered](https://static.cloud.coveo.com/react-vapor/index.html#/components/Form).
After: [the source code at the bottom is rendered](https://coveo.github.io/react-vapor/7bd41f9da5ddc65808d21af57b9236a7/index.html#/components/Form)

### Potential Breaking Changes

None, it only affects the demo

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
