### PR TITLE
improvement(inputconnected.tsx): added toggle dispatch on inputconnected

### DIFF
--- a/packages/react-vapor/src/components/input/Input.tsx
+++ b/packages/react-vapor/src/components/input/Input.tsx
@@ -52,6 +52,7 @@ export interface IInputDispatchProps {
     onRender?: (value?: string, valid?: boolean, disabled?: boolean) => void;
     onChange?: (value?: string, valid?: boolean) => void;
     onClick?: (e: React.MouseEvent<HTMLElement>) => void;
+    changeToDirty?: (value?: string, valid?: boolean) => void;
 }
 
 const inputPropsToOmit = keys<IInputAdditionalOwnProps & IInputAdditionalStateProps & IInputDispatchProps>();

--- a/packages/react-vapor/src/components/input/Input.tsx
+++ b/packages/react-vapor/src/components/input/Input.tsx
@@ -52,7 +52,7 @@ export interface IInputDispatchProps {
     onRender?: (value?: string, valid?: boolean, disabled?: boolean) => void;
     onChange?: (value?: string, valid?: boolean) => void;
     onClick?: (e: React.MouseEvent<HTMLElement>) => void;
-    changeToDirty?: (value?: string, valid?: boolean) => void;
+    changeDirtyState?: (value?: string, valid?: boolean) => void;
 }
 
 const inputPropsToOmit = keys<IInputAdditionalOwnProps & IInputAdditionalStateProps & IInputDispatchProps>();

--- a/packages/react-vapor/src/components/input/InputConnected.tsx
+++ b/packages/react-vapor/src/components/input/InputConnected.tsx
@@ -1,4 +1,5 @@
 import {connect} from 'react-redux';
+import {WithDirtyActions} from '../../hoc/withDirty/withDirtyActions';
 import {IReactVaporState} from '../../ReactVapor';
 import {IDispatch, ReduxUtils} from '../../utils/ReduxUtils';
 import {IInputDispatchProps, IInputOwnProps, IInputProps, IInputStateProps, Input} from './Input';
@@ -18,7 +19,10 @@ const mapDispatchToProps = (dispatch: IDispatch, ownProps: IInputOwnProps): IInp
     onRender: (value: string = '', valid = true, disabled = false) =>
         dispatch(addInput(ownProps.id, value, valid, disabled)),
     onDestroy: () => dispatch(removeInput(ownProps.id)),
-    onChange: (value: string, valid = true) => dispatch(changeInputValue(ownProps.id, value, valid)),
+    onChange: (value: string, valid = true) => {
+        dispatch(changeInputValue(ownProps.id, value, valid));
+        dispatch(WithDirtyActions.toggle(ownProps.id, !!valid));
+    },
 });
 
 export const InputConnected: React.ComponentClass<IInputProps> = connect(

--- a/packages/react-vapor/src/components/input/InputConnected.tsx
+++ b/packages/react-vapor/src/components/input/InputConnected.tsx
@@ -20,7 +20,7 @@ const mapDispatchToProps = (dispatch: IDispatch, ownProps: IInputProps): IInputD
     onDestroy: () => dispatch(removeInput(ownProps.id)),
     onChange: (value: string, valid = true) => {
         dispatch(changeInputValue(ownProps.id, value, valid));
-        ownProps.changeToDirty?.(value);
+        ownProps.changeDirtyState?.(value);
     },
 });
 

--- a/packages/react-vapor/src/components/input/InputConnected.tsx
+++ b/packages/react-vapor/src/components/input/InputConnected.tsx
@@ -1,12 +1,11 @@
 import {connect} from 'react-redux';
-import {WithDirtyActions} from '../../hoc/withDirty/withDirtyActions';
 import {IReactVaporState} from '../../ReactVapor';
 import {IDispatch, ReduxUtils} from '../../utils/ReduxUtils';
-import {IInputDispatchProps, IInputOwnProps, IInputProps, IInputStateProps, Input} from './Input';
+import {IInputDispatchProps, IInputProps, IInputStateProps, Input} from './Input';
 import {addInput, changeInputValue, removeInput} from './InputActions';
 import {InputSelectors} from './InputSelectors';
 
-const mapStateToProps = (state: IReactVaporState, ownProps: IInputOwnProps): IInputStateProps => {
+const mapStateToProps = (state: IReactVaporState, ownProps: IInputProps): IInputStateProps => {
     const input = InputSelectors.getInput(state, {id: ownProps.id});
     return {
         valid: input && input.valid,
@@ -15,13 +14,13 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IInputOwnProps): IIn
     };
 };
 
-const mapDispatchToProps = (dispatch: IDispatch, ownProps: IInputOwnProps): IInputDispatchProps => ({
+const mapDispatchToProps = (dispatch: IDispatch, ownProps: IInputProps): IInputDispatchProps => ({
     onRender: (value: string = '', valid = true, disabled = false) =>
         dispatch(addInput(ownProps.id, value, valid, disabled)),
     onDestroy: () => dispatch(removeInput(ownProps.id)),
     onChange: (value: string, valid = true) => {
         dispatch(changeInputValue(ownProps.id, value, valid));
-        dispatch(WithDirtyActions.toggle(ownProps.id, !!valid));
+        ownProps.changeToDirty?.(value);
     },
 });
 

--- a/packages/react-vapor/src/components/input/tests/InputConnected.spec.tsx
+++ b/packages/react-vapor/src/components/input/tests/InputConnected.spec.tsx
@@ -175,7 +175,7 @@ describe('<InputConnected />', () => {
             expect(validate(newInputState.value)).toBe(false);
             expect(newInputState.valid).toBe(validate(newInputState.value));
         });
-        it('should call changeToDirty is set as props', () => {
+        it('should call changeToDirty if set as props', () => {
             const changeDirtyStateSpy = jasmine.createSpy();
             const wrapperInputConnected = shallowWithState(<InputConnected />, {});
 

--- a/packages/react-vapor/src/components/input/tests/InputConnected.spec.tsx
+++ b/packages/react-vapor/src/components/input/tests/InputConnected.spec.tsx
@@ -176,17 +176,17 @@ describe('<InputConnected />', () => {
             expect(newInputState.valid).toBe(validate(newInputState.value));
         });
         it('should call changeToDirty is set as props', () => {
-            const changeToDirtySpy = jasmine.createSpy();
+            const changeDirtyStateSpy = jasmine.createSpy();
             const wrapperInputConnected = shallowWithState(<InputConnected />, {});
 
             wrapperInputConnected.props().onChange();
 
-            expect(changeToDirtySpy).toHaveBeenCalledTimes(0);
+            expect(changeDirtyStateSpy).toHaveBeenCalledTimes(0);
 
-            wrapperInputConnected.setProps({changeToDirty: changeToDirtySpy});
+            wrapperInputConnected.setProps({changeToDirty: changeDirtyStateSpy});
             wrapperInputConnected.props().onChange();
 
-            expect(changeToDirtySpy).toHaveBeenCalledTimes(1);
+            expect(changeDirtyStateSpy).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/react-vapor/src/components/input/tests/InputConnected.spec.tsx
+++ b/packages/react-vapor/src/components/input/tests/InputConnected.spec.tsx
@@ -21,10 +21,8 @@ describe('<InputConnected />', () => {
     });
 
     afterEach(() => {
-        if (wrapper) {
-            store.dispatch(clearState());
-            wrapper.detach();
-        }
+        store.dispatch(clearState());
+        wrapper?.detach();
     });
 
     const mountComponentWithProps = (props: IInputProps = {}) => {
@@ -175,7 +173,7 @@ describe('<InputConnected />', () => {
             expect(validate(newInputState.value)).toBe(false);
             expect(newInputState.valid).toBe(validate(newInputState.value));
         });
-        it('should call changeToDirty if set as props', () => {
+        it('should call changeDirtyState if set as props', () => {
             const changeDirtyStateSpy = jasmine.createSpy();
             const wrapperInputConnected = shallowWithState(<InputConnected />, {});
 
@@ -183,7 +181,7 @@ describe('<InputConnected />', () => {
 
             expect(changeDirtyStateSpy).toHaveBeenCalledTimes(0);
 
-            wrapperInputConnected.setProps({changeToDirty: changeDirtyStateSpy});
+            wrapperInputConnected.setProps({changeDirtyState: changeDirtyStateSpy});
             wrapperInputConnected.props().onChange();
 
             expect(changeDirtyStateSpy).toHaveBeenCalledTimes(1);

--- a/packages/react-vapor/src/components/input/tests/InputConnected.spec.tsx
+++ b/packages/react-vapor/src/components/input/tests/InputConnected.spec.tsx
@@ -4,6 +4,7 @@ import {Provider} from 'react-redux';
 import {Store} from 'redux';
 import {findWhere} from 'underscore';
 
+import {shallowWithState} from 'enzyme-redux';
 import {IReactVaporState} from '../../../ReactVapor';
 import {clearState} from '../../../utils/ReduxUtils';
 import {TestUtils} from '../../../utils/tests/TestUtils';
@@ -20,8 +21,10 @@ describe('<InputConnected />', () => {
     });
 
     afterEach(() => {
-        store.dispatch(clearState());
-        wrapper.detach();
+        if (wrapper) {
+            store.dispatch(clearState());
+            wrapper.detach();
+        }
     });
 
     const mountComponentWithProps = (props: IInputProps = {}) => {
@@ -171,6 +174,19 @@ describe('<InputConnected />', () => {
             newInputState = findWhere(store.getState().inputs, {id: inputProps.id});
             expect(validate(newInputState.value)).toBe(false);
             expect(newInputState.valid).toBe(validate(newInputState.value));
+        });
+        it('should call changeToDirty is set as props', () => {
+            const changeToDirtySpy = jasmine.createSpy();
+            const wrapperInputConnected = shallowWithState(<InputConnected />, {});
+
+            wrapperInputConnected.props().onChange();
+
+            expect(changeToDirtySpy).toHaveBeenCalledTimes(0);
+
+            wrapperInputConnected.setProps({changeToDirty: changeToDirtySpy});
+            wrapperInputConnected.props().onChange();
+
+            expect(changeToDirtySpy).toHaveBeenCalledTimes(1);
         });
     });
 });


### PR DESCRIPTION
### Proposed Changes

Added a isdirty toggle dispatch onChange for inputConnected so that the input gets dirty if not empty and displays error message if empty

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
