### PR TITLE
Fix partial string match once again

### DIFF
--- a/packages/demo/src/components/examples/SingleSelectExamples.tsx
+++ b/packages/demo/src/components/examples/SingleSelectExamples.tsx
@@ -43,9 +43,12 @@ const defaultItems: IItemBoxProps[] = [
     {displayValue: 'Seven', value: '7', selectedDisplayValue: '007 Bond, James'},
 ];
 
-const itemsWithAppendedValue = _.map(defaultItems, (item) =>
-    _.extend({}, item, {append: {content: () => <span className="text-red ml3">{item.value}</span>}})
-);
+const itemsWithAppendedValue = _.map(defaultItems, (item) => ({
+    ...item,
+    append: {content: () => <span className="text-red ml3">{item.value}</span>},
+}));
+
+const ids = [UUID.generate(), UUID.generate(), UUID.generate(), UUID.generate(), UUID.generate(), UUID.generate()];
 
 const defaultFlatSelectOptions: IFlatSelectOptionProps[] = [
     {id: UUID.generate(), option: {content: 'All'}, selected: true},
@@ -70,7 +73,7 @@ const SingleSelectConnectedExamples: React.ComponentType = () => (
     <Section level={2} title="Single selects connected to store">
         <Section level={3} className="form-group" title="A single select with some implementation props">
             <SingleSelectConnected
-                id={UUID.generate()}
+                id={ids[0]}
                 items={defaultItems}
                 placeholder="Select something"
                 canClear
@@ -79,7 +82,7 @@ const SingleSelectConnectedExamples: React.ComponentType = () => (
         </Section>
         <Section level={3} title="A single select with some implementation props">
             <SingleSelectConnected
-                id={UUID.generate()}
+                id={ids[1]}
                 items={defaultItems}
                 toggleClasses="mod-right"
                 placeholder="Select something"
@@ -88,18 +91,18 @@ const SingleSelectConnectedExamples: React.ComponentType = () => (
         </Section>
         <Section level={3} title="A single select with predicates">
             <SingleSelectWithPredicate
-                id={UUID.generate()}
+                id={ids[2]}
                 items={itemsWithAppendedValue}
                 options={defaultFlatSelectOptions}
                 matchPredicate={(p: string, i: IItemBoxProps) => matchPredicate(p, i)}
             />
         </Section>
         <Section level={3} title="A single select with filter">
-            <SingleSelectWithFilter id={UUID.generate()} items={itemsWithAppendedValue} />
+            <SingleSelectWithFilter id={ids[3]} items={itemsWithAppendedValue} />
         </Section>
         <Section level={3} title="A single select with a custom match filter that matches the exact value">
             <SingleSelectWithFilter
-                id={UUID.generate()}
+                id={ids[4]}
                 items={itemsWithAppendedValue}
                 matchFilter={(filter: string, item: IItemBoxProps) =>
                     _.isString(item.displayValue) ? item.displayValue.indexOf(filter) !== -1 : false
@@ -108,7 +111,7 @@ const SingleSelectConnectedExamples: React.ComponentType = () => (
         </Section>
         <Section level={3} title="A single select with a filter, predicates, a lots of values and a footer">
             <SingleSelectWithPredicateAndFilter
-                id={UUID.generate()}
+                id={ids[5]}
                 items={itemsWithAppendedValue}
                 options={defaultFlatSelectOptions}
                 matchPredicate={(p: string, i: IItemBoxProps) => matchPredicate(p, i)}

--- a/packages/react-vapor/src/components/drop/Drop.tsx
+++ b/packages/react-vapor/src/components/drop/Drop.tsx
@@ -46,7 +46,7 @@ export class Drop extends React.PureComponent<IDropProps> {
         this.onClick = this.onClick.bind(this);
     }
 
-    componentWillMount() {
+    componentDidMount() {
         if (this.props.isOpen) {
             this.setEventOnClickOnDocument();
         }

--- a/packages/react-vapor/src/components/drop/DropPod.tsx
+++ b/packages/react-vapor/src/components/drop/DropPod.tsx
@@ -67,13 +67,6 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
         };
 
         this.updateOffset = this.updateOffset.bind(this);
-    }
-
-    componentWillMount() {
-        if (this.props.isOpen) {
-            this.setEventsOnDocument();
-        }
-
         if (
             this.props.positions &&
             !!this.props.positions.length &&
@@ -88,6 +81,12 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
                 position: DropPodPosition.bottom,
                 orientation: DropPodPosition.left,
             };
+        }
+    }
+
+    componentDidMount() {
+        if (this.props.isOpen) {
+            this.setEventsOnDocument();
         }
     }
 

--- a/packages/react-vapor/src/components/filterBox/FilterBox.tsx
+++ b/packages/react-vapor/src/components/filterBox/FilterBox.tsx
@@ -1,5 +1,6 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
+
 import {Svg} from '../svg/Svg';
 
 export interface IFilterBoxOwnProps extends React.ClassAttributes<FilterBox> {
@@ -34,10 +35,6 @@ export const FILTER_PLACEHOLDER: string = 'Filter';
 export class FilterBox extends React.Component<IFilterBoxProps, any> {
     filterInput: HTMLInputElement;
 
-    constructor(props: IFilterBoxProps) {
-        super(props);
-    }
-
     static defaultProps: Partial<IFilterBoxProps> = {
         isAutoFocus: false,
     };
@@ -46,32 +43,9 @@ export class FilterBox extends React.Component<IFilterBoxProps, any> {
         this.filterInput.value = nextInputValue;
         this.filterInput.nextElementSibling.setAttribute('class', this.filterInput.value.length ? '' : 'hidden');
 
-        if (this.props.onFilterCallback) {
-            this.props.onFilterCallback(this.props.id, this.filterInput.value);
-        }
-
-        if (this.props.onFilter) {
-            this.props.onFilter(this.props.id, this.filterInput.value);
-        }
+        this.props.onFilterCallback?.(this.props.id, this.filterInput.value);
+        this.props.onFilter?.(this.props.id, this.filterInput.value);
     };
-
-    private handleOnBlur() {
-        if (this.props.onBlur) {
-            this.props.onBlur();
-        }
-    }
-
-    private handleOnKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-        if (this.props.onKeyDown) {
-            this.props.onKeyDown(e);
-        }
-    }
-
-    private handleOnKeyUp(e: React.KeyboardEvent<HTMLInputElement>) {
-        if (this.props.onKeyUp) {
-            this.props.onKeyUp(e);
-        }
-    }
 
     private clearValue = () => {
         this.filterInput.focus();
@@ -85,21 +59,17 @@ export class FilterBox extends React.Component<IFilterBoxProps, any> {
         input.value = temp;
     }
 
-    componentWillMount() {
-        if (this.props.onRender) {
-            this.props.onRender(this.props.id);
-        }
+    componentDidMount() {
+        this.props.onRender?.(this.props.id);
     }
 
     componentWillUnmount() {
-        if (this.props.onDestroy) {
-            this.props.onDestroy(this.props.id);
-        }
+        this.props.onDestroy?.(this.props.id);
     }
 
-    componentWillReceiveProps(nextProps: IFilterBoxProps) {
-        if (this.props.filterText !== nextProps.filterText && this.filterInput.value !== nextProps.filterText) {
-            this.handleChange(nextProps.filterText);
+    componentDidUpdate(prevProps: IFilterBoxProps) {
+        if (this.props.filterText !== prevProps.filterText && this.filterInput?.value !== prevProps.filterText) {
+            this.handleChange(this.props.filterText);
         }
     }
 
@@ -124,12 +94,12 @@ export class FilterBox extends React.Component<IFilterBoxProps, any> {
                         className={filterInputClasses}
                         placeholder={filterPlaceholder}
                         onChange={(e: React.FormEvent<HTMLInputElement>) => this.handleChange(e.currentTarget.value)}
-                        onBlur={() => this.handleOnBlur()}
                         onFocus={(e: React.FocusEvent<HTMLInputElement>) => {
                             this.placeCursorAtEndOfInputValue(e);
                         }}
-                        onKeyDown={(e) => this.handleOnKeyDown(e)}
-                        onKeyUp={(e) => this.handleOnKeyUp(e)}
+                        onBlur={this.props.onBlur}
+                        onKeyDown={this.props.onKeyDown}
+                        onKeyUp={this.props.onKeyUp}
                         style={inputMaxWidth}
                         autoFocus={this.props.isAutoFocus}
                     />

--- a/packages/react-vapor/src/components/filterBox/tests/FilterBox.spec.tsx
+++ b/packages/react-vapor/src/components/filterBox/tests/FilterBox.spec.tsx
@@ -29,7 +29,7 @@ describe('FilterBox', () => {
         it('should call prop onRender on mounting if set', () => {
             const renderSpy = jasmine.createSpy('onRender');
 
-            expect(() => filterBoxInstance.componentWillMount()).not.toThrow();
+            expect(() => filterBoxInstance.componentDidMount()).not.toThrow();
 
             filterBox.setProps({id: id, onRender: renderSpy});
             filterBox.unmount();
@@ -40,7 +40,7 @@ describe('FilterBox', () => {
         it('should call prop onDestroy on unmounting if set', () => {
             const destroySpy = jasmine.createSpy('onDestroy');
 
-            expect(() => filterBoxInstance.componentWillUnmount()).not.toThrow();
+            expect(() => filterBoxInstance.componentDidMount()).not.toThrow();
 
             filterBox.setProps({id: id, onDestroy: destroySpy});
             filterBox.mount();

--- a/packages/react-vapor/src/components/listBox/ListBox.tsx
+++ b/packages/react-vapor/src/components/listBox/ListBox.tsx
@@ -38,7 +38,7 @@ export class ListBox extends React.Component<IListBoxProps, {}> {
         wrapItems: _.identity,
     };
 
-    componentWillMount() {
+    componentDidMount() {
         this.props.onRender?.();
     }
 

--- a/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.spec.tsx
+++ b/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.spec.tsx
@@ -110,7 +110,7 @@ describe('PartialStringMatch', () => {
         expect(component.find('Highlight').length).toBe(2);
     });
 
-    it('should highlight all matches rendered throught a connected component', () => {
+    it('should render connected components without highlighting the matches', () => {
         const Porkchop: React.FunctionComponent = () => <span>a porkchop is a chop of the pork</span>;
         const ConnectedPorkchop = connect((state: any) => ({a: state.a}))(Porkchop);
         const matcher = 'chop';
@@ -122,7 +122,7 @@ describe('PartialStringMatch', () => {
             </Provider>
         );
 
-        expect(component.find('Highlight').length).toBe(2);
+        expect(component.find('Highlight').length).toBe(0);
     });
 
     it('should render class Components that has no children without throwing', () => {

--- a/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.tsx
+++ b/packages/react-vapor/src/components/partial-string-match/PartialStringMatch.tsx
@@ -57,8 +57,9 @@ export class PartialStringMatch extends React.PureComponent<PartialStringMatchPr
                 children: this.lookupChildren(element.props.children),
             });
         } else if (/^Connect\(.+\)$/.test(element.type.displayName)) {
-            // The node is Connected component, we dive into its wrapped component
-            yield this.lookupChildren(element.type.WrappedComponent(element.props));
+            // The node is Connected component, we render it as is
+            // TODO: find a way to yield WrappedComponent properly
+            yield component;
         } else if (
             typeof element.type === 'function' &&
             !(

--- a/packages/react-vapor/src/components/select/hoc/SelectWithFilter.tsx
+++ b/packages/react-vapor/src/components/select/hoc/SelectWithFilter.tsx
@@ -91,7 +91,7 @@ export const selectWithFilter = (
 
         private dividerId: string = UUID.generate();
 
-        componentWillMount() {
+        componentDidMount() {
             this.props.onRenderFilter(this.props.defaultCustomValues);
         }
 


### PR DESCRIPTION
### Proposed Changes

- remove highlight for connected components in the PartialStringMatch, because there is no way to compute the state props properly
- make the item selection work in the single select demo page
- refactored a bunch of deprecated componentWillSomething


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
