### PR TITLE
feat(tablehoc): add tbodyclassname props

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
@@ -22,6 +22,7 @@ export interface ITableHOCOwnProps {
     tableHeader?: React.ReactNode;
     onUpdate?: () => void;
     containerClassName?: string;
+    tbodyClassName?: string;
     showBorderTop?: boolean;
     loading?: {
         numberOfColumns?: number;
@@ -47,7 +48,10 @@ export class TableHOC extends React.PureComponent<ITableHOCProps & React.HTMLAtt
         const table = (
             <table className={classNames(this.props.className)}>
                 {this.props.tableHeader}
-                <tbody key={`table-body-${this.props.id}`} className={classNames({hidden: this.props.isLoading})}>
+                <tbody
+                    key={`table-body-${this.props.id}`}
+                    className={classNames({hidden: this.props.isLoading}, this.props.tbodyClassName)}
+                >
                     {this.props.renderBody(this.props.data || [])}
                 </tbody>
                 {this.props.isLoading && (


### PR DESCRIPTION
### Proposed Changes

In order to implementing cards into `TableHOC`, we would need to apply flexbox or other styles into the parent `tbody`.

### Potential Breaking Changes

nope

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
