### PR TITLE
fix(index.ts): add missing underscore import

### DIFF
--- a/packages/react-vapor/Index.ts
+++ b/packages/react-vapor/Index.ts
@@ -1,5 +1,7 @@
+import {extend} from 'underscore';
+
 const req = require.context('./src/', true, /^((?!\.spec|examples|Tests?|\.d).)*\.tsx?$/i);
 req.keys().forEach((key) => {
     const importedModule = req(key);
-    _.extend(module.exports, importedModule);
+    extend(module.exports, importedModule);
 });


### PR DESCRIPTION
### Proposed Changes

React-vapor isn't usable in conjunction with create-react-app in its current state. It seems that underscore needs to be implicitly imported.

You can try it out here
[![Edit vibrant-smoke-g6uef](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/vibrant-smoke-g6uef?fontsize=14)

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
