### PR TITLE
fix(rollup): correct some imports to make build work for admin-ui

### DIFF
--- a/packages/react-vapor/src/components/svg/Svg.tsx
+++ b/packages/react-vapor/src/components/svg/Svg.tsx
@@ -1,5 +1,5 @@
 import * as VaporSVG from 'coveo-styleguide';
-import React from 'react';
+import * as React from 'react';
 import {keys} from 'ts-transformer-keys';
 import {extend, omit} from 'underscore';
 import {camelize} from 'underscore.string';

--- a/packages/react-vapor/src/components/tooltip/Tooltip.tsx
+++ b/packages/react-vapor/src/components/tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {OverlayTrigger, Tooltip as BootstrapTooltip} from 'react-bootstrap';
 import ReactDOM from 'react-dom';
 import * as _ from 'underscore';


### PR DESCRIPTION
### Proposed Changes

`import React from 'react'` seems to be incorrectly generating the declaration of components that explicitly use the `React` types.

For example
```tsx
import React from 'react'; // Breaks in admin-ui repo
import * as React from 'react'; // Works in admin-ui repo

export class MyComponent extends React.Component {}
```

### Potential Breaking Changes

Not sure.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
