### PR TITLE
ci(travis): skip travis builds when pushing tags

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,18 +1,14 @@
 {
-    "packages": [
-        "packages/*"
-    ],
+    "packages": ["packages/*"],
     "version": "4.19.0",
     "command": {
         "publish": {
             "conventionalCommits": true,
-            "allowBranch": [
-                "master"
-            ]
+            "allowBranch": ["master"]
         },
         "version": {
             "conventionalCommits": true,
-            "message": "chore(release): publish %s"
+            "message": "chore(release): publish %s [skip travis]"
         }
     }
 }


### PR DESCRIPTION
### Proposed Changes

This will hopefully prevent Travis from triggering a second useless build when pushing the tags and the changelogs.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
