### PR TITLE
style: added responsive breakpoints to white-space generators

### DIFF
--- a/packages/vapor/scss/utility/layout.scss
+++ b/packages/vapor/scss/utility/layout.scss
@@ -77,6 +77,20 @@
     .mod-width-#{$size} {
         width: $size * 1%;
     }
+
+    // .mod-width-#{ < 70 } used in SideNavigation and Calendar components
+    @if $size >= 70 {
+        @media (max-width: $breakpoint-desktop-large) {
+            .mod-width-#{$size} {
+                width: 95%;
+            }
+        }
+        @media (max-width: $breakpoint-desktop-small) {
+            .mod-width-#{$size} {
+                width: 99%;
+            }
+        }
+    }
 }
 
 .hidden {

--- a/packages/vapor/scss/utility/white-space.scss
+++ b/packages/vapor/scss/utility/white-space.scss
@@ -86,6 +86,16 @@
     .ml#{$i} {
         margin-left: $i * $spacing;
     }
+
+    @media (max-width: $breakpoint-desktop-small) {
+        .mr#{$i} {
+            margin-right: $i / 2 * $spacing;
+        }
+
+        .ml#{$i} {
+            margin-left: $i / 2 * $spacing;
+        }
+    }
 }
 
 .mod-header-padding {


### PR DESCRIPTION
Added conditional breakpoints within the Sass loops that generate the .mod-width and horizontal
margin classes

### Proposed Changes

`.mod-width-xx` and horizontal margin classes (`.mlxx` and `.mrxx`) are are generated in Sass loops but unresponsive at smaller desktop sizes. I added breakpoints within the loops.

Since `.mod-width-70` and larger sizes are only used for page layout rather than for individual components, I've included an if statement specifying only apply breakpoint changes on those

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
