### PR TITLE
feat(blankslate): add classname props

### DIFF
--- a/packages/react-vapor/src/components/blankSlate/BlankSlateWithTable.tsx
+++ b/packages/react-vapor/src/components/blankSlate/BlankSlateWithTable.tsx
@@ -1,9 +1,12 @@
+import * as classNames from 'classnames';
 import {ComponentClass} from 'react';
 import * as React from 'react';
 import {IBlankSlateProps} from './BlankSlate';
 
 export interface IBlankSlateWithTableProps extends IBlankSlateProps {
     numberOfColumn?: number;
+    blankSlateRowClassName?: string;
+    blankSlateCellClassName?: string;
 }
 
 export const blankSlateWithTable = <P extends IBlankSlateProps>(
@@ -17,8 +20,8 @@ export const blankSlateWithTable = <P extends IBlankSlateProps>(
         render() {
             const {numberOfColumn, ...componentProps} = this.props;
             return (
-                <tr className="blankslate-row no-hover">
-                    <td colSpan={numberOfColumn}>
+                <tr className={classNames(this.props.blankSlateRowClassName, 'blankslate-row no-hover')}>
+                    <td colSpan={numberOfColumn} className={classNames(this.props.blankSlateCellClassName)}>
                         <Component {...(componentProps as P)}>{this.props.children}</Component>
                     </td>
                 </tr>

--- a/packages/react-vapor/src/components/table-hoc/TableWithFilter.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithFilter.tsx
@@ -6,13 +6,13 @@ import * as _ from 'underscore';
 import {WithServerSideProcessingProps} from '../../hoc/withServerSideProcessing';
 import {IReactVaporState} from '../../ReactVapor';
 import {ConfigSupplier, HocUtils, UrlUtils} from '../../utils';
-import {BlankSlateWithTable, IBlankSlateProps} from '../blankSlate';
+import {BlankSlateWithTable, IBlankSlateWithTableProps} from '../blankSlate';
 import {FilterBoxConnected, FilterBoxSelectors} from '../filterBox';
 import {ITableHOCOwnProps} from './TableHOC';
 import {Params} from './TableWithUrlState';
 
 export interface ITableWithFilterConfig extends WithServerSideProcessingProps {
-    blankSlate?: IBlankSlateProps;
+    blankSlate?: IBlankSlateWithTableProps;
     matchFilter?: (filterValue: string, datum: any) => boolean;
     placeholder?: string;
 }


### PR DESCRIPTION
### Proposed Changes

We would need these two props to apply `flex` and `full-content-x` to the blankslate in a table with cards.

### Potential Breaking Changes

no i swear

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
