### PR TITLE
feat(multiselectconnected.tsx): +toggleClasses prop

### DIFF
--- a/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
@@ -21,7 +21,6 @@ import {ISelectButtonProps, ISelectOwnProps, ISelectProps, SelectConnected} from
 import {SelectSelector} from './SelectSelector';
 
 export interface IMultiSelectOwnProps extends ISelectProps, IDropTargetProps {
-    toggleClasses?: string;
     placeholder?: string;
     emptyPlaceholder?: string;
     deselectAllTooltipText?: string;

--- a/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
@@ -21,6 +21,7 @@ import {ISelectButtonProps, ISelectOwnProps, ISelectProps, SelectConnected} from
 import {SelectSelector} from './SelectSelector';
 
 export interface IMultiSelectOwnProps extends ISelectProps, IDropTargetProps {
+    toggleClasses?: string;
     placeholder?: string;
     emptyPlaceholder?: string;
     deselectAllTooltipText?: string;
@@ -161,6 +162,10 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps & React.ButtonHT
             !this.props.noDisabled && this.props.selected && this.props.selected.length === this.props.items.length
                 ? {disabled: true}
                 : {disabled: this.props.disabled};
+        const buttonClasses = classNames(
+            'btn dropdown-toggle multiselect-add dropdown-toggle-placeholder',
+            this.props.toggleClasses
+        );
         return (
             <div className={classes} style={this.props.multiSelectStyle}>
                 {this.props.connectDropTarget(
@@ -170,7 +175,7 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps & React.ButtonHT
                     </div>
                 )}
                 <button
-                    className="btn dropdown-toggle multiselect-add dropdown-toggle-placeholder"
+                    className={buttonClasses}
                     type="button"
                     onKeyDown={props.onKeyDown}
                     onKeyUp={props.onKeyUp}

--- a/packages/react-vapor/src/components/select/SelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SelectConnected.tsx
@@ -53,7 +53,9 @@ export interface ISelectButtonProps {
     placeholder?: string;
 }
 
-export interface ISelectProps extends ISelectOwnProps, Partial<ISelectStateProps>, Partial<ISelectDispatchProps> {}
+export interface ISelectProps extends ISelectOwnProps, Partial<ISelectStateProps>, Partial<ISelectDispatchProps> {
+    toggleClasses?: string;
+}
 
 const makeMapStateToProps = () => {
     const statePropsSelector = createStructuredSelector({

--- a/packages/react-vapor/src/components/select/SingleSelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SingleSelectConnected.tsx
@@ -19,7 +19,6 @@ import * as styles from './styles/SingleSelect.scss';
 
 export interface ISingleSelectOwnProps extends ISelectProps, IComponentBehaviour {
     placeholder?: string;
-    toggleClasses?: string;
     onSelectOptionCallback?: (option: string) => void;
     items?: IItemBoxProps[];
     buttonPrepend?: React.ReactNode;

--- a/packages/react-vapor/src/components/select/tests/MultiSelectConnected.spec.tsx
+++ b/packages/react-vapor/src/components/select/tests/MultiSelectConnected.spec.tsx
@@ -120,6 +120,14 @@ describe('Select', () => {
             expect(multiSelect.find('.multiselect-add').prop('disabled')).toBe(true);
         });
 
+        it('should set the toggleClasses prop if any on the dropdown-toggle', () => {
+            mountMultiSelect([], {
+                toggleClasses: 'tuna-can',
+            });
+
+            expect(multiSelect.find('.dropdown-toggle').hasClass('tuna-can')).toBe(true);
+        });
+
         it('should not disable the dropdown if one of the options is not is selected', () => {
             mountMultiSelect([
                 {value: 'a', selected: false},


### PR DESCRIPTION
added the toggleClasses prop as in singleSelect so that we can add classes on multiselect toggle
drop

Sorry, the branch name does not represent the feature, I tried it with spread syntax, didn't work really well, made the fix but forgot to change the branch name

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
