### PR TITLE
feat(validation): add withdirtysavebutton hoc

### DIFF
--- a/packages/react-vapor/src/components/button/examples/ButtonExamples.tsx
+++ b/packages/react-vapor/src/components/button/examples/ButtonExamples.tsx
@@ -1,8 +1,19 @@
 import * as VaporSVG from 'coveo-styleguide';
 import * as React from 'react';
+import {connect} from 'react-redux';
+import {IDispatch} from '../../../utils';
+import {CheckboxConnected} from '../../checkbox';
+import {Label} from '../../input/Label';
+import {LabeledInput} from '../../input/LabeledInput';
 import {Section} from '../../section/Section';
 import {Svg} from '../../svg/Svg';
+import {withDirtySaveButtonHOC} from '../../validation/hoc/WithDirtySaveButtonHOC';
+import {ValidationActions} from '../../validation/ValidationActions';
 import {Button} from '../Button';
+
+// start-print
+
+const SaveButton = withDirtySaveButtonHOC(Button);
 
 export class ButtonExamples extends React.Component<any, any> {
     static description = 'Buttons communicate actions, and, when clicked, initialize those actions.';
@@ -91,7 +102,51 @@ export class ButtonExamples extends React.Component<any, any> {
                         <Svg svgName={'add'} className="ml1 icon mod-2x" />
                     </Button>
                 </Section>
+                <Section level={2} title="Save button with validation">
+                    <DirtyCheckboxesForSaveButton />
+                    <SaveButton
+                        enabled
+                        name="Save Button"
+                        validationIds={['inputId']}
+                        onClick={() => alert('Saving!')}
+                    />
+                </Section>
             </>
         );
     }
 }
+
+// stop-print
+
+const StatefulCheckboxesForSaveButtonDisconnect: React.FunctionComponent<ReturnType<typeof mapDispatchToProps>> = ({
+    setDirty,
+    setWarning,
+    setError,
+}) => (
+    <LabeledInput label="Toggles to test the Save Button">
+        <CheckboxConnected id="saveCheckboxDirty" handleOnClick={(checked) => setDirty(!checked)} clearSides>
+            <Label>Click on me to set the component as dirty</Label>
+        </CheckboxConnected>
+        <CheckboxConnected
+            id="saveCheckboxWarning"
+            handleOnClick={(checked) => setWarning(!checked ? 'WARNING' : '')}
+            clearSides
+        >
+            <Label>Click on me to set a warning</Label>
+        </CheckboxConnected>
+        <CheckboxConnected
+            id="saveCheckboxError"
+            handleOnClick={(checked) => setError(!checked ? 'ERROR' : '')}
+            clearSides
+        >
+            <Label>Click on me to set an error</Label>
+        </CheckboxConnected>
+    </LabeledInput>
+);
+
+const mapDispatchToProps = (dispatch: IDispatch) => ({
+    setDirty: (value: boolean) => dispatch(ValidationActions.setDirty('inputId', value)),
+    setWarning: (value: string) => dispatch(ValidationActions.setWarning('inputId', value)),
+    setError: (value: string) => dispatch(ValidationActions.setError('inputId', value)),
+});
+const DirtyCheckboxesForSaveButton = connect(null, mapDispatchToProps)(StatefulCheckboxesForSaveButtonDisconnect);

--- a/packages/react-vapor/src/components/validation/hoc/WithDirtySaveButtonHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtySaveButtonHOC.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+import {IReactVaporState} from '../../../ReactVapor';
+import {IButtonProps} from '../../button/Button';
+import {ValidationSelectors} from '../ValidationSelectors';
+import {InferableComponentEnhancer} from './connectHOC';
+
+export interface IWithDirtySaveButtonHOCProps {
+    validationIds: string[];
+    skipDirty?: boolean;
+    errorMessage?: (errors: string[]) => string | undefined;
+    warningMessage?: (warnings: string[]) => string | undefined;
+    dirtyMessage?: (dirty: boolean[]) => string | undefined;
+}
+
+const mapStateToProps = (state: IReactVaporState, ownProps: IWithDirtySaveButtonHOCProps) => ({
+    dirty: ValidationSelectors.getAnyDirty(ownProps.validationIds)(state),
+    errors: ValidationSelectors.getAnyError(ownProps.validationIds)(state),
+    warnings: ValidationSelectors.getAnyWarning(ownProps.validationIds)(state),
+});
+
+export const withDirtySaveButtonHOC = <T extends IButtonProps>(Component: React.ComponentType<T>) => {
+    type StateProps = ReturnType<typeof mapStateToProps>;
+    const WrappedButton = ({
+        dirty,
+        errors,
+        warnings,
+        validationIds,
+        skipDirty,
+        errorMessage = (e) => `Cannot save because of the following errors: ${e.join('\n')}`,
+        warningMessage = (w) => `Can save but with warnings: ${w.join('\n')}`,
+        dirtyMessage = (d) => d.length === 0 && `Cannot save when there are no changes`,
+        enabled,
+        tooltip,
+        ...props
+    }: T & IWithDirtySaveButtonHOCProps & StateProps) => {
+        const hasErrors = errors.length > 0;
+        const hasWarnings = warnings.length > 0;
+        const isDirty = dirty.length > 0;
+        const canSaveWhenDirty = skipDirty ? true : isDirty;
+        const generatedTooltip =
+            (hasErrors && errorMessage(errors.map((error) => error.value))) ||
+            (hasWarnings && canSaveWhenDirty && warningMessage(warnings.map((warning) => warning.value))) ||
+            dirtyMessage(dirty.map((d) => d.value));
+
+        return (
+            <Component
+                {...((props as unknown) as T)}
+                enabled={canSaveWhenDirty && !hasErrors && enabled}
+                tooltip={generatedTooltip || tooltip}
+            />
+        );
+    };
+    const enhance = connect(mapStateToProps) as InferableComponentEnhancer<StateProps>;
+    return enhance(WrappedButton);
+};

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithDirtySaveButtonHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithDirtySaveButtonHOC.spec.tsx
@@ -1,0 +1,194 @@
+import {shallowWithStore} from 'enzyme-redux';
+import * as React from 'react';
+import * as _ from 'underscore';
+import {getStoreMock} from '../../../../utils/tests/TestUtils';
+import {Button, IButtonProps} from '../../../button';
+import {IWithDirtySaveButtonHOCProps, withDirtySaveButtonHOC} from '../WithDirtySaveButtonHOC';
+
+describe('WithDirtySaveButtonHOC', () => {
+    const ButtonWithHOC = withDirtySaveButtonHOC(Button);
+    const buttonValidationId = 'someid';
+
+    let store: ReturnType<typeof getStoreMock>;
+
+    const BUTTON_PROPS: IButtonProps & IWithDirtySaveButtonHOCProps = {
+        enabled: true,
+        validationIds: [buttonValidationId],
+    };
+
+    beforeEach(() => {
+        store = getStoreMock({
+            validation: {},
+        });
+    });
+
+    afterEach(() => {
+        store.clearActions();
+    });
+
+    it('should render without error', () => {
+        expect(() => shallowWithStore(<ButtonWithHOC {...BUTTON_PROPS} />, store)).not.toThrow();
+    });
+
+    it('should mount and unmount/detach without error', () => {
+        expect(() => {
+            const buttonWrapper = shallowWithStore(<ButtonWithHOC {...BUTTON_PROPS} />, store);
+            buttonWrapper.unmount();
+        }).not.toThrow();
+    });
+
+    describe('<ButtonWithHOC />', () => {
+        const storeWithErrorsAndDirty: ReturnType<typeof getStoreMock> = getStoreMock({
+            validation: {
+                [buttonValidationId]: {
+                    error: [{validationType: 'something', value: 'bad'}],
+                    warning: [],
+                    isDirty: [{validationType: 'something', value: true}],
+                },
+            },
+        });
+        const storeWithWarningsAndDirty: ReturnType<typeof getStoreMock> = getStoreMock({
+            validation: {
+                [buttonValidationId]: {
+                    error: [],
+                    warning: [{validationType: 'something', value: 'slightly bad'}],
+                    isDirty: [{validationType: 'something', value: true}],
+                },
+            },
+        });
+        const storeWithDirty = getStoreMock({
+            validation: {
+                [buttonValidationId]: {
+                    error: [],
+                    warning: [],
+                    isDirty: [{validationType: 'dirty', value: true}],
+                },
+            },
+        });
+        const shallowButton = (props: Partial<typeof BUTTON_PROPS>, storeToUse: ReturnType<typeof getStoreMock>) =>
+            shallowWithStore<typeof ButtonWithHOC>(<ButtonWithHOC {...BUTTON_PROPS} {...props} />, storeToUse).dive();
+
+        beforeEach(() => {
+            storeWithErrorsAndDirty.clearActions();
+            storeWithWarningsAndDirty.clearActions();
+            storeWithDirty.clearActions();
+        });
+
+        describe('button enabled prop', () => {
+            it('should be enabled when the component is dirty without errors', () => {
+                const buttonWrapper = shallowButton({}, storeWithDirty);
+
+                const enabled = buttonWrapper.find(Button).prop('enabled');
+
+                expect(enabled).toBe(true);
+            });
+
+            it('should be disabled when the enabled prop is passed down', () => {
+                const buttonWrapper = shallowButton({enabled: false}, storeWithDirty);
+
+                const enabled = buttonWrapper.find(Button).prop('enabled');
+
+                expect(enabled).toBe(false);
+            });
+
+            it('should be disabled when no component is dirty', () => {
+                const buttonWrapper = shallowButton({}, getStoreMock());
+
+                const enabled = buttonWrapper.find(Button).prop('enabled');
+
+                expect(enabled).toBe(false);
+            });
+
+            it('should be enabled when no component is dirty but the HOC is configured to skip the dirty check', () => {
+                const buttonWrapper = shallowButton({skipDirty: true}, getStoreMock());
+
+                const enabled = buttonWrapper.find(Button).prop('enabled');
+
+                expect(enabled).toBe(true);
+            });
+
+            it('should be enabled when the component is dirty with warnings', () => {
+                const buttonWrapper = shallowButton({}, storeWithWarningsAndDirty);
+
+                const enabled = buttonWrapper.find(Button).prop('enabled');
+
+                expect(enabled).toBe(true);
+            });
+
+            it('should be disabled when there are errors', () => {
+                const buttonWrapper = shallowButton({}, storeWithErrorsAndDirty);
+
+                const enabled = buttonWrapper.find(Button).prop('enabled');
+
+                expect(enabled).toBe(false);
+            });
+        });
+
+        describe('button tooltip prop', () => {
+            it('should change the tooltip to the error message formatter', () => {
+                const message = 'this is bad';
+                const buttonWrapper = shallowButton(
+                    {
+                        errorMessage: () => message,
+                    },
+                    storeWithErrorsAndDirty
+                );
+
+                const tooltip = buttonWrapper.find(Button).prop('tooltip');
+
+                expect(tooltip).toEqual(message);
+            });
+
+            it('should change the tooltip to the warning message formatter', () => {
+                const message = 'this is slightly bad';
+                const buttonWrapper = shallowButton(
+                    {
+                        warningMessage: () => message,
+                    },
+                    storeWithWarningsAndDirty
+                );
+
+                const tooltip = buttonWrapper.find(Button).prop('tooltip');
+
+                expect(tooltip).toEqual(message);
+            });
+
+            it('should change the tooltip to the dirty message formatter', () => {
+                const message = 'you must change stuff';
+                const buttonWrapper = shallowButton(
+                    {
+                        dirtyMessage: () => message,
+                    },
+                    getStoreMock()
+                );
+
+                const tooltip = buttonWrapper.find(Button).prop('tooltip');
+
+                expect(tooltip).toEqual(message);
+            });
+
+            it('should not change the tooltip when there is a warning but the component is not dirty', () => {
+                const storeWithOnlyWarning = getStoreMock({
+                    validation: {
+                        [buttonValidationId]: {
+                            error: [],
+                            warning: [{validationType: 'something', value: 'slightly bad'}],
+                            isDirty: [],
+                        },
+                    },
+                });
+                const message = 'this is slightly bad';
+                const buttonWrapper = shallowButton(
+                    {
+                        warningMessage: () => message,
+                    },
+                    storeWithOnlyWarning
+                );
+
+                const tooltip = buttonWrapper.find(Button).prop('tooltip');
+
+                expect(tooltip).not.toEqual(message);
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Proposed Changes

The idea of this HOC is to use the generic validation to wrap a button that has all the required behavior according to the components it must validate.

The Button is bound to one or multiple "validationIds". Then, for all the ID states:

If there are errors: Button disabled, shows the error tooltip
If there are warnings: Button enabled, shows the warning tooltip
If there is **no** dirty component: Button disabled, shows the dirty tooltip.

So the button is only enabled when a component is dirty and there are no errors.

`skipDirty` allows you to skip the dirty check, so only errors could disable the button.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
