### PR TITLE
fix(modalheader): add redirect on close prop

### DIFF
--- a/packages/react-vapor/src/components/modal/ModalComposite.tsx
+++ b/packages/react-vapor/src/components/modal/ModalComposite.tsx
@@ -28,6 +28,7 @@ export interface IModalCompositeOwnProps
     modalFooterClasses?: IClassName;
     isPrompt?: boolean;
     validateShouldNavigate?: (isDirty: boolean) => boolean;
+    redirectOnClose?: () => void;
 }
 
 export interface IModalCompositeStateProps extends IReduxStatePossibleProps, IModalStateProps {
@@ -112,6 +113,7 @@ export class ModalComposite extends React.PureComponent<
             title: this.props.title,
             classes: this.props.modalHeaderClasses,
             docLink: this.props.docLink,
+            redirectOnClose: this.props.redirectOnClose,
         };
 
         if (!this.props.title) {

--- a/packages/react-vapor/src/components/modal/ModalHeader.tsx
+++ b/packages/react-vapor/src/components/modal/ModalHeader.tsx
@@ -12,6 +12,7 @@ export interface IModalHeaderOwnProps {
     title: string;
     classes?: IClassName;
     docLink?: ILinkSvgProps;
+    redirectOnClose?: () => void;
 }
 
 export interface IModalHeaderStateProps {
@@ -46,6 +47,7 @@ export class ModalHeader extends React.Component<IModalHeaderProps, {}> {
     close() {
         if (this.canClose) {
             this.props.onClose?.();
+            this.props.redirectOnClose?.();
         }
     }
 


### PR DESCRIPTION
### Proposed Changes

Add redirectOnClose prop to modal header, this function will be called when clicking on close icon in modal header. 

### Potential Breaking Changes

No

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
