### PR TITLE
fix: error message alignment and buttons should not submit form for NumericInput component

### DIFF
--- a/packages/react-vapor/src/components/numericInput/NumericInputConnected.tsx
+++ b/packages/react-vapor/src/components/numericInput/NumericInputConnected.tsx
@@ -80,7 +80,7 @@ export class NumericInputConnected extends React.PureComponent<NumericInputProps
                         classes={['js-decrement mr1 p0', styles.numericInputButton]}
                         enabled={decrementEnabled}
                         onClick={this.onDecrement}
-                        type={'button'}
+                        type="button"
                     >
                         <Svg svgName="minus" svgClass="icon mod-12 fill-pure-white" />
                     </Button>

--- a/packages/react-vapor/src/components/numericInput/NumericInputConnected.tsx
+++ b/packages/react-vapor/src/components/numericInput/NumericInputConnected.tsx
@@ -96,7 +96,7 @@ export class NumericInputConnected extends React.PureComponent<NumericInputProps
                         classes={['js-increment ml1 p0', styles.numericInputButton]}
                         enabled={incrementEnabled}
                         onClick={this.onIncrement}
-                        type={'button'}
+                        type="button"
                     >
                         <Svg svgName="plus" svgClass="icon mod-12 fill-pure-white" />
                     </Button>

--- a/packages/react-vapor/src/components/numericInput/NumericInputConnected.tsx
+++ b/packages/react-vapor/src/components/numericInput/NumericInputConnected.tsx
@@ -74,30 +74,36 @@ export class NumericInputConnected extends React.PureComponent<NumericInputProps
         const decrementEnabled =
             _.isUndefined(this.props.min) || _.isNaN(valueAsNumber) || valueAsNumber > this.props.min;
         return (
-            <div className="flex flex-row">
-                <Button
-                    classes={['js-decrement mr1 p0', styles.numericInputButton]}
-                    enabled={decrementEnabled}
-                    onClick={this.onDecrement}
-                >
-                    <Svg svgName="minus" svgClass="icon mod-12 fill-pure-white" />
-                </Button>
-                <div className="flex flex-column">
-                    <input
-                        {..._.omit(this.props, keys<NumericInputProps>())}
-                        className={classNames('js-numeric-input mb1', this.props.className, styles.numericInput)}
-                        value={this.props.value}
-                        onChange={this.onChange}
-                    />
+            <div className="flex flex-column">
+                <div className="flex flex-row">
+                    <Button
+                        classes={['js-decrement mr1 p0', styles.numericInputButton]}
+                        enabled={decrementEnabled}
+                        onClick={this.onDecrement}
+                        type={'button'}
+                    >
+                        <Svg svgName="minus" svgClass="icon mod-12 fill-pure-white" />
+                    </Button>
+                    <div className="flex flex-column">
+                        <input
+                            {..._.omit(this.props, keys<NumericInputProps>())}
+                            className={classNames('js-numeric-input mb1', this.props.className, styles.numericInput)}
+                            value={this.props.value}
+                            onChange={this.onChange}
+                        />
+                    </div>
+                    <Button
+                        classes={['js-increment ml1 p0', styles.numericInputButton]}
+                        enabled={incrementEnabled}
+                        onClick={this.onIncrement}
+                        type={'button'}
+                    >
+                        <Svg svgName="plus" svgClass="icon mod-12 fill-pure-white" />
+                    </Button>
+                </div>
+                <div className="flex flex-row">
                     {this.props.hasError && <span className="generic-form-error">{this.props.invalidMessage}</span>}
                 </div>
-                <Button
-                    classes={['js-increment ml1 p0', styles.numericInputButton]}
-                    enabled={incrementEnabled}
-                    onClick={this.onIncrement}
-                >
-                    <Svg svgName="plus" svgClass="icon mod-12 fill-pure-white" />
-                </Button>
             </div>
         );
     }

--- a/packages/react-vapor/src/components/numericInput/examples/NumericInputExamples.tsx
+++ b/packages/react-vapor/src/components/numericInput/examples/NumericInputExamples.tsx
@@ -36,7 +36,7 @@ export const NumericInputExamples = () => (
                     max={300}
                     style={{width: '48px'}}
                     maxLength={3}
-                    invalidMessage="Invalid"
+                    invalidMessage="The value must be between 25 and 300."
                 />
             </div>
         </div>


### PR DESCRIPTION
### Proposed Changes

Added type={'button'} to the increment/decrement button since we don't want them to submit if they are in a Form.

Changed the error message position to fix this issue:
![NumericInputConnected](https://user-images.githubusercontent.com/55157216/66565703-1f25b300-eb31-11e9-88ce-4bf772259973.png)

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
