### PR TITLE
Revert travis deploy credentials changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
 env:
     global:
         - AWS_ACCESS_KEY_ID=AKIAJ72WQIJQMW6TCHDA
-        - secure: cr5PKJaLjVdIEqtwuUXgE4a0IuE9lxQRGoAkVQix9xl3hxQpXOEROUG9FUun4hERHVFGHfpwXAvjlZ2E2n4FyLk32ELwo0l27HaY0TvKd05JGx1u9JEX1YNZjyAxVLOJD7+5tlTA1I5wh5VjXIWr4STYul9sHq72gA1bIPD6xflIQDtNinod8Iic6ApZVtOG5fxOyXd7F//f1iDLTlZAfBbmeYWm0eWIywfH3XGk95i0ZuAjZheX7HM0FMgfxm0SDFCEM4IX2Inv6ML9eLLqSSSzo86QYEx0Y4aFEWBNKkiX7eMJZ30KH2S+4IvCeawJOvaN0utohaUiiPWEURo7JAfQZyoOlerIrbNv08xMveEjFg5CyRcfAtsGDsu6Z68bTQs7SRFivHxeQ1O84D0lbYQe77pK+c01h04USbfJwDz2hI0oIpqnfpOvcpcI1NH/Qvgrv6a8pe0nR4k7JH9BQ3fZtrRGeF8b4gyhVtDsb10m99VcKh7egMdoBaPFwpxY82hDso6lHfQzrec2YqcdMmtOAuEpKLqrFDiXhwm3QtFtbEPiPR8gQATv0FPWoXgDzjVTDv/ag6nxL7lQpVfHWRJURtuq9205CWkGqOHxDcUvG4zY/dGdil2FIwWpOpfp35N8bdfLaYKoyCugjgXycYF4rE5d/xXTvaiRKuBuwIQ=
 
 before_install:
     - eval "$(ssh-agent -s)" #start the ssh agent
@@ -46,7 +45,8 @@ deploy:
     - provider: s3
       skip_cleanup: true
       access_key_id: $AWS_ACCESS_KEY_ID
-      secret_access_key: $AWS_SECRET_ACCESS_KEY
+      secret_access_key:
+          secure: cr5PKJaLjVdIEqtwuUXgE4a0IuE9lxQRGoAkVQix9xl3hxQpXOEROUG9FUun4hERHVFGHfpwXAvjlZ2E2n4FyLk32ELwo0l27HaY0TvKd05JGx1u9JEX1YNZjyAxVLOJD7+5tlTA1I5wh5VjXIWr4STYul9sHq72gA1bIPD6xflIQDtNinod8Iic6ApZVtOG5fxOyXd7F//f1iDLTlZAfBbmeYWm0eWIywfH3XGk95i0ZuAjZheX7HM0FMgfxm0SDFCEM4IX2Inv6ML9eLLqSSSzo86QYEx0Y4aFEWBNKkiX7eMJZ30KH2S+4IvCeawJOvaN0utohaUiiPWEURo7JAfQZyoOlerIrbNv08xMveEjFg5CyRcfAtsGDsu6Z68bTQs7SRFivHxeQ1O84D0lbYQe77pK+c01h04USbfJwDz2hI0oIpqnfpOvcpcI1NH/Qvgrv6a8pe0nR4k7JH9BQ3fZtrRGeF8b4gyhVtDsb10m99VcKh7egMdoBaPFwpxY82hDso6lHfQzrec2YqcdMmtOAuEpKLqrFDiXhwm3QtFtbEPiPR8gQATv0FPWoXgDzjVTDv/ag6nxL7lQpVfHWRJURtuq9205CWkGqOHxDcUvG4zY/dGdil2FIwWpOpfp35N8bdfLaYKoyCugjgXycYF4rE5d/xXTvaiRKuBuwIQ=
       bucket: coveo-public-content
       local-dir: packages/react-vapor/docs/dist
       upload-dir: react-vapor
@@ -55,7 +55,8 @@ deploy:
     - provider: s3
       skip_cleanup: true
       access_key_id: $AWS_ACCESS_KEY_ID
-      secret_access_key: $AWS_SECRET_ACCESS_KEY
+      secret_access_key:
+          secure: cr5PKJaLjVdIEqtwuUXgE4a0IuE9lxQRGoAkVQix9xl3hxQpXOEROUG9FUun4hERHVFGHfpwXAvjlZ2E2n4FyLk32ELwo0l27HaY0TvKd05JGx1u9JEX1YNZjyAxVLOJD7+5tlTA1I5wh5VjXIWr4STYul9sHq72gA1bIPD6xflIQDtNinod8Iic6ApZVtOG5fxOyXd7F//f1iDLTlZAfBbmeYWm0eWIywfH3XGk95i0ZuAjZheX7HM0FMgfxm0SDFCEM4IX2Inv6ML9eLLqSSSzo86QYEx0Y4aFEWBNKkiX7eMJZ30KH2S+4IvCeawJOvaN0utohaUiiPWEURo7JAfQZyoOlerIrbNv08xMveEjFg5CyRcfAtsGDsu6Z68bTQs7SRFivHxeQ1O84D0lbYQe77pK+c01h04USbfJwDz2hI0oIpqnfpOvcpcI1NH/Qvgrv6a8pe0nR4k7JH9BQ3fZtrRGeF8b4gyhVtDsb10m99VcKh7egMdoBaPFwpxY82hDso6lHfQzrec2YqcdMmtOAuEpKLqrFDiXhwm3QtFtbEPiPR8gQATv0FPWoXgDzjVTDv/ag6nxL7lQpVfHWRJURtuq9205CWkGqOHxDcUvG4zY/dGdil2FIwWpOpfp35N8bdfLaYKoyCugjgXycYF4rE5d/xXTvaiRKuBuwIQ=
       bucket: coveo-public-content
       local-dir: packages/vapor/deploy
       upload-dir: styleguide


### PR DESCRIPTION
### Proposed Changes

Currently travis cannot deploy the demo, because I messed up the AWS credentials in my previous PR. Reverting to a working state. The cloudfront invalidation script is expected not to work.

