### PR TITLE
fix(multilinebox): allow usage of empty string as defaultProps

### DIFF
--- a/packages/react-vapor/src/components/multilineBox/MultilineBox.tsx
+++ b/packages/react-vapor/src/components/multilineBox/MultilineBox.tsx
@@ -103,7 +103,7 @@ export class MultilineBox<T> extends React.PureComponent<IMultilineBoxProps<T>> 
     }
 
     private getLastBoxProps(): T {
-        return deepClone(this.props.defaultProps || {});
+        return deepClone(this.props.defaultProps);
     }
 
     private getData(): Array<IMultilineSingleBoxProps<T>> {

--- a/packages/react-vapor/src/components/multilineBox/tests/MultilineBox.spec.tsx
+++ b/packages/react-vapor/src/components/multilineBox/tests/MultilineBox.spec.tsx
@@ -242,6 +242,31 @@ describe('MultilineBox', () => {
 
                     expect(dataToBody[0].props).toEqual(theInitialProps);
                 });
+
+                it('should allow empty string as the default props', () => {
+                    const testId = 'cream';
+                    RTestUtils.mockUUID(testId);
+                    shallowWithState(
+                        <MultilineBox
+                            {...propsWithData}
+                            defaultProps=""
+                            renderBody={(data: IMultilineSingleBoxProps[]) => {
+                                dataToBody = data;
+                                return <div />;
+                            }}
+                        />,
+                        {
+                            multilineIds: {
+                                [id]: {
+                                    id: id,
+                                    list: ['uniqueID'],
+                                },
+                            },
+                        }
+                    ).dive();
+
+                    expect(dataToBody[0].props).toBe('');
+                });
             });
 
             describe('on component did update', () => {


### PR DESCRIPTION
### Proposed Changes

I'm creating a MultiValuesInput and I need the defaultProps to be "" (not an object)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
