### PR TITLE
fix(input): added native html prop types for retro compatibility

### DIFF
--- a/packages/react-vapor/src/components/input/Input.tsx
+++ b/packages/react-vapor/src/components/input/Input.tsx
@@ -38,6 +38,10 @@ export interface IInputNativeTagStateProps {
     value?: string;
     checked?: boolean;
     disabled?: boolean;
+    readOnly?: boolean;
+    placeholder?: string;
+    autofocus?: boolean;
+    name?: string;
 }
 
 export interface IInputAdditionalStateProps {


### PR DESCRIPTION
### Proposed Changes

the coveo interface editor is using react-vapor v3. bumping the version breaked some props type. fixing them for retro

### Potential Breaking Changes

only added optional properties to an interface.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
