### PR TITLE
Revert max-width on headings

### DIFF
--- a/packages/react-vapor/src/components/toast/examples/ToastExamples.tsx
+++ b/packages/react-vapor/src/components/toast/examples/ToastExamples.tsx
@@ -155,7 +155,4 @@ const ToastsWithReduxStoreDisconnected: React.FunctionComponent<ReturnType<typeo
         </>
     );
 };
-const ToastsWithReduxStore = connect(
-    null,
-    MapDispatchToProps
-)(ToastsWithReduxStoreDisconnected);
+const ToastsWithReduxStore = connect(null, MapDispatchToProps)(ToastsWithReduxStoreDisconnected);

--- a/packages/vapor/scss/typography/headings.scss
+++ b/packages/vapor/scss/typography/headings.scss
@@ -4,7 +4,6 @@ h3,
 h4,
 h5,
 h6 {
-    max-width: $text-max-width;
     color: $medium-blue;
     font-family: $base-font-family;
     line-height: $standard-line-height;


### PR DESCRIPTION
### Proposed Changes

A max-width has recently been added to headings (`h1`, `h2`, ..., and friends). This makes no sense and is causing issues in some places because it wasn't thought to be used this way.

### Potential Breaking Changes

None, I'm reverting to what we had previously

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
