### PR TITLE
Fix demo page not found occasional problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ node_js:
 addons:
     chrome: stable
 
+branches:
+    only:
+        - master
+
 env:
     global:
         - AWS_ACCESS_KEY_ID=AKIAYKDJLZITTS3QHYP2

--- a/create-live-demo.sh
+++ b/create-live-demo.sh
@@ -4,26 +4,29 @@ git config user.name "Travis CI"
 git config user.email "$COMMIT_AUTHOR_EMAIL"
 
 REPO=`git config remote.origin.url`
+BASE_PATH=$PWD
 SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
 BRANCH_FOLDER_NAME=`echo "$TRAVIS_PULL_REQUEST_BRANCH" | md5sum | awk '{print $1}'`
 
 echo "Syncing with gh-pages from branch: $TRAVIS_PULL_REQUEST_BRANCH"
-git stash
-git pull --no-edit --quiet --strategy-option ours "$SSH_REPO" gh-pages
-git rm --quiet "$BRANCH_FOLDER_NAME" -r
-git commit --quiet -m "Clean old build" --no-verify
-git stash pop
+pushd $HOME
+mkdir gh-pages
+cd gh-pages
+git init
+git remote add -t gh-pages -f origin git@github.com:$TRAVIS_REPO_SLUG.git
+git checkout gh-pages
 
 echo "Creating live demo for branch: $TRAVIS_PULL_REQUEST_BRANCH";
-cp -R packages/react-vapor/docs/dist "$BRANCH_FOLDER_NAME"
+cp -R $BASE_PATH/packages/react-vapor/docs/dist "$BRANCH_FOLDER_NAME"
 
 git add "$BRANCH_FOLDER_NAME"
-git commit --quiet -m "live demo at https://coveo.github.io/react-vapor/$BRANCH_FOLDER_NAME/" --no-verify
-echo "Deploying demo at https://coveo.github.io/react-vapor/$BRANCH_FOLDER_NAME/"
+git commit --quiet -m "Demo for branch: $TRAVIS_PULL_REQUEST_BRANCH" --no-verify
 
 SHA=`git rev-parse --verify HEAD`
 
 echo "Pushing live demo to gh-pages for branch: $TRAVIS_PULL_REQUEST_BRANCH"
 git push -f "$SSH_REPO" "$SHA:gh-pages"
+echo "Demo available at https://coveo.github.io/react-vapor/$BRANCH_FOLDER_NAME/"
+popd
 
 BRANCH_FOLDER_NAME="$BRANCH_FOLDER_NAME" node ./create-live-demo.js

--- a/packages/react-vapor/.gitignore
+++ b/packages/react-vapor/.gitignore
@@ -1,7 +1,7 @@
 # Ignore compiled files
 dist
 coverage
-docs/assets/
+docs/dist/
 
 # awesome-typescript-loader
 .awcache


### PR DESCRIPTION
### Proposed Changes

I found out why sometimes our pull request demo links display `Page Not Found`. Its because in our demo build script, we were pulling the `gh-page` branch into our current branch. Occasionally there would be conflicts and therefore force pushing the current pull request branch into gh-page without conserving the old demo folders. :crying_cat_face: 

I edited the script so that we first checkout in `gh-pages`, then create or overwrite the demo folder for the current PR.

### Potential Breaking Changes

Hopefully none.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
