### PR TITLE
fixed the dateTooltip test where compared date were not the same

### DIFF
--- a/packages/react-vapor/src/components/tooltip/tests/DateTooltip.spec.tsx
+++ b/packages/react-vapor/src/components/tooltip/tests/DateTooltip.spec.tsx
@@ -7,7 +7,8 @@ import {Tooltip} from '../Tooltip';
 
 describe('Tooltip', () => {
     let tooltipWrapper: ShallowWrapper<DateTooltipsProps>;
-    let defaultFormat: string;
+    const defaultDate = '1995-12-25';
+    const defaultFormat = moment(defaultDate).format('LLL');
     const stringFormat = 'ddd, hA';
 
     describe('<DateTooltip />', () => {
@@ -17,20 +18,17 @@ describe('Tooltip', () => {
         });
 
         it('should display content in LLL if no format is given on moment date', () => {
-            defaultFormat = moment().format('LLL');
-            tooltipWrapper = shallow(<DateTooltip date={moment()} />);
+            tooltipWrapper = shallow(<DateTooltip date={moment(defaultDate)} />);
             expect(tooltipWrapper.find(Tooltip).props().title).toEqual(defaultFormat);
         });
 
         it('should display the tooltip in the given tooltipformat', () => {
-            defaultFormat = moment().format('LLL');
-            tooltipWrapper = shallow(<DateTooltip date={moment()} tooltipFormat={stringFormat} />);
+            tooltipWrapper = shallow(<DateTooltip date={moment(defaultDate)} tooltipFormat={stringFormat} />);
             expect(tooltipWrapper.find(Tooltip).props().title).toEqual(moment(defaultFormat).format(stringFormat));
         });
 
         it('should display the children of the tooltip in the given format', () => {
-            defaultFormat = moment().format('LLL');
-            tooltipWrapper = shallow(<DateTooltip date={moment()} format={stringFormat} />);
+            tooltipWrapper = shallow(<DateTooltip date={moment(defaultDate)} format={stringFormat} />);
             expect(tooltipWrapper.find(Tooltip).props().children).toEqual(moment(defaultFormat).format(stringFormat));
         });
     });

--- a/packages/react-vapor/src/components/tooltip/tests/DateTooltip.spec.tsx
+++ b/packages/react-vapor/src/components/tooltip/tests/DateTooltip.spec.tsx
@@ -7,7 +7,7 @@ import {Tooltip} from '../Tooltip';
 
 describe('Tooltip', () => {
     let tooltipWrapper: ShallowWrapper<DateTooltipsProps>;
-    const defaultFormat = moment().format('LLL');
+    let defaultFormat: string;
     const stringFormat = 'ddd, hA';
 
     describe('<DateTooltip />', () => {
@@ -17,16 +17,19 @@ describe('Tooltip', () => {
         });
 
         it('should display content in LLL if no format is given on moment date', () => {
+            defaultFormat = moment().format('LLL');
             tooltipWrapper = shallow(<DateTooltip date={moment()} />);
             expect(tooltipWrapper.find(Tooltip).props().title).toEqual(defaultFormat);
         });
 
         it('should display the tooltip in the given tooltipformat', () => {
+            defaultFormat = moment().format('LLL');
             tooltipWrapper = shallow(<DateTooltip date={moment()} tooltipFormat={stringFormat} />);
             expect(tooltipWrapper.find(Tooltip).props().title).toEqual(moment(defaultFormat).format(stringFormat));
         });
 
         it('should display the children of the tooltip in the given format', () => {
+            defaultFormat = moment().format('LLL');
             tooltipWrapper = shallow(<DateTooltip date={moment()} format={stringFormat} />);
             expect(tooltipWrapper.find(Tooltip).props().children).toEqual(moment(defaultFormat).format(stringFormat));
         });


### PR DESCRIPTION
### Proposed Changes

the date of reference was few minutes late from the date in the test since they were not made in the same scope. Fixed it

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
