### PR TITLE
added no-hover class if no actions associated with that row

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableRowConnected.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableRowConnected.tsx
@@ -159,6 +159,7 @@ class TableRowConnected extends React.PureComponent<
                         opened: this.props.opened,
                         'heading-row': rowIsCollapsible,
                         'row-disabled': this.props.disabled,
+                        'no-hover': _.isEmpty(this.props.actions),
                     })}
                     onClick={this.handleClick}
                     onDoubleClick={this.handleDoubleClick}

--- a/packages/react-vapor/src/components/table-hoc/tests/TableRowConnected.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableRowConnected.spec.tsx
@@ -63,6 +63,17 @@ describe('Table HOC', () => {
             expect(wrapper.find('tr').hasClass('row-disabled')).toBe(true);
         });
 
+        it('should have the class "no-hover" if the row has actions prop empty', () => {
+            const wrapper = shallowWithStore(<TableRowConnected id="a" tableId="b" />, store).dive();
+            expect(wrapper.find('tr').hasClass('no-hover')).toBe(true);
+        });
+
+        it('should not have the class "no-hover" if the row has actions prop', () => {
+            const actions = [{name: 'name', enabled: true}];
+            const wrapper = shallowWithStore(<TableRowConnected id="a" tableId="b" actions={actions} />, store).dive();
+            expect(wrapper.find('tr').hasClass('no-hover')).not.toBe(true);
+        });
+
         it('should not have the class selected if the row is not selected in the state', () => {
             store = getStoreMock({
                 tableHOCRow: [


### PR DESCRIPTION
### Proposed Changes

Added a class `no-hover` if the row has no actions associated

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
