### PR TITLE
Deprecate `callIfDefined` util

### DIFF
--- a/packages/react-vapor/docs/src/demo-building-blocs/NavigationSection.tsx
+++ b/packages/react-vapor/docs/src/demo-building-blocs/NavigationSection.tsx
@@ -6,7 +6,6 @@ import {
     ISideNavigationSectionProps,
     SideNavigationMenuSection,
 } from '../../../src/components/sideNavigation/SideNavigationMenuSection';
-import {callIfDefined} from '../../../src/utils/FalsyValuesUtils';
 
 type NavSectionControlledProps = Omit<ISideNavigationSectionProps, 'expanded' | 'expandable'>;
 
@@ -31,7 +30,7 @@ const Section: React.FunctionComponent<NavSectionProps> = ({
         if (hasMoreThanOneSection) {
             toggleOpened(!isOpened);
         }
-        callIfDefined(onClick);
+        onClick?.();
     };
 
     return (

--- a/packages/react-vapor/src/components/actionable-item/ActionableItem.tsx
+++ b/packages/react-vapor/src/components/actionable-item/ActionableItem.tsx
@@ -1,7 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
+
 import {DropPodPosition} from '../drop/DomPositionCalculator';
 import {Drop} from '../drop/Drop';
 import {IItemBoxProps} from '../itemBox/ItemBox';
@@ -32,7 +32,7 @@ export class ActionableItem extends React.Component<IActionableItemProps & React
                         actionableItemContainer,
                         this.props.containerClassName
                     )}
-                    onClick={(e: React.MouseEvent<HTMLDivElement>) => callIfDefined(this.props.onItemClick, e)}
+                    onClick={(e: React.MouseEvent<HTMLDivElement>) => this.props.onItemClick?.(e)}
                 >
                     {this.props.children}
                 </div>

--- a/packages/react-vapor/src/components/collapsible/Collapsible.tsx
+++ b/packages/react-vapor/src/components/collapsible/Collapsible.tsx
@@ -2,7 +2,6 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 
 import {SlideY} from '../../animations/SlideY';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {CollapsibleToggle} from './CollapsibleToggle';
 
 export interface CollapsibleOwnProps {
@@ -31,11 +30,11 @@ export class Collapsible extends React.Component<CollapsibleProps> {
     static TIMEOUT = 150;
 
     componentWillMount() {
-        callIfDefined(this.props.onMount);
+        this.props.onMount?.();
     }
 
     componentWillUnmount() {
-        callIfDefined(this.props.onUnmount);
+        this.props.onUnmount?.();
     }
 
     render() {
@@ -66,6 +65,6 @@ export class Collapsible extends React.Component<CollapsibleProps> {
     }
 
     private handleHeaderClick() {
-        callIfDefined(this.props.onToggleExpandedState, this.props.expanded);
+        this.props.onToggleExpandedState?.(this.props.expanded);
     }
 }

--- a/packages/react-vapor/src/components/dropdownSearch/DropdownSearch.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/DropdownSearch.tsx
@@ -4,7 +4,6 @@ import {InfiniteScrollProps} from 'react-infinite-scroll-component';
 import * as _ from 'underscore';
 import * as s from 'underscore.string';
 
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {keyCode} from '../../utils/InputUtils';
 import {Content} from '../content/Content';
 import {FilterBox} from '../filterBox/FilterBox';
@@ -479,7 +478,7 @@ export class DropdownSearch extends React.Component<IDropdownSearchProps, {}> {
         if (this.props.customFiltering) {
             this.props.customFiltering(filterText);
         } else {
-            callIfDefined(this.props.onFilterTextChange, filterText);
+            this.props.onFilterTextChange?.(filterText);
         }
     }
 

--- a/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/SelectedOption.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/SelectedOption.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import * as _ from 'underscore';
-import {callIfDefined} from '../../../utils/FalsyValuesUtils';
+
 import {TooltipPlacement} from '../../../utils/TooltipUtils';
 import {Svg} from '../../svg/Svg';
 import {Tooltip} from '../../tooltip/Tooltip';
@@ -13,7 +12,7 @@ export interface ISelectedOptionProps {
 
 export class SelectedOption extends React.PureComponent<ISelectedOptionProps> {
     handleOnRemove = () => {
-        callIfDefined(this.props.onRemoveClick, this.props.value);
+        this.props.onRemoveClick?.(this.props.value);
     };
 
     render() {

--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -13,7 +13,6 @@ import * as React from 'react';
 import * as ReactCodeMirror from 'react-codemirror2';
 import * as _ from 'underscore';
 
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {CodeMirrorGutters} from './EditorConstants';
 
 export interface ICodeEditorProps {
@@ -59,7 +58,7 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
     }
 
     componentDidMount() {
-        callIfDefined(this.props.onMount, this.codemirror.current);
+        this.props.onMount?.(this.codemirror.current);
     }
 
     componentDidUpdate(prevProps: ICodeEditorProps) {
@@ -96,7 +95,7 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
     }
 
     private handleChange(code: string) {
-        callIfDefined(this.props.onChange, code);
+        this.props.onChange?.(code);
     }
 
     private addExtraKeywords() {

--- a/packages/react-vapor/src/components/editor/JSONEditor.tsx
+++ b/packages/react-vapor/src/components/editor/JSONEditor.tsx
@@ -3,7 +3,6 @@ import 'codemirror/mode/javascript/javascript';
 import * as classNames from 'classnames';
 import * as React from 'react';
 
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {Svg} from '../svg/Svg';
 import {CodeEditor} from './CodeEditor';
 import {CodeMirrorModes} from './EditorConstants';
@@ -73,6 +72,6 @@ export class JSONEditor extends React.Component<IJSONEditorProps, IJSONEditorSta
     }
 
     private callOnChange(json: string, inError: boolean) {
-        callIfDefined(this.props.onChange, json, inError);
+        this.props.onChange?.(json, inError);
     }
 }

--- a/packages/react-vapor/src/components/listBox/ListBox.tsx
+++ b/packages/react-vapor/src/components/listBox/ListBox.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import * as _ from 'underscore';
 
 import {mod} from '../../utils/DataStructuresUtils';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {IItemBoxProps, ItemBox} from '../itemBox/ItemBox';
 
 export type IItemBoxPropsWithIndex = {index?: number} & IItemBoxProps;
@@ -39,11 +38,11 @@ export class ListBox extends React.Component<IListBoxProps, {}> {
     };
 
     componentWillMount() {
-        callIfDefined(this.props.onRender);
+        this.props.onRender?.();
     }
 
     componentWillUnmount() {
-        callIfDefined(this.props.onDestroy);
+        this.props.onDestroy?.();
     }
 
     private getClasses(): string {
@@ -116,8 +115,8 @@ export class ListBox extends React.Component<IListBoxProps, {}> {
 
     private onSelectItem(item: IItemBoxProps, index?: number) {
         if (!item.disabled) {
-            callIfDefined(this.props.onOptionClick, item, index);
-            callIfDefined(item.onOptionClick, item, index);
+            this.props.onOptionClick?.(item, index);
+            item.onOptionClick?.(item, index);
         }
     }
 }

--- a/packages/react-vapor/src/components/modal/Modal.tsx
+++ b/packages/react-vapor/src/components/modal/Modal.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 
 import {Defaults} from '../../Defaults';
 import {IClassName} from '../../utils/ClassNameUtils';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 
 export interface IModalOwnProps {
     id?: string;
@@ -61,7 +60,7 @@ export class Modal extends React.Component<IModalProps, {}> {
     private handleCloseCallback() {
         window.clearTimeout(this.timeoutId);
         this.timeoutId = window.setTimeout(() => {
-            callIfDefined(this.props.closeCallback);
+            this.props.closeCallback?.();
         }, this.props.closeTimeout);
     }
 

--- a/packages/react-vapor/src/components/modal/ModalComposite.tsx
+++ b/packages/react-vapor/src/components/modal/ModalComposite.tsx
@@ -7,7 +7,6 @@ import * as _ from 'underscore';
 import {Defaults} from '../../Defaults';
 import {IWithDirtyProps} from '../../hoc/withDirty/withDirty';
 import {IClassName} from '../../utils/ClassNameUtils';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {IReduxStatePossibleProps} from '../../utils/ReduxUtils';
 import {IModalDispatchProps, IModalOwnProps, IModalStateProps} from './Modal';
 import {IModalBackdropOwnProps} from './ModalBackdrop';
@@ -87,11 +86,11 @@ export class ModalComposite extends React.PureComponent<
     }
 
     componentDidMount() {
-        callIfDefined(this.props.onRender);
+        this.props.onRender?.();
     }
 
     componentWillUnmount() {
-        callIfDefined(this.props.onDestroy);
+        this.props.onDestroy?.();
     }
 
     private onRequestClose = (e: React.MouseEvent | React.KeyboardEvent) => {
@@ -100,10 +99,10 @@ export class ModalComposite extends React.PureComponent<
 
         if (this.props.validateShouldNavigate) {
             if (this.props.validateShouldNavigate(this.props.isDirty)) {
-                callIfDefined(this.props.onClose);
+                this.props.onClose?.();
             }
         } else {
-            callIfDefined(this.props.onClose);
+            this.props.onClose?.();
         }
     };
 

--- a/packages/react-vapor/src/components/modal/ModalHeader.tsx
+++ b/packages/react-vapor/src/components/modal/ModalHeader.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import * as _ from 'underscore';
 
 import {IClassName} from '../../utils/ClassNameUtils';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {ILinkSvgProps} from '../svg/LinkSvg';
 import {Svg} from '../svg/Svg';
 import {Title} from '../title/Title';
@@ -46,7 +45,7 @@ export class ModalHeader extends React.Component<IModalHeaderProps, {}> {
 
     close() {
         if (this.canClose) {
-            callIfDefined(this.props.onClose);
+            this.props.onClose?.();
         }
     }
 

--- a/packages/react-vapor/src/components/modalPrompt/ModalPrompt.tsx
+++ b/packages/react-vapor/src/components/modalPrompt/ModalPrompt.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {Modal} from '../modal/Modal';
 import {ModalBody} from '../modal/ModalBody';
 import {ModalFooter} from '../modal/ModalFooter';
@@ -40,11 +39,11 @@ export class ModalPrompt extends React.Component<IModalPromptProps, any> {
     };
 
     private confirm() {
-        callIfDefined(this.props.onConfirm, this.props.id);
+        this.props.onConfirm?.(this.props.id);
     }
 
     private cancel() {
-        callIfDefined(this.props.onCancel, this.props.id);
+        this.props.onCancel?.(this.props.id);
     }
 
     render() {

--- a/packages/react-vapor/src/components/navigation/perPage/NavigationPerPage.tsx
+++ b/packages/react-vapor/src/components/navigation/perPage/NavigationPerPage.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'underscore';
 
-import {callIfDefined} from '../../../utils/FalsyValuesUtils';
 import {NavigationPerPageSelect} from './NavigationPerPageSelect';
 
 export interface INavigationPerPageOwnProps extends React.ClassAttributes<NavigationPerPage> {
@@ -49,11 +48,11 @@ export class NavigationPerPage extends React.Component<INavigationPerPageProps> 
         this.initialPosition = !_.isUndefined(this.props.initialPosition)
             ? this.props.initialPosition
             : Math.ceil(this.props.perPageNumbers.length / 2) - 1;
-        callIfDefined(this.props.onRender, this.props.perPageNumbers[this.initialPosition]);
+        this.props.onRender?.(this.props.perPageNumbers[this.initialPosition]);
     }
 
     componentWillUnmount() {
-        callIfDefined(this.props.onDestroy);
+        this.props.onDestroy?.();
     }
 
     render() {

--- a/packages/react-vapor/src/components/optionsCycle/OptionsCycle.tsx
+++ b/packages/react-vapor/src/components/optionsCycle/OptionsCycle.tsx
@@ -1,7 +1,6 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {Svg} from '../svg/Svg';
 
 export interface IOptionsCycleConnectedOwnProps {
@@ -58,11 +57,11 @@ export class OptionsCycle extends React.Component<IOptionsCycleProps> {
     }
 
     componentDidMount() {
-        callIfDefined(this.props.onRender);
+        this.props.onRender?.();
     }
 
     componentWillUnmount() {
-        callIfDefined(this.props.onDestroy);
+        this.props.onDestroy?.();
     }
 
     render() {

--- a/packages/react-vapor/src/components/popover/Popover.tsx
+++ b/packages/react-vapor/src/components/popover/Popover.tsx
@@ -4,8 +4,6 @@ import {findDOMNode} from 'react-dom';
 import TetherComponent from 'react-tether';
 import * as _ from 'underscore';
 
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
-
 export interface ITetherComponentCopiedProps {
     renderElementTag?: string;
     renderElementTo?: Element | string;
@@ -76,12 +74,12 @@ export class Popover extends React.Component<IPopoverProps, IPopoverState> {
     }
 
     componentDidMount() {
-        callIfDefined(this.props.onMount, this.props.isOpenOnMount);
+        this.props.onMount?.(this.props.isOpenOnMount);
         document.addEventListener('click', this.handleDocumentClick, true);
     }
 
     componentWillUnmount() {
-        callIfDefined(this.props.onUnmount);
+        this.props.onUnmount?.();
         document.removeEventListener('click', this.handleDocumentClick, true);
     }
 

--- a/packages/react-vapor/src/components/radio/RadioSelect.tsx
+++ b/packages/react-vapor/src/components/radio/RadioSelect.tsx
@@ -1,7 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
+
 import {ToggleForm} from '../childForm/ToggleForm';
 import {Radio} from './Radio';
 
@@ -43,11 +43,11 @@ export interface IRadioSelectAllProps
 
 export class RadioSelect extends React.PureComponent<IRadioSelectAllProps> {
     componentDidMount() {
-        callIfDefined(this.props.onMount, this.props.id, this.props.valueOnMount, this.props.disabledValuesOnMount);
+        this.props.onMount?.(this.props.id, this.props.valueOnMount, this.props.disabledValuesOnMount);
     }
 
     componentWillUnmount() {
-        callIfDefined(this.props.onUnmount, this.props.id);
+        this.props.onUnmount?.(this.props.id);
     }
 
     render() {
@@ -68,8 +68,8 @@ export class RadioSelect extends React.PureComponent<IRadioSelectAllProps> {
     }
 
     private handleToggle(value: string, e: React.MouseEvent<HTMLElement>) {
-        callIfDefined(this.props.onChange, value, this.props.id, e);
-        callIfDefined(this.props.onChangeCallback, value, this.props.id, e);
+        this.props.onChange?.(value, this.props.id, e);
+        this.props.onChangeCallback?.(value, this.props.id, e);
     }
 
     private isValueDisabled(childValue: string): boolean {

--- a/packages/react-vapor/src/components/select/SingleSelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SingleSelectConnected.tsx
@@ -5,7 +5,6 @@ import {keys} from 'ts-transformer-keys';
 import * as _ from 'underscore';
 
 import {IReactVaporState} from '../../ReactVapor';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {getReactNodeTextContent} from '../../utils/JSXUtils';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
 import {Content} from '../content/Content';
@@ -64,7 +63,7 @@ export class SingleSelectConnected extends React.PureComponent<
 
     componentDidUpdate(prevProps: ISingleSelectProps) {
         if (prevProps.selectedOption !== this.props.selectedOption) {
-            callIfDefined(this.props.onSelectOptionCallback, this.props.selectedOption);
+            this.props.onSelectOptionCallback?.(this.props.selectedOption);
         }
     }
 

--- a/packages/react-vapor/src/components/select/hoc/SelectWithFilter.tsx
+++ b/packages/react-vapor/src/components/select/hoc/SelectWithFilter.tsx
@@ -7,7 +7,6 @@ import * as _ from 'underscore';
 import {WithServerSideProcessingProps} from '../../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {IReactVaporState} from '../../../ReactVapor';
 import {addStringList, addValueStringList, removeStringList} from '../../../reusableState/customList/StringListActions';
-import {callIfDefined} from '../../../utils/FalsyValuesUtils';
 import {MatchFilter} from '../../../utils/FilterUtils';
 import {IDispatch, ReduxConnect} from '../../../utils/ReduxUtils';
 import {UUID} from '../../../utils/UUID';
@@ -98,7 +97,7 @@ export const selectWithFilter = (
 
         componentDidUpdate(prevProps: ISelectWithFilterProps) {
             if (prevProps.filterValue !== this.props.filterValue) {
-                callIfDefined(this.props.onUpdate);
+                this.props.onUpdate?.();
             }
         }
 

--- a/packages/react-vapor/src/components/select/hoc/SelectWithPredicate.tsx
+++ b/packages/react-vapor/src/components/select/hoc/SelectWithPredicate.tsx
@@ -5,7 +5,6 @@ import * as _ from 'underscore';
 
 import {WithServerSideProcessingProps} from '../../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {IReactVaporState} from '../../../ReactVapor';
-import {callIfDefined} from '../../../utils/FalsyValuesUtils';
 import {FlatSelectConnected} from '../../flatSelect/FlatSelectConnected';
 import {IFlatSelectOptionProps} from '../../flatSelect/FlatSelectOption';
 import {FlatSelectSelectors} from '../../flatSelect/FlatSelectSelectors';
@@ -33,7 +32,7 @@ export const selectWithPredicate = (
 ): React.ComponentType<ISelectWithPredicateProps> => {
     const WrappedComponent: React.FunctionComponent<ISelectWithPredicateProps> = (props) => {
         React.useEffect(() => {
-            callIfDefined(props.onUpdate);
+            props.onUpdate?.();
         }, [props.predicate, props.onUpdate]);
 
         return (

--- a/packages/react-vapor/src/components/subNavigation/SubNavigation.tsx
+++ b/packages/react-vapor/src/components/subNavigation/SubNavigation.tsx
@@ -3,8 +3,6 @@ import * as React from 'react';
 import {keys} from 'ts-transformer-keys';
 import {map, omit} from 'underscore';
 
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
-
 export interface ISubNavigationOwnProps extends React.ClassAttributes<SubNavigation> {
     id?: string;
     items: ISubNavigationItem[];
@@ -36,11 +34,11 @@ const ISubNavigationPropsToOmit = keys<ISubNavigationProps>();
 
 export class SubNavigation extends React.PureComponent<ISubNavigationProps & React.HTMLAttributes<HTMLElement>> {
     componentWillMount() {
-        callIfDefined(this.props.onRender);
+        this.props.onRender?.();
     }
 
     componentWillUnmount() {
-        callIfDefined(this.props.onDestroy);
+        this.props.onDestroy?.();
     }
 
     render() {
@@ -67,6 +65,6 @@ export class SubNavigation extends React.PureComponent<ISubNavigationProps & Rea
 
     private handleItemClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
         e.preventDefault();
-        callIfDefined(this.props.onClickItem, id);
+        this.props.onClickItem?.(id);
     };
 }

--- a/packages/react-vapor/src/components/tab/Tab.tsx
+++ b/packages/react-vapor/src/components/tab/Tab.tsx
@@ -1,8 +1,6 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
-import * as _ from 'underscore';
 
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {TooltipPlacement} from '../../utils/TooltipUtils';
 import {Tooltip} from '../tooltip/Tooltip';
 
@@ -44,16 +42,16 @@ export class Tab extends React.Component<ITabProps, any> {
     }
 
     componentDidMount() {
-        callIfDefined(this.props.onRender);
+        this.props.onRender?.();
     }
 
     componentWillUnmount() {
-        callIfDefined(this.props.onDestroy);
+        this.props.onDestroy?.();
     }
 
     private handleSelect = (e: React.MouseEvent) => {
         if (!this.props.disabled) {
-            callIfDefined(this.props.onSelect, e);
+            this.props.onSelect?.(e);
         }
     };
 }

--- a/packages/react-vapor/src/components/table-hoc/TableRowConnected.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableRowConnected.tsx
@@ -6,7 +6,6 @@ import * as _ from 'underscore';
 import {SlideY} from '../../animations/SlideY';
 import {IReactVaporState} from '../../ReactVapor';
 import {EventUtils} from '../../utils/EventUtils';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
 import {IActionOptions} from '../actions/Action';
 import {addActionsToActionBar} from '../actions/ActionBarActions';
@@ -84,7 +83,7 @@ const mapDispatchToProps = (dispatch: IDispatch, ownProps: ITableRowOwnProps): I
         handleClick: (isMulti: boolean, isOpened: boolean) => {
             refreshActionBarActions(isMulti);
             if (isCollapsible(ownProps)) {
-                callIfDefined(ownProps.collapsible.onToggleCollapsible, !isOpened);
+                ownProps.collapsible.onToggleCollapsible?.(!isOpened);
                 dispatch(TableHOCRowActions.toggleCollapsible(ownProps.id));
             }
         },
@@ -145,7 +144,7 @@ class TableRowConnected extends React.PureComponent<
 
         let collapsibleRowToggle: React.ReactNode = [];
         if (rowIsCollapsible) {
-            const customToggle = callIfDefined(this.props.collapsible.renderCustomToggleCell, this.props.opened);
+            const customToggle = this.props.collapsible.renderCustomToggleCell?.(this.props.opened);
             collapsibleRowToggle = React.isValidElement(customToggle) ? (
                 customToggle
             ) : (
@@ -185,7 +184,7 @@ class TableRowConnected extends React.PureComponent<
 
     private handleClick = (e: React.MouseEvent<HTMLTableRowElement>) => {
         if (!EventUtils.isClickingInsideElementWithClassname(e, 'dropdown')) {
-            callIfDefined(this.props.onClick, e);
+            this.props.onClick?.(e);
             const isMulti = (e.metaKey || e.ctrlKey) && this.props.isMultiselect;
             this.props.handleClick(isMulti, this.props.opened);
         }

--- a/packages/react-vapor/src/components/table-hoc/TableWithDatePicker.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithDatePicker.tsx
@@ -5,7 +5,6 @@ import * as _ from 'underscore';
 
 import {WithServerSideProcessingProps} from '../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {IReactVaporState} from '../../ReactVapor';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {ConfigSupplier, HocUtils} from '../../utils/HocUtils';
 import {ReduxConnect} from '../../utils/ReduxUtils';
 import {IDatePickerDropdownChildrenProps, IDatePickerDropdownOwnProps} from '../datePicker/DatePickerDropdown';
@@ -71,7 +70,7 @@ export const tableWithDatePicker = (supplier: ConfigSupplier<ITableWithDatePicke
 
         componentDidUpdate(prevProps: ITableWithDatePickerProps) {
             if (prevProps.lowerLimit !== this.props.lowerLimit || prevProps.upperLimit !== this.props.upperLimit) {
-                callIfDefined(this.props.onUpdate);
+                this.props.onUpdate?.();
             }
         }
 

--- a/packages/react-vapor/src/components/table-hoc/TableWithFilter.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithFilter.tsx
@@ -4,7 +4,6 @@ import * as _ from 'underscore';
 
 import {WithServerSideProcessingProps} from '../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {IReactVaporState} from '../../ReactVapor';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {ConfigSupplier, HocUtils} from '../../utils/HocUtils';
 import {ReduxConnect} from '../../utils/ReduxUtils';
 import {FilterBoxConnected} from '../filterBox/FilterBoxConnected';
@@ -62,7 +61,7 @@ export const tableWithFilter = (supplier: ConfigSupplier<ITableWithFilterConfig>
     class TableWithFilter extends React.Component<ITableWithFilterProps> {
         componentDidUpdate(prevProps: ITableWithFilterProps) {
             if (prevProps.filter !== this.props.filter) {
-                callIfDefined(this.props.onUpdate);
+                this.props.onUpdate?.();
             }
         }
 

--- a/packages/react-vapor/src/components/table-hoc/TableWithPagination.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithPagination.tsx
@@ -4,7 +4,6 @@ import * as _ from 'underscore';
 
 import {WithServerSideProcessingProps} from '../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {IReactVaporState, IReduxActionsPayload} from '../../ReactVapor';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {ConfigSupplier, HocUtils} from '../../utils/HocUtils';
 import {IReduxAction, ReduxConnect} from '../../utils/ReduxUtils';
 import {turnOffLoading} from '../loading/LoadingActions';
@@ -95,7 +94,7 @@ export const tableWithPagination = (supplier: ConfigSupplier<ITableWithPaginatio
 
         componentDidUpdate(prevProps: ITableWithPaginationProps) {
             if (prevProps.pageNb !== this.props.pageNb || prevProps.perPage !== this.props.perPage) {
-                callIfDefined(this.props.onUpdate);
+                this.props.onUpdate?.();
             }
         }
 

--- a/packages/react-vapor/src/components/table-hoc/TableWithPredicate.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithPredicate.tsx
@@ -5,7 +5,6 @@ import * as _ from 'underscore';
 
 import {WithServerSideProcessingProps} from '../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {IReactVaporState} from '../../ReactVapor';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {ConfigSupplier, HocUtils} from '../../utils/HocUtils';
 import {ReduxConnect} from '../../utils/ReduxUtils';
 import {IItemBoxProps} from '../itemBox/ItemBox';
@@ -65,7 +64,7 @@ export const tableWithPredicate = (supplier: ConfigSupplier<ITableWithPredicateC
     class TableWithPredicate extends React.Component<ITableWithPredicateProps> {
         componentDidUpdate(prevProps: ITableWithPredicateProps) {
             if (prevProps.predicate !== this.props.predicate) {
-                callIfDefined(this.props.onUpdate);
+                this.props.onUpdate?.();
             }
         }
 

--- a/packages/react-vapor/src/components/table-hoc/TableWithSort.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithSort.tsx
@@ -4,7 +4,6 @@ import * as _ from 'underscore';
 
 import {WithServerSideProcessingProps} from '../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {IReactVaporState} from '../../ReactVapor';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {ConfigSupplier, HocUtils} from '../../utils/HocUtils';
 import {ReduxConnect} from '../../utils/ReduxUtils';
 import {ITableWithSortState} from './reducers/TableWithSortReducers';
@@ -57,7 +56,7 @@ export const tableWithSort = (supplier: ConfigSupplier<ITableWithSortConfig> = {
     class TableWithSort extends React.Component<ITableWithSortProps> {
         componentDidUpdate(prevProps: ITableWithSortProps) {
             if (prevProps.sortKey !== this.props.sortKey || prevProps.isAsc !== this.props.isAsc) {
-                callIfDefined(this.props.onUpdate);
+                this.props.onUpdate?.();
             }
         }
 

--- a/packages/react-vapor/src/components/table-hoc/TableWithUrlState.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithUrlState.tsx
@@ -3,7 +3,6 @@ import {connect} from 'react-redux';
 import * as _ from 'underscore';
 
 import {IReactVaporState} from '../../ReactVapor';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {IDispatch, IThunkAction} from '../../utils/ReduxUtils';
 import {UrlUtils} from '../../utils/UrlUtils';
 import {applyDatePicker, changeDatePickerLowerLimit, changeDatePickerUpperLimit} from '../datePicker/DatePickerActions';
@@ -62,7 +61,7 @@ function tableWithUrlState<P extends ITableHOCOwnProps>(Component: React.Compone
 
         private onUpdate = () => {
             this.updateUrl(this.props.query);
-            callIfDefined(this.props.onUpdate);
+            this.props.onUpdate?.();
         };
 
         private updateUrl = _.debounce(this.props.onUpdateUrl || _.noop, 100);

--- a/packages/react-vapor/src/components/tables/TableHeadingRow.tsx
+++ b/packages/react-vapor/src/components/tables/TableHeadingRow.tsx
@@ -2,7 +2,6 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 
 import {EventUtils} from '../../utils/EventUtils';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {TableCollapsibleRowToggle} from './TableCollapsibleRowToggle';
 
 export interface ITableHeadingRowOwnProps extends React.ClassAttributes<TableHeadingRow> {
@@ -36,11 +35,11 @@ export interface ITableHeadingRowProps
 
 export class TableHeadingRow extends React.Component<ITableHeadingRowProps, any> {
     componentWillMount() {
-        callIfDefined(this.props.onRender);
+        this.props.onRender?.();
     }
 
     componentWillUnmount() {
-        callIfDefined(this.props.onDestroy);
+        this.props.onDestroy?.();
     }
 
     render() {
@@ -74,12 +73,12 @@ export class TableHeadingRow extends React.Component<ITableHeadingRowProps, any>
         if (!EventUtils.isClickingInsideElementWithClassname(e, 'dropdown')) {
             const hasMultipleSelectedRow = (e.metaKey || e.ctrlKey) && this.props.isMultiSelect;
 
-            callIfDefined(this.props.onClick, hasMultipleSelectedRow);
-            callIfDefined(this.props.onClickCallback);
+            this.props.onClick?.(hasMultipleSelectedRow);
+            this.props.onClickCallback?.();
         }
     }
 
     private handleDoubleClick() {
-        callIfDefined(this.props.onDoubleClick);
+        this.props.onDoubleClick?.();
     }
 }

--- a/packages/react-vapor/src/components/tables/table-children/TableChildBody.tsx
+++ b/packages/react-vapor/src/components/tables/table-children/TableChildBody.tsx
@@ -1,8 +1,9 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
+
 import {getAdditionalClasses, IAdditionalClass} from '../../../utils/ClassNameUtils';
-import {callIfDefined, convertUndefinedAndNullToEmptyString} from '../../../utils/FalsyValuesUtils';
+import {convertUndefinedAndNullToEmptyString} from '../../../utils/FalsyValuesUtils';
 import {JSXRenderable} from '../../../utils/JSXUtils';
 import {IActionOptions} from '../../actions/Action';
 import {IData, ITableHeadingAttribute} from '../Table';
@@ -124,5 +125,5 @@ const handleOnClick = (
     headingAttributes: ITableHeadingAttribute,
     childBodyProps: ITableChildBodyProps
 ) => {
-    callIfDefined(headingAttributes.onClickCell, event, childBodyProps);
+    headingAttributes.onClickCell?.(event, childBodyProps);
 };

--- a/packages/react-vapor/src/components/textarea/TextArea.tsx
+++ b/packages/react-vapor/src/components/textarea/TextArea.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import {connect} from 'react-redux';
 import TextareaAutosize, {TextareaAutosizeProps} from 'react-textarea-autosize';
 import * as _ from 'underscore';
+
 import {IReactVaporState} from '../../ReactVapor';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
 import {IDispatch, ReduxUtils} from '../../utils/ReduxUtils';
 import {addTextArea, changeTextAreaValue, removeTextArea} from './TextAreaActions';
 
@@ -90,8 +90,8 @@ export class TextArea extends React.Component<ITextAreaProps, {}> {
     }
 
     private handleOnChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
-        callIfDefined(this.props.onChange, e);
-        callIfDefined(this.props.onChangeCallback, e);
+        this.props.onChange?.(e);
+        this.props.onChangeCallback?.(e);
     }
 }
 

--- a/packages/react-vapor/src/components/toast/ToastContainer.tsx
+++ b/packages/react-vapor/src/components/toast/ToastContainer.tsx
@@ -1,7 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
-import {callIfDefined} from '../../utils/FalsyValuesUtils';
+
 import {IToastProps, Toast} from './Toast';
 import {IToastState} from './ToastReducers';
 
@@ -60,7 +60,7 @@ export class ToastContainer extends React.Component<IToastContainerProps, {}> {
                       {...toast}
                       onClose={() => {
                           this.onCloseToast(toast.id);
-                          callIfDefined(toast.onClose);
+                          toast.onClose?.();
                       }}
                   />
               ))

--- a/packages/react-vapor/src/utils/FalsyValuesUtils.ts
+++ b/packages/react-vapor/src/utils/FalsyValuesUtils.ts
@@ -3,6 +3,16 @@ import * as _ from 'underscore';
 export const convertUndefinedAndNullToEmptyString = (value: any) =>
     _.isUndefined(value) || _.isNull(value) ? '' : value;
 
+/**
+ * @deprecated Typescript 3.7 now has built-in optional function calls.
+ *
+ * ```
+ * callIfDefined(myfunction, arg1, arg2);
+ *
+ * // can be replaced with
+ * myFunction?.(arg1, arg2);
+ * ```
+ */
 export const callIfDefined = <T>(callback?: ((...params: any[]) => T) | null, ...args: any[]): T | undefined => {
     if (_.isFunction(callback)) {
         return callback(...args);


### PR DESCRIPTION
### Proposed Changes

With the new TypeScript optional calls feature, this util becomes pretty much useless. It was good while it lasted, but a new era has begun :dove: 

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
