### PR TITLE
fix(drop pod): the Defaults.DROP_ROOT was not properly set

### DIFF
--- a/packages/react-vapor/src/components/drop/DropPod.tsx
+++ b/packages/react-vapor/src/components/drop/DropPod.tsx
@@ -53,8 +53,6 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
         minWidth: 0,
         minHeight: 0,
         hasSameWidth: false,
-        selector: Defaults.DROP_ROOT,
-        parentSelector: Defaults.DROP_PARENT_ROOT,
     };
     private parentMutationObserver: MutationObserver;
 
@@ -135,16 +133,21 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
         return this.dropRef.current && this.props.isOpen && !!this.props.positions.length;
     }
 
+    private getRelativeParent = () => {
+        const closestCurrentRef = this.props.buttonRef.current?.closest(
+            this.props.parentSelector ?? Defaults.DROP_PARENT_ROOT
+        );
+        return closestCurrentRef ?? this.props.buttonRef.current?.parentElement;
+    };
+
     private calculateStyleOffset(): React.CSSProperties {
         let newDomPosition: IDomPositionCalculatorReturn = {};
         if (this.canRenderDrop()) {
             const buttonOffset: ClientRect | DOMRect =
                 this.props.buttonRef.current?.getBoundingClientRect() ?? this.state.offset;
             const dropOffset: ClientRect | DOMRect = this.dropRef.current.getBoundingClientRect();
-            const relativeParent =
-                this.props.buttonRef.current?.closest(this.props.parentSelector) ??
-                this.props.buttonRef.current?.parentElement;
 
+            const relativeParent = this.getRelativeParent();
             const parentOffset = relativeParent.getBoundingClientRect();
 
             const boundingLimit: IBoundingLimit = {
@@ -235,7 +238,7 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
             this.lastPosition
         );
 
-        return ReactDOM.createPortal(drop, document.querySelector(this.props.selector));
+        return ReactDOM.createPortal(drop, document.querySelector(this.props.selector ?? Defaults.DROP_ROOT));
     }
 }
 

--- a/packages/react-vapor/src/components/drop/tests/DropPod.spec.tsx
+++ b/packages/react-vapor/src/components/drop/tests/DropPod.spec.tsx
@@ -3,6 +3,8 @@ import {shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
 import * as _ from 'underscore';
 
+import * as ReactDOM from 'react-dom';
+import {Defaults} from '../../../Defaults';
 import {DomPositionCalculator, DropPodPosition} from '../DomPositionCalculator';
 import {defaultDropPodPosition, DropPod, IDropPodProps} from '../DropPod';
 
@@ -129,6 +131,34 @@ describe('DropPod', () => {
                     }).dive();
 
                     expect(styleRendered.visibility).toBe('hidden');
+                });
+
+                describe('portal creation selector', () => {
+                    afterEach(() => {
+                        Defaults.DROP_ROOT = 'body';
+                    });
+
+                    it('should create a portal with the Defaults.DROP_ROOT if no selector is passed in props', () => {
+                        const expectedElement = document.querySelector('head');
+                        Defaults.DROP_ROOT = 'head';
+
+                        spyOn(document, 'querySelector').and.callThrough();
+                        const portalSpy: jasmine.Spy = spyOn(ReactDOM, 'createPortal');
+                        shallow(<DropPod renderDrop={() => '🍟'} ref={buttonRef} />, {}).dive();
+
+                        expect(portalSpy).toHaveBeenCalledWith('🍟', expectedElement);
+                    });
+
+                    it('should create a portal with the selector prop if passed to the dropPod', () => {
+                        const expectedElement = document.querySelector('head');
+                        Defaults.DROP_ROOT = '#🥔';
+
+                        spyOn(document, 'querySelector').and.callThrough();
+                        const portalSpy: jasmine.Spy = spyOn(ReactDOM, 'createPortal');
+                        shallow(<DropPod renderDrop={() => '🍟'} selector="head" ref={buttonRef} />, {}).dive();
+
+                        expect(portalSpy).toHaveBeenCalledWith('🍟', expectedElement);
+                    });
                 });
 
                 describe('calculate style position for the dropPod', () => {


### PR DESCRIPTION
The default props in the drop pod are set before the Defaults variables are loaded, thus defaulting
to 'body' all the time.

### Proposed Changes

passing the Defaults.DROP_ROOT and the Defaults.DROP_PARENT_ROOT directly where they are used instead of relying on defaultProps

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
