### PR TITLE
fix(navigation): adjust computed height

### DIFF
--- a/packages/vapor/scss/components/navigation.scss
+++ b/packages/vapor/scss/components/navigation.scss
@@ -52,7 +52,7 @@
     .navigation-menu {
         position: relative;
         height: 100%;
-        margin-top: 1em;
+        padding-top: 1em;
         overflow-x: visible;
         color: $white;
         background-color: $navigation-background-color;


### PR DESCRIPTION
When setting the css `height` property, the margin is added to this value so it because tricky to set the right parent height.

### Proposed Changes

- Changed `margin-top` for `padding-top`

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
