### PR TITLE
fix(tableWithPagination): NavigationPagination unUpdate select the la…

### DIFF
--- a/packages/react-vapor/src/components/navigation/pagination/NavigationPagination.tsx
+++ b/packages/react-vapor/src/components/navigation/pagination/NavigationPagination.tsx
@@ -34,21 +34,23 @@ export const NEXT_LABEL: string = 'Next';
 
 export class NavigationPagination extends React.Component<INavigationPaginationProps, any> {
     private handlePageClick = (pageNb: number) => {
-        if (this.props.onPageClick && pageNb >= 0 && this.props.currentPage !== pageNb) {
-            this.props.onPageClick(pageNb);
+        if (pageNb >= 0 && this.props.currentPage !== pageNb) {
+            this.props.onPageClick?.(pageNb);
         }
     };
 
-    componentWillMount() {
-        if (this.props.onRender) {
-            this.props.onRender();
+    componentDidUpdate() {
+        if (this.props.currentPage > this.props.totalPages - 1) {
+            this.props.onPageClick?.(this.props.totalPages - 1);
         }
     }
 
+    componentDidMount() {
+        this.props.onRender?.();
+    }
+
     componentWillUnmount() {
-        if (this.props.onDestroy) {
-            this.props.onDestroy();
-        }
+        this.props.onDestroy?.();
     }
 
     render() {

--- a/packages/react-vapor/src/components/navigation/pagination/tests/NavigationPagination.spec.tsx
+++ b/packages/react-vapor/src/components/navigation/pagination/tests/NavigationPagination.spec.tsx
@@ -42,7 +42,7 @@ describe('NavigationPagination', () => {
             const renderSpy: jasmine.Spy = jasmine.createSpy('onRender');
 
             expect(() => {
-                navigationPaginationInstance.componentWillMount();
+                navigationPaginationInstance.componentDidMount();
             }).not.toThrow();
 
             navigationPagination = mount(

--- a/packages/react-vapor/src/components/navigation/tests/NavigationConnected.spec.tsx
+++ b/packages/react-vapor/src/components/navigation/tests/NavigationConnected.spec.tsx
@@ -103,6 +103,6 @@ describe('<NavigationConnected />', () => {
 
         expect(
             _.findWhere(store.getState().paginationComposite, {id: `pagination-${basicNavigationProps.id}`}).pageNb
-        ).toBe(10);
+        ).toBe(9);
     });
 });


### PR DESCRIPTION

### Proposed Changes

When the CurrentPage received from props is Higher than the last page, the table renders nothing because the page selected doesn't exist.
Now, when the component updates, it will make sure that if the currentPage will fall back on the last page if it was initially higher.

### Potential Breaking Changes

None that I know of.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
