### PR TITLE
Fix mapStateToProp condition on ToastContainer

### DIFF
--- a/packages/react-vapor/src/components/toast/ToastContainerConnected.tsx
+++ b/packages/react-vapor/src/components/toast/ToastContainerConnected.tsx
@@ -12,7 +12,7 @@ import {
 } from './ToastContainer';
 
 const mapStateToProps = (state: IReactVaporState, ownProps: IToastContainerOwnProps): IToastContainerStateProps => {
-    const container = _.findWhere(state.toastContainers, {id: ownProps.id}) || {id: null, toasts: []};
+    const container = _.where(state.toastContainers, {id: ownProps.id}) || {id: null, toasts: []};
     return {
         toasts: container.toasts,
     };


### PR DESCRIPTION
### Proposed Changes

`_.findWhere` always return null because it try to deeply match `{id: 'someID'}` with `IToastsState` https://github.com/coveo/react-vapor/blob/master/packages/react-vapor/src/components/toast/ToastReducers.ts#L7-L10
This cannot works because it will always be missing the toasts property of `IToastsState`.
See: https://underscorejs.org/#findWhere

What I think would be the correct behavior is a match by id, which is done through the use of `_.where`: https://underscorejs.org/#where

### Potential Breaking Changes

Should be already fully broken, so no breaking I guess?

### Acceptance Criteria

-   [?] The proposed changes are covered by unit tests - Didn't find UT for the react part?
-   [?] The potential breaking changes are clearly identified - Not really, Idk how it was used before.
-   [X] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant) - Not relevant.
