### PR TITLE
fix(tablerow): remove action not checking tableId

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/reducers/TableRowReducers.ts
+++ b/packages/react-vapor/src/components/table-hoc/reducers/TableRowReducers.ts
@@ -30,8 +30,11 @@ const addTableRowReducer = (state: ITableRowState[], action: IReduxAction<ITable
     ];
 };
 
-const removeTableRowReducer = (state: ITableRowState[], action: IReduxAction<BasePayload>) => {
-    return _.reject(state, (header: ITableRowState) => header.id === action.payload.id);
+const removeTableRowReducer = (state: ITableRowState[], {payload}: IReduxAction<ITableRowAddPayload>) => {
+    return _.reject(
+        state,
+        ({tableId, id}: ITableRowState) => (!payload.tableId || payload.tableId === tableId) && id === payload.id
+    );
 };
 
 const selectTableRowReducer = (state: ITableRowState[], action: IReduxAction<ITableRowSelectPayload>) => {

--- a/packages/react-vapor/src/components/table-hoc/tests/TableRowReducers.spec.ts
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableRowReducers.spec.ts
@@ -61,29 +61,56 @@ describe('Table HOC', () => {
             expect(headerState.selected).toBe(expectedSelected);
         });
 
-        it('should return the old state without the ITableRowState when the action is "TableHOCRowActions.removeTableRow"', () => {
+        it('should remove all rows that match the action payload id when no tableId is specified', () => {
             const oldState: ITableRowState[] = [
                 {
-                    id: 'some-table-header-1',
-                    tableId: 'not-important',
+                    id: '🥑',
+                    tableId: 'fruits',
+                    selected: true,
+                },
+                {
+                    id: '🥑',
+                    tableId: 'organic',
                     selected: false,
                 },
                 {
-                    id: 'some-table-header-2',
-                    tableId: 'not-important',
+                    id: '🥦',
+                    tableId: 'organic',
+                    selected: false,
+                },
+            ];
+            const action = TableHOCRowActions.remove('🥑');
+            const tableRowsState: ITableRowState[] = TableRowReducers(oldState, action);
+
+            expect(tableRowsState.length).toBe(1);
+            expect(_.findWhere(tableRowsState, {id: '🥑', tableId: 'fruits'})).toBeUndefined();
+            expect(_.findWhere(tableRowsState, {id: '🥑', tableId: 'organic'})).toBeUndefined();
+        });
+
+        it('should remove a table row from the state only if the rowId and the tableId match the action payload', () => {
+            const oldState: ITableRowState[] = [
+                {
+                    id: '🥑',
+                    tableId: 'fruits',
                     selected: true,
                 },
                 {
-                    id: 'some-table-header-3',
-                    tableId: 'not-important',
-                    selected: true,
+                    id: '🥑',
+                    tableId: 'organic',
+                    selected: false,
+                },
+                {
+                    id: '🥦',
+                    tableId: 'organic',
+                    selected: false,
                 },
             ];
-            const action = TableHOCRowActions.remove(oldState[1].id);
-            const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
+            const action = TableHOCRowActions.remove('🥑', 'fruits');
+            const tableRowsState: ITableRowState[] = TableRowReducers(oldState, action);
 
-            expect(tableHeadersState.length).toBe(oldState.length - 1);
-            expect(_.findWhere(tableHeadersState, {id: action.payload.id})).toBeUndefined();
+            expect(tableRowsState.length).toBe(2);
+            expect(_.findWhere(tableRowsState, {id: '🥑', tableId: 'fruits'})).toBeUndefined();
+            expect(_.findWhere(tableRowsState, {id: '🥑', tableId: 'organic'})).toBeDefined();
         });
 
         it('should set the selected on the table row when the action is "TableHOCRowActions.selectRow"', () => {


### PR DESCRIPTION
### Proposed Changes

`TableHOCRowActions.remove` action was removing all rows with an id that match the id in the action payload no mater what is the tableId specified. This was causing the action to delete rows across tables.

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
