### PR TITLE
Remove turnOnLoading in the navigation components

### DIFF
--- a/packages/react-vapor/src/components/navigation/pagination/NavigationPaginationConnected.tsx
+++ b/packages/react-vapor/src/components/navigation/pagination/NavigationPaginationConnected.tsx
@@ -3,7 +3,6 @@ import {connect} from 'react-redux';
 import * as _ from 'underscore';
 import {IReactVaporState, IReduxActionsPayload} from '../../../ReactVapor';
 import {IReduxAction, ReduxUtils} from '../../../utils/ReduxUtils';
-import {turnOnLoading} from '../../loading/LoadingActions';
 import {
     INavigationPaginationDispatchProps,
     INavigationPaginationOwnProps,
@@ -31,10 +30,7 @@ const mapDispatchToProps = (
 ): INavigationPaginationDispatchProps => ({
     onRender: () => dispatch(addPagination(ownProps.id)),
     onDestroy: () => dispatch(removePagination(ownProps.id)),
-    onPageClick: (pageNb: number) => {
-        dispatch(turnOnLoading(ownProps.loadingIds));
-        dispatch(changePage(ownProps.id, pageNb));
-    },
+    onPageClick: (pageNb: number) => dispatch(changePage(ownProps.id, pageNb)),
 });
 
 export const NavigationPaginationConnected: React.ComponentClass<INavigationPaginationProps> = connect(

--- a/packages/react-vapor/src/components/navigation/pagination/tests/NavigationPaginationConnected.spec.tsx
+++ b/packages/react-vapor/src/components/navigation/pagination/tests/NavigationPaginationConnected.spec.tsx
@@ -162,17 +162,6 @@ describe('<NavigationPaginationConnected />', () => {
         expect(wrapper.findWhere((select) => select.prop('pageNb') === lastPage).length).toBe(1);
     });
 
-    it('should add loading on page click', () => {
-        expect(_.findWhere(store.getState().loadings, {id: loadingId}).isOn).toBe(false);
-
-        navigationPagination
-            .find('.flat-select-option')
-            .last()
-            .simulate('click');
-
-        expect(_.findWhere(store.getState().loadings, {id: loadingId}).isOn).toBe(true);
-    });
-
     it('should change the current page on page click', () => {
         expect(_.findWhere(store.getState().paginationComposite, {id: basicNavigationPaginationProps.id}).pageNb).toBe(
             0

--- a/packages/react-vapor/src/components/navigation/perPage/NavigationPerPageConnected.tsx
+++ b/packages/react-vapor/src/components/navigation/perPage/NavigationPerPageConnected.tsx
@@ -4,7 +4,6 @@ import * as _ from 'underscore';
 
 import {IReactVaporState} from '../../../ReactVapor';
 import {IDispatch, ReduxUtils} from '../../../utils/ReduxUtils';
-import {turnOnLoading} from '../../loading/LoadingActions';
 import {changePage} from '../pagination/NavigationPaginationActions';
 import {IPaginationState} from '../pagination/NavigationPaginationReducers';
 import {
@@ -43,7 +42,6 @@ const mapDispatchToProps = (
     onRender: (perPageNb: number) => dispatch(addPerPage(ownProps.id, perPageNb)),
     onDestroy: () => dispatch(removePerPage(ownProps.id)),
     onPerPageClick: (perPageNb: number, oldPerPageNb: number, currentPage: number) => {
-        dispatch(turnOnLoading(ownProps.loadingIds));
         dispatch(changePerPage(ownProps.id, perPageNb));
         dispatch(changePage(`pagination-${ownProps.id}`, Math.floor((currentPage * oldPerPageNb) / perPageNb)));
     },

--- a/packages/react-vapor/src/components/navigation/perPage/tests/NavigationPerPageConnected.spec.tsx
+++ b/packages/react-vapor/src/components/navigation/perPage/tests/NavigationPerPageConnected.spec.tsx
@@ -107,18 +107,13 @@ describe('<NavigationPerPageConnected />', () => {
         expect(_.findWhere(store.getState().perPageComposite, {id: basicNavigationPerPageProps.id})).toBeUndefined();
     });
 
-    it('should turn on loading and change the per page number when clicking on a <NavigationPerPageSelect /> link', () => {
+    it('should change the per page number when clicking on a <NavigationPerPageSelect /> link', () => {
         const perPageSelected = navigationPerPage.find('a').last();
-
-        expect(_.findWhere(store.getState().loadings, {id: basicNavigationPerPageProps.loadingIds[0]}).isOn).toBe(
-            false
-        );
 
         perPageSelected.simulate('click');
         expect(
             _.findWhere(store.getState().perPageComposite, {id: basicNavigationPerPageProps.id}).perPage.toString()
         ).toBe(perPageSelected.find('span').text());
-        expect(_.findWhere(store.getState().loadings, {id: basicNavigationPerPageProps.loadingIds[0]}).isOn).toBe(true);
     });
 
     it('should not update the currentPerPage prop if a selected <NavigationPerPageSelect /> is clicked', () => {


### PR DESCRIPTION
### Proposed Changes

The `turnOnLoading` in the `tableWithPagination` imposes the parent to turn off the loading after changing page, which causes issues for client-side tables. The client-side table does not require a loader while changing page, and for server-side tables, we can handle the loader with the fetch action.   

### Potential Breaking Changes

The loader won't be triggered by the onPageClick and onPerPageClick events.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
