### PR TITLE
fix(form): changed the classname order to allow overrides

### DIFF
--- a/packages/react-vapor/src/components/form/Form.tsx
+++ b/packages/react-vapor/src/components/form/Form.tsx
@@ -11,7 +11,7 @@ export interface IFormProps {
 
 export const Form: React.FunctionComponent<IFormProps> = ({children, className, title, mods}) => {
     return (
-        <fieldset className={classNames(className, mods, 'coveo-form mb2 mt2 mod-padding-children')}>
+        <fieldset className={classNames('coveo-form mb2 mt2 mod-padding-children', mods, className)}>
             {title && <h2 className="text-medium-blue mb2">{title}</h2>}
             {children}
         </fieldset>


### PR DESCRIPTION
### Proposed Changes

Changed the className order on the `Form` component so that we can override the `mt2` style.

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
