### PR TITLE
Fix adui 5080 add input validation in textarea component

### DIFF
--- a/packages/react-vapor/src/components/textarea/TextArea.tsx
+++ b/packages/react-vapor/src/components/textarea/TextArea.tsx
@@ -62,9 +62,10 @@ export const TextArea: React.FunctionComponent<ITextAreaProps> = (props) => {
     const [isValid, setIsValid] = React.useState(true);
 
     React.useEffect(() => {
-        setTimeout(() => {
+        const timeout = setTimeout(() => {
             setDebouncedValue(props.value);
         }, 300);
+        return () => clearTimeout(timeout);
     }, [props.value]);
 
     React.useEffect(() => {
@@ -74,9 +75,7 @@ export const TextArea: React.FunctionComponent<ITextAreaProps> = (props) => {
     React.useEffect(() => {
         props.onMount?.();
         setIsValid(true);
-        if (props.onUnmount) {
-            return props.onUnmount;
-        }
+        return props.onUnmount;
     }, []);
 
     const getValidationLabel = () => {

--- a/packages/react-vapor/src/components/textarea/TextArea.tsx
+++ b/packages/react-vapor/src/components/textarea/TextArea.tsx
@@ -4,12 +4,9 @@ import TextareaAutosize, {TextareaAutosizeProps} from 'react-textarea-autosize';
 import * as _ from 'underscore';
 
 import {IReactVaporState} from '../../ReactVapor';
-import {IDispatch, ReduxUtils} from '../../utils/ReduxUtils';
+import {IDispatch, ReduxUtils} from '../../utils';
+import {ILabelProps, Label} from '../input';
 import {addTextArea, changeTextAreaValue, removeTextArea} from './TextAreaActions';
-
-/**
- * TODO: autoresize is not yet implemented on TextArea
- */
 
 export interface ITextAreaOwnProps {
     id: string;
@@ -31,6 +28,9 @@ export interface ITextAreaOwnProps {
     isAutosize?: boolean;
 
     onChangeCallback?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+    validate?: (value: string) => boolean;
+    validationMessage?: string;
+    validationLabelProps?: ILabelProps;
 }
 
 export interface ITextAreaStateProps {
@@ -57,43 +57,61 @@ const mapDispatchToProps = (dispatch: IDispatch, ownProps: ITextAreaOwnProps): I
     onUnmount: () => dispatch(removeTextArea(ownProps.id)),
 });
 
-export class TextArea extends React.Component<ITextAreaProps, {}> {
-    static defaultProps: Partial<ITextAreaOwnProps> = {
-        additionalAttributes: {},
-        className: '',
+export const TextArea: React.FunctionComponent<ITextAreaProps> = (props) => {
+    const [debouncedValue, setDebouncedValue] = React.useState(props.value);
+    const [isValid, setIsValid] = React.useState(true);
+
+    React.useEffect(() => {
+        setTimeout(() => {
+            setDebouncedValue(props.value);
+        }, 300);
+    }, [props.value]);
+
+    React.useEffect(() => {
+        setIsValid(props.validate?.(debouncedValue));
+    }, [debouncedValue]);
+
+    React.useEffect(() => {
+        props.onMount?.();
+        setIsValid(true);
+        if (props.onUnmount) {
+            return props.onUnmount;
+        }
+    }, []);
+
+    const getValidationLabel = () => {
+        return (
+            !isValid && (
+                <div className={'pt1'}>
+                    <Label id={'textarea-validation-label'} className={'text-red'} {...props.validationLabelProps}>
+                        {props.validationMessage}
+                    </Label>
+                </div>
+            )
+        );
     };
 
-    componentWillMount() {
-        if (this.props.onMount) {
-            this.props.onMount();
-        }
-    }
+    const handleOnChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        props.onChange?.(e);
+        props.onChangeCallback?.(e);
+    };
 
-    componentWillUnmount() {
-        if (this.props.onUnmount) {
-            this.props.onUnmount();
-        }
-    }
+    const TextareaTagName: any = props.isAutosize ? TextareaAutosize : 'textarea';
 
-    render() {
-        const TextareaTagName: any = this.props.isAutosize ? TextareaAutosize : 'textarea';
-        return (
+    return (
+        <>
             <TextareaTagName
-                {...this.props.additionalAttributes}
-                id={this.props.id}
-                disabled={this.props.disabled}
-                className={this.props.className}
-                value={this.props.value}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => this.handleOnChange(e)}
+                {...props.additionalAttributes}
+                disabled={props.disabled}
+                className={props.className}
+                value={props.value}
+                onChange={handleOnChange}
             />
-        );
-    }
-
-    private handleOnChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
-        this.props.onChange?.(e);
-        this.props.onChangeCallback?.(e);
-    }
-}
+            {props.children}
+            {getValidationLabel()}
+        </>
+    );
+};
 
 export const TextAreaConnected: React.ComponentClass<ITextAreaProps> = connect(
     mapStateToProps,

--- a/packages/react-vapor/src/components/textarea/examples/TextAreaExamples.tsx
+++ b/packages/react-vapor/src/components/textarea/examples/TextAreaExamples.tsx
@@ -96,8 +96,6 @@ export const TextAreaExamples = (): JSX.Element => (
                     additionalAttributes={{
                         required: true,
                     }}
-                    validate={(value: string) => value !== ''}
-                    validationMessage={'TextArea should not be empty!'}
                 >
                     <Label htmlFor="super-textarea-8">Beautiful Textarea</Label>
                 </TextAreaConnected>

--- a/packages/react-vapor/src/components/textarea/examples/TextAreaExamples.tsx
+++ b/packages/react-vapor/src/components/textarea/examples/TextAreaExamples.tsx
@@ -96,6 +96,8 @@ export const TextAreaExamples = (): JSX.Element => (
                     additionalAttributes={{
                         required: true,
                     }}
+                    validate={(value: string) => value !== ''}
+                    validationMessage={'TextArea should not be empty!'}
                 >
                     <Label htmlFor="super-textarea-8">Beautiful Textarea</Label>
                 </TextAreaConnected>

--- a/packages/react-vapor/src/components/textarea/examples/TextAreaExamples.tsx
+++ b/packages/react-vapor/src/components/textarea/examples/TextAreaExamples.tsx
@@ -5,7 +5,6 @@ import {ExamplesStore} from '../../../../docs/Store';
 import {Label} from '../../input/Label';
 import {TextAreaConnected} from '../TextArea';
 import {setDisabledTextArea} from '../TextAreaActions';
-import {TextAreaLabel} from '../TextAreaLabel';
 
 export const TextAreaExamples = (): JSX.Element => (
     <div className="mt2">
@@ -20,13 +19,19 @@ export const TextAreaExamples = (): JSX.Element => (
                 />
             </div>
             <div className="form-group">
+                <div>
+                    <label className="form-control-label">Textarea with validation</label>
+                </div>
                 <TextAreaConnected
                     id="awesome-textarea-2"
                     className="admin-invisible-textbox mod-border"
                     additionalAttributes={{
-                        placeholder: 'I am a simple text area',
+                        placeholder: 'I am a simple text area with validation!',
                     }}
-                    valueOnMount="I have a non empty value on mount"
+                    valueOnMount="I have a non empty value on mount and should not be empty!"
+                    validate={(value: string) => value !== ''}
+                    validationMessage={'TextArea should not be empty!'}
+                    isAutosize
                 />
             </div>
             <div className="form-group">
@@ -53,10 +58,14 @@ export const TextAreaExamples = (): JSX.Element => (
                     Toggle TextArea disabled state
                 </button>
             </div>
-            <div className="form-group">
-                <TextAreaLabel label="simple text area with label">
-                    <TextAreaConnected id="super-textarea-4" />
-                </TextAreaLabel>
+            <div className="form-group input-field">
+                <TextAreaConnected
+                    id="super-textarea-4"
+                    validate={(value: string) => value !== ''}
+                    validationMessage={'TextArea should not be empty!'}
+                >
+                    <Label htmlFor="super-textarea-4"> Simple text area with label </Label>
+                </TextAreaConnected>
             </div>
             <div className="form-group">
                 <label className="form-control-label">Default textarea autosize empty</label>
@@ -87,8 +96,9 @@ export const TextAreaExamples = (): JSX.Element => (
                     additionalAttributes={{
                         required: true,
                     }}
-                />
-                <Label htmlFor="super-textarea-8">Beautiful Textarea</Label>
+                >
+                    <Label htmlFor="super-textarea-8">Beautiful Textarea</Label>
+                </TextAreaConnected>
             </div>
         </div>
     </div>

--- a/packages/react-vapor/src/components/textarea/tests/TextArea.spec.tsx
+++ b/packages/react-vapor/src/components/textarea/tests/TextArea.spec.tsx
@@ -1,14 +1,11 @@
-import {HTMLAttributes, mount, ReactWrapper, shallow} from 'enzyme';
+import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
-import {Provider} from 'react-redux';
-import {Store} from 'redux';
-import {findWhere} from 'underscore';
+import {act} from 'react-dom/test-utils';
 
-import {IReactVaporState} from '../../../ReactVapor';
-import {clearState} from '../../../utils/ReduxUtils';
-import {TestUtils} from '../../../utils/tests/TestUtils';
+import {mountWithStore, shallowWithStore} from 'enzyme-redux';
+import {getStoreMock, ReactVaporMockStore} from '../../../utils/tests/TestUtils';
 import {ITextAreaProps, TextArea, TextAreaConnected} from '../TextArea';
-import {ITextAreaState} from '../TextAreaReducers';
+import {TextAreaActions} from '../TextAreaActions';
 
 describe('TextArea', () => {
     describe('<TextArea />', () => {
@@ -20,13 +17,11 @@ describe('TextArea', () => {
     });
 
     describe('<TextArea />', () => {
+        let hookWrapper: ReactWrapper<ITextAreaProps, any>;
         let wrapper: ReactWrapper<ITextAreaProps, any>;
-        let textArea: ReactWrapper<HTMLAttributes, any>;
 
         beforeEach(() => {
             wrapper = mount(<TextArea id="textarea-id" />, {attachTo: document.getElementById('App')});
-
-            textArea = wrapper.find('textarea').first();
         });
 
         afterEach(() => {
@@ -34,31 +29,39 @@ describe('TextArea', () => {
         });
 
         it('should set textarea id when specified', () => {
-            expect(textArea.prop('id')).toBe('textarea-id');
+            expect(wrapper.prop('id')).toBe('textarea-id');
         });
 
         it('should set className when specified', () => {
             const className = 'a-class';
-            expect(textArea.hasClass(className)).toBe(false);
+            expect(wrapper.hasClass(className)).toBe(false);
 
             wrapper.setProps({className}).update();
             expect(wrapper.find('textarea').hasClass(className)).toBe(true);
         });
 
         it('should set additionalAttributes when specified', () => {
-            expect(textArea.prop('placeholder')).toBeUndefined();
+            expect(wrapper.prop('placeholder')).toBeUndefined();
             wrapper.setProps({additionalAttributes: {placeholder: 'not null'}}).update();
             expect(wrapper.find('textarea').prop('placeholder')).toBe('not null');
         });
 
         it('should set disabled prop when specified', () => {
-            expect(textArea.prop('disabled')).toBeUndefined();
+            expect(wrapper.prop('disabled')).toBeUndefined();
             wrapper.setProps({disabled: true}).update();
             expect(wrapper.find('textarea').prop('disabled')).toBe(true);
         });
 
+        it('should set validate prop when specified', () => {
+            const validation = (value: string) => value !== '';
+
+            expect(wrapper.prop('validate')).toBeUndefined();
+            wrapper.setProps({validate: validation}).update();
+            expect(wrapper.prop('validate')).toBe(validation);
+        });
+
         it('should set value prop when specified', () => {
-            expect(textArea.prop('value')).toBeUndefined();
+            expect(wrapper.prop('value')).toBeUndefined();
             wrapper.setProps({value: 'non empty'}).update();
             expect(wrapper.find('textarea').prop('value')).toBe('non empty');
         });
@@ -66,13 +69,13 @@ describe('TextArea', () => {
         it('should not throw if the onChange prop is not defined onChange', () => {
             wrapper.setProps({onChange: undefined}).update();
 
-            expect(() => (wrapper.instance() as any).handleOnChange()).not.toThrow();
+            expect(() => wrapper.find('textarea').simulate('change')).not.toThrow();
         });
 
         it('should not throw if the onChangeCallback prop is not defined onChange', () => {
             wrapper.setProps({onChangeCallback: undefined});
 
-            expect(() => (wrapper.instance() as any).handleOnChange()).not.toThrow();
+            expect(() => wrapper.find('textarea').simulate('change')).not.toThrow();
         });
 
         it('should call prop onChange on textarea change', () => {
@@ -93,13 +96,47 @@ describe('TextArea', () => {
             expect(onChangeCallback).toHaveBeenCalledTimes(1);
         });
 
+        it('should contains validation message if changed value is invalid', () => {
+            const validation = (value: string) => value !== '';
+            const validationMessage = 'invalid value';
+            const invalidValue = '';
+            jasmine.clock().install();
+
+            wrapper.setProps({validate: validation, validationMessage: validationMessage, value: invalidValue});
+            act(() => {
+                wrapper.update();
+            });
+            expect(wrapper.contains(validationMessage)).toBeFalsy();
+
+            wrapper.setProps({value: invalidValue});
+            act(() => {
+                wrapper.update();
+            });
+
+            jasmine.clock().tick(301);
+            expect(wrapper.contains(validationMessage)).toBeTruthy();
+        });
+
+        it('should call prop validate on value change', () => {
+            const validate = jasmine.createSpy('validate');
+            hookWrapper = mount(<TextArea id="textarea-id" validate={validate} />);
+
+            hookWrapper.find('textarea').simulate('change', {target: {value: 'new value'}});
+            act(() => {
+                hookWrapper.update();
+            });
+
+            expect(validate).toHaveBeenCalledTimes(1);
+        });
+
         it('should call prop onMount on mount', () => {
             const onMount = jasmine.createSpy('onMount');
 
-            wrapper
-                .setProps({onMount})
-                .unmount()
-                .mount();
+            hookWrapper = mount(<TextArea id="textarea-id" onMount={onMount} />);
+
+            act(() => {
+                hookWrapper.update();
+            });
 
             expect(onMount).toHaveBeenCalledTimes(1);
         });
@@ -107,32 +144,33 @@ describe('TextArea', () => {
         it('should call prop onUnmount on Unmount', () => {
             const onUnmount = jasmine.createSpy('onUnmount');
 
+            hookWrapper = mount(<TextArea id="textarea-id" onUnmount={onUnmount} />);
+
+            act(() => {
+                hookWrapper.unmount();
+            });
+
+            expect(onUnmount).toHaveBeenCalledTimes(1);
+
             wrapper.setProps({onUnmount}).unmount();
 
             expect(onUnmount).toHaveBeenCalledTimes(1);
         });
 
         describe('<TextAreaConnected />', () => {
-            let store: Store<IReactVaporState>;
+            let store: ReactVaporMockStore;
             let textAreaProps: ITextAreaProps;
 
-            const getTextAreaStateFromId = (id: string): ITextAreaState => findWhere(store.getState().textAreas, {id});
-
             const mountComponentWithProps = (props: ITextAreaProps) =>
-                mount(
-                    <Provider store={store}>
-                        <TextAreaConnected {...props} />
-                    </Provider>,
-                    {attachTo: document.getElementById('App')}
-                );
+                shallowWithStore(<TextAreaConnected {...props} />, store);
 
             beforeEach(() => {
-                store = TestUtils.buildStore();
+                store = getStoreMock();
                 textAreaProps = {id: 'textarea-id'};
             });
 
             afterEach(() => {
-                store.dispatch(clearState());
+                store.clearActions();
                 wrapper.detach();
             });
 
@@ -164,55 +202,81 @@ describe('TextArea', () => {
 
             describe('onMount', () => {
                 it('should add a textArea in the store with default values', () => {
-                    mountComponentWithProps(textAreaProps);
+                    const add = spyOn(TextAreaActions, 'add');
 
-                    const connectedTextArea: ITextAreaState = getTextAreaStateFromId(textAreaProps.id);
-                    expect(connectedTextArea.value).toBe('');
-                    expect(connectedTextArea.disabled).toBe(false);
+                    hookWrapper = mountWithStore(<TextAreaConnected id={'textarea-id'} onMount={add} />, store);
+                    act(() => {
+                        hookWrapper.update();
+                    });
+
+                    expect(add).toHaveBeenCalledTimes(1);
                 });
 
                 it('should add a textArea in the store with the valueOnMount if there is one in the props', () => {
                     const valueOnMount = 'non empty value';
-                    mountComponentWithProps({...textAreaProps, valueOnMount});
 
-                    const connectedTextArea: ITextAreaState = getTextAreaStateFromId(textAreaProps.id);
-                    expect(connectedTextArea.value).toBe(valueOnMount);
-                    expect(connectedTextArea.disabled).toBe(false);
+                    hookWrapper = mountWithStore(
+                        <TextAreaConnected {...textAreaProps} valueOnMount={valueOnMount} />,
+                        store
+                    );
+                    act(() => {
+                        hookWrapper.mount();
+                    });
+                    expect(store.getActions().find((action) => action.type === 'ADD_TEXTAREA')).toEqual(
+                        jasmine.objectContaining({
+                            payload: jasmine.objectContaining({id: textAreaProps.id, value: valueOnMount}),
+                        })
+                    );
                 });
 
                 it('should add a textArea in the store with the disabledOnMount value if there is one in the props', () => {
                     const disabledOnMount = true;
-                    mountComponentWithProps({...textAreaProps, disabledOnMount});
 
-                    const connectedTextArea: ITextAreaState = getTextAreaStateFromId(textAreaProps.id);
-                    expect(connectedTextArea.value).toBe('');
-                    expect(connectedTextArea.disabled).toBe(disabledOnMount);
+                    hookWrapper = mountWithStore(
+                        <TextAreaConnected {...textAreaProps} disabledOnMount={disabledOnMount} />,
+                        store
+                    );
+                    act(() => {
+                        hookWrapper.mount();
+                    });
+
+                    expect(store.getActions().find((action) => action.type === 'ADD_TEXTAREA')).toEqual(
+                        jasmine.objectContaining({
+                            payload: jasmine.objectContaining({id: textAreaProps.id, disabled: disabledOnMount}),
+                        })
+                    );
                 });
             });
 
             describe('onUnmount', () => {
                 it('should remove the textArea from the store', () => {
-                    const connectedTextArea = mountComponentWithProps(textAreaProps);
+                    store = getStoreMock();
+                    const component = mountWithStore(<TextAreaConnected {...textAreaProps} />, store);
+                    act(() => {
+                        component.unmount();
+                    });
 
-                    expect(getTextAreaStateFromId(textAreaProps.id)).toBeDefined();
-
-                    connectedTextArea.unmount();
-
-                    expect(getTextAreaStateFromId(textAreaProps.id)).toBeUndefined();
+                    expect(store.getActions().find((action) => action.type === 'REMOVE_TEXTAREA')).toEqual(
+                        jasmine.objectContaining({payload: jasmine.objectContaining({id: textAreaProps.id})})
+                    );
                 });
             });
 
             describe('onChange', () => {
                 it('should change the value in the store to the new value', () => {
-                    const connectedTextArea = mountComponentWithProps(textAreaProps);
-                    const oldTextAreaState: ITextAreaState = getTextAreaStateFromId(textAreaProps.id);
-                    expect(oldTextAreaState.value).toBe('');
+                    store = getStoreMock();
+                    const component = mountWithStore(<TextAreaConnected {...textAreaProps} />, store);
 
-                    (document.querySelector(`#${textAreaProps.id}`) as HTMLTextAreaElement).value = 'new value';
-                    connectedTextArea.find('textarea').simulate('change', {target: {value: 'new value'}});
+                    component.find('textarea').simulate('change', {target: {value: 'new value'}});
+                    act(() => {
+                        component.update();
+                    });
 
-                    const newTextAreaState: ITextAreaState = getTextAreaStateFromId(textAreaProps.id);
-                    expect(newTextAreaState.value).toBe('new value');
+                    expect(store.getActions().find((action) => action.type === 'CHANGE_VALUE_TEXTAREA')).toEqual(
+                        jasmine.objectContaining({
+                            payload: jasmine.objectContaining({id: textAreaProps.id, value: 'new value'}),
+                        })
+                    );
                 });
             });
         });

--- a/packages/react-vapor/src/components/textarea/tests/TextArea.spec.tsx
+++ b/packages/react-vapor/src/components/textarea/tests/TextArea.spec.tsx
@@ -1,6 +1,7 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 import {act} from 'react-dom/test-utils';
+import * as _ from 'underscore';
 
 import {mountWithStore, shallowWithStore} from 'enzyme-redux';
 import {getStoreMock, ReactVaporMockStore} from '../../../utils/tests/TestUtils';

--- a/packages/react-vapor/src/components/textarea/tests/TextArea.spec.tsx
+++ b/packages/react-vapor/src/components/textarea/tests/TextArea.spec.tsx
@@ -96,25 +96,32 @@ describe('TextArea', () => {
             expect(onChangeCallback).toHaveBeenCalledTimes(1);
         });
 
-        it('should contains validation message if changed value is invalid', () => {
-            const validation = (value: string) => value !== '';
-            const validationMessage = 'invalid value';
-            const invalidValue = '';
+        it('should contains validation message if debounced value is invalid', () => {
             jasmine.clock().install();
+            const invalidValue = '';
+            const validation = (value: string) => value !== invalidValue;
+            const validationMessage = 'invalid value';
 
-            wrapper.setProps({validate: validation, validationMessage: validationMessage, value: invalidValue});
+            wrapper.setProps({validate: validation, validationMessage: validationMessage, value: 'anyValue'});
             act(() => {
-                wrapper.update();
+                wrapper.mount();
             });
-            expect(wrapper.contains(validationMessage)).toBeFalsy();
+            expect(wrapper.contains(validationMessage)).toBeFalsy(); // initial mount is not validated
 
             wrapper.setProps({value: invalidValue});
             act(() => {
-                wrapper.update();
+                wrapper.update(); // set value to invalid value
+            });
+            jasmine.clock().tick(400);
+            act(() => {
+                wrapper.update(); // setTimeout call back set the debouncedValue
+            });
+            act(() => {
+                wrapper.update(); // validation of the debouncedValue
             });
 
-            jasmine.clock().tick(301);
             expect(wrapper.contains(validationMessage)).toBeTruthy();
+            jasmine.clock().uninstall();
         });
 
         it('should call prop validate on value change', () => {

--- a/packages/react-vapor/src/components/textarea/tests/TextArea.spec.tsx
+++ b/packages/react-vapor/src/components/textarea/tests/TextArea.spec.tsx
@@ -210,7 +210,6 @@ describe('TextArea', () => {
             describe('onMount', () => {
                 it('should add a textArea in the store with default values', () => {
                     const add = spyOn(TextAreaActions, 'add');
-
                     hookWrapper = mountWithStore(<TextAreaConnected id={'textarea-id'} onMount={add} />, store);
                     act(() => {
                         hookWrapper.update();


### PR DESCRIPTION
### Proposed Changes

Added validation to the textare component

### Potential Breaking Changes

Now when using Labels with htmlFor props you need to give it as a children to the component.
```tsx
                <TextAreaConnected
                    id="super-textarea-8"
                     validate={(value: string) => value !== ''}
                   validationMessage={'TextArea should not be empty!'}
                >
                    <Label htmlFor="super-textarea-8">Beautiful Textarea</Label>
                </TextAreaConnected>
```

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
