### PR TITLE
feat(tablewithfilter): allow specifying config through props

### DIFF
--- a/packages/demo/src/components/examples/TableHOCwithBlankSlateExamples.tsx
+++ b/packages/demo/src/components/examples/TableHOCwithBlankSlateExamples.tsx
@@ -25,19 +25,19 @@ export interface IExampleRowData {
 const TableWithBlankSlateExample: React.FunctionComponent = () => (
     <Section>
         <TableWithBlankSlateComposed
-            id={'tableWithBlankSlate'}
+            id="tableWithBlankSlate"
             className="table"
             data={generateDataWithFacker(0)}
-            renderBody={generateTableRow}
+            renderBody={(data) => generateTableRow(data, 'tableWithBlankSlate')}
+            filterMatcher={(filter: string, data: IExampleRowData) =>
+                data.username.toLowerCase().indexOf(filter.toLowerCase()) !== -1
+            }
         />
     </Section>
 );
 
 const TableWithBlankSlateComposed = _.compose(
     tableWithBlankSlate({title: 'No data caused the table to be empty'}),
-    tableWithFilter({
-        matchFilter: (filter: string, data: IExampleRowData) =>
-            data.username.toLowerCase().indexOf(filter.toLowerCase()) !== -1,
-    }),
+    tableWithFilter(),
     tableWithBlankSlate({title: 'Filter caused the table to be empty'})
-)(TableHOC);
+)(TableHOC) as ReturnType<ReturnType<typeof tableWithFilter>>;

--- a/packages/react-vapor/src/components/table-hoc/TableWithFilter.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithFilter.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {connect} from 'react-redux';
-import {keys} from 'ts-transformer-keys';
 import * as _ from 'underscore';
 
 import {WithServerSideProcessingProps} from '../../hoc/withServerSideProcessing';
@@ -8,7 +7,7 @@ import {IReactVaporState} from '../../ReactVapor';
 import {ConfigSupplier, HocUtils, UrlUtils} from '../../utils';
 import {BlankSlateWithTable, IBlankSlateWithTableProps} from '../blankSlate';
 import {FilterBoxConnected, FilterBoxSelectors} from '../filterBox';
-import {ITableHOCOwnProps} from './TableHOC';
+import {ITableHOCOwnProps, TableHOC} from './TableHOC';
 import {Params} from './TableWithUrlState';
 
 export interface ITableWithFilterConfig extends WithServerSideProcessingProps {
@@ -17,23 +16,11 @@ export interface ITableWithFilterConfig extends WithServerSideProcessingProps {
     placeholder?: string;
 }
 
-export interface ITableWithFilterStateProps {
-    filter: string;
-    urlFilter: string;
+export interface TableWithFilterProps {
+    filterBlankslate?: IBlankSlateWithTableProps;
+    filterMatcher?: (filterValue: string, datum: any) => boolean;
+    filterPlaceholder?: string;
 }
-
-export interface ITableWithFilterDispatchProps {
-    addFilter: (filterText: string) => void;
-    onRender: () => void;
-}
-
-export interface ITableWithFilterProps
-    extends Partial<ITableWithFilterStateProps>,
-        Partial<ITableWithFilterDispatchProps>,
-        ITableHOCOwnProps,
-        WithServerSideProcessingProps {}
-
-const TableWithFilterPropsToOmit = keys<ITableWithFilterStateProps>();
 
 const defaultMatchFilter = (filter: string, datum: any) =>
     JSON.stringify(_.values(datum).map((v: any) => _.isString(v) && v.toLowerCase())).indexOf(filter.toLowerCase()) !==
@@ -42,17 +29,17 @@ const defaultMatchFilter = (filter: string, datum: any) =>
 export const tableWithFilter = (
     supplier: ConfigSupplier<ITableWithFilterConfig> = {blankSlate: {title: 'No results'}}
 ) => (
-    Component: React.ComponentClass<ITableWithFilterProps>
-): React.ComponentClass<ITableWithFilterProps & React.HTMLAttributes<HTMLTableElement>> => {
+    WrappedTable: typeof TableHOC
+): React.ComponentType<ITableHOCOwnProps & TableWithFilterProps & React.HTMLAttributes<HTMLTableElement>> => {
+    type OwnProps = ITableHOCOwnProps & TableWithFilterProps & WithServerSideProcessingProps;
+    type Props = OwnProps & ReturnType<typeof mapStateToProps>;
+
     const config = HocUtils.supplyConfig(supplier);
 
-    const mapStateToProps = (
-        state: IReactVaporState,
-        ownProps: ITableWithFilterProps
-    ): ITableWithFilterStateProps | ITableHOCOwnProps => {
+    const mapStateToProps = (state: IReactVaporState, ownProps: OwnProps) => {
         const filterText = FilterBoxSelectors.getFilterText(state, ownProps);
 
-        const matchFilter = config.matchFilter || defaultMatchFilter;
+        const matchFilter = ownProps.filterMatcher || config.matchFilter || defaultMatchFilter;
         const filterData = () =>
             filterText ? _.filter(ownProps.data, (datum: any) => matchFilter(filterText, datum)) : ownProps.data;
         const urlParams = UrlUtils.getSearchParams();
@@ -63,36 +50,40 @@ export const tableWithFilter = (
         };
     };
 
-    class TableWithFilter extends React.Component<ITableWithFilterProps> {
-        componentDidUpdate(prevProps: ITableWithFilterProps) {
+    class TableWithFilter extends React.Component<Props> {
+        componentDidUpdate(prevProps: Props) {
             if (prevProps.filter !== this.props.filter && this.props.filter !== this.props.urlFilter) {
                 this.props.onUpdate?.();
             }
         }
 
         render() {
+            const {filterBlankslate, filterMatcher, filterPlaceholder, filter, urlFilter, ...tableProps} = this.props;
+            const blankSlateProps = filterBlankslate || config.blankSlate;
+            const shouldShowBlankslate =
+                _.isEmpty(this.props.data) && !_.isEmpty(this.props.filter) && !_.isEmpty(blankSlateProps);
             const filterAction = (
                 <FilterBoxConnected
                     key="FilterBox"
                     id={this.props.id}
                     className="coveo-table-actions"
-                    filterPlaceholder={config.placeholder}
+                    filterPlaceholder={filterPlaceholder || config.placeholder}
                     isAutoFocus
                 />
             );
-            const newActions = [...(this.props.actions || []), filterAction];
-            const newProps = {
-                ..._.omit(this.props, [...TableWithFilterPropsToOmit]),
-                renderBody:
-                    _.isEmpty(this.props.data) && this.props.filter !== '' && config.blankSlate
-                        ? () => <BlankSlateWithTable {...HocUtils.supplyConfig(config.blankSlate)} />
-                        : this.props.renderBody,
-            };
 
             return (
-                <Component {...newProps} actions={newActions} withFilter>
+                <WrappedTable
+                    {...tableProps}
+                    actions={[...(this.props.actions ?? []), filterAction]}
+                    renderBody={
+                        shouldShowBlankslate
+                            ? () => <BlankSlateWithTable {...blankSlateProps} />
+                            : this.props.renderBody
+                    }
+                >
                     {this.props.children}
-                </Component>
+                </WrappedTable>
             );
         }
     }


### PR DESCRIPTION
### Proposed Changes

Allow specifying the `tableWithFilter` related options through the props:

#### Usage
```tsx
// before
const Table = _.compose(
    tableWithFilter({
        matchFilter: (filterText, row) => true,
        blankslate: filterBlankslateProps
    }),
    tableWithActions()
)(TableHOC)

<Table
    id='table-id'
    className='table'
    data={myData}
    renderBody={renderMyRows}
/>

// now you also can do:
const Table = _.compose(
    tableWithFilter(),
    tableWithActions()
)(TableHOC)

<Table
    id='table-id'
    className='table'
    data={myData}
    renderBody={renderMyRows}
    matchFilter={(filterText, row) => true}
    blankslate={filterBlankslateProps}
/>
```

This new way of doing things is more convenient because usually you have the dispatch props in the scope when setting the props on the `Table`.

### Potential Breaking Changes

Deleted some useless interfaces:

- `ITableWithFilterStateProps`
- `ITableWithFilterDispatchProps`
- `ITableWithFilterProps`

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
