### PR TITLE
Remove unwanted max-width on `p` and `li`

### DIFF
--- a/packages/vapor/scss/components/markdown-documentation.scss
+++ b/packages/vapor/scss/components/markdown-documentation.scss
@@ -67,4 +67,9 @@
     em {
         font-style: italic;
     }
+
+    p,
+    li {
+        max-width: $text-max-width;
+    }
 }

--- a/packages/vapor/scss/typography/elements.scss
+++ b/packages/vapor/scss/typography/elements.scss
@@ -3,8 +3,3 @@
     font-size: $default-font-size;
     line-height: $big-line-height;
 }
-
-p,
-li {
-    max-width: $text-max-width;
-}


### PR DESCRIPTION
### Proposed Changes

Some max-width css rule has been added to `p` and `li` html tags. I guess that was intended to be scoped under the `.markdown-documentation` class and not for any `p` or `li`.

### Potential Breaking Changes

`¯\_(ツ)_/¯`

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
