### PR TITLE
add Defaults DropRoot as default parentSelector for a SelectConnected

### DIFF
--- a/packages/react-vapor/src/Defaults.ts
+++ b/packages/react-vapor/src/Defaults.ts
@@ -5,6 +5,7 @@ export abstract class Defaults {
     static MODAL_TIMEOUT: number = 300;
 
     static DROP_ROOT: string = 'body';
+    static DROP_PARENT_ROOT: string = 'body';
 
     static set APP_ELEMENT(appElement: string | HTMLElement) {
         ReactModal.setAppElement(appElement);

--- a/packages/react-vapor/src/components/select/SelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SelectConnected.tsx
@@ -130,6 +130,7 @@ export class SelectConnected extends React.PureComponent<ISelectProps & ISelectS
                 )}
                 minWidth={minWidth}
                 closeOnClickDrop={false}
+                parentSelector={Defaults.DROP_ROOT}
                 {...this.props.dropOption}
             >
                 <div

--- a/packages/react-vapor/src/components/select/SelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SelectConnected.tsx
@@ -130,7 +130,7 @@ export class SelectConnected extends React.PureComponent<ISelectProps & ISelectS
                 )}
                 minWidth={minWidth}
                 closeOnClickDrop={false}
-                parentSelector={Defaults.DROP_ROOT}
+                parentSelector={Defaults.DROP_PARENT_ROOT}
                 {...this.props.dropOption}
             >
                 <div


### PR DESCRIPTION
### Proposed Changes

Every SelectConnect use the default drop root as parent Selector to avoid bad rendering when a single select is used inside a small container "position: relative"

### Potential Breaking Changes

I not sure yet but I dont think its a bad idea to always use the default root as parent selector to have the maximum space to render the dropdown

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
