### PR TITLE
fix(actionbar): make disabled actions stay that way

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
         "test": "lerna run test --parallel",
         "build": "lerna run build --parallel",
         "lintfix": "stylelint --fix \"**/*.scss\" && prettier --write \"**/*.{scss,json,js,jsx,ts,tsx,md}\" && tslint -c ./tslint.json -p ./packages/react-vapor/tsconfig.json --fix",
-        "commit-cli": "git-cz"
+        "commit-cli": "git-cz",
+        "reconstruct": "npx lerna clean --yes && npx rimraf node_modules && npm i && echo done"
     },
     "config": {
         "commitizen": {

--- a/packages/react-vapor/src/components/actions/ActionBar.tsx
+++ b/packages/react-vapor/src/components/actions/ActionBar.tsx
@@ -87,11 +87,11 @@ export class ActionBar extends React.PureComponent<
                 .map((action: IActionOptions, index: number) => {
                     const primaryAction = this.props.withReduxState ? (
                         <PrimaryActionConnected
-                            action={{...action, enabled: !this.props.disabled}}
+                            action={{...action, enabled: action.enabled && !this.props.disabled}}
                             parentId={this.props.id}
                         />
                     ) : (
-                        <PrimaryAction action={{...action, enabled: !this.props.disabled}} />
+                        <PrimaryAction action={{...action, enabled: action.enabled && !this.props.disabled}} />
                     );
                     return (
                         <div className="action primary-action" key={`primary-${index}`}>
@@ -100,11 +100,16 @@ export class ActionBar extends React.PureComponent<
                     );
                 }) ?? [];
 
-        const secondaryActions: IActionOptions[] = this.props.actions?.filter(({primary}) => !primary) ?? [];
+        const secondaryActions: IActionOptions[] =
+            this.props.actions
+                ?.filter(({primary}) => !primary)
+                .map((action: IActionOptions) => ({
+                    ...action,
+                    enabled: action.enabled && !this.props.disabled,
+                })) ?? [];
 
         let secondaryActionsView: JSX.Element = null;
         if (!_.isEmpty(secondaryActions)) {
-            secondaryActions.forEach((action: IActionOptions) => ({...action, enabled: !this.props.disabled}));
             secondaryActionsView = (
                 <SecondaryActions
                     id={this.props.id}

--- a/packages/react-vapor/src/components/actions/tests/ActionBar.spec.tsx
+++ b/packages/react-vapor/src/components/actions/tests/ActionBar.spec.tsx
@@ -54,6 +54,13 @@ describe('ActionsBar', () => {
         expect(wrapper.find(PrimaryAction).props().action.enabled).toBe(true);
     });
 
+    it('should not enable a PrimaryAction that is set as disabled', () => {
+        const wrapper = shallow(<ActionBar actions={[{enabled: false, primary: true}]} />)
+            .childAt(1)
+            .dive();
+        expect(wrapper.find(PrimaryAction).props().action.enabled).toBe(false);
+    });
+
     it('should return PrimaryAction disabled', () => {
         const wrapper = shallow(<ActionBar actions={[{enabled: true, primary: true}]} disabled />)
             .childAt(1)
@@ -63,6 +70,13 @@ describe('ActionsBar', () => {
 
     it('should return PrimaryActionConnected disabled', () => {
         const wrapper = shallow(<ActionBar actions={[{enabled: true, primary: true}]} withReduxState disabled />)
+            .childAt(1)
+            .dive();
+        expect(wrapper.find(PrimaryActionConnected).props().action.enabled).toBe(false);
+    });
+
+    it('should not enable a PrimaryActionConnected that is set as disabled', () => {
+        const wrapper = shallow(<ActionBar actions={[{enabled: false, primary: true}]} withReduxState />)
             .childAt(1)
             .dive();
         expect(wrapper.find(PrimaryActionConnected).props().action.enabled).toBe(false);

--- a/packages/react-vapor/webpack.config.js
+++ b/packages/react-vapor/webpack.config.js
@@ -142,6 +142,6 @@ module.exports = {
         compress: true,
         hot: true,
         inline: true,
-        progress: true,
+        progress: false,
     },
 };


### PR DESCRIPTION
### Proposed Changes
```tsx
// source code of the examples in the screenshots below
{
    name: 'Link to Coveo (disabled)',
    link: 'http://coveo.com',
    target: '_blank',
    icon: 'edit',
    primary: true,
    enabled: false, //        <--- Here
    hideDisabled: false,
},
{
    name: 'Action 3',
    trigger: () => alert('You cannot trigger me'),
    icon: 'edit',
    primary: true,
    enabled: false, //        <--- Here
    hideDisabled: false,
},
```

Before:
![image](https://user-images.githubusercontent.com/35579930/74375326-18909c00-4dae-11ea-80a0-0f1d04a958f4.png)

After:
![image](https://user-images.githubusercontent.com/35579930/74375271-09115300-4dae-11ea-8cb6-059848e934e5.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
