### PR TITLE
Add ColorPicker component

### DIFF
--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -43,7 +43,7 @@
         "diff2html": "2.5.0",
         "react-bootstrap": "0.32.4",
         "react-codemirror2": "5.1.0",
-        "react-color": "^2.17.3",
+        "react-color": "2.17.3",
         "react-infinite-scroll-component": "4.2.0",
         "react-modal": "3.10.1",
         "react-tether": "1.0.4",
@@ -63,7 +63,7 @@
     },
     "devDependencies": {
         "@loadable/component": "5.10.2",
-        "@types/react-color": "^3.0.1",
+        "@types/react-color": "3.0.1",
         "@types/chosen-js": "1.6.2",
         "@types/classnames": "2.2.6",
         "@types/codemirror": "0.0.62",

--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -43,6 +43,7 @@
         "diff2html": "2.5.0",
         "react-bootstrap": "0.32.4",
         "react-codemirror2": "5.1.0",
+        "react-color": "^2.17.3",
         "react-infinite-scroll-component": "4.2.0",
         "react-modal": "3.10.1",
         "react-tether": "1.0.4",
@@ -62,6 +63,7 @@
     },
     "devDependencies": {
         "@loadable/component": "5.10.2",
+        "@types/react-color": "^3.0.1",
         "@types/chosen-js": "1.6.2",
         "@types/classnames": "2.2.6",
         "@types/codemirror": "0.0.62",

--- a/packages/react-vapor/src/components/color-picker/ColorPicker.spec.tsx
+++ b/packages/react-vapor/src/components/color-picker/ColorPicker.spec.tsx
@@ -2,9 +2,10 @@ import {mount, shallow} from 'enzyme';
 import * as React from 'react';
 import {ChromePicker} from 'react-color';
 import {Provider} from 'react-redux';
-import {getStoreMock} from '../../utils/tests/TestUtils';
+import {getStoreMock, TestUtils} from '../../utils/tests/TestUtils';
 import {InputConnected} from '../input/InputConnected';
-import {ColorPicker} from './ColorPicker';
+import {InputSelectors} from '../input/InputSelectors';
+import {ColorPicker, ColorPickerConnected} from './ColorPicker';
 
 describe('ColorPicker', () => {
     it('should mount and unmount without error', () => {
@@ -37,5 +38,15 @@ describe('ColorPicker', () => {
         const picker = shallow(<ColorPicker color="#fff" />);
         expect(picker.find(ChromePicker).prop('color')).toBe('#fff');
         expect(picker.find(InputConnected).prop('defaultValue')).toBe('#fff');
+    });
+
+    it('should make the color available from state', () => {
+        const store = TestUtils.buildStore();
+        mount(
+            <Provider store={store}>
+                <ColorPickerConnected defaultColor="#47FF21" id="color-picker-test" />
+            </Provider>
+        );
+        expect(InputSelectors.getValue(store.getState(), {id: 'color-picker-test'})).toBe('#47FF21');
     });
 });

--- a/packages/react-vapor/src/components/color-picker/ColorPicker.spec.tsx
+++ b/packages/react-vapor/src/components/color-picker/ColorPicker.spec.tsx
@@ -1,4 +1,4 @@
-import {shallowWithStore} from 'enzyme-redux';
+import {mountWithStore, shallowWithStore} from 'enzyme-redux';
 import * as React from 'react';
 import {ChromePicker} from 'react-color';
 import {getStoreMock, ReactVaporMockStore, TestUtils} from '../../utils/tests/TestUtils';
@@ -44,17 +44,17 @@ describe('ColorPicker', () => {
 
     it('should make the color available from state', () => {
         const nonMockStore = TestUtils.buildStore();
-        shallowWithStore(<ColorPicker defaultColor="#47FF21" id="color-picker-test" />, nonMockStore);
+        mountWithStore(<ColorPicker defaultColor="#47FF21" id="color-picker-test" />, nonMockStore);
         expect(InputSelectors.getValue(nonMockStore.getState(), {id: 'color-picker-test'})).toBe('#47FF21');
     });
 
     it('should add state input on mount', () => {
-        shallowWithStore(<ColorPicker id="foo" />, store);
+        mountWithStore(<ColorPicker id="foo" />, store);
         expect(store.getActions()).toContain(addInput('foo'));
     });
 
     it('should remove state input on destroy', () => {
-        const picker = shallowWithStore(<ColorPicker id="foo" />, store);
+        const picker = mountWithStore(<ColorPicker id="foo" />, store);
         picker.unmount();
         expect(store.getActions()).toContain(removeInput('foo'));
     });

--- a/packages/react-vapor/src/components/color-picker/ColorPicker.spec.tsx
+++ b/packages/react-vapor/src/components/color-picker/ColorPicker.spec.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {ChromePicker} from 'react-color';
 import {Provider} from 'react-redux';
 import {getStoreMock, TestUtils} from '../../utils/tests/TestUtils';
+import {removeInput} from '../input/InputActions';
 import {InputConnected} from '../input/InputConnected';
 import {InputSelectors} from '../input/InputSelectors';
 import {ColorPicker, ColorPickerConnected} from './ColorPicker';
@@ -34,7 +35,7 @@ describe('ColorPicker', () => {
         expect(picker.find(InputConnected).length).toBe(1);
     });
 
-    it('should sync the InputConnected and ChromePicker color props', () => {
+    it('should sync the InputConnected and ChromePicker with color props', () => {
         const picker = shallow(<ColorPicker color="#fff" />);
         expect(picker.find(ChromePicker).prop('color')).toBe('#fff');
         expect(picker.find(InputConnected).prop('defaultValue')).toBe('#fff');
@@ -48,5 +49,17 @@ describe('ColorPicker', () => {
             </Provider>
         );
         expect(InputSelectors.getValue(store.getState(), {id: 'color-picker-test'})).toBe('#47FF21');
+    });
+
+    it('should remove state input on destroy', () => {
+        const store = getStoreMock();
+        spyOn(store, 'dispatch');
+        const picker = mount(
+            <Provider store={store}>
+                <ColorPicker id="foo" />
+            </Provider>
+        );
+        picker.unmount();
+        expect(store.dispatch).toHaveBeenCalledWith(removeInput('foo'));
     });
 });

--- a/packages/react-vapor/src/components/color-picker/ColorPicker.spec.tsx
+++ b/packages/react-vapor/src/components/color-picker/ColorPicker.spec.tsx
@@ -1,4 +1,4 @@
-import {mountWithStore, shallowWithStore} from 'enzyme-redux';
+import {shallowWithStore} from 'enzyme-redux';
 import * as React from 'react';
 import {ChromePicker} from 'react-color';
 import {getStoreMock, ReactVaporMockStore, TestUtils} from '../../utils/tests/TestUtils';
@@ -16,7 +16,7 @@ describe('ColorPicker', () => {
 
     it('should mount and unmount without error', () => {
         expect(() => {
-            const picker = mountWithStore(<ColorPicker />, store);
+            const picker = shallowWithStore(<ColorPicker />, store);
             picker.unmount();
         }).not.toThrow();
     });
@@ -44,17 +44,17 @@ describe('ColorPicker', () => {
 
     it('should make the color available from state', () => {
         const nonMockStore = TestUtils.buildStore();
-        mountWithStore(<ColorPicker defaultColor="#47FF21" id="color-picker-test" />, nonMockStore);
+        shallowWithStore(<ColorPicker defaultColor="#47FF21" id="color-picker-test" />, nonMockStore);
         expect(InputSelectors.getValue(nonMockStore.getState(), {id: 'color-picker-test'})).toBe('#47FF21');
     });
 
     it('should add state input on mount', () => {
-        mountWithStore(<ColorPicker id="foo" />, store);
+        shallowWithStore(<ColorPicker id="foo" />, store);
         expect(store.getActions()).toContain(addInput('foo'));
     });
 
     it('should remove state input on destroy', () => {
-        const picker = mountWithStore(<ColorPicker id="foo" />, store);
+        const picker = shallowWithStore(<ColorPicker id="foo" />, store);
         picker.unmount();
         expect(store.getActions()).toContain(removeInput('foo'));
     });

--- a/packages/react-vapor/src/components/color-picker/ColorPicker.spec.tsx
+++ b/packages/react-vapor/src/components/color-picker/ColorPicker.spec.tsx
@@ -1,0 +1,41 @@
+import {mount, shallow} from 'enzyme';
+import * as React from 'react';
+import {ChromePicker} from 'react-color';
+import {Provider} from 'react-redux';
+import {getStoreMock} from '../../utils/tests/TestUtils';
+import {InputConnected} from '../input/InputConnected';
+import {ColorPicker} from './ColorPicker';
+
+describe('ColorPicker', () => {
+    it('should mount and unmount without error', () => {
+        expect(() => {
+            const picker = mount(
+                <Provider store={getStoreMock()}>
+                    <ColorPicker />
+                </Provider>
+            );
+            picker.unmount();
+        }).not.toThrow();
+    });
+
+    it('should render a ChromeColorPicker ', () => {
+        const picker = shallow(<ColorPicker />);
+        expect(picker.find(ChromePicker).length).toBe(1);
+    });
+
+    it('should pass down props to ChromePicker', () => {
+        const picker = shallow(<ColorPicker disableAlpha={true} />);
+        expect(picker.find(ChromePicker).props().disableAlpha).toBe(true);
+    });
+
+    it('should render an InputConnected', () => {
+        const picker = shallow(<ColorPicker />);
+        expect(picker.find(InputConnected).length).toBe(1);
+    });
+
+    it('should sync the InputConnected and ChromePicker color props', () => {
+        const picker = shallow(<ColorPicker color="#fff" />);
+        expect(picker.find(ChromePicker).prop('color')).toBe('#fff');
+        expect(picker.find(InputConnected).prop('defaultValue')).toBe('#fff');
+    });
+});

--- a/packages/react-vapor/src/components/color-picker/ColorPicker.spec.tsx
+++ b/packages/react-vapor/src/components/color-picker/ColorPicker.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {ChromePicker} from 'react-color';
 import {Provider} from 'react-redux';
 import {getStoreMock, TestUtils} from '../../utils/tests/TestUtils';
-import {removeInput} from '../input/InputActions';
+import {addInput, removeInput} from '../input/InputActions';
 import {InputConnected} from '../input/InputConnected';
 import {InputSelectors} from '../input/InputSelectors';
 import {ColorPicker, ColorPickerConnected} from './ColorPicker';
@@ -49,6 +49,17 @@ describe('ColorPicker', () => {
             </Provider>
         );
         expect(InputSelectors.getValue(store.getState(), {id: 'color-picker-test'})).toBe('#47FF21');
+    });
+
+    it('should add state input on mount', () => {
+        const store = getStoreMock();
+        spyOn(store, 'dispatch');
+        mount(
+            <Provider store={store}>
+                <ColorPicker id="foo" />
+            </Provider>
+        );
+        expect(store.dispatch).toHaveBeenCalledWith(addInput('foo'));
     });
 
     it('should remove state input on destroy', () => {

--- a/packages/react-vapor/src/components/color-picker/ColorPicker.tsx
+++ b/packages/react-vapor/src/components/color-picker/ColorPicker.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import {ChromePicker, ChromePickerProps, ColorResult} from 'react-color';
+import {connect} from 'react-redux';
+import {isString, noop, uniqueId} from 'underscore';
+import {IReactVaporState} from '../../ReactVapor';
+import {IDispatch} from '../../utils/ReduxUtils';
+import {addInput, changeInputValue, removeInput} from '../input/InputActions';
+import {InputConnected} from '../input/InputConnected';
+import {InputSelectors} from '../input/InputSelectors';
+
+export interface IColorPickerProps extends ChromePickerProps {
+    id?: string;
+    defaultColor?: string;
+}
+
+export interface IColorPickerDispatchProps {
+    onDestroy?: () => void;
+    onRender?: (value?: string, valid?: boolean, disabled?: boolean) => void;
+    onChangeComplete?: (colorPicked: ColorResult) => void;
+}
+
+const mapStateToProps = (state: IReactVaporState, ownProps: IColorPickerProps) => {
+    const color = InputSelectors.getValue(state, {id: ownProps.id}) || ownProps.defaultColor;
+    return {
+        color,
+    };
+};
+
+const mapDispatchToProps = (dispatch: IDispatch, ownProps: IColorPickerProps): IColorPickerDispatchProps => ({
+    onRender: (value: string = '', valid = true, disabled = false) => {
+        dispatch(addInput(ownProps.id, value, valid, disabled));
+        dispatch(changeInputValue(ownProps.id, value, true));
+    },
+    onDestroy: () => dispatch(removeInput(ownProps.id)),
+    onChangeComplete: (colorPicked: ColorResult) => dispatch(changeInputValue(ownProps.id, colorPicked.hex, true)),
+});
+
+export class ColorPicker extends React.Component<IColorPickerProps & IColorPickerDispatchProps> {
+    static defaultProps: Partial<IColorPickerProps & IColorPickerDispatchProps> = {
+        id: uniqueId('colorpicker'),
+        onChangeComplete: noop,
+    };
+
+    get colorForInput() {
+        if (this.props.color && isString(this.props.color)) {
+            return this.props.color;
+        }
+
+        if (this.props.defaultColor) {
+            return this.props.defaultColor;
+        }
+    }
+
+    componentWillMount() {
+        if (this.props.onRender) {
+            this.props.onRender(this.colorForInput);
+        }
+    }
+
+    componentWillUnmount() {
+        if (this.props.onDestroy) {
+            this.props.onDestroy();
+        }
+    }
+
+    render() {
+        return (
+            <>
+                <ChromePicker {...this.props} />
+                <InputConnected
+                    id={this.props.id}
+                    style={{display: 'none'}}
+                    defaultValue={this.colorForInput}
+                    value={this.colorForInput}
+                />
+            </>
+        );
+    }
+}
+
+export const ColorPickerConnected = connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(ColorPicker);

--- a/packages/react-vapor/src/components/color-picker/ColorPicker.tsx
+++ b/packages/react-vapor/src/components/color-picker/ColorPicker.tsx
@@ -9,14 +9,8 @@ import {InputConnected} from '../input/InputConnected';
 import {InputSelectors} from '../input/InputSelectors';
 
 export interface IColorPickerProps extends ChromePickerProps {
-    id?: string;
+    id: string;
     defaultColor?: string;
-}
-
-export interface IColorPickerDispatchProps {
-    onDestroy?: () => void;
-    componentDidMount?: (value?: string, valid?: boolean, disabled?: boolean) => void;
-    onChangeComplete?: (colorPicked: ColorResult) => void;
 }
 
 const mapStateToProps = (state: IReactVaporState, ownProps: IColorPickerProps) => {
@@ -26,19 +20,22 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IColorPickerProps) =
     };
 };
 
-const mapDispatchToProps = (dispatch: IDispatch, ownProps: IColorPickerProps): IColorPickerDispatchProps => ({
+const mapDispatchToProps = (dispatch: IDispatch, ownProps: IColorPickerProps) => ({
     componentDidMount: (value: string = '', valid = true, disabled = false) => {
         dispatch(addInput(ownProps.id, value, valid, disabled));
         dispatch(changeInputValue(ownProps.id, value, true));
     },
     onDestroy: () => dispatch(removeInput(ownProps.id)),
-    onChangeComplete: (colorPicked: ColorResult) => dispatch(changeInputValue(ownProps.id, colorPicked.hex, true)),
+    onChangeComplete: (colorPicked: ColorResult) => {
+        ownProps.onChangeComplete && ownProps.onChangeComplete(colorPicked);
+        dispatch(changeInputValue(ownProps.id, colorPicked.hex, true));
+    },
 });
 
-export class ColorPicker extends React.Component<IColorPickerProps & IColorPickerDispatchProps> {
-    static defaultProps: Partial<IColorPickerProps & IColorPickerDispatchProps> = {
+class ColorPickerDisconnected extends React.Component<IColorPickerProps & ReturnType<typeof mapDispatchToProps>> {
+    static defaultProps: Partial<IColorPickerProps & ReturnType<typeof mapDispatchToProps>> = {
         id: uniqueId('colorpicker'),
-        onChangeComplete: noop,
+        onChangeComplete: noop as any,
     };
 
     get colorForInput() {
@@ -78,7 +75,7 @@ export class ColorPicker extends React.Component<IColorPickerProps & IColorPicke
     }
 }
 
-export const ColorPickerConnected = connect(
+export const ColorPicker = connect(
     mapStateToProps,
     mapDispatchToProps
-)(ColorPicker);
+)(ColorPickerDisconnected);

--- a/packages/react-vapor/src/components/color-picker/ColorPicker.tsx
+++ b/packages/react-vapor/src/components/color-picker/ColorPicker.tsx
@@ -15,7 +15,7 @@ export interface IColorPickerProps extends ChromePickerProps {
 
 export interface IColorPickerDispatchProps {
     onDestroy?: () => void;
-    onRender?: (value?: string, valid?: boolean, disabled?: boolean) => void;
+    componentDidMount?: (value?: string, valid?: boolean, disabled?: boolean) => void;
     onChangeComplete?: (colorPicked: ColorResult) => void;
 }
 
@@ -27,7 +27,7 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IColorPickerProps) =
 };
 
 const mapDispatchToProps = (dispatch: IDispatch, ownProps: IColorPickerProps): IColorPickerDispatchProps => ({
-    onRender: (value: string = '', valid = true, disabled = false) => {
+    componentDidMount: (value: string = '', valid = true, disabled = false) => {
         dispatch(addInput(ownProps.id, value, valid, disabled));
         dispatch(changeInputValue(ownProps.id, value, true));
     },
@@ -51,9 +51,9 @@ export class ColorPicker extends React.Component<IColorPickerProps & IColorPicke
         }
     }
 
-    componentWillMount() {
-        if (this.props.onRender) {
-            this.props.onRender(this.colorForInput);
+    componentDidMount() {
+        if (this.props.componentDidMount) {
+            this.props.componentDidMount(this.colorForInput);
         }
     }
 

--- a/packages/react-vapor/src/components/color-picker/ColorPicker.tsx
+++ b/packages/react-vapor/src/components/color-picker/ColorPicker.tsx
@@ -4,7 +4,7 @@ import {connect} from 'react-redux';
 import {isString, noop, uniqueId} from 'underscore';
 import {IReactVaporState} from '../../ReactVapor';
 import {IDispatch} from '../../utils/ReduxUtils';
-import {addInput, changeInputValue, removeInput} from '../input/InputActions';
+import {changeInputValue} from '../input/InputActions';
 import {InputConnected} from '../input/InputConnected';
 import {InputSelectors} from '../input/InputSelectors';
 
@@ -21,11 +21,6 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IColorPickerProps) =
 };
 
 const mapDispatchToProps = (dispatch: IDispatch, ownProps: IColorPickerProps) => ({
-    componentDidMount: (value: string = '', valid = true, disabled = false) => {
-        dispatch(addInput(ownProps.id, value, valid, disabled));
-        dispatch(changeInputValue(ownProps.id, value, true));
-    },
-    onDestroy: () => dispatch(removeInput(ownProps.id)),
     onChangeComplete: (colorPicked: ColorResult) => {
         ownProps.onChangeComplete && ownProps.onChangeComplete(colorPicked);
         dispatch(changeInputValue(ownProps.id, colorPicked.hex, true));
@@ -45,18 +40,6 @@ class ColorPickerDisconnected extends React.Component<IColorPickerProps & Return
 
         if (this.props.defaultColor) {
             return this.props.defaultColor;
-        }
-    }
-
-    componentDidMount() {
-        if (this.props.componentDidMount) {
-            this.props.componentDidMount(this.colorForInput);
-        }
-    }
-
-    componentWillUnmount() {
-        if (this.props.onDestroy) {
-            this.props.onDestroy();
         }
     }
 

--- a/packages/react-vapor/src/components/color-picker/ColorPickerExamples.tsx
+++ b/packages/react-vapor/src/components/color-picker/ColorPickerExamples.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import {ColorResult} from 'react-color';
+import {Provider} from 'react-redux';
+import {debounce} from 'underscore';
+import {ReactVaporStore} from '../../../docs/ReactVaporStore';
+import {Button} from '../button/Button';
+import {InputSelectors} from '../input/InputSelectors';
+import {ColorPicker, ColorPickerConnected} from './ColorPicker';
+
+const logColorPicked = debounce((colorPicked: ColorResult) => {
+    /* tslint:disable */
+    console.log(colorPicked);
+    /* tslint:enable */
+}, 500);
+
+export const ColorPickerExamples = () => (
+    <div className="mt2">
+        <h2 className="mb2">
+            Built using <a href="https://github.com/casesandberg/react-color/">React Color</a>
+        </h2>
+        <div className="form-group">
+            <label className="form-control-label">ColorPicker, console log color changes</label>
+            <div className="flex">
+                <ColorPicker color="#F37231" onChangeComplete={logColorPicked} />
+            </div>
+        </div>
+        <div className="form-group">
+            <label className="form-control-label">ColorPicker with different picker styling, hiding controls</label>
+            <div className="flex">
+                <ColorPicker styles={{default: {controls: {display: 'none'}}}} />
+            </div>
+        </div>
+
+        <div className="form-group">
+            <label className="form-control-label">ColorPickerConnected with color as hex available from state</label>
+            <div className="flex">
+                <Provider store={ReactVaporStore}>
+                    <>
+                        <ColorPickerConnected id="color-picker-connected-example" defaultColor="#47FF21" />
+                        <Button
+                            className="btn mod-primary ml2"
+                            name="Click me to get color from state"
+                            onClick={() =>
+                                alert(
+                                    InputSelectors.getValue(ReactVaporStore.getState(), {
+                                        id: 'color-picker-connected-example',
+                                    })
+                                )
+                            }
+                        />
+                    </>
+                </Provider>
+            </div>
+        </div>
+    </div>
+);

--- a/packages/react-vapor/src/components/color-picker/ColorPickerExamples.tsx
+++ b/packages/react-vapor/src/components/color-picker/ColorPickerExamples.tsx
@@ -1,16 +1,14 @@
 import * as React from 'react';
 import {ColorResult} from 'react-color';
-import {Provider} from 'react-redux';
 import {debounce} from 'underscore';
 import {ReactVaporStore} from '../../../docs/ReactVaporStore';
 import {Button} from '../button/Button';
 import {InputSelectors} from '../input/InputSelectors';
-import {ColorPicker, ColorPickerConnected} from './ColorPicker';
+import {ColorPicker} from './ColorPicker';
 
 const logColorPicked = debounce((colorPicked: ColorResult) => {
-    /* tslint:disable */
+    // tslint:disable-next-line
     console.log(colorPicked);
-    /* tslint:enable */
 }, 500);
 
 export const ColorPickerExamples = () => (
@@ -19,37 +17,33 @@ export const ColorPickerExamples = () => (
             Built using <a href="https://github.com/casesandberg/react-color/">React Color</a>
         </h2>
         <div className="form-group">
-            <label className="form-control-label">ColorPicker, console log color changes</label>
+            <label className="form-control-label">Basic ColorPicker</label>
             <div className="flex">
-                <ColorPicker color="#F37231" onChangeComplete={logColorPicked} />
+                <ColorPicker id="color-picker-example-1" defaultColor="#F37231" onChangeComplete={logColorPicked} />
             </div>
         </div>
         <div className="form-group">
             <label className="form-control-label">ColorPicker with different picker styling, hiding controls</label>
             <div className="flex">
-                <ColorPicker styles={{default: {controls: {display: 'none'}}}} />
+                <ColorPicker id="color-picker-example-2" styles={{default: {controls: {display: 'none'}}}} />
             </div>
         </div>
 
         <div className="form-group">
             <label className="form-control-label">ColorPickerConnected with color as hex available from state</label>
             <div className="flex">
-                <Provider store={ReactVaporStore}>
-                    <>
-                        <ColorPickerConnected id="color-picker-connected-example" defaultColor="#47FF21" />
-                        <Button
-                            className="btn mod-primary ml2"
-                            name="Click me to get color from state"
-                            onClick={() =>
-                                alert(
-                                    InputSelectors.getValue(ReactVaporStore.getState(), {
-                                        id: 'color-picker-connected-example',
-                                    })
-                                )
-                            }
-                        />
-                    </>
-                </Provider>
+                <ColorPicker id="color-picker-example-3" defaultColor="#47FF21" />
+                <Button
+                    className="btn mod-primary ml2"
+                    name="Click me to get color from state"
+                    onClick={() =>
+                        alert(
+                            InputSelectors.getValue(ReactVaporStore.getState(), {
+                                id: 'color-picker-example-3',
+                            })
+                        )
+                    }
+                />
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Proposed Changes

Adds a new component which display a color picker, using `react-color`: https://casesandberg.github.io/react-color/

It's synched with an hidden "InputConnected" so that it's possible to retrieve the currently selected color from the state

### Potential Breaking Changes

- None that I know of ;) 

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
