### PR TITLE
Minor fixes of table style

### DIFF
--- a/packages/vapor/scss/tables/table.scss
+++ b/packages/vapor/scss/tables/table.scss
@@ -101,7 +101,7 @@
             opacity: 0.4;
         }
 
-        &:not(.no-hover):not(.collapsible-row):not(.empty):hover {
+        &:not(.no-hover):not(.collapsible-row):not(.empty):not(.mod-card):hover {
             background-color: $light-grey;
             td {
                 background-color: $light-grey;
@@ -137,7 +137,10 @@
     td {
         padding: $table-row-top-bottom-padding $table-cell-left-right-padding;
         text-align: left;
-        border-bottom: $table-border;
+
+        &:not(.no-border-bottom) {
+            border-bottom: $table-border;
+        }
 
         .mod-max-width {
             max-width: 300px;

--- a/packages/vapor/scss/tables/table.scss
+++ b/packages/vapor/scss/tables/table.scss
@@ -138,7 +138,7 @@
         padding: $table-row-top-bottom-padding $table-cell-left-right-padding;
         text-align: left;
 
-        &:not(.no-border-bottom) {
+        &:not(.mod-no-border-bottom) {
             border-bottom: $table-border;
         }
 


### PR DESCRIPTION
### Proposed Changes

1. When we use the class `.mod-card` in a table row, the background color should not be changed to light grey on hover. This will fix the conflict of background colors in the ML blacklists configuration cards.

2. Add `.no-border-bottom` to allow removing the border bottom in a table row.

### Potential Breaking Changes

Nope. The first one is only used in Blacklists, and the second one is a new class.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
