### PR TITLE
feat(validation): backbone for generic error, warning and dirty components

### DIFF
--- a/packages/react-vapor/src/ReactVapor.ts
+++ b/packages/react-vapor/src/ReactVapor.ts
@@ -49,6 +49,7 @@ import {ITableData, ITablesState} from './components/tables/TableReducers';
 import {ITableRowState} from './components/tables/TableRowReducers';
 import {ITextAreaState} from './components/textarea/TextAreaReducers';
 import {IToastsState} from './components/toast/ToastReducers';
+import {ValidationsState} from './components/validation/ValidationState';
 import {IStringListCompositeState} from './reusableState/customList/StringListReducers';
 import {ComponentId} from './utils/ComponentUtils';
 
@@ -101,6 +102,7 @@ export interface IReactVaporState {
     tableHOCPagination?: ITableWithPaginationState[];
     tableHOCRow?: HOCTableRowState[];
     textAreas?: ITextAreaState[];
+    validation?: ValidationsState;
 }
 
 export interface IReduxActionsPayload {

--- a/packages/react-vapor/src/ReactVaporReducers.ts
+++ b/packages/react-vapor/src/ReactVaporReducers.ts
@@ -43,6 +43,7 @@ import {tablesReducer} from './components/tables/TableReducers';
 import {tableRowsReducer} from './components/tables/TableRowReducers';
 import {textAreasReducer} from './components/textarea/TextAreaReducers';
 import {toastsContainerReducer} from './components/toast/ToastReducers';
+import {validationReducer} from './components/validation/ValidationReducer';
 import {withDirtyReducer} from './hoc/withDirty/withDirtyReducers';
 import {IReactVaporState} from './ReactVapor';
 import {stringListCompositeReducer} from './reusableState/customList/StringListReducers';
@@ -100,4 +101,5 @@ export const ReactVaporReducers: ReducersMapObject = {
     tabs: tabGroupsReducer,
     textAreas: textAreasReducer,
     toastContainers: toastsContainerReducer,
+    validation: validationReducer,
 };

--- a/packages/react-vapor/src/components/input/examples/InputExamples.tsx
+++ b/packages/react-vapor/src/components/input/examples/InputExamples.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
+import {connect} from 'react-redux';
+import {createStructuredSelector} from 'reselect';
 import * as _ from 'underscore';
 import {AutocompleteConnected, IItemBoxProps} from '../..';
 import {ExampleComponent} from '../../../../docs/src/components/ComponentsInterface';
 import {ExamplesStore} from '../../../../docs/Store';
-import {IWithDirtyProps, withDirty} from '../../../hoc/withDirty/withDirty';
-import {withEditing} from '../../../hoc/withEditing/withEditing';
 import {Button} from '../../button/Button';
 import {IMultilineInputValue, MultilineInput} from '../../multilineInput/MultilineInput';
 import {ISplitInput, ISplitValue, SplitMultilineInput} from '../../multilineInput/SplitMultilineInput';
 import {Section} from '../../section/Section';
+import {withDirtyInputHOC} from '../../validation/hoc/WithDirtyInputHOC';
+import {ValidationSelectors} from '../../validation/ValidationSelectors';
 import {Input} from '../Input';
 import {setDisabledInput} from '../InputActions';
 import {InputConnected} from '../InputConnected';
@@ -194,49 +196,17 @@ const SplitMultilineInputExamples: React.FunctionComponent = () => {
 
 const InputsWithDirtyManagement: React.FunctionComponent = () => (
     <Section level={2} title="Inputs with dirty management functionnalities">
-        <InputWithSimpleDirtyManagement />
-        <InputWithEditingDirtyManagement />
+        <InputWithDirty id="dirtyinput" />
+        <MessageWhenInputIsDirty />
     </Section>
 );
 
-const InputBeforeSimpleDirtyManagement: React.FunctionComponent<IWithDirtyProps> & {id: string} = (props) => (
-    <Section level={3} title="An input with a simple dirty handling">
-        <Input
-            id="super-input-4"
-            labelTitle="Dirty handling"
-            onChange={(value) => props.toggleIsDirty(_.isEmpty(value) ? false : true)}
-        />
-    </Section>
-);
+const MessageWhenInputIsDirty = connect(
+    createStructuredSelector({
+        isDirty: ValidationSelectors.isDirty(['dirtyinput']),
+    })
+)(({isDirty}) => isDirty && <div>I am now dirty!</div>);
 
-InputBeforeSimpleDirtyManagement.id = 'inputWithDirty';
-export const InputWithSimpleDirtyManagement = withDirty({
-    id: InputBeforeSimpleDirtyManagement.id,
-    showDirty: (isDirty: boolean) => isDirty && <div className="mt2">This Component is now dirty</div>,
-})(InputBeforeSimpleDirtyManagement);
-
-const InputBeforeEditingDirtyManagement: React.FunctionComponent<IWithDirtyProps> & {
-    id: string;
-    footerChildren: React.ReactNode;
-} = (props) => (
-    <Section level={3} title="An input with an editing dirty handling">
-        <Input
-            id="super-input-5"
-            labelTitle="Dirty handling with edition"
-            onChange={(value) => props.toggleIsDirty(_.isEmpty(value) ? false : true)}
-        />
-    </Section>
-);
-
-InputBeforeEditingDirtyManagement.id = 'inputWithEditingDirty';
-InputBeforeEditingDirtyManagement.footerChildren = (
-    <Button primary name="Save" onClick={() => alert('You Saved the input')} />
-);
-
-export const InputWithEditingDirtyManagement = withEditing({
-    id: InputBeforeEditingDirtyManagement.id,
-    footerChildren: InputBeforeEditingDirtyManagement.footerChildren,
-    footerClassName: 'sticky-footer-mod-header',
-})(InputBeforeEditingDirtyManagement);
+const InputWithDirty = withDirtyInputHOC(InputConnected);
 
 // stop-print

--- a/packages/react-vapor/src/components/validation/ValidationActions.ts
+++ b/packages/react-vapor/src/components/validation/ValidationActions.ts
@@ -1,0 +1,40 @@
+import {ValidationTypes} from './ValidationTypes';
+
+export const ValidationActionsTypes = {
+    updateError: 'UPDATE_VALIDATION_ERROR',
+    updateWarning: 'UPDATE_VALIDATION_WARNING',
+    updateDirty: 'UPDATE_VALIDATION_DIRTY',
+};
+
+export const ValidationActions = {
+    setError: (id: string, error: string, validationType: string = ValidationTypes.default) => ({
+        type: ValidationActionsTypes.updateError,
+        payload: {
+            id,
+            validationType,
+            value: error,
+        },
+    }),
+    clearError: (id: string, validationType: string = ValidationTypes.default) =>
+        ValidationActions.setError(id, null, validationType),
+    setWarning: (id: string, warning: string, validationType: string = ValidationTypes.default) => ({
+        type: ValidationActionsTypes.updateWarning,
+        payload: {
+            id,
+            validationType,
+            value: warning,
+        },
+    }),
+    clearWarning: (id: string, validationType: string = ValidationTypes.default) =>
+        ValidationActions.setWarning(id, null, validationType),
+    setDirty: (id: string, isDirty: boolean, validationType: string = ValidationTypes.default) => ({
+        type: ValidationActionsTypes.updateDirty,
+        payload: {
+            id,
+            validationType,
+            value: isDirty,
+        },
+    }),
+    clearDirty: (id: string, validationType: string = ValidationTypes.default) =>
+        ValidationActions.setDirty(id, null, validationType),
+};

--- a/packages/react-vapor/src/components/validation/ValidationReducer.ts
+++ b/packages/react-vapor/src/components/validation/ValidationReducer.ts
@@ -1,0 +1,56 @@
+import * as _ from 'underscore';
+import {ValidationActions, ValidationActionsTypes} from './ValidationActions';
+import {ValidationsState, ValidationState} from './ValidationState';
+
+type ValidationActions =
+    | ReturnType<typeof ValidationActions.setError>
+    | ReturnType<typeof ValidationActions.setWarning>
+    | ReturnType<typeof ValidationActions.setDirty>;
+
+export const validationReducer = (state: ValidationsState = {}, action: ValidationActions): ValidationsState => {
+    switch (action.type) {
+        case ValidationActionsTypes.updateError:
+        case ValidationActionsTypes.updateWarning:
+        case ValidationActionsTypes.updateDirty:
+            return {
+                ...state,
+                [action.payload.id]: oneValidationReducer(state[action.payload.id], action),
+            };
+        default:
+            return state;
+    }
+};
+
+const oneValidationReducer = (
+    state: ValidationState = {error: [], isDirty: [], warning: []},
+    action: ValidationActions
+): ValidationState => {
+    switch (action.type) {
+        case ValidationActionsTypes.updateError:
+            return {
+                ...state,
+                error: [
+                    ...state.error.filter((error) => error.validationType !== action.payload.validationType),
+                    {validationType: action.payload.validationType, value: action.payload.value as string},
+                ],
+            };
+        case ValidationActionsTypes.updateWarning:
+            return {
+                ...state,
+                warning: [
+                    ...state.warning.filter((warning) => warning.validationType !== action.payload.validationType),
+                    {validationType: action.payload.validationType, value: action.payload.value as string},
+                ],
+            };
+        case ValidationActionsTypes.updateDirty:
+            return {
+                ...state,
+                isDirty: [
+                    ...state.isDirty.filter((dirty) => dirty.validationType !== action.payload.validationType),
+                    {validationType: action.payload.validationType, value: action.payload.value as boolean},
+                ],
+            };
+        default:
+            return state;
+    }
+};

--- a/packages/react-vapor/src/components/validation/ValidationSelectors.ts
+++ b/packages/react-vapor/src/components/validation/ValidationSelectors.ts
@@ -20,6 +20,10 @@ const getAnyDirty = (ids: string[]) => (state: IReactVaporState) =>
         .reduce((all, id) => all.concat(getIsDirty(id)(state)), [] as ValidationState['isDirty'])
         .filter((dirty) => dirty.value);
 
+const isInError = (ids: string[]) => (state: IReactVaporState) => getAnyError(ids)(state).length > 0;
+const isInWarning = (ids: string[]) => (state: IReactVaporState) => getAnyWarning(ids)(state).length > 0;
+const isDirty = (ids: string[]) => (state: IReactVaporState) => getAnyDirty(ids)(state).length > 0;
+
 export const ValidationSelectors = {
     getErrors,
     getWarnings,
@@ -27,4 +31,7 @@ export const ValidationSelectors = {
     getAnyError,
     getAnyWarning,
     getAnyDirty,
+    isInError,
+    isInWarning,
+    isDirty,
 };

--- a/packages/react-vapor/src/components/validation/ValidationSelectors.ts
+++ b/packages/react-vapor/src/components/validation/ValidationSelectors.ts
@@ -1,0 +1,30 @@
+import {IReactVaporState} from '../../ReactVapor';
+import {ValidationState} from './ValidationState';
+
+const getErrors = (id: string) => (state: IReactVaporState) =>
+    state.validation?.[id]?.error?.filter((error) => !!error.value) || [];
+const getWarnings = (id: string) => (state: IReactVaporState) =>
+    state.validation?.[id]?.warning?.filter((warning) => !!warning.value) || [];
+const getIsDirty = (id: string) => (state: IReactVaporState) => state.validation?.[id]?.isDirty || [];
+
+const getAnyError = (ids: string[]) => (state: IReactVaporState) =>
+    ids
+        .reduce((all, id) => all.concat(getErrors(id)(state)), [] as ValidationState['error'])
+        .filter((error) => !!error.value);
+const getAnyWarning = (ids: string[]) => (state: IReactVaporState) =>
+    ids
+        .reduce((all, id) => all.concat(getWarnings(id)(state)), [] as ValidationState['warning'])
+        .filter((warning) => !!warning.value);
+const getAnyDirty = (ids: string[]) => (state: IReactVaporState) =>
+    ids
+        .reduce((all, id) => all.concat(getIsDirty(id)(state)), [] as ValidationState['isDirty'])
+        .filter((dirty) => dirty.value);
+
+export const ValidationSelectors = {
+    getErrors,
+    getWarnings,
+    getIsDirty,
+    getAnyError,
+    getAnyWarning,
+    getAnyDirty,
+};

--- a/packages/react-vapor/src/components/validation/ValidationState.ts
+++ b/packages/react-vapor/src/components/validation/ValidationState.ts
@@ -1,7 +1,12 @@
+export type ISingleValidation<T> = {
+    validationType: string;
+    value: T;
+};
+
 export type ValidationState = {
-    isDirty: Array<{validationType: string; value: boolean}>;
-    error: Array<{validationType: string; value: string}>;
-    warning: Array<{validationType: string; value: string}>;
+    isDirty: Array<ISingleValidation<boolean>>;
+    error: Array<ISingleValidation<string>>;
+    warning: Array<ISingleValidation<string>>;
 };
 
 export type ValidationsState = Record<string, ValidationState>;

--- a/packages/react-vapor/src/components/validation/ValidationState.ts
+++ b/packages/react-vapor/src/components/validation/ValidationState.ts
@@ -1,0 +1,7 @@
+export type ValidationState = {
+    isDirty: Array<{validationType: string; value: boolean}>;
+    error: Array<{validationType: string; value: string}>;
+    warning: Array<{validationType: string; value: string}>;
+};
+
+export type ValidationsState = Record<string, ValidationState>;

--- a/packages/react-vapor/src/components/validation/ValidationTypes.ts
+++ b/packages/react-vapor/src/components/validation/ValidationTypes.ts
@@ -1,0 +1,5 @@
+export const ValidationTypes = {
+    nonEmpty: 'non-empty',
+    wrongInitialValue: 'initial-value',
+    default: 'default',
+};

--- a/packages/react-vapor/src/components/validation/components/ValidationMessage.tsx
+++ b/packages/react-vapor/src/components/validation/components/ValidationMessage.tsx
@@ -1,0 +1,44 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import {connect} from 'react-redux';
+import {IReactVaporState} from '../../../ReactVapor';
+import {ValidationSelectors} from '../ValidationSelectors';
+
+export interface IValidationMessageProps {
+    id: string;
+}
+
+const mapStateToProps = (state: IReactVaporState, ownProps: IValidationMessageProps) => ({
+    errors: ValidationSelectors.getErrors(ownProps.id)(state),
+    warnings: ValidationSelectors.getWarnings(ownProps.id)(state),
+});
+
+export const ValidationMessageClasses = {
+    error: 'text-red',
+    warning: 'text-yellow',
+};
+
+export const ValidationMessageDisconnect: React.FunctionComponent<IValidationMessageProps &
+    ReturnType<typeof mapStateToProps>> = ({errors, warnings}) => {
+    const hasErrors = errors.length > 0;
+    const hasWarnings = warnings.length > 0;
+    const eitherErrorsOrWarnings = hasErrors ? errors : warnings;
+    return (
+        <>
+            {(hasErrors || hasWarnings) &&
+                eitherErrorsOrWarnings.map(({validationType, value}) => (
+                    <span
+                        key={validationType}
+                        className={classNames({
+                            [ValidationMessageClasses.error]: hasErrors,
+                            [ValidationMessageClasses.warning]: !hasErrors,
+                        })}
+                    >
+                        {value}
+                    </span>
+                ))}
+        </>
+    );
+};
+
+export const ValidationMessage = connect(mapStateToProps)(ValidationMessageDisconnect);

--- a/packages/react-vapor/src/components/validation/components/tests/ValidationMessage.spec.tsx
+++ b/packages/react-vapor/src/components/validation/components/tests/ValidationMessage.spec.tsx
@@ -1,0 +1,121 @@
+import {shallowWithState} from 'enzyme-redux';
+import * as React from 'react';
+import {ValidationState} from '../../ValidationState';
+import {IValidationMessageProps, ValidationMessage, ValidationMessageClasses} from '../ValidationMessage';
+
+describe('ValidationMessage', () => {
+    const defaultProps: IValidationMessageProps = {
+        id: 'wow',
+    };
+    const nonEmptyValidationType = '⛳';
+    const nonEmptyMessage = 'ohnoitshouldbeempty';
+
+    const getValidationState = (validation: Partial<ValidationState>) =>
+        ({
+            isDirty: [],
+            error: [],
+            warning: [],
+            ...validation,
+        } as ValidationState);
+    const getStateForExistingComponent = (validation: Partial<ValidationState>) => ({
+        validation: {
+            [defaultProps.id]: getValidationState(validation),
+        },
+    });
+
+    it('should render nothing if the store is empty', () => {
+        const result = shallowWithState(<ValidationMessage {...defaultProps} />, {}).dive();
+        expect(result.text()).toBe('');
+    });
+
+    it('should render nothing if the store does not contain errors for the given ID', () => {
+        const result = shallowWithState(<ValidationMessage {...defaultProps} />, {
+            validation: {
+                anotherone: getValidationState({
+                    error: [
+                        {
+                            validationType: nonEmptyValidationType,
+                            value: nonEmptyMessage,
+                        },
+                    ],
+                }),
+            },
+        }).dive();
+        expect(result.text()).toBe('');
+    });
+
+    it('should render errors when there are errors', () => {
+        const result = shallowWithState(
+            <ValidationMessage {...defaultProps} />,
+            getStateForExistingComponent({
+                error: [
+                    {
+                        validationType: nonEmptyValidationType,
+                        value: nonEmptyMessage,
+                    },
+                    {
+                        validationType: 'anotherone',
+                        value: 'wow',
+                    },
+                ],
+            })
+        ).dive();
+
+        expect(result.find(`.${ValidationMessageClasses.error}`).length).toBe(2);
+        expect(
+            result
+                .find(`.${ValidationMessageClasses.error}`)
+                .first()
+                .text()
+        ).toContain(nonEmptyMessage);
+    });
+
+    it('should render warnings when there are warnings', () => {
+        const result = shallowWithState(
+            <ValidationMessage {...defaultProps} />,
+            getStateForExistingComponent({
+                warning: [
+                    {
+                        validationType: nonEmptyValidationType,
+                        value: nonEmptyMessage,
+                    },
+                    {
+                        validationType: 'anotherone',
+                        value: 'bloup',
+                    },
+                ],
+            })
+        ).dive();
+
+        expect(result.find(`.${ValidationMessageClasses.warning}`).length).toBe(2);
+        expect(
+            result
+                .find(`.${ValidationMessageClasses.warning}`)
+                .first()
+                .text()
+        ).toContain(nonEmptyMessage);
+    });
+
+    it('should render not render warnings if there are already errors', () => {
+        const result = shallowWithState(
+            <ValidationMessage {...defaultProps} />,
+            getStateForExistingComponent({
+                error: [
+                    {
+                        validationType: nonEmptyValidationType,
+                        value: nonEmptyMessage,
+                    },
+                ],
+                warning: [
+                    {
+                        validationType: 'somethingelse',
+                        value: 'ohno',
+                    },
+                ],
+            })
+        ).dive();
+
+        expect(result.find(`.${ValidationMessageClasses.error}`).length).toBe(1);
+        expect(result.find(`.${ValidationMessageClasses.warning}`).length).toBe(0);
+    });
+});

--- a/packages/react-vapor/src/components/validation/hoc/WithDirtyInputHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtyInputHOC.tsx
@@ -35,9 +35,10 @@ export const withDirtyInputHOC = <T extends IInputOwnProps>(Component: React.Com
             <Component
                 {...(props as T)}
                 validate={(value: string) => {
-                    setIsDirty(props.id, value !== props.defaultValue);
+                    setIsDirty(props.id, value !== (props.defaultValue || ''));
                     return validate ? validate(value) : true;
                 }}
+                validateOnChange
             />
         );
     };

--- a/packages/react-vapor/src/components/validation/hoc/WithDirtyInputHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtyInputHOC.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+import {IDispatch} from '../../../utils/ReduxUtils';
+import {IInputOwnProps} from '../../input/Input';
+import {ValidationActions} from '../ValidationActions';
+import {ValidationTypes} from '../ValidationTypes';
+import {InferableComponentEnhancer} from './connectHOC';
+
+export interface IWithDirtyInputOwnProps {
+    resetDirtyOnUnmount?: boolean;
+}
+
+const mapDispatchToProps = (dispatch: IDispatch) => ({
+    setIsDirty: (id: string, isDirty: boolean) =>
+        dispatch(ValidationActions.setDirty(id, isDirty, ValidationTypes.wrongInitialValue)),
+    clearIsDirty: (id: string) => dispatch(ValidationActions.clearDirty(id, ValidationTypes.wrongInitialValue)),
+});
+
+export const withDirtyInputHOC = <T extends IInputOwnProps>(Component: React.ComponentType<T>) => {
+    type DispatchProps = ReturnType<typeof mapDispatchToProps>;
+    const WrappedInput: React.FunctionComponent<T & IWithDirtyInputOwnProps & DispatchProps> = ({
+        setIsDirty,
+        clearIsDirty,
+        validate,
+        resetDirtyOnUnmount,
+        ...props
+    }) => {
+        React.useEffect(() => {
+            return () => {
+                resetDirtyOnUnmount && clearIsDirty(props.id);
+            };
+        }, []);
+
+        return (
+            <Component
+                {...(props as T)}
+                validate={(value: string) => {
+                    setIsDirty(props.id, value !== props.defaultValue);
+                    return validate ? validate(value) : true;
+                }}
+            />
+        );
+    };
+
+    const enhance = connect(null, mapDispatchToProps) as InferableComponentEnhancer<DispatchProps>;
+    return enhance(WrappedInput);
+};

--- a/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+import * as _ from 'underscore';
+import {IDispatch} from '../../../utils/ReduxUtils';
+import {IInputOwnProps} from '../../input/Input';
+import {ValidationActions} from '../ValidationActions';
+import {ValidationTypes} from '../ValidationTypes';
+import {InferableComponentEnhancer} from './connectHOC';
+
+export interface IWithNonEmptyValueInputValidationProps {
+    validationMessage?: string;
+    resetErrorOnUnmount?: boolean;
+}
+
+const mapDispatchToProps = (dispatch: IDispatch) => ({
+    setError: (id: string, error: string) => dispatch(ValidationActions.setError(id, error, ValidationTypes.nonEmpty)),
+    clearError: (id: string) => dispatch(ValidationActions.clearError(id)),
+});
+
+export const withNonEmptyValueInputValidationHOC = <T extends IInputOwnProps>(
+    Component: React.ComponentClass<T> | React.FunctionComponent<T>
+) => {
+    type NewOwnProps = T & IWithNonEmptyValueInputValidationProps;
+    type DispatchProps = ReturnType<typeof mapDispatchToProps>;
+    const WrappedInput: React.FunctionComponent<NewOwnProps & DispatchProps> = ({
+        setError,
+        clearError,
+        validationMessage = 'Input is empty and should not be empty',
+        resetErrorOnUnmount,
+        validate,
+        ...props
+    }) => {
+        React.useEffect(() => {
+            setError(props.id, '');
+            return () => {
+                resetErrorOnUnmount && clearError(props.id!);
+            };
+        }, []);
+
+        return (
+            <Component
+                {...(props as T)}
+                validate={(value: string) => {
+                    const isEmpty = _.isEmpty(value);
+                    setError(props.id, isEmpty ? validationMessage : '');
+                    return !isEmpty || (validate ? validate(value) : true);
+                }}
+            />
+        );
+    };
+
+    const enhance = connect(null, mapDispatchToProps) as InferableComponentEnhancer<DispatchProps>;
+    return enhance(WrappedInput);
+};

--- a/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
@@ -31,9 +31,9 @@ export const withNonEmptyValueInputValidationHOC = <T extends IInputOwnProps>(
         ...props
     }) => {
         React.useEffect(() => {
-            setError(props.id, '');
+            clearError(props.id);
             return () => {
-                resetErrorOnUnmount && clearError(props.id!);
+                resetErrorOnUnmount && clearError(props.id);
             };
         }, []);
 

--- a/packages/react-vapor/src/components/validation/hoc/WithValidationMessageHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithValidationMessageHOC.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import {ValidationMessage} from '../components/ValidationMessage';
+
+export const withValidationMessage = <T extends {id?: string}, R = any>(
+    Component: React.ComponentClass<T, R> | React.FunctionComponent<T>
+) => (props: T) => {
+    return (
+        <>
+            <Component {...(props as T)} />
+            <div>
+                <ValidationMessage id={props.id!} />
+            </div>
+        </>
+    );
+};

--- a/packages/react-vapor/src/components/validation/hoc/connectHOC.d.ts
+++ b/packages/react-vapor/src/components/validation/hoc/connectHOC.d.ts
@@ -1,0 +1,20 @@
+/*
+ Fixes a typing issue when using connect inside a HOC component: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31363
+ The definition was picked from @types/react-redux@5.0.8
+
+ Without this, we get a "non-assignable type" with the following detail:
+ Argument of type 'FunctionComponent<T & { ... }>' is not assignable to parameter of type 'ComponentType<Matching<{ ... }, T & { setIsDirty: (id: string, isDirty: boolean) => { type: string; payload: { ...; }; }; }>>'.
+  Type 'FunctionComponent<T & { ... }>' is not assignable to type 'FunctionComponent<Matching<{ ... }, T & { setIsDirty: (id: string, isDirty: boolean) => { type: string; payload: { ...; }; }; }>>'.
+    Types of property 'propTypes' are incompatible.
+      Type 'WeakValidationMap<T & { ... }>' is not assignable to type 'WeakValidationMap<Matching<{ ... }, T & { setIsDirty: (id: string, isDirty: boolean) => { type: string; payload: { ...; }; }; }>>'.
+        Type 'null extends (T & { ... })[K] ? Validator<(T & { setIsDirty: (id: string, isDirty: boolean) => { ...; }; })[K]> : undefined extends (T & { ...; })[K] ? Validator<...> : Validator<...>' is not assignable to type 'null extends Matching<{ ... }, T & { setIsDirty: (id: string, isDirty: boolean) => { type: string; payload: { ...; }; }; }>[K] ? Validator<...> : undefined extends Matching<...>[K] ? Validator<...> :...'.ts(2345)
+*/
+import {ComponentClass, ComponentType} from 'react';
+
+export type InferableComponentEnhancer<TInjectedProps> = InferableComponentEnhancerWithProps<TInjectedProps, {}>;
+
+export interface InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> {
+    <P extends TInjectedProps>(component: ComponentType<P>): ComponentClass<
+        Omit<P, keyof TInjectedProps> & TNeedsProps
+    > & {WrappedComponent: Component<P>};
+}

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithDirtyInputHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithDirtyInputHOC.spec.tsx
@@ -1,0 +1,83 @@
+import {ShallowWrapper} from 'enzyme';
+import {shallowWithStore} from 'enzyme-redux';
+import * as React from 'react';
+import * as _ from 'underscore';
+import {getStoreMock} from '../../../../utils/tests/TestUtils';
+import {IInputOwnProps} from '../../../input/Input';
+import {InputConnected} from '../../../input/InputConnected';
+import {ValidationActions} from '../../ValidationActions';
+import {ValidationTypes} from '../../ValidationTypes';
+import {withDirtyInputHOC} from '../WithDirtyInputHOC';
+
+describe('WithDirtyInputHOC', () => {
+    const InputWithHOC = withDirtyInputHOC(InputConnected);
+
+    let store: ReturnType<typeof getStoreMock>;
+    let inputWrapper: ShallowWrapper<IInputOwnProps>;
+
+    const INPUT_PROPS: IInputOwnProps = {
+        id: '🥔',
+        title: 'ok',
+        defaultValue: '🧀',
+    };
+
+    beforeEach(() => {
+        store = getStoreMock({
+            validation: {},
+        });
+    });
+
+    afterEach(() => {
+        store.clearActions();
+    });
+
+    describe('<InputWithHOC />', () => {
+        it('should render without error', () => {
+            expect(() => shallowWithStore(<InputWithHOC {...INPUT_PROPS} />, store)).not.toThrow();
+        });
+
+        it('should mount and unmount/detach without error', () => {
+            expect(() => {
+                inputWrapper = shallowWithStore(<InputWithHOC {...INPUT_PROPS} />, store);
+                inputWrapper.unmount();
+            }).not.toThrow();
+        });
+
+        describe('after mount', () => {
+            let validateSpy: jasmine.Spy;
+
+            beforeEach(() => {
+                validateSpy = jasmine.createSpy('validate');
+                inputWrapper = shallowWithStore<typeof InputWithHOC>(
+                    <InputWithHOC {...INPUT_PROPS} validate={validateSpy} />,
+                    store
+                ).dive();
+            });
+
+            it('should dispatch a set dirty action with true when the value is different from the initial value', () => {
+                inputWrapper.prop('validate')('🍕');
+
+                expect(store.getActions()).toContain(
+                    ValidationActions.setDirty(INPUT_PROPS.id, true, ValidationTypes.wrongInitialValue)
+                );
+            });
+
+            it('should dispatch a set dirty action with false when the value is the same as the initial value', () => {
+                inputWrapper.prop('validate')(INPUT_PROPS.defaultValue);
+
+                expect(store.getActions()).toContain(
+                    ValidationActions.setDirty(INPUT_PROPS.id, false, ValidationTypes.wrongInitialValue)
+                );
+            });
+
+            it('should call the original validate function and return the same value', () => {
+                validateSpy.and.returnValue(true);
+
+                const result = inputWrapper.prop('validate')('🧀');
+
+                expect(validateSpy).toHaveBeenCalledWith('🧀');
+                expect(result).toBe(true);
+            });
+        });
+    });
+});

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithNonEmptyValueInputValidationHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithNonEmptyValueInputValidationHOC.spec.tsx
@@ -1,0 +1,74 @@
+import {ShallowWrapper} from 'enzyme';
+import {shallowWithStore} from 'enzyme-redux';
+import * as React from 'react';
+import * as _ from 'underscore';
+import {getStoreMock} from '../../../../utils/tests/TestUtils';
+import {IInputOwnProps} from '../../../input/Input';
+import {InputConnected} from '../../../input/InputConnected';
+import {ValidationActions} from '../../ValidationActions';
+import {ValidationTypes} from '../../ValidationTypes';
+import {
+    IWithNonEmptyValueInputValidationProps,
+    withNonEmptyValueInputValidationHOC,
+} from '../WithNonEmptyValueInputValidationHOC';
+
+describe('WithNonEmptyValueInputValidationHOC', () => {
+    const InputWithHOC = withNonEmptyValueInputValidationHOC(InputConnected);
+
+    let store: ReturnType<typeof getStoreMock>;
+    let inputWrapper: ShallowWrapper<IWithNonEmptyValueInputValidationProps & IInputOwnProps>;
+
+    const INPUT_PROPS: IWithNonEmptyValueInputValidationProps & IInputOwnProps = {
+        id: '🥔',
+        title: 'ok',
+        validationMessage: 'ohno',
+    };
+
+    beforeEach(() => {
+        store = getStoreMock({
+            validation: {},
+        });
+    });
+
+    afterEach(() => {
+        store.clearActions();
+    });
+
+    describe('<InputWithHOC />', () => {
+        it('should render without error', () => {
+            expect(() => shallowWithStore(<InputWithHOC {...INPUT_PROPS} />, store)).not.toThrow();
+        });
+
+        it('should mount and unmount/detach without error', () => {
+            expect(() => {
+                inputWrapper = shallowWithStore(<InputWithHOC {...INPUT_PROPS} />, store);
+                inputWrapper.unmount();
+            }).not.toThrow();
+        });
+
+        describe('after mount', () => {
+            let validateSpy: jasmine.Spy;
+
+            beforeEach(() => {
+                validateSpy = jasmine.createSpy('validate');
+                inputWrapper = shallowWithStore(<InputWithHOC {...INPUT_PROPS} validate={validateSpy} />, store).dive();
+            });
+
+            it('should dispatch a set error action when the validation fails', () => {
+                inputWrapper.prop('validate')('');
+
+                expect(store.getActions()).toContain(
+                    ValidationActions.setError(INPUT_PROPS.id, INPUT_PROPS.validationMessage, ValidationTypes.nonEmpty)
+                );
+            });
+
+            it('should not dispatch a set error action when the validation succeeds', () => {
+                inputWrapper.prop('validate')('some correct value');
+
+                expect(store.getActions()).not.toContain(
+                    ValidationActions.setError(INPUT_PROPS.id, INPUT_PROPS.validationMessage, ValidationTypes.nonEmpty)
+                );
+            });
+        });
+    });
+});

--- a/packages/react-vapor/src/components/validation/tests/ValidationReducer.spec.ts
+++ b/packages/react-vapor/src/components/validation/tests/ValidationReducer.spec.ts
@@ -1,0 +1,251 @@
+import {ValidationActionsTypes} from '../ValidationActions';
+import {validationReducer} from '../ValidationReducer';
+
+describe('ValidationReducer', () => {
+    const componentId = '🐟';
+    const nonEmptyValidationType = '🕳';
+    const aMessage = 'ohno';
+
+    it('should ignore a random action type', () => {
+        const newState = validationReducer(
+            {},
+            {type: 'sorandom', payload: {id: 'jenkins', validationType: 'wow', value: 'bloup'}}
+        );
+
+        expect(newState).toEqual({});
+    });
+
+    describe('updateError', () => {
+        it('should create the validation state of a new component', () => {
+            const newState = validationReducer(
+                {},
+                {
+                    type: ValidationActionsTypes.updateError,
+                    payload: {
+                        id: componentId,
+                        validationType: nonEmptyValidationType,
+                        value: aMessage,
+                    },
+                }
+            );
+
+            expect(newState[componentId].error).toContain({
+                validationType: nonEmptyValidationType,
+                value: aMessage,
+            });
+        });
+
+        it('should append a new validationType to an existing component', () => {
+            const newState = validationReducer(
+                {
+                    [componentId]: {
+                        error: [
+                            {
+                                validationType: 'wow',
+                                value: 'ok',
+                            },
+                        ],
+                        warning: [],
+                        isDirty: [],
+                    },
+                },
+                {
+                    type: ValidationActionsTypes.updateError,
+                    payload: {
+                        id: componentId,
+                        validationType: nonEmptyValidationType,
+                        value: aMessage,
+                    },
+                }
+            );
+
+            expect(newState[componentId].error.length).toBe(2);
+        });
+
+        it('should update an existing validationType', () => {
+            const newState = validationReducer(
+                {
+                    [componentId]: {
+                        error: [
+                            {
+                                validationType: nonEmptyValidationType,
+                                value: 'oldvalue',
+                            },
+                        ],
+                        warning: [],
+                        isDirty: [],
+                    },
+                },
+                {
+                    type: ValidationActionsTypes.updateError,
+                    payload: {
+                        id: componentId,
+                        validationType: nonEmptyValidationType,
+                        value: aMessage,
+                    },
+                }
+            );
+
+            expect(newState[componentId].error[0]).toEqual({
+                validationType: nonEmptyValidationType,
+                value: aMessage,
+            });
+        });
+    });
+
+    describe('updateWarning', () => {
+        it('should create the validation state of a new component', () => {
+            const newState = validationReducer(
+                {},
+                {
+                    type: ValidationActionsTypes.updateWarning,
+                    payload: {
+                        id: componentId,
+                        validationType: nonEmptyValidationType,
+                        value: aMessage,
+                    },
+                }
+            );
+
+            expect(newState[componentId].warning).toContain({
+                validationType: nonEmptyValidationType,
+                value: aMessage,
+            });
+        });
+
+        it('should append a new validationType to an existing component', () => {
+            const newState = validationReducer(
+                {
+                    [componentId]: {
+                        error: [],
+                        warning: [
+                            {
+                                validationType: 'wow',
+                                value: 'ok',
+                            },
+                        ],
+                        isDirty: [],
+                    },
+                },
+                {
+                    type: ValidationActionsTypes.updateWarning,
+                    payload: {
+                        id: componentId,
+                        validationType: nonEmptyValidationType,
+                        value: aMessage,
+                    },
+                }
+            );
+
+            expect(newState[componentId].warning.length).toBe(2);
+        });
+
+        it('should update an existing validationType', () => {
+            const newState = validationReducer(
+                {
+                    [componentId]: {
+                        error: [,],
+                        warning: [
+                            {
+                                validationType: nonEmptyValidationType,
+                                value: 'oldvalue',
+                            },
+                        ],
+                        isDirty: [],
+                    },
+                },
+                {
+                    type: ValidationActionsTypes.updateWarning,
+                    payload: {
+                        id: componentId,
+                        validationType: nonEmptyValidationType,
+                        value: aMessage,
+                    },
+                }
+            );
+
+            expect(newState[componentId].warning[0]).toEqual({
+                validationType: nonEmptyValidationType,
+                value: aMessage,
+            });
+        });
+    });
+
+    describe('updateWarning', () => {
+        it('should create the validation state of a new component', () => {
+            const newState = validationReducer(
+                {},
+                {
+                    type: ValidationActionsTypes.updateDirty,
+                    payload: {
+                        id: componentId,
+                        validationType: nonEmptyValidationType,
+                        value: true,
+                    },
+                }
+            );
+
+            expect(newState[componentId].isDirty).toContain({
+                validationType: nonEmptyValidationType,
+                value: true,
+            });
+        });
+
+        it('should append a new validationType to an existing component', () => {
+            const newState = validationReducer(
+                {
+                    [componentId]: {
+                        error: [],
+                        warning: [],
+                        isDirty: [
+                            {
+                                validationType: 'wow',
+                                value: true,
+                            },
+                        ],
+                    },
+                },
+                {
+                    type: ValidationActionsTypes.updateDirty,
+                    payload: {
+                        id: componentId,
+                        validationType: nonEmptyValidationType,
+                        value: false,
+                    },
+                }
+            );
+
+            expect(newState[componentId].isDirty.length).toBe(2);
+        });
+
+        it('should update an existing validationType', () => {
+            const newState = validationReducer(
+                {
+                    [componentId]: {
+                        error: [,],
+                        warning: [],
+                        isDirty: [
+                            {
+                                validationType: nonEmptyValidationType,
+                                value: false,
+                            },
+                        ],
+                    },
+                },
+                {
+                    type: ValidationActionsTypes.updateDirty,
+                    payload: {
+                        id: componentId,
+                        validationType: nonEmptyValidationType,
+                        value: true,
+                    },
+                }
+            );
+
+            expect(newState[componentId].isDirty[0]).toEqual({
+                validationType: nonEmptyValidationType,
+                value: true,
+            });
+        });
+    });
+});

--- a/packages/react-vapor/src/components/validation/tests/ValidationSelectors.spec.ts
+++ b/packages/react-vapor/src/components/validation/tests/ValidationSelectors.spec.ts
@@ -1,0 +1,295 @@
+import {ValidationSelectors} from '../ValidationSelectors';
+import {ValidationState} from '../ValidationState';
+
+describe('ValidationSelectors', () => {
+    const existingComponentId = '🥝';
+
+    const getValidationState = (validation: Partial<ValidationState>) =>
+        ({
+            isDirty: [],
+            error: [],
+            warning: [],
+            ...validation,
+        } as ValidationState);
+    const getStateForExistingComponent = (validation: Partial<ValidationState>) => ({
+        validation: {
+            [existingComponentId]: getValidationState(validation),
+        },
+    });
+
+    describe('getErrors', () => {
+        it('should return an empty array if the state is empty', () => {
+            const errors = ValidationSelectors.getErrors(existingComponentId)({
+                validation: {},
+            });
+
+            expect(errors.length).toBe(0);
+        });
+
+        it('should return the error for the given component', () => {
+            const validationType = 'something';
+            const errorValue = '🔴';
+            const result = ValidationSelectors.getErrors(existingComponentId)(
+                getStateForExistingComponent({
+                    error: [
+                        {
+                            validationType,
+                            value: errorValue,
+                        },
+                    ],
+                })
+            );
+
+            expect(result.length).toBe(1);
+            expect(result[0]).toEqual({
+                validationType,
+                value: errorValue,
+            });
+        });
+
+        it('should not return errors that have been cleared for the given component', () => {
+            const validationType = 'something';
+            const result = ValidationSelectors.getErrors(existingComponentId)(
+                getStateForExistingComponent({
+                    error: [
+                        {
+                            validationType,
+                            value: '',
+                        },
+                    ],
+                })
+            );
+
+            expect(result.length).toBe(0);
+        });
+    });
+
+    describe('getWarnings', () => {
+        it('should return an empty array if the state is empty', () => {
+            const result = ValidationSelectors.getWarnings(existingComponentId)({
+                validation: {},
+            });
+
+            expect(result.length).toBe(0);
+        });
+
+        it('should return the warning', () => {
+            const validationType = 'something';
+            const warningValue = '🟡';
+            const result = ValidationSelectors.getWarnings(existingComponentId)(
+                getStateForExistingComponent({
+                    warning: [
+                        {
+                            validationType,
+                            value: warningValue,
+                        },
+                    ],
+                })
+            );
+
+            expect(result.length).toBe(1);
+            expect(result[0]).toEqual({
+                validationType,
+                value: warningValue,
+            });
+        });
+
+        it('should not return warnings that have been cleared', () => {
+            const validationType = 'something';
+            const result = ValidationSelectors.getErrors(existingComponentId)(
+                getStateForExistingComponent({
+                    warning: [
+                        {
+                            validationType,
+                            value: '',
+                        },
+                    ],
+                })
+            );
+
+            expect(result.length).toBe(0);
+        });
+    });
+
+    describe('getIsDirty', () => {
+        it('should return an empty array if the state is empty', () => {
+            const result = ValidationSelectors.getIsDirty(existingComponentId)({
+                validation: {},
+            });
+
+            expect(result.length).toBe(0);
+        });
+
+        it('should return the registered dirty component', () => {
+            const validationType = 'something';
+            const result = ValidationSelectors.getIsDirty(existingComponentId)(
+                getStateForExistingComponent({
+                    isDirty: [
+                        {
+                            validationType,
+                            value: true,
+                        },
+                    ],
+                })
+            );
+
+            expect(result.length).toBe(1);
+            expect(result[0]).toEqual({
+                validationType,
+                value: true,
+            });
+        });
+
+        it('should return the registered non-dirty component', () => {
+            const validationType = 'something';
+            const result = ValidationSelectors.getIsDirty(existingComponentId)(
+                getStateForExistingComponent({
+                    isDirty: [
+                        {
+                            validationType,
+                            value: false,
+                        },
+                    ],
+                })
+            );
+
+            expect(result.length).toBe(1);
+            expect(result[0]).toEqual({
+                validationType,
+                value: false,
+            });
+        });
+    });
+
+    describe('getAnyError', () => {
+        it('should return an empty array if the state is empty', () => {
+            const result = ValidationSelectors.getAnyError([existingComponentId])({
+                validation: {},
+            });
+
+            expect(result.length).toBe(0);
+        });
+
+        it('should return only error states for the given ids', () => {
+            const anotherComponentId = '🌷';
+            const state = {
+                validation: {
+                    [existingComponentId]: getValidationState({
+                        error: [
+                            {
+                                validationType: 'some-input',
+                                value: 'someerror',
+                            },
+                        ],
+                    }),
+                    [anotherComponentId]: getValidationState({
+                        error: [
+                            {
+                                validationType: 'not-empty',
+                                value: 'hey this should not be empty',
+                            },
+                            {
+                                validationType: 'thisvalidationsucceeded',
+                                value: '',
+                            },
+                        ],
+                    }),
+                },
+            };
+            const result = ValidationSelectors.getAnyError([existingComponentId, anotherComponentId])(state);
+
+            expect(result.length).toBe(2);
+            expect(result).toContain(state.validation[existingComponentId].error[0]);
+            expect(result).toContain(state.validation[anotherComponentId].error[0]);
+            expect(result).not.toContain(state.validation[anotherComponentId].error[1]);
+        });
+    });
+
+    describe('getAnyWarning', () => {
+        it('should return an empty array if the state is empty', () => {
+            const result = ValidationSelectors.getAnyWarning([existingComponentId])({
+                validation: {},
+            });
+
+            expect(result.length).toBe(0);
+        });
+
+        it('should return only error states for the given ids', () => {
+            const anotherComponentId = '🌷';
+            const state = {
+                validation: {
+                    [existingComponentId]: getValidationState({
+                        warning: [
+                            {
+                                validationType: 'some-input',
+                                value: 'somewarning',
+                            },
+                        ],
+                    }),
+                    [anotherComponentId]: getValidationState({
+                        warning: [
+                            {
+                                validationType: 'not-empty',
+                                value: 'be careful',
+                            },
+                            {
+                                validationType: 'thisvalidationsucceeded',
+                                value: '',
+                            },
+                        ],
+                    }),
+                },
+            };
+            const result = ValidationSelectors.getAnyWarning([existingComponentId, anotherComponentId])(state);
+
+            expect(result.length).toBe(2);
+            expect(result).toContain(state.validation[existingComponentId].warning[0]);
+            expect(result).toContain(state.validation[anotherComponentId].warning[0]);
+            expect(result).not.toContain(state.validation[anotherComponentId].warning[1]);
+        });
+    });
+
+    describe('getAnyDirty', () => {
+        it('should return an empty array if the state is empty', () => {
+            const result = ValidationSelectors.getAnyDirty([existingComponentId])({
+                validation: {},
+            });
+
+            expect(result.length).toBe(0);
+        });
+
+        it('should return only dirty states for the given ids', () => {
+            const anotherComponentId = '🌷';
+            const state = {
+                validation: {
+                    [existingComponentId]: getValidationState({
+                        isDirty: [
+                            {
+                                validationType: 'some-input',
+                                value: true,
+                            },
+                        ],
+                    }),
+                    [anotherComponentId]: getValidationState({
+                        isDirty: [
+                            {
+                                validationType: 'not-empty',
+                                value: true,
+                            },
+                            {
+                                validationType: 'thisisnotdirty',
+                                value: false,
+                            },
+                        ],
+                    }),
+                },
+            };
+            const result = ValidationSelectors.getAnyDirty([existingComponentId, anotherComponentId])(state);
+
+            expect(result.length).toBe(2);
+            expect(result).toContain(state.validation[existingComponentId].isDirty[0]);
+            expect(result).toContain(state.validation[anotherComponentId].isDirty[0]);
+            expect(result).not.toContain(state.validation[anotherComponentId].isDirty[1]);
+        });
+    });
+});


### PR DESCRIPTION
### Proposed Changes

The idea here is to have actions and selectors to easily manage errors, warnings and dirty state for components.

Then, we can add HOCs to wrap existing components with features related to this state. 

Some ground rules for those HOCs, which follow React's doc about it:

* Ensure that you pass all the original props to the child component
* Ensure that you pass down props that might be used in multiple HOCs
    * For instance, wrapping a component that does not have an initial value with a new `initialValue` could pretty well be used across multiple validation HOC. Hence it should be propagated
* Do not always reset the state on unmount. The component might be dirty, but unmounted temporarily, for some reason.

Then, there would be Components that read those states and output something. I have one `ValidationMessage` component that simply outputs errors, and if there are no errors, warnings.

As an alternative to HOCs, some components could implement this directly in their code.

Next steps would be to create some more HOCs. For instance, one for a "Save Button" that is disabled when there are errors, or if nothing is dirty.

Let me know what you think of it! :)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
