### PR TITLE
feat(middle slider): can append a value on both side

### DIFF
--- a/packages/demo/src/components/examples/SliderExamples.tsx
+++ b/packages/demo/src/components/examples/SliderExamples.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {MiddleSlider, Section, Slider} from 'react-vapor';
+import {AppendedValueSide, MiddleSlider, Section, Slider} from 'react-vapor';
 
 import {ExampleComponent} from '../ComponentsInterface';
 
@@ -9,6 +9,7 @@ export const InputSliderExample: ExampleComponent = () => (
         <Section level={2} title="Middle Slider">
             <MiddleSliderExample />
             <MiddleSliderAsymetric />
+            <MiddleSliderWithPercent />
         </Section>
     </Section>
 );
@@ -78,6 +79,42 @@ const MiddleSliderAsymetric: React.FunctionComponent = () => {
                 hasTooltip
                 appendValue
                 customTooltip={() => <span>this custom tooltip shows the slider current value of {value}</span>}
+            />
+        </Section>
+    );
+};
+
+const ValueHolder: React.FunctionComponent<{value: string; label: string}> = ({value, label}) => (
+    <div style={{textAlign: 'center'}}>
+        <label style={{display: 'block', marginBottom: '10px', textAlign: 'center'}}>{label}</label>
+        <span style={{margin: '0 auto'}}>{value}</span>
+    </div>
+);
+
+const MiddleSliderWithPercent: React.FunctionComponent = () => {
+    const appendValueFormatter = (value: number, side: string) => {
+        let formattedValue: string;
+        let valueLabel: string;
+        if (side === AppendedValueSide.right) {
+            formattedValue = value === 0 ? `${value + 50}%` : `${50 + value}%`;
+            valueLabel = 'Right Label';
+        } else if (side === AppendedValueSide.left) {
+            formattedValue = value === 0 ? `${value + 50}%` : `${50 - value}%`;
+            valueLabel = 'Left Label';
+        }
+        return <ValueHolder value={formattedValue} label={valueLabel} />;
+    };
+
+    return (
+        <Section key="one" level={3} title={`MiddleSlider showing the percent allocated to each side`}>
+            <MiddleSlider
+                key="gnagnagna"
+                min={-50}
+                max={50}
+                marks={{0: '', 50: '', 100: ''}}
+                id="percentSliderId"
+                appendValueFormatter={appendValueFormatter}
+                appendValue={AppendedValueSide.both}
             />
         </Section>
     );

--- a/packages/react-vapor/src/components/slider/MiddleSlider.tsx
+++ b/packages/react-vapor/src/components/slider/MiddleSlider.tsx
@@ -5,6 +5,7 @@ import {Range, SliderProps} from 'rc-slider';
 import {RCTooltip} from 'rc-tooltip';
 import * as React from 'react';
 import {connect} from 'react-redux';
+import {isBoolean} from 'underscore';
 
 import {IDispatch} from '../../utils/ReduxUtils';
 import {SliderActions} from './SliderActions';
@@ -20,6 +21,12 @@ import {
     valuesPositionOnRange,
 } from './SliderUtils';
 
+export enum AppendedValueSide {
+    left = 'LEFT',
+    right = 'RIGHT',
+    both = 'BOTH',
+}
+
 export interface MiddleSliderOwnProps extends SliderProps {
     id: string;
     enabled?: boolean;
@@ -32,8 +39,11 @@ export interface MiddleSliderOwnProps extends SliderProps {
     tabIndex?: number[];
     onChange?: (rangeOutputValue: number) => any;
     customTooltip?: (value: any) => JSX.Element;
-    appendValue?: boolean;
-    appendValueFormatter?: (value: number) => React.ReactNode;
+    appendValue?: boolean | AppendedValueSide;
+    appendValueFormatter?: (
+        value: number,
+        side?: Exclude<AppendedValueSide, AppendedValueSide.both>
+    ) => React.ReactNode;
     tooltipStyle?: Partial<RCTooltip.Props>;
 }
 
@@ -138,9 +148,21 @@ const MiddleSliderDisconnected: React.FunctionComponent<MiddleSliderOwnProps &
     };
 
     const computedStep = computeStep(step, min, max);
+    const isAppendedLeft = appendValue === AppendedValueSide.both || appendValue === AppendedValueSide.left;
+    const isAppendedRight =
+        (isBoolean(appendValue) && appendValue) ||
+        appendValue === AppendedValueSide.right ||
+        appendValue === AppendedValueSide.both;
 
     return (
         <div className="flex full-content-x slider-container">
+            <div
+                className={classNames('slider-value flex', {
+                    hidden: !isAppendedLeft,
+                })}
+            >
+                {appendValueFormatter(rangeOutputValue, AppendedValueSide.left)}
+            </div>
             <Range
                 key={id}
                 value={[lowRange, highRange]}
@@ -151,8 +173,12 @@ const MiddleSliderDisconnected: React.FunctionComponent<MiddleSliderOwnProps &
                 step={computedStep}
                 disabled={!enabled}
             />
-            <div className={classNames('slider-value flex', {hidden: !appendValue})}>
-                <span>{appendValueFormatter(rangeOutputValue)}</span>
+            <div
+                className={classNames('slider-value flex', {
+                    hidden: !isAppendedRight,
+                })}
+            >
+                {appendValueFormatter(rangeOutputValue, AppendedValueSide.right)}
             </div>
         </div>
     );

--- a/packages/react-vapor/src/components/slider/SliderHandle.tsx
+++ b/packages/react-vapor/src/components/slider/SliderHandle.tsx
@@ -20,7 +20,7 @@ export interface HandleProps {
 const SliderHandle: React.FunctionComponent<{
     handleProps: HandleProps;
     handleCustomProps: CustomHandleProps;
-    tooltipProps: Partial<RCTooltip.Props>;
+    tooltipProps?: Partial<RCTooltip.Props>;
 }> = ({handleProps, handleCustomProps, tooltipProps = {}}) => (
     <Tooltip
         prefixCls="rc-slider-tooltip"

--- a/packages/react-vapor/src/components/slider/tests/MiddleSlider.spec.tsx
+++ b/packages/react-vapor/src/components/slider/tests/MiddleSlider.spec.tsx
@@ -6,7 +6,7 @@ import {act} from 'react-dom/test-utils';
 import {Provider} from 'react-redux';
 
 import {getStoreMock, ReactVaporMockStore} from '../../../utils/tests/TestUtils';
-import {MiddleSlider} from '../MiddleSlider';
+import {AppendedValueSide, MiddleSlider} from '../MiddleSlider';
 import {computeStep} from '../SliderUtils';
 
 describe('<MiddleSlider/>', () => {
@@ -76,13 +76,24 @@ describe('<MiddleSlider/>', () => {
                 appendValueFormatter: (value: number) => `+${value}`,
                 appendValue: true,
             }).dive();
-            expect(middleSlider.find('.slider-value').text()).toBe('+0');
+            expect(
+                middleSlider
+                    .find('.slider-value')
+                    .first()
+                    .text()
+            ).toBe('+0');
+            expect(
+                middleSlider
+                    .find('.slider-value')
+                    .first()
+                    .text()
+            ).toBe('+0');
         });
 
         it('should render a track it with its marks', () => {
             middleSlider = shallowedMiddleSlider()
                 .dive()
-                .childAt(0)
+                .childAt(1)
                 .dive();
             const children: any = middleSlider.prop('children');
             const marks = children[2].props.marks;
@@ -92,7 +103,7 @@ describe('<MiddleSlider/>', () => {
         it('should apply the computed step prop to the range slider', () => {
             middleSlider = shallowedMiddleSlider()
                 .dive()
-                .childAt(0)
+                .childAt(1)
                 .dive();
             const children: any = middleSlider.prop('children');
             const computedStep = computeStep(step, middleSliderRequiredProps.min, middleSliderRequiredProps.max);
@@ -103,7 +114,7 @@ describe('<MiddleSlider/>', () => {
         it('should set the handle hasTooltip prop to true when slider hasTooltip his passed', () => {
             middleSlider = shallowedMiddleSlider()
                 .dive()
-                .childAt(0)
+                .childAt(1)
                 .dive();
             const children: any = middleSlider.prop('children');
             const firstHandle = children[3][0];
@@ -124,7 +135,7 @@ describe('<MiddleSlider/>', () => {
                 store
             )
                 .dive()
-                .childAt(0)
+                .childAt(1)
                 .dive();
             const children: any = middleSlider.prop('children');
             const firstHandle = children[3][0];
@@ -134,7 +145,7 @@ describe('<MiddleSlider/>', () => {
         it('should not pass the disabled props to the handle if the enable prop is set to true', () => {
             middleSlider = shallowedMiddleSlider()
                 .dive()
-                .childAt(0)
+                .childAt(1)
                 .dive();
             const children: any = middleSlider.prop('children');
             const firstHandle = children[3][0];
@@ -155,7 +166,7 @@ describe('<MiddleSlider/>', () => {
                 store
             )
                 .dive()
-                .childAt(0)
+                .childAt(1)
                 .dive();
 
             const children: any = middleSlider.prop('children');
@@ -163,7 +174,67 @@ describe('<MiddleSlider/>', () => {
             expect(firstHandle.props.handleProps.disabled).toBeTruthy();
         });
 
-        it('should append the computed  value if the appendedValue prop is passed', () => {
+        it('should append the computed to the right value if the appendedValue prop is passed with a AppendedValueSide at right', () => {
+            middleSlider = shallowWithStore(
+                <MiddleSlider
+                    {...middleSliderRequiredProps}
+                    onChange={(value) => value}
+                    initialValue={20}
+                    customTooltip={() => <span>customTooltip</span>}
+                    marks={{0: '-2000', 33: '2000', 17: '0', 100: '10,000'}}
+                    step={5}
+                    enabled={false}
+                    appendValue={AppendedValueSide.right}
+                />,
+                store
+            ).dive();
+
+            expect(middleSlider.childAt(1).prop('className')).toContain('appended-value');
+            expect(middleSlider.childAt(0).prop('className')).toContain('hidden');
+            expect(middleSlider.childAt(2).prop('className')).not.toContain('hidden');
+        });
+
+        it('should append the computed to the left value if the appendedValue prop is passed with a AppendedValueSide at left', () => {
+            middleSlider = shallowWithStore(
+                <MiddleSlider
+                    {...middleSliderRequiredProps}
+                    onChange={(value) => value}
+                    initialValue={20}
+                    customTooltip={() => <span>customTooltip</span>}
+                    marks={{0: '-2000', 33: '2000', 17: '0', 100: '10,000'}}
+                    step={5}
+                    enabled={false}
+                    appendValue={AppendedValueSide.left}
+                />,
+                store
+            ).dive();
+
+            expect(middleSlider.childAt(1).prop('className')).toContain('appended-value');
+            expect(middleSlider.childAt(0).prop('className')).not.toContain('hidden');
+            expect(middleSlider.childAt(2).prop('className')).toContain('hidden');
+        });
+
+        it('should append the computed on both sides value if the appendedValue prop is passed with a AppendedValueSide at both', () => {
+            middleSlider = shallowWithStore(
+                <MiddleSlider
+                    {...middleSliderRequiredProps}
+                    onChange={(value) => value}
+                    initialValue={20}
+                    customTooltip={() => <span>customTooltip</span>}
+                    marks={{0: '-2000', 33: '2000', 17: '0', 100: '10,000'}}
+                    step={5}
+                    enabled={false}
+                    appendValue={AppendedValueSide.both}
+                />,
+                store
+            ).dive();
+
+            expect(middleSlider.childAt(1).prop('className')).toContain('appended-value');
+            expect(middleSlider.childAt(0).prop('className')).not.toContain('hidden');
+            expect(middleSlider.childAt(2).prop('className')).not.toContain('hidden');
+        });
+
+        it('should append the computed to the right value if the appendedValue prop is passed with a TRUE value', () => {
             middleSlider = shallowWithStore(
                 <MiddleSlider
                     {...middleSliderRequiredProps}
@@ -178,8 +249,9 @@ describe('<MiddleSlider/>', () => {
                 store
             ).dive();
 
-            expect(middleSlider.childAt(0).prop('className')).toContain('appended-value');
-            expect(middleSlider.childAt(1).prop('className')).not.toContain('hidden');
+            expect(middleSlider.childAt(1).prop('className')).toContain('appended-value');
+            expect(middleSlider.childAt(0).prop('className')).toContain('hidden');
+            expect(middleSlider.childAt(2).prop('className')).not.toContain('hidden');
         });
         it('should NOT append the computed  value if the appendedValue prop is passed', () => {
             middleSlider = shallowWithStore(
@@ -194,9 +266,9 @@ describe('<MiddleSlider/>', () => {
                 />,
                 store
             ).dive();
-
-            expect(middleSlider.childAt(0).prop('className')).not.toContain('appended-value');
-            expect(middleSlider.childAt(1).prop('className')).toContain('hidden');
+            expect(middleSlider.childAt(0).prop('className')).toContain('hidden');
+            expect(middleSlider.childAt(1).prop('className')).not.toContain('appended-value');
+            expect(middleSlider.childAt(2).prop('className')).toContain('hidden');
         });
     });
 

--- a/packages/vapor/scss/controls/slider.scss
+++ b/packages/vapor/scss/controls/slider.scss
@@ -2,11 +2,15 @@
 @import '../variables';
 
 div.slider-container {
+    display: flex;
+    align-items: flex-end;
+
     div.appended-value.vapor-slider.rc-slider {
         flex: 15;
     }
     div.slider-value {
         flex: 2;
+        align-items: flex-end;
 
         justify-content: center;
         padding-top: 1.2em;


### PR DESCRIPTION
### Proposed Changes

we can now append the slider values to both side of the slider. The to side can be formatted with the `appendedValueFormatter` props

I created an union type for the `appendedValue` props. So if we simply pass the `appendedValue` to `true`, the appended value will normaly appear to the right of the slider. But we can pass it with the `AppendedValueSide` enum that has the `left` `right` `both` keys and the value will appear accordingly.

The Initial implementation of the `appendedValueFormatter` prop still work as intended, but depending of the side it formats, the `left` or `right` will be passed in the params to grant the developer the possibility to customize the format differently if need be. 

### Potential Breaking Changes

no breaking change intended

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
