### PR TITLE
fix(ie-11-drop): ie 11 drop

### DIFF
--- a/packages/react-vapor/src/components/drop/DropPod.tsx
+++ b/packages/react-vapor/src/components/drop/DropPod.tsx
@@ -3,6 +3,7 @@ import * as ReactDOM from 'react-dom';
 import * as _ from 'underscore';
 
 import {Defaults} from '../../Defaults';
+import {BrowserUtils} from '../../utils/BrowserUtils';
 import {
     DomPositionCalculator,
     DropPodPosition,
@@ -224,18 +225,20 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
     }
 
     render() {
-        const drop: React.ReactNode = this.props.renderDrop(
-            {
-                position: 'absolute',
-                display: 'inline-block',
-                ...{
-                    ...this.calculateStyleOffset(),
-                    visibility: this.canRenderDrop() ? 'visible' : 'hidden',
-                },
-            },
-            this.dropRef,
-            this.lastPosition
-        );
+        const style: React.CSSProperties = {
+            display: 'inline-block',
+            position: 'absolute',
+            visibility: this.canRenderDrop() ? 'visible' : 'hidden',
+            ...this.calculateStyleOffset(),
+        };
+
+        // set the display none for ei 11
+        // this browser dont handle position absolute and visibility hidden like other browser
+        if (!this.canRenderDrop() && BrowserUtils.isIE()) {
+            style.display = 'none';
+        }
+
+        const drop: React.ReactNode = this.props.renderDrop(style, this.dropRef, this.lastPosition);
 
         return ReactDOM.createPortal(drop, document.querySelector(this.props.selector ?? Defaults.DROP_ROOT));
     }


### PR DESCRIPTION
update display to none if ie 11

### Proposed Changes

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
