### PR TITLE
+onClose from toast that removed the error in handledErrors array

### DIFF
--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -27,7 +27,7 @@
         "build": "gulp clean && concurrently \"npm run compileTs\" \"npm run minify\" \"gulp ts:definitions\"",
         "build:dev": "gulp clean && concurrently \"npm run compileTs\" \"gulp ts:definitions\"",
         "pretest": "gulp clean:tests",
-        "test": "karma start",
+        "test": "node --max-old-space-size=2048 node_modules/karma/bin/karma start",
         "test:compile": "tslint --project ./tsconfig.test.json -c ../../tslint.json",
         "test:watch": "node --max-old-space-size=2048 node_modules/karma/bin/karma start --no-single-run --auto-watch",
         "test:browser": "karma start --browsers Chrome --no-single-run",

--- a/packages/react-vapor/src/components/toast/ToastContainer.tsx
+++ b/packages/react-vapor/src/components/toast/ToastContainer.tsx
@@ -54,7 +54,14 @@ export class ToastContainer extends React.Component<IToastContainerProps, {}> {
         });
         const toasts = this.props.toasts
             ? _.map(this.props.toasts, (toast: IToastProps) => (
-                  <Toast key={toast.id} {...toast} onClose={() => this.onCloseToast(toast.id)} />
+                  <Toast
+                      key={toast.id}
+                      {...toast}
+                      onClose={() => {
+                          this.onCloseToast(toast.id);
+                          toast.onClose();
+                      }}
+                  />
               ))
             : this.props.children;
 

--- a/packages/react-vapor/src/components/toast/ToastContainer.tsx
+++ b/packages/react-vapor/src/components/toast/ToastContainer.tsx
@@ -1,6 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
+import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {IToastProps, Toast} from './Toast';
 import {IToastState} from './ToastReducers';
 
@@ -59,7 +60,7 @@ export class ToastContainer extends React.Component<IToastContainerProps, {}> {
                       {...toast}
                       onClose={() => {
                           this.onCloseToast(toast.id);
-                          toast.onClose ? toast.onClose() : '';
+                          callIfDefined(toast.onClose);
                       }}
                   />
               ))

--- a/packages/react-vapor/src/components/toast/ToastContainer.tsx
+++ b/packages/react-vapor/src/components/toast/ToastContainer.tsx
@@ -59,7 +59,7 @@ export class ToastContainer extends React.Component<IToastContainerProps, {}> {
                       {...toast}
                       onClose={() => {
                           this.onCloseToast(toast.id);
-                          toast.onClose();
+                          toast.onClose ? toast.onClose() : '';
                       }}
                   />
               ))

--- a/packages/react-vapor/src/components/toast/tests/ToastContainer.spec.tsx
+++ b/packages/react-vapor/src/components/toast/tests/ToastContainer.spec.tsx
@@ -100,5 +100,32 @@ describe('Toasts', () => {
             expect(onCloseToast).toHaveBeenCalledTimes(1);
             expect(onCloseToast).toHaveBeenCalledWith(newToastAttributes.toasts[0].id);
         });
+
+        it('should not throw if toast method onClose is not defined', () => {
+            const newToastAttributes = _.extend({}, basicProps, {
+                toasts: [{id: 'toast-id', title: 'some toast title'}],
+            });
+
+            component.setProps(newToastAttributes).mount();
+            expect(() =>
+                component
+                    .find(Toast)
+                    .props()
+                    .onClose()
+            ).not.toThrow();
+        });
+
+        it('should call toast method onClose when defined', () => {
+            const onCloseSpy = jasmine.createSpy('onClose');
+            const newToastAttributes = _.extend({}, basicProps, {
+                toasts: [{id: 'toast-id', title: 'some toast title', onClose: onCloseSpy}],
+            });
+            component.setProps(newToastAttributes).mount();
+            component
+                .find(Toast)
+                .props()
+                .onClose();
+            expect(onCloseSpy).toHaveBeenCalledTimes(1);
+        });
     });
 });


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->
I added in the onClose from the Toast component the step that delete the error from the handledErrors array
### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
