### PR TITLE
revert(datepicker): use drop

### DIFF
--- a/packages/demo/src/components/examples/DatePickerExamples.tsx
+++ b/packages/demo/src/components/examples/DatePickerExamples.tsx
@@ -7,7 +7,6 @@ import {
     Section,
 } from 'react-vapor';
 import * as _ from 'underscore';
-import {ChildForm} from '../../../../react-vapor/src/components/childForm/ChildForm';
 
 import {ExampleComponent} from '../ComponentsInterface';
 import {
@@ -73,23 +72,6 @@ const DatePickerComponents: React.FunctionComponent = () => (
                     isClearable
                     initiallyUnselected
                 />
-            </Section>
-
-            <Section level={3} title="Date picker dropdown with drop and a child form">
-                <ChildForm>
-                    <Section level={2} title="My date picker label">
-                        <DatePickerDropdownConnected
-                            id="date-picker-dropdown-4"
-                            datesSelectionBoxes={[{...FOUR_SELECTION_BOXES[0], isRange: false}]}
-                            selectionRules={[]}
-                            isClearable
-                            initiallyUnselected
-                            dropOptions={{
-                                parentSelector: 'body',
-                            }}
-                        />
-                    </Section>
-                </ChildForm>
             </Section>
         </Section>
     </Section>

--- a/packages/react-vapor/src/components/datePicker/DatePickerDropdown.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePickerDropdown.tsx
@@ -7,8 +7,6 @@ import {DateUtils} from '../../utils/DateUtils';
 import {IReduxStatePossibleProps} from '../../utils/ReduxUtils';
 import {Button} from '../button/Button';
 import {DEFAULT_YEARS, ICalendarSelectionRule} from '../calendar/Calendar';
-import {DropPodPosition} from '../drop/DomPositionCalculator';
-import {Drop, IDropOwnProps} from '../drop/Drop';
 import {ModalFooter} from '../modal/ModalFooter';
 import {DatePickerBox, IDatePickerBoxChildrenProps, IDatePickerBoxProps, IDatesSelectionBox} from './DatePickerBox';
 import {DatePickerDateRange} from './DatePickerConstants';
@@ -21,7 +19,7 @@ export interface IDatePickerDropdownOwnProps extends React.ClassAttributes<DateP
     applyLabel?: string;
     cancelLabel?: string;
     toLabel?: string;
-    onRight?: boolean; // Deprecated
+    onRight?: boolean;
     onBeforeApply?: () => void;
     extraDropdownClasses?: string[];
     extraDropdownToggleClasses?: string[];
@@ -30,7 +28,6 @@ export interface IDatePickerDropdownOwnProps extends React.ClassAttributes<DateP
     isClearable?: boolean;
     attributeName?: string;
     readonly?: boolean;
-    dropOptions?: Partial<IDropOwnProps>;
 }
 
 export interface IDatePickerDropdownChildrenProps extends IDatePickerBoxChildrenProps {
@@ -141,6 +138,10 @@ export class DatePickerDropdown extends React.Component<IDatePickerDropdownProps
             open: this.props.isOpened,
         });
 
+        const menuClasses: string = classNames('dropdown-menu', 'normal-height', {
+            'on-right': this.props.onRight,
+        });
+
         const toggleClasses = classNames(
             'dropdown-toggle btn inline-flex flex-center',
             this.props.extraDropdownToggleClasses,
@@ -148,40 +149,22 @@ export class DatePickerDropdown extends React.Component<IDatePickerDropdownProps
                 'dropdown-toggle-placeholder': !this.props.datePicker || !this.props.datePicker.appliedLowerLimit,
             }
         );
-
         return (
-            <Drop
-                id={this.props.id}
-                positions={[DropPodPosition.bottom, DropPodPosition.top]}
-                buttonContainerProps={{className: 'inline-block'}}
-                renderOpenButton={(onClick: () => void) => (
-                    <div className={classNames('date-picker-dropdown', this.props.className)}>
-                        <div className={dropdownClasses}>
-                            <button
-                                className={toggleClasses}
-                                onClick={() => {
-                                    this.handleClick();
-                                    onClick();
-                                }}
-                                disabled={this.props.readonly}
-                            >
-                                <span className="dropdown-selected-value">
-                                    <label>
-                                        {label}
-                                        {toLabel}
-                                        {labelSecondPart}
-                                    </label>
-                                </span>
-                                <span className="dropdown-toggle-arrow"></span>
-                            </button>
-                        </div>
-                    </div>
-                )}
-                closeOnClickDrop={false}
-                {...this.props.dropOptions}
-            >
-                {this.getDatePickerBox()}
-            </Drop>
+            <div className={classNames('date-picker-dropdown', this.props.className)}>
+                <div className={dropdownClasses} ref={(dropdown: HTMLDivElement) => (this.dropdown = dropdown)}>
+                    <button className={toggleClasses} onClick={this.handleClick} disabled={this.props.readonly}>
+                        <span className="dropdown-selected-value">
+                            <label>
+                                {label}
+                                {toLabel}
+                                {labelSecondPart}
+                            </label>
+                        </span>
+                        <span className="dropdown-toggle-arrow"></span>
+                    </button>
+                    <div className={menuClasses}>{this.getDatePickerBox()}</div>
+                </div>
+            </div>
         );
     }
 

--- a/packages/react-vapor/src/components/datePicker/DatePickerDropdownConnected.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePickerDropdownConnected.tsx
@@ -4,7 +4,6 @@ import * as _ from 'underscore';
 import {IReactVaporState, IReduxActionsPayload} from '../../ReactVapor';
 import {IReduxAction, ReduxUtils} from '../../utils/ReduxUtils';
 import {MONTH_PICKER_ID, YEAR_PICKER_ID} from '../calendar/Calendar';
-import {DefaultGroupIds, DropActions} from '../drop/redux/DropActions';
 import {addDropdown, closeDropdown, removeDropdown, toggleDropdown} from '../dropdown/DropdownActions';
 import {IDropdownState} from '../dropdown/DropdownReducers';
 import {resetOptionPickers} from '../optionPicker/OptionPickerActions';
@@ -49,7 +48,6 @@ const mapDispatchToProps = (
     onDocumentClick: () => dispatch(closeDropdown(ownProps.id)),
     onApply: () => {
         dispatch(closeDropdown(ownProps.id));
-        dispatch(DropActions.toggle(ownProps.id, ownProps?.dropOptions?.groupId ?? DefaultGroupIds.default, false));
         dispatch(applyDatePicker(ownProps.id));
         dispatch(resetDatePickers(ownProps.id));
     },
@@ -60,7 +58,6 @@ const mapDispatchToProps = (
             dispatch(resetDatePickers(ownProps.id));
             dispatch(resetOptionPickers(ownProps.id));
             dispatch(closeDropdown(ownProps.id));
-            dispatch(DropActions.toggle(ownProps.id, ownProps?.dropOptions?.groupId ?? DefaultGroupIds.default, false));
         }
     },
     onClear: () => {


### PR DESCRIPTION
### Proposed Changes

It was breaking the DatePickerDropdown component.

### Potential Breaking Changes

DatePickers wont be using the drop anymore.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
