### PR TITLE
Fix(SplitMultilineInput): Remove duplicate label and validate onChange

### DIFF
--- a/packages/react-vapor/src/components/multilineInput/SplitMultilineInput.tsx
+++ b/packages/react-vapor/src/components/multilineInput/SplitMultilineInput.tsx
@@ -75,6 +75,7 @@ export class SplitMultilineInput extends React.PureComponent<ISplitMultilineInpu
                     let inputRef: Input;
                     return (
                         <Input
+                            id={`${input.id}-${index}`}
                             validateOnChange
                             labelTitle={input.label}
                             labelProps={{invalidMessage: input.validationMessage}}
@@ -84,9 +85,10 @@ export class SplitMultilineInput extends React.PureComponent<ISplitMultilineInpu
                             placeholder={input.placeholder}
                             validate={input.validation ? (value: any) => input.validation(value) : undefined}
                             key={labelId + inputIndex}
-                            onChange={(value?: string, valid?: boolean) =>
-                                this.changeValue(value, valid, index, labelId, inputRef)
-                            }
+                            onChange={(value?: string, valid?: boolean) => {
+                                this.changeValue(value, valid, index, labelId, inputRef);
+                                inputRef.validate();
+                            }}
                         >
                             {deleteButton}
                         </Input>
@@ -106,11 +108,14 @@ export class SplitMultilineInput extends React.PureComponent<ISplitMultilineInpu
         const inputRefs: Input[] = [];
         const inputs: JSX.Element[] = _.map(this.props.inputs, (input: ISplitInput, inputIndex: number) => (
             <Input
+                id={`add-${input.id}-${inputIndex}`}
                 ref={(ref: Input) => inputRefs.push(ref)}
                 key={`add-${inputIndex}`}
                 classes={styles.input}
                 placeholder={input.placeholder}
                 validate={input.validation ? (value: any) => input.validation(value) : undefined}
+                labelTitle={false}
+                onChange={() => inputRefs[inputIndex].validate()}
             >
                 <Label invalidMessage={input.validationMessage}>{!this.state.values.length ? input.label : ''}</Label>
                 {inputIndex + 1 === this.props.inputs.length ? (


### PR DESCRIPTION
### Proposed Changes

This PR should fix following issue: 
- Remove duplicate label title
![image](https://user-images.githubusercontent.com/52677246/72816891-d94faf00-3c36-11ea-88d9-0ea714e4b326.png)

- Validate onChange

- Add different id to input
![image](https://user-images.githubusercontent.com/52677246/72816976-02703f80-3c37-11ea-92c7-b8ac06976c6a.png)


### Potential Breaking Changes

This component has not been used in the project AFAIK, so we will not have any negative influence

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
