### PR TITLE
fix(partialstringmatch): allow class components without children

### DIFF
--- a/packages/demo/src/components/examples/PartialStringMatchExamples.tsx
+++ b/packages/demo/src/components/examples/PartialStringMatchExamples.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {CheckboxConnected, InfoBox, InfoBoxLink, Label, PartialStringMatch} from 'react-vapor';
+import {CheckboxConnected, InfoBox, InfoBoxLink, Label, Loading, PartialStringMatch} from 'react-vapor';
 
 export class PartialStringMatchExamples extends React.Component<any, any> {
     render() {
@@ -72,6 +72,7 @@ export class PartialStringMatchExamples extends React.Component<any, any> {
                                         is this working with deep structure? <span>(hello, still reading?)</span>
                                     </span>
                                 </div>
+                                <Loading />
                                 <InfoBox>
                                     What about custom components? <InfoBoxLink>Can they contain hello?</InfoBoxLink>
                                     <div>

--- a/packages/react-vapor/src/components/loading/Loading.tsx
+++ b/packages/react-vapor/src/components/loading/Loading.tsx
@@ -21,16 +21,12 @@ export class Loading extends React.Component<ILoadingProps & React.HTMLProps<HTM
         fullContent: false,
     };
 
-    componentWillMount() {
-        if (this.props.onRender) {
-            this.props.onRender();
-        }
+    componentDidMount() {
+        this.props.onRender?.();
     }
 
     componentWillUnmount() {
-        if (this.props.onDestroy) {
-            this.props.onDestroy();
-        }
+        this.props.onDestroy?.();
     }
 
     render() {

--- a/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.spec.tsx
+++ b/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.spec.tsx
@@ -10,6 +10,7 @@ describe('PartialStringMatch', () => {
 
     it('should not throw when there is no children', () => {
         expect(() => shallow(<PartialStringMatch partialMatch="a" />)).not.toThrow();
+        expect(() => shallow(<PartialStringMatch></PartialStringMatch>)).not.toThrow();
     });
 
     it('should render an empty string if the wholeString is a falsy value', () => {
@@ -122,5 +123,20 @@ describe('PartialStringMatch', () => {
         );
 
         expect(component.find('Highlight').length).toBe(2);
+    });
+
+    it('should render class Components that has no children without throwing', () => {
+        class ClassComponent extends React.Component {
+            render() {
+                return <span>aa</span>;
+            }
+        }
+        expect(() => {
+            shallow(
+                <PartialStringMatch partialMatch="a">
+                    <ClassComponent />
+                </PartialStringMatch>
+            );
+        }).not.toThrow();
     });
 });

--- a/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.tsx
+++ b/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.tsx
@@ -50,7 +50,6 @@ export class PartialStringMatch extends React.PureComponent<PartialStringMatchPr
             yield this.hightlightMatches(component);
         } else if (element.props && element.props.children) {
             // The node is a React.Component, we iterate over its children
-            // We iterate over its children
             yield React.cloneElement(element, {
                 ...element.props,
                 children: this.lookupChildren(element.props.children),
@@ -58,7 +57,13 @@ export class PartialStringMatch extends React.PureComponent<PartialStringMatchPr
         } else if (/^Connect\(.+\)$/.test(element.type.displayName)) {
             // The node is Connected component, we dive into its wrapped component
             yield this.lookupChildren(element.type.WrappedComponent(element.props));
-        } else if (typeof element.type === 'function') {
+        } else if (
+            typeof element.type === 'function' &&
+            !(
+                element.type.prototype instanceof React.Component ||
+                element.type.prototype instanceof React.PureComponent
+            )
+        ) {
             // The node is a React.FunctionComponent, we iterate over what's rendered by the function
             yield this.lookupChildren(element.type(element.props));
         } else {


### PR DESCRIPTION
### Proposed Changes

It seems the `PartialStringMatch` was breaking when trying to render class components that had no children such as the `Loading`.

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
