### PR TITLE
Add getSearchParams util in UrlUtil

### DIFF
--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -41,6 +41,7 @@
     },
     "dependencies": {
         "diff2html": "2.5.0",
+        "query-string": "6.8.3",
         "react-bootstrap": "0.32.4",
         "react-codemirror2": "5.1.0",
         "react-color": "2.17.3",

--- a/packages/react-vapor/src/utils/UrlUtils.ts
+++ b/packages/react-vapor/src/utils/UrlUtils.ts
@@ -1,0 +1,13 @@
+import * as QueryString from 'query-string';
+
+/* istanbul ignore next */
+function getSearchParams() {
+    const currentUrl = window.location.href;
+    const qPos = currentUrl.lastIndexOf('?');
+    const query = qPos >= 0 ? currentUrl.substring(qPos, currentUrl.length) : '';
+    return {...QueryString.parse(query, {parseBooleans: true, parseNumbers: true})};
+}
+
+export const UrlUtils = {
+    getSearchParams,
+};


### PR DESCRIPTION
### Proposed Changes

Added a small util to that parses the current url and returns the search params as an object. I added a new lib at the same time that handles query-strings in a graceful way. I will need this lib in some incoming PR.

I didn't do any tests for that one because its simply impossible to mock `window.location` in any way with jasmine :hankey: 

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
