### PR TITLE
feat(editor): add text mode to code mirror modes

### DIFF
--- a/packages/react-vapor/src/components/editor/EditorConstants.ts
+++ b/packages/react-vapor/src/components/editor/EditorConstants.ts
@@ -8,5 +8,5 @@ export const CodeMirrorModes = {
     JSON: 'application/json',
     XML: 'xml',
     Python: 'python',
-    Text: 'text/javascript',
+    Text: 'text/plain',
 };

--- a/packages/react-vapor/src/components/editor/EditorConstants.ts
+++ b/packages/react-vapor/src/components/editor/EditorConstants.ts
@@ -8,4 +8,5 @@ export const CodeMirrorModes = {
     JSON: 'application/json',
     XML: 'xml',
     Python: 'python',
+    Text: 'text/javascript',
 };


### PR DESCRIPTION
### Proposed Changes

To be used for advanced parameters editor in ML model configuration.

This is a temporary solution, since I did not find the mode of _HOCON_ for CodeMirror. https://codemirror.net/mode/index.html

### Potential Breaking Changes

nope

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
