### PR TITLE
Fix margin-top rule issued from bad merge

### DIFF
--- a/packages/vapor/scss/forms/block-form.scss
+++ b/packages/vapor/scss/forms/block-form.scss
@@ -81,6 +81,11 @@ form {
                     margin-top: $scaledSpacing;
                 }
             }
+            > .btn {
+                + .input-field {
+                    margin-top: $scaledSpacing + $inputFieldLabelSpacing;
+                }
+            }
             > .input-field {
                 margin-top: $scaledSpacing + $inputFieldLabelSpacing;
             }
@@ -102,9 +107,6 @@ form {
 
             > .btn {
                 margin-top: 0;
-                + .input-field {
-                    margin-top: (($spacing * $level) /2) + 0.75rem;
-                }
             }
 
             &.level-1 {


### PR DESCRIPTION
### Proposed Changes

This [PR here](https://github.com/coveo/react-vapor/commit/4cd24c62caebed6daadbc21aeacbd6d62b826621) introduced a rule which broke when I merged the [Scaled Section description PR](https://github.com/coveo/react-vapor/pull/1339)

This will fix the build

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
