### PR TITLE
Implement tableWithUrlState HOC

### DIFF
--- a/packages/react-vapor/docs/src/components/index.tsx
+++ b/packages/react-vapor/docs/src/components/index.tsx
@@ -27,15 +27,23 @@ const Components: React.FunctionComponent<RouteComponentProps> = ({match}) => {
         };
         loadAll().then((all) => setComponents(all.filter(Boolean)));
     }, []);
-    const routes = components
-        .sort((a: IComponent, b: IComponent) => a.name.localeCompare(b.name))
-        .map(({path, ...rest}: IComponent) => (
-            <Route
-                key={path}
-                path={`${match.url}/${rest.name}`}
-                component={() => <ComponentPage path={path} {...rest} />}
-            />
-        ));
+
+    const routes = React.useMemo(
+        () =>
+            components
+                .sort((a: IComponent, b: IComponent) => a.name.localeCompare(b.name))
+                .map(({path, ...rest}: IComponent) => {
+                    return (
+                        <Route
+                            key={rest.name}
+                            path={`${match.url}/${rest.name}`}
+                            component={() => <ComponentPage path={path} {...rest} />}
+                        />
+                    );
+                }),
+        [components]
+    );
+
     if (components.length === 0) {
         return <Loading fullContent />;
     }

--- a/packages/react-vapor/src/components/table-hoc/TableHOCUtils.ts
+++ b/packages/react-vapor/src/components/table-hoc/TableHOCUtils.ts
@@ -39,7 +39,7 @@ const getCompositeState = (id: string, state: IReactVaporState): ITableHOCCompos
 
         // sort
         sortKey: tableSort && tableSort.id,
-        sortAscending: tableSort && tableSort.isAsc,
+        sortAscending: (tableSort && tableSort.isAsc) || null,
 
         // pagination
         perPage: perPageState && perPageState.perPage,

--- a/packages/react-vapor/src/components/table-hoc/TableWithUrlState.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithUrlState.tsx
@@ -1,4 +1,3 @@
-import * as QueryString from 'query-string';
 import * as React from 'react';
 import {connect} from 'react-redux';
 import * as _ from 'underscore';
@@ -35,7 +34,7 @@ const Params = {
     filter: 'q',
 };
 
-export function tableWithUrlState<P extends ITableHOCOwnProps>(Component: React.ComponentType<P>) {
+function tableWithUrlState<P extends ITableHOCOwnProps>(Component: React.ComponentType<P>) {
     type Props = P &
         TableWithUrlStateProps &
         ReturnType<typeof mapStateToProps> &
@@ -85,26 +84,23 @@ function getQuery(state: IReactVaporState, tableId: string): string {
         order = tableState.sortAscending ? SortOrderValues.ascending : SortOrderValues.descending;
     }
 
-    return QueryString.stringify(
-        {
-            [Params.filter]: tableState.filter || undefined,
-            [Params.pageNumber]: tableState.pageNb,
-            [Params.pageSize]: tableState.perPage,
-            [Params.sortKey]: tableState.sortKey,
-            [Params.sortOrder]: order,
-            ..._.reduce(
-                tableState.predicates,
-                (memo, {id, value}: ITableHOCPredicateValue) => ({
-                    ...memo,
-                    [id]: value,
-                }),
-                {}
-            ),
-            [Params.lowerDateLimit]: from || undefined,
-            [Params.upperDateLimit]: to || undefined,
-        },
-        {sort: false}
-    );
+    return UrlUtils.toQueryString({
+        [Params.filter]: tableState.filter || undefined,
+        [Params.pageNumber]: tableState.pageNb,
+        [Params.pageSize]: tableState.perPage,
+        [Params.sortKey]: tableState.sortKey,
+        [Params.sortOrder]: order,
+        ..._.reduce(
+            tableState.predicates,
+            (memo, {id, value}: ITableHOCPredicateValue) => ({
+                ...memo,
+                [id]: value,
+            }),
+            {}
+        ),
+        [Params.lowerDateLimit]: from || undefined,
+        [Params.upperDateLimit]: to || undefined,
+    });
 }
 
 function updateTableStateFromUrl(tableId: string): IThunkAction {
@@ -164,3 +160,5 @@ function updateTableStateFromUrl(tableId: string): IThunkAction {
         }
     };
 }
+
+export {tableWithUrlState, Params as TableWithUrlStateParameters};

--- a/packages/react-vapor/src/components/table-hoc/TableWithUrlState.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithUrlState.tsx
@@ -1,0 +1,166 @@
+import * as QueryString from 'query-string';
+import * as React from 'react';
+import {connect} from 'react-redux';
+import * as _ from 'underscore';
+
+import {IReactVaporState} from '../../ReactVapor';
+import {callIfDefined} from '../../utils/FalsyValuesUtils';
+import {IDispatch, IThunkAction} from '../../utils/ReduxUtils';
+import {UrlUtils} from '../../utils/UrlUtils';
+import {applyDatePicker, changeDatePickerLowerLimit, changeDatePickerUpperLimit} from '../datePicker/DatePickerActions';
+import {filterThrough} from '../filterBox/FilterBoxActions';
+import {selectListBoxOption} from '../listBox/ListBoxActions';
+import {changePage} from '../navigation/pagination/NavigationPaginationActions';
+import {changePerPage} from '../navigation/perPage/NavigationPerPageActions';
+import {TableHeaderActions} from './actions/TableHeaderActions';
+import {ITableHOCOwnProps} from './TableHOC';
+import {ITableHOCPredicateValue, TableHOCUtils} from './TableHOCUtils';
+
+export interface TableWithUrlStateProps {
+    onUpdateUrl: (queryString: string) => void;
+}
+
+enum SortOrderValues {
+    ascending = 'asc',
+    descending = 'desc',
+}
+
+const Params = {
+    pageNumber: 'page',
+    pageSize: 'pageSize',
+    sortKey: 'sortBy',
+    sortOrder: 'order',
+    lowerDateLimit: 'from',
+    upperDateLimit: 'to',
+    filter: 'q',
+};
+
+export function tableWithUrlState<P extends ITableHOCOwnProps>(Component: React.ComponentType<P>) {
+    type Props = P &
+        TableWithUrlStateProps &
+        ReturnType<typeof mapStateToProps> &
+        ReturnType<typeof mapDispatchToProps>;
+
+    const mapStateToProps = (state: IReactVaporState, ownProps: P) => ({
+        query: getQuery(state, ownProps.id),
+    });
+
+    const mapDispatchToProps = (dispatch: IDispatch, ownProps: P) => ({
+        initializeFromUrl: () => dispatch(updateTableStateFromUrl(ownProps.id)),
+    });
+
+    class WrappedComponentDisconnected extends React.PureComponent<Props> {
+        static displayName = `withUrlState(${Component.displayName})`;
+
+        render() {
+            const wrappedProps = _.omit(this.props, 'onUpdate', 'onUpdateUrl', 'query', 'initializeFromUrl');
+            return <Component {...(wrappedProps as P)} onUpdate={this.onUpdate} />;
+        }
+
+        componentDidMount() {
+            this.props.initializeFromUrl();
+        }
+
+        private onUpdate = () => {
+            this.updateUrl(this.props.query);
+            callIfDefined(this.props.onUpdate);
+        };
+
+        private updateUrl = _.debounce(this.props.onUpdateUrl || _.noop, 100);
+    }
+
+    return connect(
+        mapStateToProps,
+        mapDispatchToProps
+        // @ts-ignore
+    )(WrappedComponentDisconnected);
+}
+
+function getQuery(state: IReactVaporState, tableId: string): string {
+    let order: SortOrderValues.ascending | SortOrderValues.descending;
+    const tableState = TableHOCUtils.getCompositeState(tableId, state);
+    const [from, to] = _.map(tableState.dateLimits, (limit) => limit && limit.toISOString());
+
+    if (_.isBoolean(tableState.sortAscending)) {
+        order = tableState.sortAscending ? SortOrderValues.ascending : SortOrderValues.descending;
+    }
+
+    return QueryString.stringify(
+        {
+            [Params.filter]: tableState.filter || undefined,
+            [Params.pageNumber]: tableState.pageNb,
+            [Params.pageSize]: tableState.perPage,
+            [Params.sortKey]: tableState.sortKey,
+            [Params.sortOrder]: order,
+            ..._.reduce(
+                tableState.predicates,
+                (memo, {id, value}: ITableHOCPredicateValue) => ({
+                    ...memo,
+                    [id]: value,
+                }),
+                {}
+            ),
+            [Params.lowerDateLimit]: from || undefined,
+            [Params.upperDateLimit]: to || undefined,
+        },
+        {sort: false}
+    );
+}
+
+function updateTableStateFromUrl(tableId: string): IThunkAction {
+    return (dispatch: IDispatch, getState) => {
+        const urlParams = UrlUtils.getSearchParams();
+        const possiblePredicates = TableHOCUtils.getPredicateIds(tableId, getState());
+
+        Object.keys(urlParams)
+            .filter((key) => possiblePredicates.includes(key))
+            .forEach((key) =>
+                dispatch(
+                    selectListBoxOption(TableHOCUtils.getPredicateId(tableId, key), false, urlParams[key] as string)
+                )
+            );
+
+        if (urlParams.hasOwnProperty(Params.lowerDateLimit)) {
+            dispatch(
+                changeDatePickerLowerLimit(
+                    TableHOCUtils.getDatePickerId(tableId),
+                    new Date(urlParams[Params.lowerDateLimit] as string)
+                )
+            );
+        }
+
+        if (urlParams.hasOwnProperty(Params.upperDateLimit)) {
+            dispatch(
+                changeDatePickerUpperLimit(
+                    TableHOCUtils.getDatePickerId(tableId),
+                    new Date(urlParams[Params.upperDateLimit] as string)
+                )
+            );
+        }
+
+        if (urlParams.hasOwnProperty(Params.lowerDateLimit) || urlParams.hasOwnProperty(Params.upperDateLimit)) {
+            dispatch(applyDatePicker(tableId));
+        }
+
+        if (urlParams.hasOwnProperty(Params.filter)) {
+            dispatch(filterThrough(tableId, urlParams[Params.filter] as string));
+        }
+
+        if (urlParams.hasOwnProperty(Params.sortKey) && urlParams.hasOwnProperty(Params.sortOrder)) {
+            dispatch(
+                TableHeaderActions.sortTable(
+                    urlParams[Params.sortKey] as string,
+                    urlParams[Params.sortOrder] === SortOrderValues.ascending
+                )
+            );
+        }
+
+        if (urlParams.hasOwnProperty(Params.pageSize)) {
+            dispatch(changePerPage(tableId, urlParams[Params.pageSize] as number));
+        }
+
+        if (urlParams.hasOwnProperty(Params.pageNumber)) {
+            dispatch(changePage(TableHOCUtils.getPaginationId(tableId), urlParams[Params.pageNumber] as number));
+        }
+    };
+}

--- a/packages/react-vapor/src/components/table-hoc/examples/TableHOCServerExampleReducer.ts
+++ b/packages/react-vapor/src/components/table-hoc/examples/TableHOCServerExampleReducer.ts
@@ -1,12 +1,13 @@
 import * as $ from 'jquery';
 import * as moment from 'moment';
 import * as _ from 'underscore';
+
 import {IDispatch, IReduxAction, IThunkAction} from '../../../utils/ReduxUtils';
 import {IReactVaporTestState} from '../../../utils/tests/TestUtils';
 import {turnOffLoading} from '../../loading/LoadingActions';
 import {TableWithPaginationActions} from '../actions/TableWithPaginationActions';
 import {ITableHOCCompositeState, TableHOCUtils} from '../TableHOCUtils';
-import {TableHOCServerExamples} from './TableHOCServerExamples';
+import {TableHOCServerExampleId} from './TableHOCServerExamples';
 
 export interface IExampleServerTableState {
     data: IExampleRowData[];
@@ -47,17 +48,18 @@ const setIsLoading = (isLoading: boolean): IReduxAction<ISetExampleIsLoadingPayl
 
 const fetchData = (): IThunkAction => (dispatch: IDispatch, getState: () => IReactVaporTestState) => {
     const compositeState: ITableHOCCompositeState = TableHOCUtils.getCompositeState(
-        TableHOCServerExamples.TABLE_ID,
+        TableHOCServerExampleId,
         getState()
     );
+    const [from, to] = _.map(compositeState.dateLimits, (limit) => limit && limit.toISOString());
     const params: any = {
         _page: compositeState.pageNb + 1,
         _limit: compositeState.perPage,
         _sort: compositeState.sortKey,
         _order: compositeState.sortAscending ? 'asc' : 'desc',
         q: compositeState.filter || undefined,
-        from: compositeState.dateLimits[0].toISOString(),
-        to: compositeState.dateLimits[1].toISOString(),
+        from,
+        to,
     };
     _.each(compositeState.predicates, (predicate: {id: string; value: string}) => {
         params[predicate.id] = predicate.value;
@@ -74,8 +76,8 @@ const fetchData = (): IThunkAction => (dispatch: IDispatch, getState: () => IRea
                 .toDate(), // fake a year of birth
         }));
         dispatch(setData(users));
-        dispatch(turnOffLoading([TableHOCServerExamples.TABLE_ID]));
-        dispatch(TableWithPaginationActions.setCount(TableHOCServerExamples.TABLE_ID, count));
+        dispatch(turnOffLoading([TableHOCServerExampleId]));
+        dispatch(TableWithPaginationActions.setCount(TableHOCServerExampleId, count));
     });
 };
 

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithUrlState.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithUrlState.spec.tsx
@@ -1,0 +1,249 @@
+import {ShallowWrapper} from 'enzyme';
+import {shallowWithStore} from 'enzyme-redux';
+import * as React from 'react';
+import * as _ from 'underscore';
+
+import {getStoreMock, TestUtils} from '../../../utils/tests/TestUtils';
+import {UrlUtils} from '../../../utils/UrlUtils';
+import {
+    applyDatePicker,
+    changeDatePickerLowerLimit,
+    changeDatePickerUpperLimit,
+} from '../../datePicker/DatePickerActions';
+import {filterThrough} from '../../filterBox/FilterBoxActions';
+import {selectListBoxOption} from '../../listBox/ListBoxActions';
+import {changePage} from '../../navigation/pagination/NavigationPaginationActions';
+import {changePerPage} from '../../navigation/perPage/NavigationPerPageActions';
+import {TableHeaderActions} from '../actions/TableHeaderActions';
+import {ITableHOCOwnProps, TableHOC} from '../TableHOC';
+import {TableHOCUtils} from '../TableHOCUtils';
+import {tableWithDatePicker} from '../TableWithDatePicker';
+import {tableWithFilter} from '../TableWithFilter';
+import {tableWithPagination} from '../TableWithPagination';
+import {tableWithPredicate} from '../TableWithPredicate';
+import {tableWithSort} from '../TableWithSort';
+import {tableWithUrlState} from '../TableWithUrlState';
+
+describe('Table HOC', () => {
+    describe('tableWithUrlState', () => {
+        let table: ShallowWrapper<ITableHOCOwnProps>;
+        let store: ReturnType<typeof getStoreMock>;
+
+        beforeAll(() => {
+            store = getStoreMock();
+            TestUtils.makeDebounceStatic();
+        });
+
+        beforeEach(() => {
+            store.clearActions();
+        });
+
+        afterEach(() => {
+            table && table.exists() && table.unmount();
+        });
+
+        it('should not throw when creating the HOC component', () => {
+            expect(() => {
+                tableWithUrlState(TableHOC);
+            }).not.toThrow();
+        });
+
+        it('should not throw when rendering the HOC component', () => {
+            expect(() => {
+                const TableWithUrlState = tableWithUrlState(TableHOC);
+                table = shallowWithStore(<TableWithUrlState />, store).dive();
+                table.unmount();
+            }).not.toThrow();
+        });
+
+        it('should call the "onUpdateUrl" prop with the query string representing the current state when the table needs to update', () => {
+            const onUpdateUrlSpy = jasmine.createSpy('onUpdateUrl');
+            const TableWithUrlState = tableWithUrlState(TableHOC);
+            table = shallowWithStore(<TableWithUrlState onUpdateUrl={onUpdateUrlSpy} />, store).dive();
+
+            expect(onUpdateUrlSpy).not.toHaveBeenCalled();
+            table.prop('onUpdate')();
+            expect(onUpdateUrlSpy).toHaveBeenCalledTimes(1);
+            expect(onUpdateUrlSpy).toHaveBeenCalledWith('');
+        });
+
+        describe('when table has pagination', () => {
+            const TableWithUrlState = _.compose(
+                tableWithUrlState,
+                tableWithPagination()
+            )(TableHOC);
+
+            it('should set the current page number in the url using "page" as param name', () => {
+                spyOn(TableHOCUtils, 'getCompositeState').and.returnValue({
+                    pageNb: 2,
+                });
+
+                table = shallowWithStore(<TableWithUrlState />, store);
+                expect(table.prop('query')).toContain('page=2');
+            });
+
+            it('should set the current perPage number in the url using "pageSize" as param name', () => {
+                spyOn(TableHOCUtils, 'getCompositeState').and.returnValue({
+                    perPage: 5,
+                });
+
+                table = shallowWithStore(<TableWithUrlState />, store);
+                expect(table.prop('query')).toContain('pageSize=5');
+            });
+
+            it('should dispatch an action to set the page number on mount if "page" param is specified in the url', () => {
+                spyOn(UrlUtils, 'getSearchParams').and.returnValue({page: 4});
+                table = shallowWithStore(<TableWithUrlState id="🦋" />, store).dive();
+
+                expect(store.getActions()).toContain(changePage(TableHOCUtils.getPaginationId('🦋'), 4));
+            });
+
+            it('should dispatch an action to set the page size on mount if "pageSize" param is specified in the url', () => {
+                spyOn(UrlUtils, 'getSearchParams').and.returnValue({pageSize: 3});
+                table = shallowWithStore(<TableWithUrlState id="💎" />, store).dive();
+
+                expect(store.getActions()).toContain(changePerPage('💎', 3));
+            });
+        });
+
+        describe('when table has sortable columns', () => {
+            const TableWithUrlState = _.compose(
+                tableWithUrlState,
+                tableWithSort()
+            )(TableHOC);
+
+            it('should set the current sorted column key in the url using "sortBy" as param name', () => {
+                spyOn(TableHOCUtils, 'getCompositeState').and.returnValue({
+                    sortKey: 'bacon',
+                });
+
+                table = shallowWithStore(<TableWithUrlState />, store);
+                expect(table.prop('query')).toContain('sortBy=bacon');
+            });
+
+            it('should set the current sort direction in the url using "order" as param name', () => {
+                spyOn(TableHOCUtils, 'getCompositeState').and.returnValue({
+                    sortAscending: true,
+                });
+
+                table = shallowWithStore(<TableWithUrlState />, store);
+                expect(table.prop('query')).toContain('order=asc');
+            });
+
+            it('should dispatch an action to set the sort key on mount if "sortBy" and "order" params are specified in the url', () => {
+                spyOn(UrlUtils, 'getSearchParams').and.returnValue({sortBy: '🔥', order: 'desc'});
+                table = shallowWithStore(<TableWithUrlState id="🦋" />, store).dive();
+
+                expect(store.getActions()).toContain(TableHeaderActions.sortTable('🔥', false));
+            });
+        });
+
+        describe('when the table is filterable', () => {
+            const TableWithUrlState = _.compose(
+                tableWithUrlState,
+                tableWithFilter()
+            )(TableHOC);
+
+            it('should set the current filter text in the url using "q" as param name', () => {
+                const filterText = 'not so black sheep 🐑';
+                spyOn(TableHOCUtils, 'getCompositeState').and.returnValue({
+                    filter: filterText,
+                });
+
+                table = shallowWithStore(<TableWithUrlState />, store);
+                expect(table.prop('query')).toContain(`q=${encodeURIComponent(filterText)}`);
+            });
+
+            it('should dispatch an action to set the filter value on mount if "q" param is specified in the url', () => {
+                spyOn(UrlUtils, 'getSearchParams').and.returnValue({q: '💧'});
+                table = shallowWithStore(<TableWithUrlState id="🎠" />, store).dive();
+
+                expect(store.getActions()).toContain(filterThrough('🎠', '💧'));
+            });
+        });
+
+        describe('when the table has a date picker', () => {
+            const lowerLimit = new Date(2019, 1, 1);
+            const upperLimit = new Date(2019, 1, 2);
+            const TableWithUrlState = _.compose(
+                tableWithUrlState,
+                tableWithDatePicker()
+            )(TableHOC);
+
+            it('should set the current lower date limit in the url using "from" as param name', () => {
+                spyOn(TableHOCUtils, 'getCompositeState').and.returnValue({
+                    dateLimits: [lowerLimit],
+                });
+
+                table = shallowWithStore(<TableWithUrlState />, store);
+                expect(table.prop('query')).toContain(`from=${encodeURIComponent(lowerLimit.toISOString())}`);
+            });
+
+            it('should set the current upper date limit in the url using "to" as param name', () => {
+                spyOn(TableHOCUtils, 'getCompositeState').and.returnValue({
+                    dateLimits: [null, upperLimit],
+                });
+
+                table = shallowWithStore(<TableWithUrlState />, store);
+                expect(table.prop('query')).toContain(`to=${encodeURIComponent(upperLimit.toISOString())}`);
+            });
+
+            it('should dispatch an action to set the lower date limit on mount if "from" param is specified in the url', () => {
+                spyOn(UrlUtils, 'getSearchParams').and.returnValue({from: lowerLimit.toISOString()});
+                table = shallowWithStore(<TableWithUrlState id="🏦" />, store).dive();
+
+                expect(store.getActions()).toContain(
+                    changeDatePickerLowerLimit(TableHOCUtils.getDatePickerId('🏦'), lowerLimit)
+                );
+                expect(store.getActions()).toContain(applyDatePicker('🏦'));
+            });
+
+            it('should dispatch an action to set the upper date limit on mount if "to" param is specified in the url', () => {
+                spyOn(UrlUtils, 'getSearchParams').and.returnValue({to: upperLimit.toISOString()});
+                table = shallowWithStore(<TableWithUrlState id="🏥" />, store).dive();
+
+                expect(store.getActions()).toContain(
+                    changeDatePickerUpperLimit(TableHOCUtils.getDatePickerId('🏥'), upperLimit)
+                );
+                expect(store.getActions()).toContain(applyDatePicker('🏥'));
+            });
+        });
+
+        describe('when the table has predicates', () => {
+            const TableWithUrlState = _.compose(
+                tableWithUrlState,
+                tableWithPredicate({
+                    id: 'size',
+                    values: [],
+                }),
+                tableWithPredicate({
+                    id: 'topping',
+                    values: [],
+                })
+            )(TableHOC);
+
+            it('should set the selected predicate values in the url using the each predicate id as param name', () => {
+                spyOn(TableHOCUtils, 'getCompositeState').and.returnValue({
+                    predicates: [{id: 'size', value: '12 inches'}, {id: 'topping', value: 'pepperoni'}],
+                });
+
+                table = shallowWithStore(<TableWithUrlState />, store);
+                expect(table.prop('query')).toContain(`size=${encodeURIComponent('12 inches')}`);
+                expect(table.prop('query')).toContain('topping=pepperoni');
+            });
+
+            it('should dispatch an action to set each selected predicate on mount if its id is specified in the url', () => {
+                spyOn(TableHOCUtils, 'getPredicateIds').and.returnValue(['size', 'topping']);
+                spyOn(UrlUtils, 'getSearchParams').and.returnValue({size: '12 inches', topping: 'pepperoni'});
+                table = shallowWithStore(<TableWithUrlState id="🍕" />, store).dive();
+
+                expect(store.getActions()).toContain(
+                    selectListBoxOption(TableHOCUtils.getPredicateId('🍕', 'size'), false, '12 inches')
+                );
+                expect(store.getActions()).toContain(
+                    selectListBoxOption(TableHOCUtils.getPredicateId('🍕', 'topping'), false, 'pepperoni')
+                );
+            });
+        });
+    });
+});

--- a/packages/react-vapor/src/utils/UrlUtils.spec.ts
+++ b/packages/react-vapor/src/utils/UrlUtils.spec.ts
@@ -1,0 +1,50 @@
+import {UrlUtils} from './UrlUtils';
+
+describe('UrlUtils', () => {
+    describe('toObject', () => {
+        it('should parse the query string into the proper object ', () => {
+            expect(UrlUtils.toObject('a=b&c=d')).toEqual({a: 'b', c: 'd'});
+        });
+        it('should parse "true" and "false" as booleans in the object', () => {
+            expect(UrlUtils.toObject('story=true')).not.toEqual({story: 'true'});
+            expect(UrlUtils.toObject('story=true')).toEqual({story: true});
+        });
+        it('should parse digits as numbers in the object', () => {
+            expect(UrlUtils.toObject('count=123')).not.toEqual({count: '123'});
+            expect(UrlUtils.toObject('count=123')).toEqual({count: 123});
+        });
+        it('should return an object that extends the Object prototype', () => {
+            expect(UrlUtils.toObject('abc=def') instanceof Object).toBe(true);
+        });
+        it('should not change the order of the key-value pairs in the object', () => {
+            const obj = UrlUtils.toObject('vehicle=🛥&beverage=🥛');
+            expect(JSON.stringify(obj)).toBe(JSON.stringify({vehicle: '🛥', beverage: '🥛'}));
+            expect(JSON.stringify(obj)).not.toBe(JSON.stringify({beverage: '🥛', vehicle: '🛥'}));
+        });
+    });
+
+    describe('toQueryString', () => {
+        it('should translate objects into query strings properly', () => {
+            expect(UrlUtils.toQueryString({a: 'b', c: 'd'})).toBe('a=b&c=d');
+        });
+        it('should encode values so that it produces a valid url', () => {
+            const favoriteBaconFlavor = 'smoked maple';
+            expect(UrlUtils.toQueryString({flavor: favoriteBaconFlavor})).toBe(
+                `flavor=${encodeURIComponent(favoriteBaconFlavor)}`
+            );
+            expect(UrlUtils.toQueryString({flavor: favoriteBaconFlavor})).not.toBe(`flavor=${favoriteBaconFlavor}`);
+        });
+        it('should not change the order of the key-value pairs in the query string', () => {
+            const query = UrlUtils.toQueryString({fruit: 'apple', color: 'red'});
+            expect(query).toBe('fruit=apple&color=red');
+            expect(query).not.toBe('color=red&fruit=apple');
+        });
+    });
+
+    describe('getSearchParams', () => {
+        it('should transform the current query string into a parameters object', () => {
+            spyOn(UrlUtils, 'getQuery').and.returnValue('animal=tiger&age=7');
+            expect(UrlUtils.getSearchParams()).toEqual({animal: 'tiger', age: 7});
+        });
+    });
+});

--- a/packages/react-vapor/src/utils/UrlUtils.ts
+++ b/packages/react-vapor/src/utils/UrlUtils.ts
@@ -1,13 +1,34 @@
 import * as QueryString from 'query-string';
 
 /* istanbul ignore next */
+function getQuery() {
+    const queryPosition = window.location.hash.lastIndexOf('?');
+    return queryPosition >= 0 ? window.location.hash.substring(queryPosition, window.location.hash.length) : '';
+}
+
+/* istanbul ignore next */
+function getPathName() {
+    return window.location.hash.indexOf('?') >= 0
+        ? window.location.href.substring(0, window.location.href.lastIndexOf('?'))
+        : window.location.href;
+}
+
+function toObject(query: string) {
+    return {...QueryString.parse(query, {parseBooleans: true, parseNumbers: true, sort: false})};
+}
+
+function toQueryString(obj: object): string {
+    return QueryString.stringify(obj, {sort: false});
+}
+
 function getSearchParams() {
-    const currentUrl = window.location.href;
-    const qPos = currentUrl.lastIndexOf('?');
-    const query = qPos >= 0 ? currentUrl.substring(qPos, currentUrl.length) : '';
-    return {...QueryString.parse(query, {parseBooleans: true, parseNumbers: true})};
+    return UrlUtils.toObject(UrlUtils.getQuery());
 }
 
 export const UrlUtils = {
+    getQuery,
     getSearchParams,
+    getPathName,
+    toQueryString,
+    toObject,
 };


### PR DESCRIPTION
### Proposed Changes

I implemented a `tableWithUrlState` HOC that basically saves any table state in the url query params. 

Usage: 
```tsx
const MyTable = _.compose(
    tableWithUrlState,
    tableWithPagination()
    // whatever other table HOC
)(TableHOC);

<>
    <MyTable 
        // the usual TableHOC props
        onUpdateUrl={(currentQueryString: string) => {
            // Update the window href using your favorite way
        }}
    />
</>
```

To test it in the demo you can simply navigate to the `TableHOCServer` example and play with the table there.

### Potential Breaking Changes

None expected.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
