### PR TITLE
fix(filterbox): remove input text when reset filter value

### DIFF
--- a/packages/react-vapor/src/components/filterBox/FilterBox.tsx
+++ b/packages/react-vapor/src/components/filterBox/FilterBox.tsx
@@ -68,7 +68,7 @@ export class FilterBox extends React.Component<IFilterBoxProps, any> {
     }
 
     componentDidUpdate(prevProps: IFilterBoxProps) {
-        if (this.props.filterText !== prevProps.filterText && this.filterInput?.value !== prevProps.filterText) {
+        if (this.props.filterText !== prevProps.filterText && this.filterInput?.value !== this.props.filterText) {
             this.handleChange(this.props.filterText);
         }
     }


### PR DESCRIPTION
### Proposed Changes

Changed the condition in `componentDidUpdate`. Input text value in filter box should be updated to empty string, when resetting filter box by clicking on Clear Filter button in table blank slate.

### Potential Breaking Changes

No

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
