### PR TITLE
Fix the padding of TextArea component

### DIFF
--- a/packages/vapor/scss/controls/input-field.scss
+++ b/packages/vapor/scss/controls/input-field.scss
@@ -99,7 +99,7 @@
 
     > textarea {
         min-height: $input-height;
-        padding: 10px 0 24px 0;
+        padding: 5px 0 2px;
 
         -ms-overflow-y: hidden !important;
         overflow-y: hidden; // ie
@@ -109,7 +109,6 @@
     }
 
     &.mod-resizeable textarea {
-        padding: 5px 0 2px; // Tweak to make it look like a normal input-field
         resize: vertical;
     }
 


### PR DESCRIPTION
### Proposed Changes

We want a smaller default padding for the TextArea component, which will make it look like a normal input.

Before:
![image](https://user-images.githubusercontent.com/52677246/79385290-550b8000-7f36-11ea-8070-e2db68230479.png)

After:
![image](https://user-images.githubusercontent.com/52677246/79385504-b5022680-7f36-11ea-9605-b05c8ee5141e.png)

### Potential Breaking Changes

All the _textarea_ under _.input-field_ will have a smaller padding.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
