### PR TITLE
feat(optionscycle): add option change callback

### DIFF
--- a/packages/react-vapor/src/components/menu/MenuConnected.tsx
+++ b/packages/react-vapor/src/components/menu/MenuConnected.tsx
@@ -18,7 +18,6 @@ export interface IMenuOwnProps {
     buttonSvg?: React.ReactNode;
     customOffset?: number;
     buttonProps?: Partial<IButtonProps>;
-    disabled?: boolean;
 }
 
 export interface IMenuStateProps {
@@ -58,7 +57,6 @@ export class MenuConnected extends React.Component<IMenuProps, {}> {
         positionRight: false,
         closeOnSelectItem: true,
         customOffset: 0,
-        disabled: false,
     };
 
     componentWillMount() {

--- a/packages/react-vapor/src/components/optionsCycle/OptionsCycle.tsx
+++ b/packages/react-vapor/src/components/optionsCycle/OptionsCycle.tsx
@@ -16,6 +16,7 @@ export interface IOptionsCycleOwnProps {
     previousClassName?: string;
     nextClassName?: string;
     buttonClassName?: string;
+    onChangeOption?: (index: number) => void;
 }
 
 export interface IOptionsCycleStateProps {
@@ -40,20 +41,16 @@ export class OptionsCycle extends React.Component<IOptionsCycleProps> {
     };
 
     private goToPreviousOption() {
-        if (this.props.onChange) {
-            const newOptionIndex = this.props.currentOption
-                ? this.props.currentOption - 1
-                : this.props.options.length - 1;
-            this.props.onChange(newOptionIndex);
-        }
+        const newOptionIndex = this.props.currentOption ? this.props.currentOption - 1 : this.props.options.length - 1;
+        this.props.onChange?.(newOptionIndex);
+        this.props.onChangeOption?.(newOptionIndex);
     }
 
     private goToNextOption() {
-        if (this.props.onChange) {
-            const newOptionIndex =
-                this.props.currentOption === this.props.options.length - 1 ? 0 : this.props.currentOption + 1;
-            this.props.onChange(newOptionIndex);
-        }
+        const newOptionIndex =
+            this.props.currentOption === this.props.options.length - 1 ? 0 : this.props.currentOption + 1;
+        this.props.onChange?.(newOptionIndex);
+        this.props.onChangeOption?.(newOptionIndex);
     }
 
     componentDidMount() {


### PR DESCRIPTION
add a prop to handle something when the option change in the OptionCycle
update uts without a mount in the dom
add uts for this new props

### Proposed Changes

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
