### PR TITLE
fix(dependencies): add rc-slider as dependency

### DIFF
--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -44,7 +44,8 @@
         "react-modal": "3.10.1",
         "react-tether": "1.0.4",
         "react-textarea-autosize": "7.1.0",
-        "unidiff": "0.0.4"
+        "unidiff": "0.0.4",
+        "rc-slider": "8.7.1"
     },
     "peerDependencies": {
         "codemirror": "^5.39.2",
@@ -127,7 +128,6 @@
         "moment": "2.24.0",
         "node-sass": "4.13.1",
         "postcss-loader": "3.0.0",
-        "rc-slider": "8.7.1",
         "react": "16.12.0",
         "react-dnd": "2.5.1",
         "react-dnd-html5-backend": "2.5.1",

--- a/packages/vapor/package.json
+++ b/packages/vapor/package.json
@@ -64,6 +64,9 @@
         "webpack": "4.41.6",
         "webpack-cli": "3.3.11"
     },
+    "dependencies": {
+        "rc-slider": "8.7.1"
+    },
     "files": [
         "dist",
         "gulpTasks",


### PR DESCRIPTION
### Proposed Changes

It was only added in the devDependencies of react-vapor package, but we actually import the style in vapor and import the js also in the react-vapor package, so clearly it should be a depedency.

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
