### PR TITLE
Add missing Table HOC utils

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableHOCUtils.ts
+++ b/packages/react-vapor/src/components/table-hoc/TableHOCUtils.ts
@@ -60,6 +60,16 @@ const getComponentIdFromPredicateId = (predicateId: string) => predicateId.split
 
 const getPredicateId = (tableId: string, componentId: string) => `${tableId}${PREDICATE_SEPARATOR}${componentId}`;
 
+const getPredicateIds = (tableId: string, state: IReactVaporState): string[] =>
+    _.chain(state.listBoxes)
+        .filter((list: IListBoxState) => {
+            const startWithIdRegexp = new RegExp(`^${tableId}(.+)`);
+            return startWithIdRegexp.test(list.id);
+        })
+        .pluck('id')
+        .map(getComponentIdFromPredicateId)
+        .value();
+
 const getPaginationId = (tableId: string) => `pagination-${tableId}`;
 
 const getTablePredicates = (tableId: string, state: IReactVaporState): ITableHOCPredicateValue[] => {
@@ -73,9 +83,13 @@ const getTablePredicates = (tableId: string, state: IReactVaporState): ITableHOC
         .value();
 };
 
+const getDatePickerId = (tableId: string) => `${tableId}-date-range`;
+
 export const TableHOCUtils = {
     getCompositeState,
     getPredicateId,
+    getPredicateIds,
     getPaginationId,
     getTableIdFromPredicateId,
+    getDatePickerId,
 };

--- a/packages/react-vapor/src/components/table-hoc/TableHOCUtils.ts
+++ b/packages/react-vapor/src/components/table-hoc/TableHOCUtils.ts
@@ -1,4 +1,5 @@
 import * as _ from 'underscore';
+
 import {IReactVaporState} from '../../ReactVapor';
 import {DatePickerSelectors} from '../datePicker/DatePickerSelectors';
 import {IFilterState} from '../filterBox/FilterBoxReducers';
@@ -62,10 +63,7 @@ const getPredicateId = (tableId: string, componentId: string) => `${tableId}${PR
 
 const getPredicateIds = (tableId: string, state: IReactVaporState): string[] =>
     _.chain(state.listBoxes)
-        .filter((list: IListBoxState) => {
-            const startWithIdRegexp = new RegExp(`^${tableId}(.+)`);
-            return startWithIdRegexp.test(list.id);
-        })
+        .filter(filterTablePredicate.bind(null, tableId))
         .pluck('id')
         .map(getComponentIdFromPredicateId)
         .value();
@@ -74,10 +72,7 @@ const getPaginationId = (tableId: string) => `pagination-${tableId}`;
 
 const getTablePredicates = (tableId: string, state: IReactVaporState): ITableHOCPredicateValue[] => {
     return _.chain(state.listBoxes)
-        .filter((list: IListBoxState) => {
-            const startWithIdRegexp = new RegExp(`^${tableId}(.+)`);
-            return startWithIdRegexp.test(list.id);
-        })
+        .filter(filterTablePredicate.bind(null, tableId))
         .filter((list: IListBoxState) => list.selected && list.selected[0] !== '')
         .map((list: IListBoxState) => ({id: getComponentIdFromPredicateId(list.id), value: list.selected[0]}))
         .value();
@@ -93,3 +88,7 @@ export const TableHOCUtils = {
     getTableIdFromPredicateId,
     getDatePickerId,
 };
+
+function filterTablePredicate(tableId: string, {id}: IListBoxState): boolean {
+    return new RegExp(`^${tableId}(.+)`).test(id);
+}

--- a/packages/react-vapor/src/components/table-hoc/tests/TableHOCUtils.spec.ts
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableHOCUtils.spec.ts
@@ -11,6 +11,26 @@ describe('TableHOCUtils', () => {
         });
     });
 
+    describe('getPredicateIds', () => {
+        it('should get predicate all the predicate ids associated with the table id', () => {
+            const predicates = TableHOCUtils.getPredicateIds(defaultProps.tableId, {
+                listBoxes: [
+                    {
+                        id: TableHOCUtils.getPredicateId(defaultProps.tableId, '🦇'),
+                        selected: ['🎃'],
+                    },
+                    {
+                        id: TableHOCUtils.getPredicateId(defaultProps.tableId, '🌳'),
+                        selected: ['🐍'],
+                    },
+                ],
+            });
+
+            expect(predicates).toContain(`🦇`);
+            expect(predicates).toContain(`🌳`);
+        });
+    });
+
     describe('getTableIdFromPredicateId', () => {
         it('should parse predicated id to table id', () => {
             const predicateId = TableHOCUtils.getPredicateId(defaultProps.tableId, defaultProps.componentId);
@@ -53,6 +73,14 @@ describe('TableHOCUtils', () => {
             };
 
             expect(compositeState).toEqual(expectedResult);
+        });
+    });
+
+    describe('getDatePickerId', () => {
+        it('should get the table date picker id', () => {
+            const datePickerId = TableHOCUtils.getDatePickerId('🐞');
+
+            expect(datePickerId).toEqual('🐞-date-range');
         });
     });
 });


### PR DESCRIPTION
### Proposed Changes

I needed two more table HOC utils:
- A way to know what are the `id`s of all the predicates associated with a given table
- A way to know what is the date picker id associated with a given table

### Potential Breaking Changes

None, those a new utils

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
