### PR TITLE
Change calendar dropdown layout classes

### DIFF
--- a/packages/react-vapor/src/components/calendar/Calendar.tsx
+++ b/packages/react-vapor/src/components/calendar/Calendar.tsx
@@ -251,7 +251,7 @@ export class Calendar extends React.Component<ICalendarProps, any> {
         });
 
         const wrapperClasses: string = classNames('calendar', {
-            column: !this.props.simple,
+            'mod-width-50': !this.props.simple,
         });
 
         return (

--- a/packages/react-vapor/src/components/calendar/tests/Calendar.spec.tsx
+++ b/packages/react-vapor/src/components/calendar/tests/Calendar.spec.tsx
@@ -622,12 +622,12 @@ describe('Calendar', () => {
                     expect(day.isSelectable).toBe(false);
                 });
 
-                it('should not have the class column if it has the prop simple', () => {
-                    expect(calendar.find('.column').length).toBe(1);
+                it('should not have the class mod-width-50 if it has the prop simple', () => {
+                    expect(calendar.find('.mod-width-50').length).toBe(1);
 
                     calendar.setProps({simple: true});
 
-                    expect(calendar.find('.column').length).toBe(0);
+                    expect(calendar.find('.mod-width-50').length).toBe(0);
                 });
             });
         });

--- a/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
@@ -98,7 +98,7 @@ export class DatePickerBox extends React.Component<IDatePickerBoxProps, any> {
         const inside: JSX.Element = this.props.simple ? (
             calendar
         ) : (
-            <div className="split-layout">
+            <div className="flex">
                 {calendar}
                 {this.getdatePickerRightPart()}
             </div>
@@ -114,7 +114,7 @@ export class DatePickerBox extends React.Component<IDatePickerBoxProps, any> {
 
     private getdatePickerRightPart(): JSX.Element {
         return (
-            <div className="date-selection column mod-small-content p2">
+            <div className="date-selection mod-width-50 mod-border-left mod-small-content p2">
                 {this.getdateSelectionBoxes()}
                 {this.getClearOptions()}
             </div>


### PR DESCRIPTION
### Proposed Changes

The split-layout is dependent on the window's width and under a certain resolution it wraps.

![image](https://user-images.githubusercontent.com/260007/66210657-522afb00-e688-11e9-8c1c-6319cbad9f7b.png)

I replaced the classes with flex to avoid this issue

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
