### PR TITLE
fix(modcard): update css rules to make it reusable

### DIFF
--- a/packages/vapor/scss/tables/table.scss
+++ b/packages/vapor/scss/tables/table.scss
@@ -101,7 +101,7 @@
             opacity: 0.4;
         }
 
-        &:not(.no-hover):not(.collapsible-row):not(.empty):not(.mod-card):hover {
+        &:not(.no-hover):not(.collapsible-row):not(.empty):hover {
             background-color: $light-grey;
             td {
                 background-color: $light-grey;
@@ -113,7 +113,7 @@
             text-align: center;
         }
 
-        &.selected {
+        &.selected:not(.no-selection-indicator) {
             &:not(:hover) {
                 background-color: $white;
                 td {
@@ -194,39 +194,48 @@
         grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
         padding: $mod-card-list-vertical-padding $mod-card-list-horizontal-padding;
 
-        &.hidden {
-            display: none;
-        }
+        & tr {
+            height: unset;
 
-        .mod-card {
-            height: unset !important;
-
-            & td {
+            &.mod-card {
                 padding: $status-card-padding;
-                border-radius: $big-border-radius;
-
-                &:hover {
-                    background-color: $grey-2;
-                }
-
-                &:focus {
-                    background-color: $grey-1;
-                    border-left: $status-card-border-width solid $orange;
-                }
-
-                & span {
-                    color: $dark-grey;
-                }
             }
         }
 
-        td {
-            border-bottom: none !important;
+        &.hidden {
+            display: none;
         }
 
         .blankslate-row td.p0 {
             padding: 0;
         }
+    }
+
+    .mod-card-row .mod-card {
+        min-height: $mod-card-row-min-height;
+        border-left: $status-card-border-width solid $transparent;
+
+        & .mod-card-header {
+            color: $medium-blue;
+            font-weight: bold;
+            font-size: $medium-title-font-size;
+            border-bottom: 2px solid $light-grey;
+        }
+    }
+
+    .mod-card {
+        border-radius: $big-border-radius;
+        box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.2);
+        cursor: pointer;
+
+        &:hover {
+            background-color: $grey-2;
+        }
+    }
+
+    tr.selected .mod-card {
+        background-color: $grey-1;
+        border-left: $status-card-border-width solid $orange;
     }
 }
 

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -307,6 +307,7 @@ $table-header-title-loading-width: 300px;
 $table-header-action-bar-button: 300px;
 $mod-card-list-vertical-padding: 24px;
 $mod-card-list-horizontal-padding: 32px;
+$mod-card-row-min-height: 184px;
 
 // Table actions
 $table-actions-container-height: 52px;


### PR DESCRIPTION
### Proposed Changes

`.mod-card` was created for the feature of blacklists configuration, and it was scoped in `.mod-card-list` which used css grid layout for some specific situations. Currently, for the `StatementGroupCard`, I think we could reuse certain rules of `.mod-card` since they have the same behavior, ex: box-radius, box-shadow, hover effect etc. One thing different from `BlacklistCard` is that we only have one card per row in `StatementGroupsTable`.
 
![screenshot](https://user-images.githubusercontent.com/52677246/80546516-d1b14c00-8983-11ea-8200-3a3295f9a702.jpg)

### Potential Breaking Changes

Nope. I'll possibly make some tiny adjustments in `BlacklistCard` later when I continue working on this story, but now it's on hold and behind a feature flag.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
