### PR TITLE
Allow connected components to be rendered as children of the `PartialStringMatch` component.

### DIFF
--- a/packages/demo/src/components/examples/PartialStringMatchExamples.tsx
+++ b/packages/demo/src/components/examples/PartialStringMatchExamples.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {InfoBox, InfoBoxLink, PartialStringMatch} from 'react-vapor';
+import {CheckboxConnected, InfoBox, InfoBoxLink, Label, PartialStringMatch} from 'react-vapor';
 
 export class PartialStringMatchExamples extends React.Component<any, any> {
     render() {
@@ -74,6 +74,11 @@ export class PartialStringMatchExamples extends React.Component<any, any> {
                                 </div>
                                 <InfoBox>
                                     What about custom components? <InfoBoxLink>Can they contain hello?</InfoBoxLink>
+                                    <div>
+                                        <CheckboxConnected label="boom">
+                                            <Label>Hello connected components too</Label>
+                                        </CheckboxConnected>
+                                    </div>
                                 </InfoBox>
                             </div>
                         </PartialStringMatch>

--- a/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.spec.tsx
+++ b/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.spec.tsx
@@ -1,5 +1,7 @@
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import * as React from 'react';
+import {connect, Provider} from 'react-redux';
+import createMockStore from 'redux-mock-store';
 
 import {PartialStringMatch} from './PartialStringMatch';
 
@@ -102,6 +104,21 @@ describe('PartialStringMatch', () => {
             <PartialStringMatch partialMatch={matcher}>
                 <Porkchop />
             </PartialStringMatch>
+        );
+
+        expect(component.find('Highlight').length).toBe(2);
+    });
+
+    it('should highlight all matches rendered throught a connected component', () => {
+        const Porkchop: React.FunctionComponent = () => <span>a porkchop is a chop of the pork</span>;
+        const ConnectedPorkchop = connect((state: any) => ({a: state.a}))(Porkchop);
+        const matcher = 'chop';
+        const component = mount(
+            <Provider store={createMockStore()()}>
+                <PartialStringMatch partialMatch={matcher}>
+                    <ConnectedPorkchop />
+                </PartialStringMatch>
+            </Provider>
         );
 
         expect(component.find('Highlight').length).toBe(2);

--- a/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.tsx
+++ b/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.tsx
@@ -55,6 +55,9 @@ export class PartialStringMatch extends React.PureComponent<PartialStringMatchPr
                 ...element.props,
                 children: this.lookupChildren(element.props.children),
             });
+        } else if (/^Connect\(.+\)$/.test(element.type.displayName)) {
+            // The node is Connected component, we dive into its wrapped component
+            yield this.lookupChildren(element.type.WrappedComponent(element.props));
         } else if (typeof element.type === 'function') {
             // The node is a React.FunctionComponent, we iterate over what's rendered by the function
             yield this.lookupChildren(element.type(element.props));


### PR DESCRIPTION
### Proposed Changes

Allow connected components to be rendered as children of the `PartialStringMatch` component.

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
