### PR TITLE
remove margin-top

### DIFF
--- a/packages/vapor/scss/typography/headings.scss
+++ b/packages/vapor/scss/typography/headings.scss
@@ -13,16 +13,25 @@ h6 {
 h1,
 .h1 {
     font-size: $big-font-size;
+    &.mod-margin {
+        margin-top: 1.2em;
+    }
 }
 
 h2,
 .h2 {
     font-size: 20px;
+    &.mod-margin {
+        margin-top: 1.3em;
+    }
 }
 
 h3,
 .h3 {
     font-size: $default-font-size;
+    &.mod-margin {
+        margin-top: 1.4em;
+    }
 }
 
 h4,
@@ -30,12 +39,25 @@ h4,
     font-size: $small-font-size;
 }
 
-h5 {
+h5,
+.h5 {
     font-size: $small-font-size;
 }
 
-h6 {
+h6,
+.h6 {
     font-size: $small-font-size;
+}
+
+.h4,
+h4,
+.h5,
+h5,
+.h6,
+h6 {
+    &.mod-margin {
+        margin-top: 1.5em;
+    }
 }
 
 #header {
@@ -48,7 +70,9 @@ h6 {
     h4,
     .h4,
     h5,
-    h6 {
+    .h5,
+    h6,
+    .h6 {
         margin: 0;
     }
     h1,
@@ -59,22 +83,4 @@ h6 {
 
 .mod-header-min-height {
     min-height: $header-line-height;
-}
-
-.mod-h1-margin {
-    margin-top: 1.2em;
-}
-
-.mod-h2-margin {
-    margin-top: 1.3em;
-}
-
-.mod-h3-margin {
-    margin-top: 1.4em;
-}
-
-.mod-h4-margin,
-.mod-h5-margin,
-.mod-h6-margin {
-    margin-top: 1.5em;
 }

--- a/packages/vapor/scss/typography/headings.scss
+++ b/packages/vapor/scss/typography/headings.scss
@@ -12,35 +12,29 @@ h6 {
 
 h1,
 .h1 {
-    margin-top: 1.2em;
     font-size: $big-font-size;
 }
 
 h2,
 .h2 {
-    margin-top: 1.3em;
     font-size: 20px;
 }
 
 h3,
 .h3 {
-    margin-top: 1.4em;
     font-size: $default-font-size;
 }
 
 h4,
 .h4 {
-    margin-top: 1.5em;
     font-size: $small-font-size;
 }
 
 h5 {
-    margin-top: 1.5em;
     font-size: $small-font-size;
 }
 
 h6 {
-    margin-top: 1.5em;
     font-size: $small-font-size;
 }
 
@@ -65,4 +59,22 @@ h6 {
 
 .mod-header-min-height {
     min-height: $header-line-height;
+}
+
+.mod-h1-margin {
+    margin-top: 1.2em;
+}
+
+.mod-h2-margin {
+    margin-top: 1.3em;
+}
+
+.mod-h3-margin {
+    margin-top: 1.4em;
+}
+
+.mod-h4-margin,
+.mod-h5-margin,
+.mod-h6-margin {
+    margin-top: 1.5em;
 }


### PR DESCRIPTION
add mod for the margin-top for each h

### Proposed Changes

do not use margin on h tag. H tag is used for the font size only

### Potential Breaking Changes

remove breaking change

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
