### PR TITLE
Change the Style and Behavior of the Table Collapsible Button

### DIFF
--- a/packages/react-vapor/src/components/collapsible/CollapsibleToggle.tsx
+++ b/packages/react-vapor/src/components/collapsible/CollapsibleToggle.tsx
@@ -9,10 +9,16 @@ export interface CollapsibleToggleProps {
     svgClassName?: string;
 }
 
-export const CollapsibleToggle: React.SFC<CollapsibleToggleProps> = ({expanded, className, svgClassName}) => (
+export const CollapsibleToggle: React.SFC<CollapsibleToggleProps & React.HTMLAttributes<HTMLSpanElement>> = ({
+    expanded,
+    className,
+    svgClassName,
+    ...rest
+}) => (
     <Svg
         svgName={expanded ? 'arrow-top-rounded' : 'arrow-bottom-rounded'}
         svgClass={classNames('icon', svgClassName)}
         className={className}
+        {...rest}
     />
 );

--- a/packages/react-vapor/src/components/table-hoc/examples/TableHOCServerExamples.tsx
+++ b/packages/react-vapor/src/components/table-hoc/examples/TableHOCServerExamples.tsx
@@ -85,6 +85,7 @@ const generateRows = (allData: IExampleRowData[]) =>
             actions={tableActions(data.username)}
             isMultiselect
             disabled={i % 3 === 0}
+            collapsible={{content: <div className="py2">👋</div>}}
         >
             <TableRowNumberColumn number={i + 1} />
             <td key="city">{data.city}</td>
@@ -108,6 +109,7 @@ const renderHeader = () => (
                 Username
             </TableHeaderWithSort>
             <th key="date-of-birth">Date of Birth</th>
+            <th>{/* Empty th for the collapsible */}</th>
         </tr>
     </thead>
 );
@@ -167,7 +169,7 @@ const TableExampleDisconnected: React.FunctionComponent<TableHOCServerProps> = (
             </span>
             <ServerTableComposed
                 id={TableHOCServerExampleId}
-                className="table table-numbered"
+                className="table table-numbered mod-collapsible-rows"
                 data={props.serverData}
                 renderBody={generateRows}
                 tableHeader={renderHeader()}

--- a/packages/react-vapor/src/components/table-hoc/reducers/TableRowReducers.ts
+++ b/packages/react-vapor/src/components/table-hoc/reducers/TableRowReducers.ts
@@ -66,7 +66,7 @@ const toggleCollasibleTableRowReducer = (
                     opened: _.isBoolean(action.payload.opened) ? action.payload.opened : !current.opened,
                 };
             }
-            return row.tableId === current.tableId ? {...row, opened: false} : row;
+            return row;
         });
     }
     return state;

--- a/packages/react-vapor/src/components/table-hoc/tests/TableRowConnected.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableRowConnected.spec.tsx
@@ -284,10 +284,12 @@ describe('Table HOC', () => {
                 ).toBe(true);
             });
 
-            it('should dispatch a toggleCollapsible action when clicking on a collapsible heading-row', () => {
+            it('should dispatch a toggleCollapsible action when clicking on the collapsible button', () => {
                 const expectedAction = TableHOCRowActions.toggleCollapsible(defaultProps.id);
 
-                wrapper.find('tr.heading-row').simulate('click', {});
+                wrapper
+                    .find(CollapsibleToggle)
+                    .simulate('click', jasmine.createSpyObj('event', ['preventDefault', 'stopPropagation']));
 
                 expect(store.getActions()).toContain(expectedAction);
             });
@@ -408,7 +410,10 @@ describe('Table HOC', () => {
                 store
             ).dive();
 
-            row.find('tr.heading-row').simulate('click', {});
+            row.find(CollapsibleToggle).simulate(
+                'click',
+                jasmine.createSpyObj('event', ['preventDefault', 'stopPropagation'])
+            );
             expect(spy).toHaveBeenCalledWith(true);
         });
 
@@ -437,7 +442,10 @@ describe('Table HOC', () => {
                 store
             ).dive();
 
-            row.find('tr.heading-row').simulate('click', {});
+            row.find(CollapsibleToggle).simulate(
+                'click',
+                jasmine.createSpyObj('event', ['preventDefault', 'stopPropagation'])
+            );
             expect(spy).toHaveBeenCalledWith(false);
         });
     });

--- a/packages/react-vapor/src/components/table-hoc/tests/TableRowReducers.spec.ts
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableRowReducers.spec.ts
@@ -154,7 +154,7 @@ describe('Table HOC', () => {
 
             expect(tableHeadersState.length).toBe(oldState.length);
             expect(_.findWhere(tableHeadersState, {id: oldState[0].id}).opened).toBe(true);
-            expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).opened).toBe(false);
+            expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).opened).toBe(undefined);
         });
 
         it('should toggle opened the row when the action is "TableHOCRowActions.toggleCollapsible" and no opened payload is specified', () => {
@@ -176,10 +176,10 @@ describe('Table HOC', () => {
 
             expect(tableHeadersState.length).toBe(oldState.length);
             expect(_.findWhere(tableHeadersState, {id: oldState[0].id}).opened).toBe(true);
-            expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).opened).toBe(false);
+            expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).opened).toBe(undefined);
         });
 
-        it('should collapse other rows of the same table row when the action is "TableHOCRowActions.toggleCollapsible"', () => {
+        it('should not collapse other rows of the same table row when the action is "TableHOCRowActions.toggleCollapsible"', () => {
             const oldState: ITableRowState[] = [
                 {
                     id: 'some-table-header-1',
@@ -199,7 +199,7 @@ describe('Table HOC', () => {
             const tableHeadersState: ITableRowState[] = TableRowReducers(oldState, action);
 
             expect(tableHeadersState.length).toBe(oldState.length);
-            expect(_.findWhere(tableHeadersState, {id: oldState[0].id}).opened).toBe(false);
+            expect(_.findWhere(tableHeadersState, {id: oldState[0].id}).opened).toBe(true);
             expect(_.findWhere(tableHeadersState, {id: oldState[1].id}).opened).toBe(true);
         });
 

--- a/packages/vapor/scss/tables/table-collapsible-rows.scss
+++ b/packages/vapor/scss/tables/table-collapsible-rows.scss
@@ -21,12 +21,6 @@ table {
                 }
             }
 
-            &.heading-row {
-                &.opened:not(:hover) td {
-                    background-color: $white;
-                }
-            }
-
             &.collapsible-row {
                 height: 0;
 


### PR DESCRIPTION
### Proposed Changes

Multiple rows can be opened at the same time (easier to compare)
Clicking on the row selects it but doesn't open it
Clicking on the collapse button doesn't select the row but toggle its collapsed state
Opened rows doesn't have a different background anymore

### Potential Breaking Changes

Different behavior but usage stays the same

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
