### PR TITLE
Set default tooltip container as 'body'

### DIFF
--- a/packages/react-vapor/src/Defaults.ts
+++ b/packages/react-vapor/src/Defaults.ts
@@ -6,6 +6,8 @@ export abstract class Defaults {
 
     static DROP_ROOT: string = 'body';
 
+    static TOOLTIP_ROOT: string = 'body';
+
     static set APP_ELEMENT(appElement: string | HTMLElement) {
         ReactModal.setAppElement(appElement);
     }

--- a/packages/react-vapor/src/components/tooltip/Tooltip.tsx
+++ b/packages/react-vapor/src/components/tooltip/Tooltip.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {OverlayTrigger, Tooltip as BootstrapTooltip} from 'react-bootstrap';
 import * as ReactDOM from 'react-dom';
 import * as _ from 'underscore';
+import {Defaults} from '../../Defaults';
 
 // Copy of the OverlayTriggerProps but without the overlay prop since we are building it here
 export interface IOverlayTriggerProps {
@@ -104,7 +105,7 @@ export class Tooltip extends React.Component<ITooltipProps> {
             <BootstrapTooltip
                 id={_.uniqueId('tooltip-')}
                 ref={this.overlay}
-                container={this.props.container || 'body'}
+                container={this.props.container || Defaults.TOOLTIP_ROOT}
                 {..._.omit(this.props, TOOLTIP_PROPS_TO_OMIT)}
                 className="react-vapor-tooltip"
             >

--- a/packages/react-vapor/src/components/tooltip/Tooltip.tsx
+++ b/packages/react-vapor/src/components/tooltip/Tooltip.tsx
@@ -62,6 +62,7 @@ const TOOLTIP_PROPS_TO_OMIT: string[] = [
     'overlay',
     'rootClose',
     'trigger',
+    'container',
 ];
 const OVERLAY_PROPS_TO_OMIT: string[] = [
     ...PROPS_TO_OMIT,
@@ -103,6 +104,7 @@ export class Tooltip extends React.Component<ITooltipProps> {
             <BootstrapTooltip
                 id={_.uniqueId('tooltip-')}
                 ref={this.overlay}
+                container={this.props.container || 'body'}
                 {..._.omit(this.props, TOOLTIP_PROPS_TO_OMIT)}
                 className="react-vapor-tooltip"
             >


### PR DESCRIPTION
### Proposed Changes

We start using a lot '_body_' for tooltip.container in the table headers with react. 

![image](https://user-images.githubusercontent.com/52677246/65784371-e1339280-e11f-11e9-9486-740c7cd92188.png)

### Potential Breaking Changes

no

### Acceptance Criteria

-   [ x] The proposed changes are covered by unit tests
-   [ x] The potential breaking changes are clearly identified
-   [ x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
