### PR TITLE
feat: allow specifing isAsc in sortTable action

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/actions/TableHeaderActions.ts
+++ b/packages/react-vapor/src/components/table-hoc/actions/TableHeaderActions.ts
@@ -10,6 +10,10 @@ export interface ITableHeaderBasePayload {
     id: string;
 }
 
+export interface ITableHeaderSortPayload extends ITableHeaderBasePayload {
+    ascending: boolean;
+}
+
 export interface ITableHeaderAddPayload extends ITableHeaderBasePayload {
     tableId: string;
     isDefault: boolean;
@@ -25,9 +29,9 @@ const removeTableHeader = (id: string): IReduxAction<ITableHeaderBasePayload> =>
     payload: {id},
 });
 
-const sortTable = (id: string): IReduxAction<ITableHeaderBasePayload> => ({
+const sortTable = (id: string, ascending?: boolean): IReduxAction<ITableHeaderSortPayload> => ({
     type: TableHeaderActionTypes.sort,
-    payload: {id},
+    payload: {id, ascending},
 });
 
 export const TableHeaderActions = {

--- a/packages/react-vapor/src/components/table-hoc/reducers/TableWithSortReducers.ts
+++ b/packages/react-vapor/src/components/table-hoc/reducers/TableWithSortReducers.ts
@@ -1,6 +1,12 @@
 import * as _ from 'underscore';
+
 import {IReduxAction} from '../../../utils/ReduxUtils';
-import {ITableHeaderAddPayload, ITableHeaderBasePayload, TableHeaderActionTypes} from '../actions/TableHeaderActions';
+import {
+    ITableHeaderAddPayload,
+    ITableHeaderBasePayload,
+    ITableHeaderSortPayload,
+    TableHeaderActionTypes,
+} from '../actions/TableHeaderActions';
 
 export interface ITableWithSortState {
     id: string;
@@ -23,14 +29,14 @@ const removeTableHeaderReducer = (state: ITableWithSortState[], action: IReduxAc
     return _.reject(state, (header: ITableWithSortState) => header.id === action.payload.id);
 };
 
-const sortTableHeaderReducer = (state: ITableWithSortState[], action: IReduxAction<ITableHeaderBasePayload>) => {
+const sortTableHeaderReducer = (state: ITableWithSortState[], action: IReduxAction<ITableHeaderSortPayload>) => {
     const current = _.findWhere(state, {id: action.payload.id});
     if (current) {
         return _.map(state, (header: ITableWithSortState) => {
             if (header.id === current.id) {
                 return {
                     ...header,
-                    isAsc: !header.isAsc,
+                    isAsc: _.isBoolean(action.payload.ascending) ? action.payload.ascending : !header.isAsc,
                 };
             }
             return header.tableId === current.tableId ? {...header, isAsc: undefined} : header;

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithSortReducers.spec.ts
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithSortReducers.spec.ts
@@ -82,52 +82,82 @@ describe('Table HOC', () => {
             expect(_.findWhere(tableHeadersState, {id: action.payload.id})).toBeUndefined();
         });
 
-        it('should set the sort on the table header when the action is "TableHeaderActions.sortTable"', () => {
-            const oldState: ITableWithSortState[] = [
-                {
-                    id: 'some-table-header-1',
-                    tableId: 'not-important',
-                    isAsc: undefined,
-                },
-                {
-                    id: 'some-table-header-2',
-                    tableId: 'not-important',
-                    isAsc: true,
-                },
-            ];
+        describe('when the action is "TableHeaderActions.sortTable"', () => {
+            it('should not throw on sort if the table header does not exists', () => {
+                const oldState: ITableWithSortState[] = [];
+                const action = TableHeaderActions.sortTable('To be or not to be');
 
-            const action = TableHeaderActions.sortTable(oldState[0].id);
-            const tableHeadersState: ITableWithSortState[] = TableWithSortReducers(oldState, action);
+                expect(() => TableWithSortReducers(oldState, action)).not.toThrow();
+            });
 
-            expect(tableHeadersState.length).toBe(oldState.length);
-            expect(_.findWhere(tableHeadersState, {id: oldState[0].id}).isAsc).toBe(true);
-            expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).isAsc).toBe(undefined);
-        });
+            it('should set the sort on the table header"', () => {
+                const oldState: ITableWithSortState[] = [
+                    {
+                        id: 'some-table-header-1',
+                        tableId: 'not-important',
+                        isAsc: undefined,
+                    },
+                    {
+                        id: 'some-table-header-2',
+                        tableId: 'not-important',
+                        isAsc: true,
+                    },
+                ];
 
-        it('should not modify the isAsc for the other tables when the action is "TableHeaderActions.sortTable"', () => {
-            const oldState: ITableWithSortState[] = [
-                {
-                    id: 'some-table-header',
-                    tableId: 'current-table',
-                    isAsc: undefined,
-                },
-                {
-                    id: 'other-table-header',
-                    tableId: 'other-table',
-                    isAsc: true,
-                },
-            ];
+                const action = TableHeaderActions.sortTable(oldState[0].id);
+                const tableHeadersState: ITableWithSortState[] = TableWithSortReducers(oldState, action);
 
-            const action = TableHeaderActions.sortTable(oldState[0].id);
-            const tableHeadersState: ITableWithSortState[] = TableWithSortReducers(oldState, action);
-            expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).isAsc).toBe(oldState[1].isAsc);
-        });
+                expect(tableHeadersState.length).toBe(oldState.length);
+                expect(_.findWhere(tableHeadersState, {id: oldState[0].id}).isAsc).toBe(true);
+                expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).isAsc).toBe(undefined);
+            });
 
-        it('should not throw on sort if the table header does not exists', () => {
-            const oldState: ITableWithSortState[] = [];
-            const action = TableHeaderActions.sortTable('To be or not to be');
+            it('should not modify the isAsc for the other tables"', () => {
+                const oldState: ITableWithSortState[] = [
+                    {
+                        id: 'some-table-header',
+                        tableId: 'current-table',
+                        isAsc: undefined,
+                    },
+                    {
+                        id: 'other-table-header',
+                        tableId: 'other-table',
+                        isAsc: true,
+                    },
+                ];
 
-            expect(() => TableWithSortReducers(oldState, action)).not.toThrow();
+                const action = TableHeaderActions.sortTable(oldState[0].id);
+                const tableHeadersState: ITableWithSortState[] = TableWithSortReducers(oldState, action);
+                expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).isAsc).toBe(oldState[1].isAsc);
+            });
+
+            it('should set isAsc to the value specified in the action payload', () => {
+                const oldState: ITableWithSortState[] = [
+                    {
+                        id: '🐌',
+                        tableId: '🐋',
+                        isAsc: undefined,
+                    },
+                ];
+
+                const action = TableHeaderActions.sortTable('🐌', false);
+                const tableHeadersState: ITableWithSortState[] = TableWithSortReducers(oldState, action);
+                expect(_.findWhere(tableHeadersState, {id: '🐌'}).isAsc).toBe(false);
+            });
+
+            it('should set isAsc to the opposite value of the current one if no "ascending" value is specified in the action payload', () => {
+                const oldState: ITableWithSortState[] = [
+                    {
+                        id: '🐊',
+                        tableId: '🐋',
+                        isAsc: true,
+                    },
+                ];
+
+                const action = TableHeaderActions.sortTable('🐊');
+                const tableHeadersState: ITableWithSortState[] = TableWithSortReducers(oldState, action);
+                expect(_.findWhere(tableHeadersState, {id: '🐊'}).isAsc).toBe(false);
+            });
         });
     });
 });


### PR DESCRIPTION
### Proposed Changes

The `sortTable` action was not allowing to specify in which order you want to sort (ascending vs descending). Added the possibility to do so while maintaining the default behavior of toggling between ascending and descending.

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
