### PR TITLE
fix(breadcrumbheader): pass down children prop

### DIFF
--- a/packages/demo/src/components/examples/HeaderExamples.tsx
+++ b/packages/demo/src/components/examples/HeaderExamples.tsx
@@ -56,7 +56,9 @@ const BreadcrumbHeaders: React.FunctionComponent = () => (
                 breadcrumb={{...defaultBreadcrumb, links: [link1, {name: 'not a link'}, link2]}}
                 description="Simple description for the title"
                 hasBorderBottom={false}
-            />
+            >
+                <Svg svgName="brain" svgClass="icon mod-20 fill-dodger-blue ml1" />
+            </BreadcrumbHeader>
         </Section>
     </Section>
 );

--- a/packages/react-vapor/src/components/breadcrumbs/Breadcrumb.tsx
+++ b/packages/react-vapor/src/components/breadcrumbs/Breadcrumb.tsx
@@ -32,7 +32,7 @@ export class Breadcrumb extends React.Component<IBreadcrumbProps, {}> {
                 <ul className="flex">
                     {this.getLinks()}
                     <li className="breadcrumb-title truncate">
-                        <Title {...this.props.title} />
+                        <Title {...this.props.title}>{this.props.children}</Title>
                     </li>
                 </ul>
             </nav>

--- a/packages/react-vapor/src/components/headers/BreadcrumbHeader.tsx
+++ b/packages/react-vapor/src/components/headers/BreadcrumbHeader.tsx
@@ -23,7 +23,7 @@ export class BreadcrumbHeader extends React.Component<IBreadcrumbHeaderProps, {}
     render() {
         return (
             <HeaderWrapper {..._.omit(this.props, 'breadcrumb')}>
-                <Breadcrumb {...this.props.breadcrumb} />
+                <Breadcrumb {...this.props.breadcrumb}>{this.props.children}</Breadcrumb>
             </HeaderWrapper>
         );
     }


### PR DESCRIPTION
### Proposed Changes

`BreadcrumbHeader` will now pass down its children to the `Breadcrumb`, then `Title` component so that they get rendered after the title but before the actions.

Such as the `brain` icon here
![image](https://user-images.githubusercontent.com/35579930/76247866-9f526080-6216-11ea-87ba-511ed6d5d821.png)


### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
