### PR TITLE
fix(tablehoc): added isCard in tableLoading.body

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
@@ -61,6 +61,7 @@ export class TableHOC extends React.PureComponent<ITableHOCProps & React.HTMLAtt
                 {this.props.isLoading && (
                     <TableLoading.Body
                         key={`table-loading-${this.props.id}`}
+                        isCard={this.props?.loading?.isCard}
                         numberOfRow={_.size(this.props.data) || this.props?.loading?.defaultLoadingRow}
                         numberOfColumns={this.props?.loading?.numberOfColumns}
                         numberOfSubRow={this.props?.loading?.numberOfSubRow}

--- a/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
@@ -61,10 +61,10 @@ export class TableHOC extends React.PureComponent<ITableHOCProps & React.HTMLAtt
                 {this.props.isLoading && (
                     <TableLoading.Body
                         key={`table-loading-${this.props.id}`}
-                        isCard={this.props?.loading?.isCard}
-                        numberOfRow={_.size(this.props.data) || this.props?.loading?.defaultLoadingRow}
-                        numberOfColumns={this.props?.loading?.numberOfColumns}
-                        numberOfSubRow={this.props?.loading?.numberOfSubRow}
+                        isCard={this.props.loading?.isCard}
+                        numberOfRow={_.size(this.props.data) || this.props.loading?.defaultLoadingRow}
+                        numberOfColumns={this.props.loading?.numberOfColumns}
+                        numberOfSubRow={this.props.loading?.numberOfSubRow}
                     />
                 )}
             </table>


### PR DESCRIPTION
### Proposed Changes

I wanted to make the change in ml blacklist but i forgot to add isCard in TableLoading.Body in tableHOC

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
