### PR TITLE
Fix declaration file

### DIFF
--- a/packages/react-vapor/tsconfig.build.json
+++ b/packages/react-vapor/tsconfig.build.json
@@ -13,6 +13,10 @@
         "src/utils/tests/TestUtils.tsx",
         "src/components/tables/tests/TableTestCommon.tsx",
         "karma.entry.ts",
-        "Index.ts"
+        "Index.ts",
+        "node_modules",
+        "dist",
+        "coverage",
+        "*.js"
     ]
 }


### PR DESCRIPTION
It seems like `tsconfig` extends no longer extend the `exlcude` field properly.