### PR TITLE
Add hasBorderTop prop to the TableHOC

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
@@ -19,6 +19,7 @@ export interface ITableHOCOwnProps {
     tableHeader?: React.ReactNode;
     onUpdate?: () => void;
     containerClassName?: string;
+    hasBorderTop?: boolean;
 }
 
 export interface ITableHOCProps extends ITableHOCOwnProps {}
@@ -53,11 +54,14 @@ export class TableHOC extends React.PureComponent<ITableHOCProps & React.HTMLAtt
                 <ActionBarConnected
                     id={this.props.id}
                     removeDefaultContainerClasses
-                    extraContainerClasses={[
+                    extraContainerClasses={classNames(
                         'coveo-table-actions-container',
                         'mod-cancel-header-padding',
                         'mod-align-header',
-                    ]}
+                        {
+                            'mod-border-top': this.props.hasBorderTop,
+                        }
+                    ).split(' ')}
                 >
                     {this.props.actions}
                 </ActionBarConnected>

--- a/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
@@ -19,7 +19,7 @@ export interface ITableHOCOwnProps {
     tableHeader?: React.ReactNode;
     onUpdate?: () => void;
     containerClassName?: string;
-    hasBorderTop?: boolean;
+    showBorderTop?: boolean;
 }
 
 export interface ITableHOCProps extends ITableHOCOwnProps {}
@@ -29,6 +29,7 @@ export class TableHOC extends React.PureComponent<ITableHOCProps & React.HTMLAtt
         isLoading: false,
         hasActionButtons: false,
         actions: [],
+        showBorderTop: false,
     };
 
     render() {
@@ -59,7 +60,7 @@ export class TableHOC extends React.PureComponent<ITableHOCProps & React.HTMLAtt
                         'mod-cancel-header-padding',
                         'mod-align-header',
                         {
-                            'mod-border-top': this.props.hasBorderTop,
+                            'mod-border-top': this.props.showBorderTop,
                         }
                     ).split(' ')}
                 >

--- a/packages/react-vapor/src/components/table-hoc/examples/TableHOCExamples.tsx
+++ b/packages/react-vapor/src/components/table-hoc/examples/TableHOCExamples.tsx
@@ -158,6 +158,7 @@ const TableWithActionsAndDataFilteringDisconnected: TableWithActionsType = ({dat
             data={data}
             renderBody={(Alldata: IExampleRowData[]) => generateTableRow(Alldata, tableId)}
             tableHeader={renderHeader(tableId)}
+            hasBorderTop
         />
     );
 };
@@ -172,6 +173,6 @@ const TableWithActionsAndDataFilteringComposed = _.compose(
     tableWithDatePicker(...(tableDatePickerConfig as any)),
     tableWithPagination({perPageNumbers: [3, 5, 10]}),
     tableWithActions()
-)(TableHOC);
+)(TableHOC) as typeof TableHOC;
 
 const TableWithActionsAndDataFiltering = connect(mapStateToProps)(TableWithActionsAndDataFilteringDisconnected);

--- a/packages/react-vapor/src/components/table-hoc/examples/TableHOCExamples.tsx
+++ b/packages/react-vapor/src/components/table-hoc/examples/TableHOCExamples.tsx
@@ -158,7 +158,7 @@ const TableWithActionsAndDataFilteringDisconnected: TableWithActionsType = ({dat
             data={data}
             renderBody={(Alldata: IExampleRowData[]) => generateTableRow(Alldata, tableId)}
             tableHeader={renderHeader(tableId)}
-            hasBorderTop
+            showBorderTop
         />
     );
 };

--- a/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
@@ -76,7 +76,7 @@ describe('TableHOC', () => {
         });
 
         it('should render an ActionBarConnected with a top border if the "hasBorderTop" is set to true', () => {
-            const wrapper = shallow(<TableHOC {...defaultProps} hasActionButtons hasBorderTop />);
+            const wrapper = shallow(<TableHOC {...defaultProps} hasActionButtons showBorderTop />);
             expect(wrapper.find(ActionBarConnected).prop('extraContainerClasses')).toContain('mod-border-top');
         });
 

--- a/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
@@ -75,6 +75,11 @@ describe('TableHOC', () => {
             expect(wrapper.find(ActionBarConnected).exists()).toBe(true);
         });
 
+        it('should render an ActionBarConnected with a top border if the "hasBorderTop" is set to true', () => {
+            const wrapper = shallow(<TableHOC {...defaultProps} hasActionButtons hasBorderTop />);
+            expect(wrapper.find(ActionBarConnected).prop('extraContainerClasses')).toContain('mod-border-top');
+        });
+
         it('should render an ActionBarConnected if the table prop hasActionButtons is false but the table have some actions', () => {
             const wrapper = shallow(
                 <TableHOC {...defaultProps} actions={[<FilterBoxConnected />]} hasActionButtons={false} />


### PR DESCRIPTION
### Proposed Changes

Added a prop `hasBorderTop` to the TableHOC, because there was no clean way to add a border top on the actions bar.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
