### PR TITLE
Add class to remove the 40px for the first row on table align header with a blankslate in error

### DIFF
--- a/packages/react-vapor/src/components/blankSlate/BlankSlateWithTable.tsx
+++ b/packages/react-vapor/src/components/blankSlate/BlankSlateWithTable.tsx
@@ -17,7 +17,7 @@ export const blankSlateWithTable = <P extends IBlankSlateProps>(
         render() {
             const {numberOfColumn, ...componentProps} = this.props;
             return (
-                <tr className="no-hover">
+                <tr className="blankslate-row no-hover">
                     <td colSpan={numberOfColumn}>
                         <Component {...(componentProps as P)}>{this.props.children}</Component>
                     </td>

--- a/packages/vapor/scss/tables/table-align-header.scss
+++ b/packages/vapor/scss/tables/table-align-header.scss
@@ -7,6 +7,10 @@ table.mod-align-header {
         padding-left: $header-padding;
     }
 
+    tbody tr.blankslate-row td:first-child {
+        padding-left: $table-blankslate-row-width;
+    }
+
     &.mod-collapsible-rows tbody tr.collapsible-row td:first-child {
         padding-left: $header-padding;
 

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -299,6 +299,7 @@ $table-small-svg-width: 20px;
 $table-action-margin-left: 10px;
 $table-shadow: 0 2px 8px 1px $medium-grey;
 $table-state-icon-size: 25px;
+$table-blankslate-row-width: 20px;
 
 // Table actions
 $table-actions-container-height: 52px;


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
