### PR TITLE
docs(demo): remove empty navigation entries

### DIFF
--- a/packages/demo/src/components/examples/LinkSvgExamples.tsx
+++ b/packages/demo/src/components/examples/LinkSvgExamples.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import {ILinkSvgProps, ISvgProps, ITooltipProps, LinkSvg} from 'react-vapor';
 import * as _ from 'underscore';
 
-export const defaultSvgProps: ISvgProps = {
+const defaultSvgProps: ISvgProps = {
     svgName: 'domain-google',
     svgClass: 'icon mod-2x',
 };
 
-export const defaultTooltipProps: ITooltipProps = {
+const defaultTooltipProps: ITooltipProps = {
     title: 'default tooltip description',
     placement: 'bottom',
     container: 'body',

--- a/packages/demo/src/styles/Menu.tsx
+++ b/packages/demo/src/styles/Menu.tsx
@@ -29,7 +29,6 @@ const Navigation: React.FunctionComponent = () => (
             <NavigationLink href="/slide-toggle-modifiers" name="Slide toggle modifiers" />
             <NavigationLink href="/slide-toggle-double" name="Slide toggle double" />
             <NavigationLink href="/progress-bar" name="Progress bar" />
-            <NavigationLink href="/file-input" name="File input" />
         </NavigationSection>
         <NavigationSection title="Headers" baseUrl="/headers">
             <NavigationLink href="/site" name="Site" />


### PR DESCRIPTION
### Proposed Changes

Removed the following navigation entries in the demo:
![image](https://user-images.githubusercontent.com/35579930/77571490-d7f36a80-6ea3-11ea-8469-2138103edbe7.png)
![image](https://user-images.githubusercontent.com/35579930/77571541-ea6da400-6ea3-11ea-8e66-e7478cde20ae.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
