### PR TITLE
fix(partialstringmatch): allow rendering redux Provider inside it

### DIFF
--- a/packages/demo/src/components/examples/PartialStringMatchExamples.tsx
+++ b/packages/demo/src/components/examples/PartialStringMatchExamples.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import {Provider} from 'react-redux';
 import {CheckboxConnected, InfoBox, InfoBoxLink, Label, Loading, PartialStringMatch} from 'react-vapor';
+import {Store} from '../../Store';
 
 export class PartialStringMatchExamples extends React.Component<any, any> {
     render() {
@@ -65,23 +67,25 @@ export class PartialStringMatchExamples extends React.Component<any, any> {
                             <div>World</div>
                         </PartialStringMatch>
                         <PartialStringMatch key="b" caseInsensitive partialMatch={'hello'}>
-                            <div className="py2">
-                                <div className="my2">
-                                    Hello{' '}
-                                    <span>
-                                        is this working with deep structure? <span>(hello, still reading?)</span>
-                                    </span>
-                                </div>
-                                <Loading />
-                                <InfoBox>
-                                    What about custom components? <InfoBoxLink>Can they contain hello?</InfoBoxLink>
-                                    <div>
-                                        <CheckboxConnected label="boom">
-                                            <Label>Hello connected components too</Label>
-                                        </CheckboxConnected>
+                            <Provider store={Store}>
+                                <div className="py2">
+                                    <div className="my2">
+                                        Hello{' '}
+                                        <span>
+                                            is this working with deep structure? <span>(hello, still reading?)</span>
+                                        </span>
                                     </div>
-                                </InfoBox>
-                            </div>
+                                    <Loading />
+                                    <InfoBox>
+                                        What about custom components? <InfoBoxLink>Can they contain hello?</InfoBoxLink>
+                                        <div>
+                                            <CheckboxConnected label="boom">
+                                                <Label>Hello connected components too</Label>
+                                            </CheckboxConnected>
+                                        </div>
+                                    </InfoBox>
+                                </div>
+                            </Provider>
                         </PartialStringMatch>
                     </div>
                 </div>

--- a/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.spec.tsx
+++ b/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.spec.tsx
@@ -1,8 +1,8 @@
 import {mount, shallow} from 'enzyme';
 import * as React from 'react';
 import {connect, Provider} from 'react-redux';
-import createMockStore from 'redux-mock-store';
 
+import {getStoreMock} from '../../utils/tests/TestUtils';
 import {PartialStringMatch} from './PartialStringMatch';
 
 describe('PartialStringMatch', () => {
@@ -115,7 +115,7 @@ describe('PartialStringMatch', () => {
         const ConnectedPorkchop = connect((state: any) => ({a: state.a}))(Porkchop);
         const matcher = 'chop';
         const component = mount(
-            <Provider store={createMockStore()()}>
+            <Provider store={getStoreMock()}>
                 <PartialStringMatch partialMatch={matcher}>
                     <ConnectedPorkchop />
                 </PartialStringMatch>
@@ -135,6 +135,18 @@ describe('PartialStringMatch', () => {
             shallow(
                 <PartialStringMatch partialMatch="a">
                     <ClassComponent />
+                </PartialStringMatch>
+            );
+        }).not.toThrow();
+    });
+
+    it('should not throw errors when rendering a Provider inside the PartialStringMatch', () => {
+        expect(() => {
+            mount(
+                <PartialStringMatch partialMatch="here">
+                    <Provider store={getStoreMock()}>
+                        <div>Something here</div>
+                    </Provider>
                 </PartialStringMatch>
             );
         }).not.toThrow();

--- a/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.tsx
+++ b/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.tsx
@@ -25,17 +25,19 @@ export class PartialStringMatch extends React.PureComponent<PartialStringMatchPr
         return this.lookupChildren(toRender);
     }
 
-    private lookupChildren(component: React.ReactNode): React.ReactNode[] {
+    private lookupChildren(component: React.ReactNode): React.ReactNode {
         const iterator = this.deepReplaceStrings(component);
 
         const children: React.ReactNode[] = [];
         let result: IteratorResult<React.ReactNode>;
         do {
             result = iterator.next();
-            children.push(result.value);
+            if (result.value) {
+                children.push(result.value);
+            }
         } while (!result.done);
 
-        return children;
+        return children.length === 1 ? children[0] : children;
     }
 
     private *deepReplaceStrings(component: React.ReactNode): IterableIterator<React.ReactNode> {

--- a/packages/react-vapor/tsconfig.json
+++ b/packages/react-vapor/tsconfig.json
@@ -11,5 +11,5 @@
         "noUnusedLocals": true,
         "lib": ["es2015", "dom"]
     },
-    "exclude": ["node_modules", "dist", "coverage", "*.js"]
+    "exclude": ["**/node_modules", "**/dist", "**/coverage", "*.js", "**/target"]
 }


### PR DESCRIPTION
### Proposed Changes

The PartialStringMatch is throwing an error when rendering a redux Provider inside it.

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
