### PR TITLE
ci(travis): stop invalidating cloudfront on PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ deploy:
 
 after_script:
     - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then ./create-live-demo.sh; fi' # run this line on pull request builds only
-    - 'if [ "$TRAVIS_BRANCH" = "master" ]; then node ./invalidate-cloudfront.js; fi'
+    - 'if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "" ]; then node ./invalidate-cloudfront.js; fi'
 
 notifications:
     email:


### PR DESCRIPTION
### Proposed Changes

I noticed Travis was invalidating the cloudfront cache when building pull requests.

This is because `$TRAVIS_BRANCH` equals to `master` for pull requests that target master. See Travis docs:

![image](https://user-images.githubusercontent.com/35579930/74979167-09d46580-53fc-11ea-959c-e07851d90fef.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
