### PR TITLE
fix(table-loading): table loading improvement

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
@@ -47,17 +47,18 @@ export class TableHOC extends React.PureComponent<ITableHOCProps & React.HTMLAtt
         const table = (
             <table className={classNames(this.props.className)}>
                 {this.props.tableHeader}
+                <tbody key={`table-body-${this.props.id}`} className={classNames({hidden: this.props.isLoading})}>
+                    {this.props.renderBody(this.props.data || [])}
+                </tbody>
                 {this.props.isLoading && (
                     <TableLoading.Body
+                        key={`table-loading-${this.props.id}`}
                         numberOfRow={
                             _.size(this.props.data) || (this.props?.loading?.defaultLoadingRow ?? PER_PAGE_NUMBERS[1])
                         }
                         numberOfColumns={this.props?.loading?.numberOfColumns ?? 5}
                     />
                 )}
-                <tbody className={classNames({hidden: this.props.isLoading})}>
-                    {this.props.renderBody(this.props.data || [])}
-                </tbody>
             </table>
         );
 


### PR DESCRIPTION
Its more easy for react to render and remove the last element instead of the first one.
I change the order because the tbody with the data always stay but the loading is unmount when the loading is false