### PR TITLE
fix(css): sticky footer css adjusted

### DIFF
--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -178,7 +178,7 @@ $base-modal-z-index: $base-backdrop-z-index;
 $modal-header-height: 100px;
 $modal-form-width-small: 440px;
 $modal-footer-padding: 24px 40px;
-$modal-footer-small-padding: 12px 20px;
+$modal-footer-small-padding: 12px 40px 12px 20px;
 $modal-width: 45%;
 $modal-height: 50%;
 $modal-height-stick: 55%;


### PR DESCRIPTION
### Proposed Changes

@oliviertaillon made the remark that the sticky footed did not have the same padding right as it is applied everywhere else. So I adjusted it.

### Potential Breaking Changes

small style change.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
