### PR TITLE
Add align-start class to flex.scss

### DIFF
--- a/packages/vapor/scss/utility/flex.scss
+++ b/packages/vapor/scss/utility/flex.scss
@@ -32,6 +32,10 @@
     justify-content: center;
 }
 
+.align-start {
+    align-self: flex-start;
+}
+
 .align-end {
     align-self: flex-end;
 }


### PR DESCRIPTION
### Proposed Changes

We already have `align-end` and now we need `align-start` =D

### Potential Breaking Changes

No I swear 

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
