### PR TITLE
fix(drop): fallback on Defaults for selector and parentSelector props

### DIFF
--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -22,7 +22,6 @@
     "scripts": {
         "start": "webpack-dev-server",
         "docs": "webpack",
-        "compileTs": "webpack --config webpack.config.prod.js",
         "build": "gulp clean && webpack --config webpack.config.prod.js",
         "pretest": "gulp clean:tests",
         "test": "node --max-old-space-size=2048 node_modules/karma/bin/karma start",

--- a/packages/react-vapor/src/components/actionable-item/ActionableItem.tsx
+++ b/packages/react-vapor/src/components/actionable-item/ActionableItem.tsx
@@ -42,7 +42,6 @@ export class ActionableItem extends React.Component<IActionableItemProps & React
                         id={this.props.id}
                         positions={[DropPodPosition.bottom, DropPodPosition.top]}
                         buttonContainerProps={{className: 'inline-block'}}
-                        parentSelector={'body'}
                         renderOpenButton={(onClick: () => void) => (
                             <div
                                 onClick={onClick}

--- a/packages/react-vapor/src/components/chart/ChartTooltip.tsx
+++ b/packages/react-vapor/src/components/chart/ChartTooltip.tsx
@@ -1,6 +1,5 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
-import {Defaults} from '../../Defaults';
 
 import {VaporColors} from '../color/Color';
 import {DropPodPosition, IDropUIPosition} from '../drop/DomPositionCalculator';
@@ -69,7 +68,6 @@ export const ChartTooltip: React.FunctionComponent<ChartTooltipProps> = ({sort =
                 ref={dropRoot}
                 isOpen={!!position.position}
                 positions={[position.position, DropPodPosition.left, DropPodPosition.right]}
-                parentSelector={Defaults.DROP_ROOT}
                 renderDrop={(
                     style: React.CSSProperties,
                     dropRef: React.RefObject<HTMLDivElement>,

--- a/packages/react-vapor/src/components/drop/Drop.tsx
+++ b/packages/react-vapor/src/components/drop/Drop.tsx
@@ -1,6 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+
 import {IReactVaporState} from '../../ReactVapor';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
 import {defaultDropPodPosition, DropPod, IDropPodProps} from './DropPod';
@@ -91,10 +92,10 @@ export class Drop extends React.PureComponent<IDropProps> {
                 ref={this.button}
                 isOpen={this.props.isOpen}
                 positions={this.props.positions || []}
-                selector={this.props.selector}
                 minHeight={this.props.minHeight}
                 minWidth={this.props.minWidth}
                 hasSameWidth={this.props.hasSameWidth}
+                selector={this.props.selector}
                 parentSelector={this.props.parentSelector}
                 renderDrop={(style: React.CSSProperties, dropRef: React.RefObject<HTMLDivElement>): React.ReactNode => (
                     // Use dropRef as a reference of the drop element because we need to calculate later if the click is inside or not the drop container

--- a/packages/react-vapor/src/components/drop/DropPod.tsx
+++ b/packages/react-vapor/src/components/drop/DropPod.tsx
@@ -53,6 +53,8 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
         minWidth: 0,
         minHeight: 0,
         hasSameWidth: false,
+        selector: Defaults.DROP_ROOT,
+        parentSelector: Defaults.DROP_PARENT_ROOT,
     };
     private parentMutationObserver: MutationObserver;
 
@@ -137,12 +139,11 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
         let newDomPosition: IDomPositionCalculatorReturn = {};
         if (this.canRenderDrop()) {
             const buttonOffset: ClientRect | DOMRect =
-                (this.props.buttonRef.current && this.props.buttonRef.current.getBoundingClientRect()) ||
-                this.state.offset;
+                this.props.buttonRef.current?.getBoundingClientRect() ?? this.state.offset;
             const dropOffset: ClientRect | DOMRect = this.dropRef.current.getBoundingClientRect();
             const relativeParent =
-                this.props.buttonRef?.current.closest(this.props.parentSelector) ??
-                this.props.buttonRef?.current.parentElement;
+                this.props.buttonRef.current?.closest(this.props.parentSelector) ??
+                this.props.buttonRef.current?.parentElement;
 
             const parentOffset = relativeParent.getBoundingClientRect();
 
@@ -221,7 +222,6 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
     }
 
     render() {
-        const selector: any = this.props.selector || Defaults.DROP_ROOT;
         const drop: React.ReactNode = this.props.renderDrop(
             {
                 position: 'absolute',
@@ -235,7 +235,7 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
             this.lastPosition
         );
 
-        return ReactDOM.createPortal(drop, document.querySelector(selector));
+        return ReactDOM.createPortal(drop, document.querySelector(this.props.selector));
     }
 }
 

--- a/packages/react-vapor/src/components/select/SelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SelectConnected.tsx
@@ -1,10 +1,9 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import {createStructuredSelector} from 'reselect';
+import {keys} from 'ts-transformer-keys';
 import * as _ from 'underscore';
 
-import {keys} from 'ts-transformer-keys';
-import {Defaults} from '../../Defaults';
 import {IReactVaporState, IReduxActionsPayload} from '../../ReactVapor';
 import {IComponentBehaviour} from '../../utils/ComponentUtils';
 import {mod} from '../../utils/DataStructuresUtils';
@@ -123,7 +122,6 @@ export class SelectConnected extends React.PureComponent<ISelectProps & ISelectS
             <Drop
                 id={this.props.id}
                 groupId={SelectConnected.DropGroup}
-                selector={Defaults.DROP_ROOT}
                 positions={[DropPodPosition.bottom, DropPodPosition.top]}
                 buttonContainerProps={{className: pickerClasses}}
                 renderOpenButton={(onClick: () => void) => (
@@ -143,7 +141,6 @@ export class SelectConnected extends React.PureComponent<ISelectProps & ISelectS
                 )}
                 minWidth={minWidth}
                 closeOnClickDrop={false}
-                parentSelector={Defaults.DROP_PARENT_ROOT}
                 {...this.props.dropOption}
             >
                 <div


### PR DESCRIPTION
### Proposed Changes

Make the `DropPod` component fallback on the `Defaults.DROP_ROOT` and `Defaults.DROP_PARENT_ROOT` for `selector` and `parentSelector` props respectively.

### Potential Breaking Changes

None expected.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
