### PR TITLE
Improve the header styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "not dead"
     ],
     "scripts": {
-        "start": "lerna run start --parallel"
+        "start": "lerna run start --parallel",
+        "test": "lerna run test --parallel"
     }
 }

--- a/packages/react-vapor/src/components/headers/HeaderWrapper.tsx
+++ b/packages/react-vapor/src/components/headers/HeaderWrapper.tsx
@@ -20,43 +20,39 @@ export class HeaderWrapper extends React.Component<IHeaderWrapperProps, {}> {
 
     render() {
         return (
-            <div className={this.getContainerClasses()}>
-                <div className={this.getClasses()}>
+            <div className={this.containerClasses}>
+                <div className={this.classes}>
                     <div className="truncate mr2">
                         {this.props.children}
-                        <h4 className="mt1 text-dark-grey normal-white-space">{this.props.description}</h4>
+                        <h4 className="admin-description text-dark-grey normal-white-space">
+                            {this.props.description}
+                        </h4>
                     </div>
-                    <div className="flex">{this.getActions()}</div>
+                    <div className="action-bar">{this.actions}</div>
                 </div>
                 <TabsHeader tabs={this.props.tabs} />
             </div>
         );
     }
 
-    private getContainerClasses(): string {
+    private get containerClasses(): string {
         return classNames('header-wrapper-container', {
             'header-wrapper-container-with-tabs': !!this.props.tabs,
-            'mod-border-bottom': !!this.props.hasBorderBottom && !this.props.tabs,
         });
     }
 
-    private getClasses(): string {
+    private get classes(): string {
         return classNames(
-            'flex',
-            'flex-center',
-            'space-between',
-            'header-height',
-            'pt1',
+            'flex flex-center space-between header-height panel-header',
             {
-                pb2: !!this.props.tabs,
-                pb1: !this.props.tabs,
-                'mod-header-padding': this.props.hasPadding,
+                'mod-no-border-bottom': !this.props.hasBorderBottom || this.props.tabs,
+                px0: !this.props.hasPadding,
             },
             this.props.classes
         );
     }
 
-    private getActions(): JSX.Element[] {
+    private get actions(): JSX.Element[] {
         return this.props.actions
             ? _.map(this.props.actions, (action: IContentProps, index: number) => <Content key={index} {...action} />)
             : null;

--- a/packages/react-vapor/src/components/headers/tests/HeaderWrapper.spec.tsx
+++ b/packages/react-vapor/src/components/headers/tests/HeaderWrapper.spec.tsx
@@ -1,111 +1,51 @@
-import {mount, ReactWrapper, shallow} from 'enzyme';
+import {shallow} from 'enzyme';
 import * as React from 'react';
-import {Provider} from 'react-redux';
-import {Store} from 'redux';
-import * as _ from 'underscore';
-import {IReactVaporState} from '../../../ReactVapor';
-import {clearState} from '../../../utils/ReduxUtils';
-import {TestUtils} from '../../../utils/tests/TestUtils';
-import {Button} from '../../button/Button';
-import {Content, IContentProps} from '../../content/Content';
-import {HeaderWrapper, IHeaderWrapperProps} from '../HeaderWrapper';
+
+import {HeaderWrapper} from '../HeaderWrapper';
 import {TabsHeader} from '../TabsHeader';
 
 describe('<HeaderWrapper/>', () => {
-    let headerWrapperComponent: ReactWrapper<IHeaderWrapperProps, any>;
-    let store: Store<IReactVaporState>;
-
-    beforeEach(() => {
-        store = TestUtils.buildStore();
-    });
-
-    afterEach(() => {
-        store.dispatch(clearState());
-    });
-
     it('should render without errors', () => {
         expect(() => {
-            shallow(<HeaderWrapper />);
+            const header = shallow(<HeaderWrapper />);
+            header.unmount();
         }).not.toThrow();
     });
 
-    describe('<HeaderWrapper /> with custom props', () => {
-        const customProps: IHeaderWrapperProps = {
-            description: 'description test',
-            actions: [{content: Button}, {content: Button}],
-            classes: ['class-test'],
-            tabs: [{id: '1', title: '1'}, {id: '2', title: '2'}],
-        };
+    it('should render the description when specified', () => {
+        const money = '💰';
+        const header = shallow(<HeaderWrapper description={money} />);
+        expect(header.find('h4').text()).toBe(money);
+    });
 
-        const renderComponent = (props: IHeaderWrapperProps = {}) => {
-            headerWrapperComponent = mount(
-                <Provider store={store}>
-                    <HeaderWrapper {..._.extend({}, customProps, props)} />
-                </Provider>,
-                {attachTo: document.getElementById('App')}
-            );
-        };
+    it('should render actions when specified', () => {
+        const myActions = [{content: '📗'}, {content: '📘'}, {content: '📙'}];
+        const header = shallow(<HeaderWrapper actions={myActions} />);
+        const actions = header.find('.action-bar').children();
 
-        afterEach(() => {
-            headerWrapperComponent.detach();
+        expect(actions.length).toBe(myActions.length);
+        actions.forEach((action, index) => {
+            expect(action.prop('content')).toBe(myActions[index].content);
         });
+    });
 
-        it('should render the description', () => {
-            renderComponent();
-            expect(headerWrapperComponent.find('h4').text()).toEqual(customProps.description);
-        });
+    it('should render tabs when specified', () => {
+        const myTabs = [{id: 'tomato', title: '🍅'}, {id: 'sweet-potato', title: '🍠'}];
+        const header = shallow(<HeaderWrapper tabs={myTabs} />);
 
-        it('should render actions', () => {
-            renderComponent();
-            const contents = headerWrapperComponent.find(Content);
+        expect(header.find(TabsHeader).exists()).toBe(true);
+        expect(header.find(TabsHeader).prop('tabs')).toBe(myTabs);
+    });
 
-            expect(contents.length).toEqual(2);
-            expect((contents.first().props() as IContentProps).content).toEqual(Button);
-            expect((contents.last().props() as IContentProps).content).toEqual(Button);
-        });
+    it('should not render a border on the bottom', () => {
+        const header = shallow(<HeaderWrapper hasBorderBottom={false} />);
 
-        it('should render tabs', () => {
-            renderComponent();
-            const tabs = headerWrapperComponent.find(TabsHeader);
+        expect(header.find('.panel-header').hasClass('mod-no-border-bottom')).toBe(true);
+    });
 
-            expect(tabs.length).toEqual(1);
-        });
+    it('should render without padding', () => {
+        const header = shallow(<HeaderWrapper hasPadding={false} />);
 
-        it('should render without the border bottom', () => {
-            renderComponent({
-                hasBorderBottom: false,
-            });
-            const tabs = headerWrapperComponent.find('.mod-border-bottom');
-
-            expect(tabs.length).toEqual(0);
-        });
-
-        it('should render with the border bottom', () => {
-            renderComponent({
-                hasBorderBottom: true,
-                tabs: undefined,
-            });
-            const tabs = headerWrapperComponent.find('.mod-border-bottom');
-
-            expect(tabs.length).toEqual(1);
-        });
-
-        it('should render without padding', () => {
-            renderComponent({
-                hasPadding: false,
-            });
-            const tabs = headerWrapperComponent.find('.mod-header-padding');
-
-            expect(tabs.length).toEqual(0);
-        });
-
-        it('should render with padding', () => {
-            renderComponent({
-                hasPadding: true,
-            });
-            const tabs = headerWrapperComponent.find('.mod-header-padding');
-
-            expect(tabs.length).toEqual(1);
-        });
+        expect(header.find('.panel-header').hasClass('px0')).toBe(true);
     });
 });


### PR DESCRIPTION
Our headers didn't use the `panel-header` class which was already defined in vapor and specially designed for panel and modal headers. Some other classes like `action` depended on having `panel-header` as parent to be applied.

### Proposed Changes

- Refactored the `HeaderWrapper` component (used by the `BasicHeader` and `BreadcrumbHeader` components) so that it has the `.panel-header` class.

#### Before
![image](https://user-images.githubusercontent.com/35579930/66163992-9cb46500-e5ff-11e9-9845-75154a381302.png)

#### After
![image](https://user-images.githubusercontent.com/35579930/66164008-a9d15400-e5ff-11e9-97f5-b413be0dd59e.png)


### Potential Breaking Changes

None, I made sure the rendered DOM nodes structured the same way and that all the existing props are still supported.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
