### PR TITLE
style(table.scss): remove display when mod-card-list is hidden

### DIFF
--- a/packages/vapor/scss/tables/table.scss
+++ b/packages/vapor/scss/tables/table.scss
@@ -191,6 +191,10 @@
         grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
         padding: $mod-card-list-vertical-padding $mod-card-list-horizontal-padding;
 
+        &:hidden {
+            display: none;
+        }
+
         .mod-card {
             height: unset !important;
 

--- a/packages/vapor/scss/tables/table.scss
+++ b/packages/vapor/scss/tables/table.scss
@@ -191,7 +191,7 @@
         grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
         padding: $mod-card-list-vertical-padding $mod-card-list-horizontal-padding;
 
-        &:hidden {
+        &.hidden {
             display: none;
         }
 


### PR DESCRIPTION
### Proposed Changes

made the mod-card-list display: none when :hidden because the loading cards were not align with the one rendered

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
