### PR TITLE
Invalidate AWS CloudFront cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,9 @@ deploy:
           tags: true
           repo: coveo/react-vapor
 
+after_deploy:
+    - node invalidate-cloudfront.js
+
 notifications:
     email:
         on_success: never

--- a/invalidate-cloudfront.js
+++ b/invalidate-cloudfront.js
@@ -1,0 +1,49 @@
+const exec = require('child_process').exec;
+const colors = require('colors');
+const AWS = require('aws-sdk');
+
+const cloudfront = new AWS.CloudFront();
+const pathToInvalidate = `/react-vapor/*`;
+
+const shouldDoInvalidation = () => {
+    if (!process.env.TRAVIS) {
+        return false;
+    }
+    if (!process.env.TRAVIS_TAG) {
+        return false;
+    }
+    return true;
+};
+
+if (shouldDoInvalidation()) {
+    const invalidationRequest = cloudfront.createInvalidation({
+        DistributionId: process.env.AWS_CLOUDFRONT_DISTRIBUTION_ID,
+        InvalidationBatch: {
+            CallerReference: new Date().getTime().toString(),
+            Paths: {
+                Quantity: 1,
+                Items: [pathToInvalidate],
+            },
+        },
+    });
+
+    invalidationRequest.send((error, success) => {
+        if (error) {
+            console.log(colors.red('ERROR WHILE INVALIDATING RESSOURCES ON CLOUDFRONT'));
+            console.log(colors.red('*************'));
+            console.log(colors.red(error.message));
+            console.log(colors.red('*************'));
+            exec('travis_terminate 1');
+            throw error;
+        }
+        if (success) {
+            console.log(colors.green('INVALIDATED CLOUDFRONT CACHE SUCCESSFULLY'));
+            console.log(colors.green('*************'));
+            console.log(colors.green(`PATH INVALIDATED: ${pathToInvalidate}`));
+            console.log(colors.green(`INVALIDATION ID : ${success.Invalidation.Id}`));
+            console.log(colors.green('*************'));
+        }
+    });
+} else {
+    console.log(colors.white('INVALIDATION FROM CLOUDFRONT SKIPPED BECAUSE THIS IS NOT AN OFFICIAL RELEASE'));
+}

--- a/invalidate-cloudfront.js
+++ b/invalidate-cloudfront.js
@@ -5,45 +5,37 @@ const AWS = require('aws-sdk');
 const cloudfront = new AWS.CloudFront();
 const pathToInvalidate = `/react-vapor/*`;
 
-const shouldDoInvalidation = () => {
-    if (!process.env.TRAVIS) {
-        return false;
-    }
-    if (!process.env.TRAVIS_TAG) {
-        return false;
-    }
-    return true;
-};
+const shouldDoInvalidation = () => !!(process.env.TRAVIS && process.env.TRAVIS_TAG);
 
 if (shouldDoInvalidation()) {
-    const invalidationRequest = cloudfront.createInvalidation({
-        DistributionId: process.env.AWS_CLOUDFRONT_DISTRIBUTION_ID,
-        InvalidationBatch: {
-            CallerReference: new Date().getTime().toString(),
-            Paths: {
-                Quantity: 1,
-                Items: [pathToInvalidate],
+    cloudfront
+        .createInvalidation({
+            DistributionId: process.env.AWS_CLOUDFRONT_DISTRIBUTION_ID,
+            InvalidationBatch: {
+                CallerReference: new Date().getTime().toString(),
+                Paths: {
+                    Quantity: 1,
+                    Items: [pathToInvalidate],
+                },
             },
-        },
-    });
-
-    invalidationRequest.send((error, success) => {
-        if (error) {
-            console.log(colors.red('ERROR WHILE INVALIDATING RESSOURCES ON CLOUDFRONT'));
-            console.log(colors.red('*************'));
-            console.log(colors.red(error.message));
-            console.log(colors.red('*************'));
-            exec('travis_terminate 1');
-            throw error;
-        }
-        if (success) {
-            console.log(colors.green('INVALIDATED CLOUDFRONT CACHE SUCCESSFULLY'));
-            console.log(colors.green('*************'));
-            console.log(colors.green(`PATH INVALIDATED: ${pathToInvalidate}`));
-            console.log(colors.green(`INVALIDATION ID : ${success.Invalidation.Id}`));
-            console.log(colors.green('*************'));
-        }
-    });
+        })
+        .send((error, success) => {
+            if (error) {
+                console.log(colors.red('ERROR WHILE INVALIDATING RESSOURCES ON CLOUDFRONT'));
+                console.log(colors.red('*************'));
+                console.log(colors.red(error.message));
+                console.log(colors.red('*************'));
+                exec('travis_terminate 1');
+                throw error;
+            }
+            if (success) {
+                console.log(colors.green('INVALIDATED CLOUDFRONT CACHE SUCCESSFULLY'));
+                console.log(colors.green('*************'));
+                console.log(colors.green(`PATH INVALIDATED: ${pathToInvalidate}`));
+                console.log(colors.green(`INVALIDATION ID : ${success.Invalidation.Id}`));
+                console.log(colors.green('*************'));
+            }
+        });
 } else {
     console.log(colors.white('INVALIDATION FROM CLOUDFRONT SKIPPED BECAUSE THIS IS NOT AN OFFICIAL RELEASE'));
 }

--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -101,6 +101,7 @@
         "ansi-colors": "3.2.4",
         "autoprefixer": "9.4.0",
         "awesome-typescript-loader": "5.2.1",
+        "aws-sdk": "2.576.0",
         "chosen-js": "1.8.2",
         "classnames": "2.2.6",
         "codecov": "3.2.0",


### PR DESCRIPTION
### Proposed Changes

When pushing new files to AWS S3 (happens each time master builds successfully), the old files were remaining in the AWS CloudFront cache. This behavior resulted in unsuccessful demo page load until the cache was successfully invalidated every 24h. 

What was done here is to trigger a cloudfront cache invalidation right after new files are deployed.

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
