### PR TITLE
Improve build speeds

### DIFF
--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -20,12 +20,10 @@
         "url": "git+https://github.com/coveo/react-vapor.git"
     },
     "scripts": {
-        "start": "webpack-dev-server --progress",
+        "start": "webpack-dev-server",
         "docs": "webpack",
         "compileTs": "webpack --config webpack.config.prod.js",
-        "minify": "webpack --config webpack.config.prod.minify.js",
-        "build": "gulp clean && concurrently \"npm run compileTs\" \"npm run minify\"",
-        "build:dev": "gulp clean && npm run compileTs",
+        "build": "gulp clean && webpack --config webpack.config.prod.js",
         "pretest": "gulp clean:tests",
         "test": "node --max-old-space-size=2048 node_modules/karma/bin/karma start",
         "test:compile": "tslint --project ./tsconfig.test.json -c ../../tslint.json",
@@ -122,6 +120,7 @@
         "faker": "4.1.0",
         "fancy-log": "1.3.3",
         "file-loader": "3.0.1",
+        "fork-ts-checker-webpack-plugin": "3.1.1",
         "gulp": "4.0.0",
         "html-webpack-plugin": "3.2.0",
         "imports-loader": "0.8.0",
@@ -173,16 +172,13 @@
         "typings-for-css-modules-loader": "1.7.0",
         "underscore": "1.9.1",
         "underscore.string": "3.3.5",
+        "unminified-webpack-plugin": "2.0.0",
         "webpack": "4.40.2",
         "webpack-bundle-analyzer": "3.0.3",
         "webpack-cli": "3.2.0",
         "webpack-dev-server": "3.1.11"
     },
     "files": [
-        "dist",
-        "src",
-        "gulpfile.js",
-        "webpack.prod.config.js",
-        "LICENSE"
+        "dist"
     ]
 }

--- a/packages/react-vapor/src/components/table-hoc/examples/TableHOCServerExamples.tsx
+++ b/packages/react-vapor/src/components/table-hoc/examples/TableHOCServerExamples.tsx
@@ -9,7 +9,6 @@ import {ExampleComponent} from '../../../../docs/src/components/ComponentsInterf
 import {withServerSideProcessing} from '../../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {DateUtils} from '../../../utils/DateUtils';
 import {IDispatch, IReduxAction, IThunkAction} from '../../../utils/ReduxUtils';
-import {IReactVaporTestState} from '../../../utils/tests/TestUtils';
 import {SELECTION_BOXES_LONG} from '../../datePicker/examples/DatePickerExamplesCommon';
 import {LastUpdated} from '../../lastUpdated/LastUpdated';
 import {turnOffLoading} from '../../loading/LoadingActions';
@@ -144,7 +143,7 @@ const tableDatePickerConfig = {
     ],
 };
 
-const mapStateToProps = (state: IReactVaporTestState) => ({
+const mapStateToProps = (state: any) => ({
     isLoading: state.tableHOCExample.isLoading,
     serverData: state.tableHOCExample.data,
 });
@@ -220,7 +219,7 @@ const setIsLoading = (isLoading: boolean): IReduxAction<ISetExampleIsLoadingPayl
     payload: {isLoading},
 });
 
-const fetchData = (): IThunkAction => (dispatch: IDispatch, getState: () => IReactVaporTestState) => {
+const fetchData = (): IThunkAction => (dispatch: IDispatch, getState) => {
     const compositeState: ITableHOCCompositeState = TableHOCUtils.getCompositeState(
         TableHOCServerExampleId,
         getState()

--- a/packages/react-vapor/webpack.config.js
+++ b/packages/react-vapor/webpack.config.js
@@ -2,6 +2,7 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 const isTravis = !!process.env.TRAVIS;
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 /**
  * Config file for the documentation project
@@ -16,7 +17,7 @@ module.exports = {
         filename: '[name].bundle.js',
         chunkFilename: 'assets/[name].bundle.js',
     },
-    devtool: isTravis ? 'source-map' : 'cheap-module-source-map',
+    devtool: isTravis ? 'source-map' : 'eval-source-map',
     resolve: {
         extensions: ['.ts', '.tsx', '.js', '.jsx'],
     },
@@ -32,40 +33,44 @@ module.exports = {
         }),
         new webpack.HotModuleReplacementPlugin(),
         new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /en-ca/),
+        new ForkTsCheckerWebpackPlugin({
+            tsconfig: path.resolve('./tsconfig.build.json'),
+            tslint: path.resolve('../../tslint.json'),
+            tslintAutoFix: true,
+            async: false,
+        }),
     ],
     stats: 'minimal',
     module: {
         rules: [
-            {
-                enforce: 'pre',
-                test: /\.tsx?$/,
-                include: [path.resolve(__dirname, 'src'), path.resolve(__dirname, 'docs')],
-                use: {
-                    loader: 'tslint-loader',
-                    options: {
-                        configFile: '../../tslint.json',
-                        tsConfigFile: './tsconfig.build.json',
-                        emitErrors: isTravis,
-                        failOnHint: isTravis,
-                    },
-                },
-            },
             {
                 /**
                  *  Transform let and const to var in js files below to make them ES5 compatible
                  *  Target only problematic files to prevent compilation from hanging
                  */
                 include: [path.resolve(__dirname, 'node_modules/unidiff/hunk.js')],
-                use: [{loader: 'ts-loader'}],
+                use: [
+                    {
+                        loader: 'ts-loader',
+                        options: {
+                            transpileOnly: true,
+                            configFile: 'tsconfig.build.json',
+                        },
+                    },
+                ],
             },
             {
                 test: /\.tsx?$/,
-                include: [path.resolve(__dirname, 'src'), path.resolve(__dirname, 'docs')],
-                loader: 'ts-loader',
-                options: {
-                    compiler: 'ttypescript',
-                    configFile: 'tsconfig.build.json',
-                },
+                use: [
+                    {
+                        loader: 'ts-loader',
+                        options: {
+                            compiler: 'ttypescript',
+                            configFile: 'tsconfig.build.json',
+                            transpileOnly: true,
+                        },
+                    },
+                ],
             },
             {
                 test: /\.scss$/,
@@ -128,5 +133,6 @@ module.exports = {
         compress: true,
         hot: true,
         inline: true,
+        progress: true,
     },
 };

--- a/packages/react-vapor/webpack.config.prod.js
+++ b/packages/react-vapor/webpack.config.prod.js
@@ -2,6 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const isTravis = process.env.TRAVIS;
+const UnminifiedWebpackPlugin = require('unminified-webpack-plugin');
 
 /**
  * Config file for the packaged library
@@ -21,11 +22,11 @@ const config = {
             'd3',
         ],
     },
-    mode: 'development',
+    mode: 'production',
     devtool: 'source-map',
     output: {
         path: path.join(__dirname, '/dist'),
-        filename: '[name].js',
+        filename: '[name].min.js',
         library: ['ReactVapor'],
         libraryTarget: 'umd',
     },
@@ -59,7 +60,14 @@ const config = {
                     path.resolve(__dirname, 'node_modules/strict-uri-encode/index.js'),
                     path.resolve(__dirname, 'node_modules/split-on-first/index.js'),
                 ],
-                loader: 'ts-loader',
+                use: [
+                    {
+                        loader: 'ts-loader',
+                        options: {
+                            configFile: 'tsconfig.build.json',
+                        },
+                    },
+                ],
             },
             {
                 test: /\.tsx?$/,
@@ -119,6 +127,7 @@ const config = {
             WEBPACK_DEFINED_VERSION: JSON.stringify(require('./package.json').version),
             'process.env.NODE_ENV': JSON.stringify('production'),
         }),
+        new UnminifiedWebpackPlugin(),
         // new BundleAnalyzerPlugin(),
     ],
     externals: {

--- a/packages/react-vapor/webpack.config.prod.minify.js
+++ b/packages/react-vapor/webpack.config.prod.minify.js
@@ -1,7 +1,0 @@
-const prodConfig = require('./webpack.config.prod');
-
-prodConfig.output.filename = '[name].min.js';
-prodConfig.mode = 'production';
-prodConfig.devtool = false;
-
-module.exports = prodConfig;

--- a/packages/react-vapor/webpack.config.test.js
+++ b/packages/react-vapor/webpack.config.test.js
@@ -7,7 +7,7 @@ module.exports = function(options) {
     const config = {
         mode: 'development',
         entry: './karma.entry.ts',
-        devtool: 'cheap-source-map',
+        devtool: 'inline-source-map',
         resolve: {
             extensions: ['.ts', '.tsx', '.js'],
         },
@@ -33,7 +33,15 @@ module.exports = function(options) {
                      *  Target only problematic files to prevent compilation from hanging
                      */
                     include: [path.resolve(__dirname, 'node_modules/unidiff/hunk.js')],
-                    loader: 'ts-loader',
+                    use: [
+                        {
+                            loader: 'ts-loader',
+                            options: {
+                                transpileOnly: true,
+                                configFile: 'tsconfig.test.json',
+                            },
+                        },
+                    ],
                 },
                 {
                     test: /\.tsx?$/,


### PR DESCRIPTION
### Proposed Changes

I had a look at our build process and did a few optimizations:

- `build` command now produce the `.js`, `.min.js` and `.min.js.map` files in one single webpack execution
- `start` and `docs` command no longer generate the definition files (`transpileOnly: true`), but they still do the necessary type checking.
- better quality source maps are generated during the unit tests and while running `npm start`

#### Benchmarks

I timed each command once with linux `time` command on master and did the same process on this branch and here are the results. The time displayed here is the `real` time on my laptop so it takes into account the multi-threading, which means it could be slower on TravisCI or faster on your machine depending on your CPU specs.

| command | master branch | this branch |
| --- | --- | --- |
| start | 3 m 19 s | 30 s |
| docs | 3 m 7 s | 25 s |
| build | 56 s | 55 s |
| test | 2 m 30 s | 2 m 30 s |

### Potential Breaking Changes

- Source maps are now only generated for the minified files
- The files published to npm are now only the ones contained in the `dist` folder
- `minify` and `build:dev` commands have been removed

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
