### PR TITLE
feat(textarea): add validation to textarea + refactoring with hooks

### DIFF
--- a/packages/demo/src/components/examples/TextAreaExamples.tsx
+++ b/packages/demo/src/components/examples/TextAreaExamples.tsx
@@ -25,7 +25,7 @@ export const TextAreaExamples = (): JSX.Element => (
                     }}
                     valueOnMount="I have a non empty value on mount and should not be empty!"
                     validate={(value: string) => value !== ''}
-                    validationMessage={'TextArea should not be empty!'}
+                    validationMessage="TextArea should not be empty!"
                     isAutosize
                 />
             </div>
@@ -53,10 +53,14 @@ export const TextAreaExamples = (): JSX.Element => (
                     Toggle TextArea disabled state
                 </button>
             </div>
-            <div className="form-group">
-                <TextAreaLabel label="simple text area with label">
-                    <TextAreaConnected id="super-textarea-4" />
-                </TextAreaLabel>
+            <div className="form-group input-field">
+                <TextAreaConnected
+                    id="super-textarea-4"
+                    validate={(value: string) => value !== ''}
+                    validationMessage="TextArea should not be empty!"
+                >
+                    <Label htmlFor="super-textarea-4"> Simple text area with label </Label>
+                </TextAreaConnected>
             </div>
             <div className="form-group">
                 <label className="form-control-label">Default textarea autosize empty</label>

--- a/packages/demo/src/components/examples/TextAreaExamples.tsx
+++ b/packages/demo/src/components/examples/TextAreaExamples.tsx
@@ -21,9 +21,12 @@ export const TextAreaExamples = (): JSX.Element => (
                     id="awesome-textarea-2"
                     className="admin-invisible-textbox mod-border"
                     additionalAttributes={{
-                        placeholder: 'I am a simple text area',
+                        placeholder: 'I am a simple text area with validation!',
                     }}
-                    valueOnMount="I have a non empty value on mount"
+                    valueOnMount="I have a non empty value on mount and should not be empty!"
+                    validate={(value: string) => value !== ''}
+                    validationMessage={'TextArea should not be empty!'}
+                    isAutosize
                 />
             </div>
             <div className="form-group">
@@ -84,8 +87,9 @@ export const TextAreaExamples = (): JSX.Element => (
                     additionalAttributes={{
                         required: true,
                     }}
-                />
-                <Label htmlFor="super-textarea-8">Beautiful Textarea</Label>
+                >
+                    <Label htmlFor="super-textarea-8">Beautiful Textarea</Label>
+                </TextAreaConnected>
             </div>
         </div>
     </div>

--- a/packages/demo/src/components/examples/TextAreaExamples.tsx
+++ b/packages/demo/src/components/examples/TextAreaExamples.tsx
@@ -24,7 +24,7 @@ export const TextAreaExamples = (): JSX.Element => (
                         placeholder: 'I am a simple text area with validation!',
                     }}
                     valueOnMount="I have a non empty value on mount and should not be empty!"
-                    validate={(value: string) => value !== ''}
+                    validate={(value: string) => !!value}
                     validationMessage="TextArea should not be empty!"
                     isAutosize
                 />
@@ -56,7 +56,7 @@ export const TextAreaExamples = (): JSX.Element => (
             <div className="form-group input-field">
                 <TextAreaConnected
                     id="super-textarea-4"
-                    validate={(value: string) => value !== ''}
+                    validate={(value: string) => !!value}
                     validationMessage="TextArea should not be empty!"
                 >
                     <Label htmlFor="super-textarea-4"> Simple text area with label </Label>

--- a/packages/react-vapor/src/components/textarea/TextArea.tsx
+++ b/packages/react-vapor/src/components/textarea/TextArea.tsx
@@ -4,12 +4,9 @@ import TextareaAutosize, {TextareaAutosizeProps} from 'react-textarea-autosize';
 import * as _ from 'underscore';
 
 import {IReactVaporState} from '../../ReactVapor';
-import {IDispatch, ReduxUtils} from '../../utils/ReduxUtils';
+import {IDispatch, ReduxUtils} from '../../utils';
+import {ILabelProps, Label} from '../input';
 import {addTextArea, changeTextAreaValue, removeTextArea} from './TextAreaActions';
-
-/**
- * TODO: autoresize is not yet implemented on TextArea
- */
 
 export interface ITextAreaOwnProps {
     id: string;
@@ -31,6 +28,9 @@ export interface ITextAreaOwnProps {
     isAutosize?: boolean;
 
     onChangeCallback?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+    validate?: (value: string) => boolean;
+    validationMessage?: string;
+    validationLabelProps?: ILabelProps;
 }
 
 export interface ITextAreaStateProps {
@@ -57,43 +57,60 @@ const mapDispatchToProps = (dispatch: IDispatch, ownProps: ITextAreaOwnProps): I
     onUnmount: () => dispatch(removeTextArea(ownProps.id)),
 });
 
-export class TextArea extends React.Component<ITextAreaProps, {}> {
-    static defaultProps: Partial<ITextAreaOwnProps> = {
-        additionalAttributes: {},
-        className: '',
+export const TextArea: React.FunctionComponent<ITextAreaProps> = (props) => {
+    const [debouncedValue, setDebouncedValue] = React.useState(props.value);
+    const [isValid, setIsValid] = React.useState(true);
+
+    React.useEffect(() => {
+        const timeout = setTimeout(() => {
+            setDebouncedValue(props.value);
+        }, 300);
+        return () => clearTimeout(timeout);
+    }, [props.value]);
+
+    React.useEffect(() => {
+        setIsValid(props.validate?.(debouncedValue));
+    }, [debouncedValue]);
+
+    React.useEffect(() => {
+        props.onMount?.();
+        setIsValid(true);
+        return props.onUnmount;
+    }, []);
+
+    const getValidationLabel = () => {
+        return (
+            !isValid && (
+                <div className={'pt1'}>
+                    <Label id={'textarea-validation-label'} className={'text-red'} {...props.validationLabelProps}>
+                        {props.validationMessage}
+                    </Label>
+                </div>
+            )
+        );
     };
 
-    componentWillMount() {
-        if (this.props.onMount) {
-            this.props.onMount();
-        }
-    }
+    const handleOnChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        props.onChange?.(e);
+        props.onChangeCallback?.(e);
+    };
 
-    componentWillUnmount() {
-        if (this.props.onUnmount) {
-            this.props.onUnmount();
-        }
-    }
+    const TextareaTagName: any = props.isAutosize ? TextareaAutosize : 'textarea';
 
-    render() {
-        const TextareaTagName: any = this.props.isAutosize ? TextareaAutosize : 'textarea';
-        return (
+    return (
+        <>
             <TextareaTagName
-                {...this.props.additionalAttributes}
-                id={this.props.id}
-                disabled={this.props.disabled}
-                className={this.props.className}
-                value={this.props.value}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => this.handleOnChange(e)}
+                {...props.additionalAttributes}
+                disabled={props.disabled}
+                className={props.className}
+                value={props.value}
+                onChange={handleOnChange}
             />
-        );
-    }
-
-    private handleOnChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
-        this.props.onChange?.(e);
-        this.props.onChangeCallback?.(e);
-    }
-}
+            {props.children}
+            {getValidationLabel()}
+        </>
+    );
+};
 
 export const TextAreaConnected: React.ComponentClass<ITextAreaProps> = connect(
     mapStateToProps,

--- a/packages/react-vapor/src/components/textarea/TextArea.tsx
+++ b/packages/react-vapor/src/components/textarea/TextArea.tsx
@@ -82,7 +82,7 @@ export const TextArea: React.FunctionComponent<ITextAreaProps> = (props) => {
         return (
             !isValid && (
                 <div className={'pt1'}>
-                    <Label id={'textarea-validation-label'} className={'text-red'} {...props.validationLabelProps}>
+                    <Label id={props.id} className="text-red" {...props.validationLabelProps}>
                         {props.validationMessage}
                     </Label>
                 </div>

--- a/packages/react-vapor/src/components/textarea/TextArea.tsx
+++ b/packages/react-vapor/src/components/textarea/TextArea.tsx
@@ -5,7 +5,7 @@ import * as _ from 'underscore';
 
 import {IReactVaporState} from '../../ReactVapor';
 import {IDispatch, ReduxUtils} from '../../utils';
-import {ILabelProps, Label} from '../input';
+import {ILabelProps} from '../input';
 import {addTextArea, changeTextAreaValue, removeTextArea} from './TextAreaActions';
 
 export interface ITextAreaOwnProps {
@@ -79,15 +79,7 @@ export const TextArea: React.FunctionComponent<ITextAreaProps> = (props) => {
     }, []);
 
     const getValidationLabel = () => {
-        return (
-            !isValid && (
-                <div className={'pt1'}>
-                    <Label id={props.id} className="text-red" {...props.validationLabelProps}>
-                        {props.validationMessage}
-                    </Label>
-                </div>
-            )
-        );
+        return !isValid && <div className="full-content-x generic-form-error my1">{props.validationMessage}</div>;
     };
 
     const handleOnChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/packages/react-vapor/src/components/textarea/tests/TextArea.spec.tsx
+++ b/packages/react-vapor/src/components/textarea/tests/TextArea.spec.tsx
@@ -1,14 +1,12 @@
-import {HTMLAttributes, mount, ReactWrapper, shallow} from 'enzyme';
+import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
-import {Provider} from 'react-redux';
-import {Store} from 'redux';
-import {findWhere} from 'underscore';
+import {act} from 'react-dom/test-utils';
+import * as _ from 'underscore';
 
-import {IReactVaporState} from '../../../ReactVapor';
-import {clearState} from '../../../utils/ReduxUtils';
-import {TestUtils} from '../../../utils/tests/TestUtils';
+import {mountWithStore, shallowWithStore} from 'enzyme-redux';
+import {getStoreMock, ReactVaporMockStore} from '../../../utils/tests/TestUtils';
 import {ITextAreaProps, TextArea, TextAreaConnected} from '../TextArea';
-import {ITextAreaState} from '../TextAreaReducers';
+import {TextAreaActions} from '../TextAreaActions';
 
 describe('TextArea', () => {
     describe('<TextArea />', () => {
@@ -20,13 +18,11 @@ describe('TextArea', () => {
     });
 
     describe('<TextArea />', () => {
+        let hookWrapper: ReactWrapper<ITextAreaProps, any>;
         let wrapper: ReactWrapper<ITextAreaProps, any>;
-        let textArea: ReactWrapper<HTMLAttributes, any>;
 
         beforeEach(() => {
             wrapper = mount(<TextArea id="textarea-id" />, {attachTo: document.getElementById('App')});
-
-            textArea = wrapper.find('textarea').first();
         });
 
         afterEach(() => {
@@ -34,31 +30,39 @@ describe('TextArea', () => {
         });
 
         it('should set textarea id when specified', () => {
-            expect(textArea.prop('id')).toBe('textarea-id');
+            expect(wrapper.prop('id')).toBe('textarea-id');
         });
 
         it('should set className when specified', () => {
             const className = 'a-class';
-            expect(textArea.hasClass(className)).toBe(false);
+            expect(wrapper.hasClass(className)).toBe(false);
 
             wrapper.setProps({className}).update();
             expect(wrapper.find('textarea').hasClass(className)).toBe(true);
         });
 
         it('should set additionalAttributes when specified', () => {
-            expect(textArea.prop('placeholder')).toBeUndefined();
+            expect(wrapper.prop('placeholder')).toBeUndefined();
             wrapper.setProps({additionalAttributes: {placeholder: 'not null'}}).update();
             expect(wrapper.find('textarea').prop('placeholder')).toBe('not null');
         });
 
         it('should set disabled prop when specified', () => {
-            expect(textArea.prop('disabled')).toBeUndefined();
+            expect(wrapper.prop('disabled')).toBeUndefined();
             wrapper.setProps({disabled: true}).update();
             expect(wrapper.find('textarea').prop('disabled')).toBe(true);
         });
 
+        it('should set validate prop when specified', () => {
+            const validation = (value: string) => value !== '';
+
+            expect(wrapper.prop('validate')).toBeUndefined();
+            wrapper.setProps({validate: validation}).update();
+            expect(wrapper.prop('validate')).toBe(validation);
+        });
+
         it('should set value prop when specified', () => {
-            expect(textArea.prop('value')).toBeUndefined();
+            expect(wrapper.prop('value')).toBeUndefined();
             wrapper.setProps({value: 'non empty'}).update();
             expect(wrapper.find('textarea').prop('value')).toBe('non empty');
         });
@@ -66,13 +70,13 @@ describe('TextArea', () => {
         it('should not throw if the onChange prop is not defined onChange', () => {
             wrapper.setProps({onChange: undefined}).update();
 
-            expect(() => (wrapper.instance() as any).handleOnChange()).not.toThrow();
+            expect(() => wrapper.find('textarea').simulate('change')).not.toThrow();
         });
 
         it('should not throw if the onChangeCallback prop is not defined onChange', () => {
             wrapper.setProps({onChangeCallback: undefined});
 
-            expect(() => (wrapper.instance() as any).handleOnChange()).not.toThrow();
+            expect(() => wrapper.find('textarea').simulate('change')).not.toThrow();
         });
 
         it('should call prop onChange on textarea change', () => {
@@ -93,13 +97,54 @@ describe('TextArea', () => {
             expect(onChangeCallback).toHaveBeenCalledTimes(1);
         });
 
+        it('should contains validation message if debounced value is invalid', () => {
+            jasmine.clock().install();
+            const invalidValue = '';
+            const validation = (value: string) => value !== invalidValue;
+            const validationMessage = 'invalid value';
+
+            wrapper.setProps({validate: validation, validationMessage: validationMessage, value: 'anyValue'});
+            act(() => {
+                wrapper.mount();
+            });
+            expect(wrapper.contains(validationMessage)).toBeFalsy(); // initial mount is not validated
+
+            wrapper.setProps({value: invalidValue});
+            act(() => {
+                wrapper.update(); // set value to invalid value
+            });
+            jasmine.clock().tick(400);
+            act(() => {
+                wrapper.update(); // setTimeout call back set the debouncedValue
+            });
+            act(() => {
+                wrapper.update(); // validation of the debouncedValue
+            });
+
+            expect(wrapper.contains(validationMessage)).toBeTruthy();
+            jasmine.clock().uninstall();
+        });
+
+        it('should call prop validate on value change', () => {
+            const validate = jasmine.createSpy('validate');
+            hookWrapper = mount(<TextArea id="textarea-id" validate={validate} />);
+
+            hookWrapper.find('textarea').simulate('change', {target: {value: 'new value'}});
+            act(() => {
+                hookWrapper.update();
+            });
+
+            expect(validate).toHaveBeenCalledTimes(1);
+        });
+
         it('should call prop onMount on mount', () => {
             const onMount = jasmine.createSpy('onMount');
 
-            wrapper
-                .setProps({onMount})
-                .unmount()
-                .mount();
+            hookWrapper = mount(<TextArea id="textarea-id" onMount={onMount} />);
+
+            act(() => {
+                hookWrapper.update();
+            });
 
             expect(onMount).toHaveBeenCalledTimes(1);
         });
@@ -107,32 +152,33 @@ describe('TextArea', () => {
         it('should call prop onUnmount on Unmount', () => {
             const onUnmount = jasmine.createSpy('onUnmount');
 
+            hookWrapper = mount(<TextArea id="textarea-id" onUnmount={onUnmount} />);
+
+            act(() => {
+                hookWrapper.unmount();
+            });
+
+            expect(onUnmount).toHaveBeenCalledTimes(1);
+
             wrapper.setProps({onUnmount}).unmount();
 
             expect(onUnmount).toHaveBeenCalledTimes(1);
         });
 
         describe('<TextAreaConnected />', () => {
-            let store: Store<IReactVaporState>;
+            let store: ReactVaporMockStore;
             let textAreaProps: ITextAreaProps;
 
-            const getTextAreaStateFromId = (id: string): ITextAreaState => findWhere(store.getState().textAreas, {id});
-
             const mountComponentWithProps = (props: ITextAreaProps) =>
-                mount(
-                    <Provider store={store}>
-                        <TextAreaConnected {...props} />
-                    </Provider>,
-                    {attachTo: document.getElementById('App')}
-                );
+                shallowWithStore(<TextAreaConnected {...props} />, store);
 
             beforeEach(() => {
-                store = TestUtils.buildStore();
+                store = getStoreMock();
                 textAreaProps = {id: 'textarea-id'};
             });
 
             afterEach(() => {
-                store.dispatch(clearState());
+                store.clearActions();
                 wrapper.detach();
             });
 
@@ -164,55 +210,80 @@ describe('TextArea', () => {
 
             describe('onMount', () => {
                 it('should add a textArea in the store with default values', () => {
-                    mountComponentWithProps(textAreaProps);
+                    const add = spyOn(TextAreaActions, 'add');
+                    hookWrapper = mountWithStore(<TextAreaConnected id={'textarea-id'} onMount={add} />, store);
+                    act(() => {
+                        hookWrapper.update();
+                    });
 
-                    const connectedTextArea: ITextAreaState = getTextAreaStateFromId(textAreaProps.id);
-                    expect(connectedTextArea.value).toBe('');
-                    expect(connectedTextArea.disabled).toBe(false);
+                    expect(add).toHaveBeenCalledTimes(1);
                 });
 
                 it('should add a textArea in the store with the valueOnMount if there is one in the props', () => {
                     const valueOnMount = 'non empty value';
-                    mountComponentWithProps({...textAreaProps, valueOnMount});
 
-                    const connectedTextArea: ITextAreaState = getTextAreaStateFromId(textAreaProps.id);
-                    expect(connectedTextArea.value).toBe(valueOnMount);
-                    expect(connectedTextArea.disabled).toBe(false);
+                    hookWrapper = mountWithStore(
+                        <TextAreaConnected {...textAreaProps} valueOnMount={valueOnMount} />,
+                        store
+                    );
+                    act(() => {
+                        hookWrapper.mount();
+                    });
+                    expect(store.getActions().find((action) => action.type === 'ADD_TEXTAREA')).toEqual(
+                        jasmine.objectContaining({
+                            payload: jasmine.objectContaining({id: textAreaProps.id, value: valueOnMount}),
+                        })
+                    );
                 });
 
                 it('should add a textArea in the store with the disabledOnMount value if there is one in the props', () => {
                     const disabledOnMount = true;
-                    mountComponentWithProps({...textAreaProps, disabledOnMount});
 
-                    const connectedTextArea: ITextAreaState = getTextAreaStateFromId(textAreaProps.id);
-                    expect(connectedTextArea.value).toBe('');
-                    expect(connectedTextArea.disabled).toBe(disabledOnMount);
+                    hookWrapper = mountWithStore(
+                        <TextAreaConnected {...textAreaProps} disabledOnMount={disabledOnMount} />,
+                        store
+                    );
+                    act(() => {
+                        hookWrapper.mount();
+                    });
+
+                    expect(store.getActions().find((action) => action.type === 'ADD_TEXTAREA')).toEqual(
+                        jasmine.objectContaining({
+                            payload: jasmine.objectContaining({id: textAreaProps.id, disabled: disabledOnMount}),
+                        })
+                    );
                 });
             });
 
             describe('onUnmount', () => {
                 it('should remove the textArea from the store', () => {
-                    const connectedTextArea = mountComponentWithProps(textAreaProps);
+                    store = getStoreMock();
+                    const component = mountWithStore(<TextAreaConnected {...textAreaProps} />, store);
+                    act(() => {
+                        component.unmount();
+                    });
 
-                    expect(getTextAreaStateFromId(textAreaProps.id)).toBeDefined();
-
-                    connectedTextArea.unmount();
-
-                    expect(getTextAreaStateFromId(textAreaProps.id)).toBeUndefined();
+                    expect(store.getActions().find((action) => action.type === 'REMOVE_TEXTAREA')).toEqual(
+                        jasmine.objectContaining({payload: jasmine.objectContaining({id: textAreaProps.id})})
+                    );
                 });
             });
 
             describe('onChange', () => {
                 it('should change the value in the store to the new value', () => {
-                    const connectedTextArea = mountComponentWithProps(textAreaProps);
-                    const oldTextAreaState: ITextAreaState = getTextAreaStateFromId(textAreaProps.id);
-                    expect(oldTextAreaState.value).toBe('');
+                    store = getStoreMock();
+                    const component = mountWithStore(<TextAreaConnected {...textAreaProps} />, store);
 
-                    (document.querySelector(`#${textAreaProps.id}`) as HTMLTextAreaElement).value = 'new value';
-                    connectedTextArea.find('textarea').simulate('change', {target: {value: 'new value'}});
+                    component.find('textarea').simulate('change', {target: {value: 'new value'}});
+                    act(() => {
+                        component.update();
+                    });
 
-                    const newTextAreaState: ITextAreaState = getTextAreaStateFromId(textAreaProps.id);
-                    expect(newTextAreaState.value).toBe('new value');
+                    expect(store.getActions().find((action) => action.type === 'CHANGE_VALUE_TEXTAREA')).toEqual(
+                        jasmine.objectContaining({
+                            payload: jasmine.objectContaining({id: textAreaProps.id, value: 'new value'}),
+                        })
+                    );
                 });
             });
         });


### PR DESCRIPTION
### Proposed Changes

Added validation to the textare component

### Potential Breaking Changes

Now when using Labels with htmlFor props you need to give it as a children to the component.
```tsx
                <TextAreaConnected
                    id="super-textarea-8"
                     validate={(value: string) => value !== ''}
                   validationMessage={'TextArea should not be empty!'}
                >
                    <Label htmlFor="super-textarea-8">Beautiful Textarea</Label>
                </TextAreaConnected>
```

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
