### PR TITLE
build: stop uploading demo source files to s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ deploy:
       secret_access_key:
           secure: cr5PKJaLjVdIEqtwuUXgE4a0IuE9lxQRGoAkVQix9xl3hxQpXOEROUG9FUun4hERHVFGHfpwXAvjlZ2E2n4FyLk32ELwo0l27HaY0TvKd05JGx1u9JEX1YNZjyAxVLOJD7+5tlTA1I5wh5VjXIWr4STYul9sHq72gA1bIPD6xflIQDtNinod8Iic6ApZVtOG5fxOyXd7F//f1iDLTlZAfBbmeYWm0eWIywfH3XGk95i0ZuAjZheX7HM0FMgfxm0SDFCEM4IX2Inv6ML9eLLqSSSzo86QYEx0Y4aFEWBNKkiX7eMJZ30KH2S+4IvCeawJOvaN0utohaUiiPWEURo7JAfQZyoOlerIrbNv08xMveEjFg5CyRcfAtsGDsu6Z68bTQs7SRFivHxeQ1O84D0lbYQe77pK+c01h04USbfJwDz2hI0oIpqnfpOvcpcI1NH/Qvgrv6a8pe0nR4k7JH9BQ3fZtrRGeF8b4gyhVtDsb10m99VcKh7egMdoBaPFwpxY82hDso6lHfQzrec2YqcdMmtOAuEpKLqrFDiXhwm3QtFtbEPiPR8gQATv0FPWoXgDzjVTDv/ag6nxL7lQpVfHWRJURtuq9205CWkGqOHxDcUvG4zY/dGdil2FIwWpOpfp35N8bdfLaYKoyCugjgXycYF4rE5d/xXTvaiRKuBuwIQ= # https://docs.travis-ci.com/user/encryption-keys/
       bucket: coveo-public-content
-      local-dir: packages/react-vapor/docs
+      local-dir: packages/react-vapor/docs/dist
       upload-dir: react-vapor
       acl: public_read
 

--- a/create-live-demo.sh
+++ b/create-live-demo.sh
@@ -15,7 +15,7 @@ git commit --quiet -m "Clean old build" --no-verify
 git stash pop
 
 echo "Creating live demo for branch: $TRAVIS_PULL_REQUEST_BRANCH";
-cp -R packages/react-vapor/docs "$BRANCH_FOLDER_NAME"
+cp -R packages/react-vapor/docs/dist "$BRANCH_FOLDER_NAME"
 
 git add "$BRANCH_FOLDER_NAME"
 git commit --quiet -m "live demo at https://coveo.github.io/react-vapor/$BRANCH_FOLDER_NAME/" --no-verify

--- a/packages/react-vapor/docs/index.html
+++ b/packages/react-vapor/docs/index.html
@@ -1,17 +1,8 @@
 <!DOCTYPE html>
 <html lang="en" class="coveo-styleguide">
-    <head>
-        <title>Vapor</title>
-
-        <meta charset="UTF-8" />
-
-        <link rel="shortcut icon" type="image/png" href="favicon.ico" />
-    </head>
-
     <body>
         <div id="App" class="full-content"></div>
         <div id="Modals"></div>
         <div id="Drops"></div>
-        <script src="assets/main.bundle.js"></script>
     </body>
 </html>

--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -126,6 +126,7 @@
         "fancy-log": "1.3.3",
         "file-loader": "3.0.1",
         "gulp": "4.0.0",
+        "html-webpack-plugin": "3.2.0",
         "imports-loader": "0.8.0",
         "istanbul-instrumenter-loader": "3.0.1",
         "jasmine-core": "3.3.0",

--- a/packages/react-vapor/webpack.config.js
+++ b/packages/react-vapor/webpack.config.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 const isTravis = !!process.env.TRAVIS;
 
@@ -11,16 +12,21 @@ module.exports = {
     },
     mode: isTravis ? 'production' : 'development',
     output: {
-        path: path.join(__dirname, '/docs/assets'),
-        publicPath: 'assets/',
+        path: path.join(__dirname, '/docs/dist'),
         filename: '[name].bundle.js',
-        chunkFilename: '[name].bundle.js',
+        chunkFilename: 'assets/[name].bundle.js',
     },
     devtool: isTravis ? 'source-map' : 'cheap-module-source-map',
     resolve: {
         extensions: ['.ts', '.tsx', '.js', '.jsx'],
     },
     plugins: [
+        new HtmlWebpackPlugin({
+            title: 'Vapor Design System',
+            favicon: 'docs/favicon.ico',
+            chunks: ['main'],
+            template: 'docs/index.html',
+        }),
         new webpack.DefinePlugin({
             WEBPACK_DEFINED_VERSION: JSON.stringify(require('./package.json').version),
         }),
@@ -105,7 +111,7 @@ module.exports = {
                 ],
             },
             {
-                test: /\.(ttf|eot|woff|svg|png)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+                test: /\.(ttf|eot|woff|svg|png|ico)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
                 loader: 'file-loader',
             },
 


### PR DESCRIPTION
### Proposed Changes

It seems we were publishing and hosting our demo page along with all its source files:

![image](https://user-images.githubusercontent.com/35579930/69362138-ef071f00-0c5b-11ea-91a1-5b3fb98bbc08.png)

This is unecessary because the browser doesn't need the .ts files to run properly, only the .js chunks.

From now on we will be publishing a `dist` folder that will look like this:
![image](https://user-images.githubusercontent.com/35579930/69362290-3db4b900-0c5c-11ea-8365-097683e6011e.png)

### Potential Breaking Changes

None expected

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
