### PR TITLE
fix(codeeditor): front all codemirror options on code editor

### DIFF
--- a/packages/demo/src/components/examples/CodeEditorExamples.tsx
+++ b/packages/demo/src/components/examples/CodeEditorExamples.tsx
@@ -6,8 +6,8 @@ export class CodeEditorExamples extends React.Component<{}, {}> {
         return (
             <div className="mt2">
                 <div className="form-group">
-                    <label className="form-control-label">Code Editor using codemirror</label>
-                    <CodeEditor value="" mode={CodeMirrorModes.Python} />
+                    <label className="form-control-label">Code Editor using codemirror with line wrapping</label>
+                    <CodeEditor value="" mode={CodeMirrorModes.Python} options={{lineWrapping: true}} />
                 </div>
 
                 <div className="form-group">

--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -9,19 +9,19 @@ import 'codemirror/mode/python/python';
 import * as CodeMirror from 'codemirror';
 import * as React from 'react';
 import * as ReactCodeMirror from 'react-codemirror2';
-import * as _ from 'underscore';
 
 import {CodeMirrorGutters} from './EditorConstants';
 
 export interface ICodeEditorProps {
     value: string;
+    mode: any;
     readOnly?: boolean;
     onChange?: (code: string) => void;
     onMount?: (codemirror: ReactCodeMirror.Controlled) => void;
     errorMessage?: string;
-    mode: any; // string or object ex.: {name: "javascript", json: true}
     extraKeywords?: string[];
     className?: string;
+    options?: CodeMirror.EditorConfiguration;
 }
 
 export interface CodeEditorState {
@@ -33,7 +33,7 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
         className: 'mod-border',
     };
 
-    static Options: CodeMirror.EditorConfiguration = {
+    static defaultOptions: CodeMirror.EditorConfiguration = {
         lineNumbers: true,
         foldGutter: true,
         lint: true,
@@ -78,11 +78,13 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
                     this.setState({value});
                 }}
                 value={this.state.value}
-                onChange={(editor, data, value: string) => this.handleChange(value)}
-                options={_.extend({}, CodeEditor.Options, {
+                onChange={(editor, data, value: string) => this.props.onChange?.(value)}
+                options={{
+                    ...CodeEditor.defaultOptions,
                     readOnly: this.removeCursorWhenEditorIsReadOnly(),
                     mode: this.props.mode,
-                })}
+                    ...this.props.options,
+                }}
                 className={this.props.className}
             />
         );
@@ -90,10 +92,6 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
 
     private removeCursorWhenEditorIsReadOnly() {
         return this.props.readOnly ? 'nocursor' : this.props.readOnly;
-    }
-
-    private handleChange(code: string) {
-        this.props.onChange?.(code);
     }
 
     private addExtraKeywords() {

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -91,10 +91,6 @@ describe('CodeEditor', () => {
             expect(onChangeSpy).toHaveBeenCalledWith(expectedValue);
         });
 
-        it('should not throw on change if the onChange prop is undefined', () => {
-            expect(() => (codeEditorInstance as any).handleChange('expectedValue')).not.toThrow();
-        });
-
         it(`should clear codemirror's history if we set a new value`, () => {
             const clearHistorySpy: jasmine.Spy = spyOn((codeEditorInstance as any).editor.getDoc(), 'clearHistory');
 


### PR DESCRIPTION
### Proposed Changes

The `CodeEditor` component is not exposing all the CodeMirror options such as line wrapping (which I wanted). So I added an optional prop `options` on the `CodeEditor`

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
