### PR TITLE
Fix navigation pagination weird state

### DIFF
--- a/packages/react-vapor/src/components/navigation/pagination/NavigationPagination.tsx
+++ b/packages/react-vapor/src/components/navigation/pagination/NavigationPagination.tsx
@@ -41,7 +41,7 @@ export class NavigationPagination extends React.Component<INavigationPaginationP
 
     componentDidUpdate() {
         if (this.props.currentPage > this.props.totalPages - 1) {
-            this.props.onPageClick?.(this.props.totalPages - 1);
+            this.handlePageClick(this.props.totalPages - 1);
         }
     }
 

--- a/packages/react-vapor/src/components/table-hoc/TableWithPagination.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithPagination.tsx
@@ -66,7 +66,7 @@ export const tableWithPagination = (supplier: ConfigSupplier<ITableWithPaginatio
             pageNb,
             perPage,
             totalEntries: length,
-            totalPages: Math.ceil(length / perPage),
+            totalPages: Math.max(Math.ceil(length / perPage), 1),
             data: isServer ? ownProps.data : ownProps.data && sliceData(ownProps.data, startingIndex, endingIndex),
         };
     };

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithPagination.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithPagination.spec.tsx
@@ -85,6 +85,15 @@ describe('Table HOC', () => {
             expect(table.find(NavigationConnected).prop('perPageNumbers')).toEqual(expectedPerPageNumbers);
         });
 
+        it('should always have a totalPages count of 1 or more', () => {
+            const table = shallowWithStore(
+                <TableWithPagination id="💎" renderBody={_.identity} data={[]} />,
+                store
+            ).dive();
+
+            expect(table.find(NavigationConnected).prop('totalPages')).toBe(1);
+        });
+
         describe('with store data', () => {
             const getStoreWithPage = (pageNb: number, perPage: number, count: number = 0) => {
                 return getStoreMock({


### PR DESCRIPTION
### Proposed Changes

The `tableWithPagination` was calculating a `totalPages` count of 0 when there are no data, but this is wrong, because there is always at least one page (aka `totalPages === 1`) which will be empty when there are no data (but the page still exist).

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
