### PR TITLE
feat(form): add noMargin prop

### DIFF
--- a/packages/react-vapor/src/components/form/Form.tsx
+++ b/packages/react-vapor/src/components/form/Form.tsx
@@ -7,11 +7,12 @@ export interface IFormProps {
     title?: string;
     className?: string;
     mods?: FormMods | FormMods[];
+    noMargin?: boolean;
 }
 
-export const Form: React.FunctionComponent<IFormProps> = ({children, className, title, mods}) => {
+export const Form: React.FunctionComponent<IFormProps> = ({children, className, title, mods, noMargin}) => {
     return (
-        <fieldset className={classNames('coveo-form mb2 mt2 mod-padding-children', mods, className)}>
+        <fieldset className={classNames('coveo-form mod-padding-children', {my2: !noMargin}, mods, className)}>
             {title && <h2 className="text-medium-blue mb2">{title}</h2>}
             {children}
         </fieldset>

--- a/packages/react-vapor/src/components/form/tests/Form.spec.tsx
+++ b/packages/react-vapor/src/components/form/tests/Form.spec.tsx
@@ -43,5 +43,19 @@ describe('Form', () => {
 
             expect(form.find(SomeComponent)).toBeDefined();
         });
+
+        it('should set margin top and bottom if "noMargin" prop is set to false', () => {
+            const form = shallow(<Form>Whatever</Form>);
+
+            expect(form.hasClass('my2')).toBe(true);
+        });
+
+        it('should not set margin top and bottom if "noMargin" prop is set to true', () => {
+            const form = shallow(<Form noMargin>Whatever</Form>);
+
+            expect(form.hasClass('my2')).toBe(false);
+            expect(form.hasClass('mt2')).toBe(false);
+            expect(form.hasClass('mb2')).toBe(false);
+        });
     });
 });


### PR DESCRIPTION
### Proposed Changes

I needed a Form without those nasty default margin top and bottom.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
