### PR TITLE
SingleSelectConnected custom button

### DIFF
--- a/packages/demo/src/components/examples/SingleSelectExamples.tsx
+++ b/packages/demo/src/components/examples/SingleSelectExamples.tsx
@@ -4,6 +4,7 @@ import {
     FilterBoxSelectors,
     IFlatSelectOptionProps,
     IItemBoxProps,
+    ISelectButtonProps,
     ISingleSelectOwnProps,
     Section,
     selectWithFilter,
@@ -48,7 +49,15 @@ const itemsWithAppendedValue = _.map(defaultItems, (item) => ({
     append: {content: () => <span className="text-red ml3">{item.value}</span>},
 }));
 
-const ids = [UUID.generate(), UUID.generate(), UUID.generate(), UUID.generate(), UUID.generate(), UUID.generate()];
+const ids = [
+    UUID.generate(),
+    UUID.generate(),
+    UUID.generate(),
+    UUID.generate(),
+    UUID.generate(),
+    UUID.generate(),
+    UUID.generate(),
+];
 
 const defaultFlatSelectOptions: IFlatSelectOptionProps[] = [
     {id: UUID.generate(), option: {content: 'All'}, selected: true},
@@ -120,8 +129,20 @@ const SingleSelectConnectedExamples: React.ComponentType = () => (
                 footer={<div className="select-footer">The single select footer</div>}
             />
         </Section>
+        <Section level={3} title="A single select with a custom button">
+            <SingleSelectConnected id={ids[6]} items={defaultItems} customButton={MyCustomButton} />
+        </Section>
     </Section>
 );
+
+const MyCustomButton: React.FunctionComponent<ISelectButtonProps> = ({onClick, selectedOptions}) => {
+    const option = selectedOptions[0];
+    return (
+        <div onClick={onClick} className="btn">
+            {option ? option.displayValue : 'Click me!'}
+        </div>
+    );
+};
 
 const PER_PAGE = 10;
 

--- a/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
@@ -71,7 +71,7 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps> {
                 id={this.props.id}
                 key={this.props.id}
                 {..._.pick(this.props, selectPropsKeys)}
-                button={this.getButton}
+                button={this.Toggle}
                 multi
             >
                 {this.props.children}
@@ -142,7 +142,7 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps> {
         ) : null;
     }
 
-    private getButton = ({onClick, onKeyDown, onKeyUp}: ISelectButtonProps): JSX.Element => {
+    private Toggle = ({onClick, onKeyDown, onKeyUp}: ISelectButtonProps): JSX.Element => {
         const classes = classNames('multiselect-input', {'mod-sortable': this.props.sortable});
         const buttonAttrs =
             !this.props.noDisabled && this.props.selected && this.props.selected.length === this.props.items.length

--- a/packages/react-vapor/src/components/select/SelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SelectConnected.tsx
@@ -8,7 +8,6 @@ import {IComponentBehaviour} from '../../utils/ComponentUtils';
 import {mod} from '../../utils/DataStructuresUtils';
 import {keyCode} from '../../utils/InputUtils';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
-import {Content} from '../content/Content';
 import {DropPodPosition} from '../drop/DomPositionCalculator';
 import {Drop} from '../drop/Drop';
 import {IDropPodProps} from '../drop/DropPod';
@@ -22,7 +21,7 @@ import * as styles from './styles/SingleSelect.scss';
 
 export interface ISelectOwnProps extends IListBoxOwnProps, IComponentBehaviour {
     id: string;
-    button: React.ReactNode;
+    button: React.ComponentType<ISelectButtonProps>;
     placeholder?: string;
     selectClasses?: string;
     dropClasses?: string;
@@ -39,6 +38,7 @@ export interface ISelectButtonProps {
     onClick: (e: React.MouseEvent) => void;
     onKeyUp: (e: React.KeyboardEvent<HTMLElement>) => void;
     onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => void;
+    selectedOptions: IItemBoxProps[];
     placeholder?: string;
 }
 
@@ -124,18 +124,18 @@ export class SelectConnected extends React.PureComponent<ISelectProps> {
         );
     }
 
+    private get selectedOptions(): IItemBoxProps[] {
+        return this.props.items.filter((option: IItemBoxProps) => _.contains(this.props.selectedValues, option.value));
+    }
+
     private renderToggle = (openDropdown: () => void) => (
         <div className="js-drop-button-container" ref={this.dropdown}>
-            <Content
-                content={this.props.button}
-                classes={['select-dropdown-button']}
-                componentProps={{
-                    onClick: openDropdown,
-                    onKeyUp: (e: React.KeyboardEvent<HTMLElement>) => this.onKeyUp(e),
-                    onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => this.onKeyDown(e),
-                    placeholder: this.props.placeholder,
-                }}
-                key={`${this.props.id}-button`}
+            <this.props.button
+                onClick={openDropdown}
+                onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => this.onKeyDown(e)}
+                onKeyUp={(e: React.KeyboardEvent<HTMLElement>) => this.onKeyUp(e)}
+                placeholder={this.props.placeholder}
+                selectedOptions={this.selectedOptions}
             />
         </div>
     );

--- a/packages/react-vapor/src/components/select/SingleSelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SingleSelectConnected.tsx
@@ -24,6 +24,7 @@ export interface ISingleSelectOwnProps extends Omit<ISelectOwnProps, 'button'> {
     canClear?: boolean;
     deselectTooltipText?: string;
     footer?: React.ReactNode;
+    customButton?: React.ComponentType<ISelectButtonProps>;
 }
 
 const selectPropsKeys = keys<ISelectOwnProps>();
@@ -61,7 +62,7 @@ class SingleSelect extends React.PureComponent<ISingleSelectProps> {
         return (
             <SelectConnected
                 {..._.pick(this.props, selectPropsKeys)}
-                button={this.getButton}
+                button={this.props.customButton ?? this.Toggle}
                 isLoading={this.props.isLoading}
             >
                 {this.props.children}
@@ -69,8 +70,8 @@ class SingleSelect extends React.PureComponent<ISingleSelectProps> {
         );
     }
 
-    private getButton = ({onClick, onKeyDown, onKeyUp}: ISelectButtonProps) => {
-        const option = _.findWhere(this.props.items, {value: this.props.selectedOption});
+    private Toggle: React.FunctionComponent<ISelectButtonProps> = ({onClick, onKeyDown, onKeyUp, selectedOptions}) => {
+        const option = selectedOptions[0];
         const showClear = !!option && this.props.canClear && !this.props.disabled;
         const buttonClasses = classNames('btn dropdown-toggle', this.props.toggleClasses, {
             'dropdown-toggle-placeholder': !option,
@@ -88,9 +89,9 @@ class SingleSelect extends React.PureComponent<ISingleSelectProps> {
                 disabled={this.props.disabled}
             >
                 {this.props.buttonPrepend}
-                {option && option.prepend ? <Content {...option.prepend} /> : null}
+                {option?.prepend ? <Content {...option.prepend} /> : null}
                 {this.getSelectedOptionElement(option)}
-                {option && option.append ? <Content {...option.append} /> : null}
+                {option?.append ? <Content {...option.append} /> : null}
                 <span className="dropdown-toggle-arrow" />
                 {showClear && this.getDeselectOptionButton()}
             </button>

--- a/packages/react-vapor/src/components/select/tests/SingleSelectConnected.spec.tsx
+++ b/packages/react-vapor/src/components/select/tests/SingleSelectConnected.spec.tsx
@@ -1,4 +1,5 @@
 import {mount, ReactWrapper} from 'enzyme';
+import {shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
 import {Store} from 'redux';
 import * as _ from 'underscore';
@@ -268,6 +269,15 @@ describe('Select', () => {
                 expect(mountedSingleSelect.find('#some-footer').matchesElement(footer)).toBeTruthy();
                 mountedSingleSelect.unmount();
             });
+        });
+
+        it('should render the custom button prop content as toggle if it is specified', () => {
+            const CustomButton = () => <span>🍄🍄🍄🍄🍄🍄</span>;
+            const component = shallowWithState(
+                <SingleSelectConnected id={id} items={[{value: 'a', selected: false}]} customButton={CustomButton} />,
+                {}
+            ).dive();
+            expect(component.prop('button')).toBe(CustomButton);
         });
     });
 });

--- a/packages/vapor/gulpfile.js
+++ b/packages/vapor/gulpfile.js
@@ -162,7 +162,7 @@ gulp.task('svg:concat', () => {
                 plugins: [
                     {
                         removeAttrs: {
-                            attrs: ['xmlns:*', 'xmlns', 'id'],
+                            attrs: ['xmlns:*', 'xmlns'],
                         },
                     },
                     {

--- a/packages/vapor/resources/icons/svg/flag-eu.svg
+++ b/packages/vapor/resources/icons/svg/flag-eu.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" 
+    xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="945" height="630" viewBox="0 0 27 18">
+    <desc>Flag of the European Union</desc>
+    <defs>
+        <g id="s">
+            <g id="c">
+                <path id="t" d="M0,0v1h0.5z" transform="translate(0,-1) rotate(18)"/>
+                <use xlink:href="#t" transform="scale(-1,1)"/>
+            </g>
+            <use xlink:href="#c" transform="rotate(72)"/>
+            <use xlink:href="#c" transform="rotate(144)"/>
+            <use xlink:href="#c" transform="rotate(216)"/>
+            <use xlink:href="#c" transform="rotate(288)"/>
+        </g>
+    </defs>
+    <path d="M0,0v18h27v-18z" fill="#039"/>
+    <g transform="translate(13.5,9)" fill="#fc0">
+        <use xlink:href="#s" transform="translate(0,-6)"/>
+        <g id="r">
+            <use xlink:href="#s" transform="rotate(30) translate(0,6) rotate(42)"/>
+            <use xlink:href="#s" transform="rotate(60) translate(0,6) rotate(12)"/>
+            <use xlink:href="#s" transform="translate(6,0)"/>
+            <use xlink:href="#s" transform="rotate(120) translate(0,6) rotate(24)"/>
+            <use xlink:href="#s" transform="rotate(150) translate(0,6) rotate(66)"/>
+        </g>
+        <use xlink:href="#s" transform="translate(0,6)"/>
+        <use xlink:href="#r" transform="scale(-1,1)"/>
+    </g>
+</svg>

--- a/packages/vapor/resources/icons/svg/flag-us.svg
+++ b/packages/vapor/resources/icons/svg/flag-us.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" 
+    xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 7410 3900">
+    <rect width="7410" height="3900" fill="#b22234"/>
+    <path d="M0,450H7410m0,600H0m0,600H7410m0,600H0m0,600H7410m0,600H0" stroke="#fff" stroke-width="300"/>
+    <rect width="2964" height="2100" fill="#3c3b6e"/>
+    <g fill="#fff">
+        <g id="s18">
+            <g id="s9">
+                <g id="s5">
+                    <g id="s4">
+                        <path id="s" d="M247,90 317.534230,307.082039 132.873218,172.917961H361.126782L176.465770,307.082039z"/>
+                        <use xlink:href="#s" y="420"/>
+                        <use xlink:href="#s" y="840"/>
+                        <use xlink:href="#s" y="1260"/>
+                    </g>
+                    <use xlink:href="#s" y="1680"/>
+                </g>
+                <use xlink:href="#s4" x="247" y="210"/>
+            </g>
+            <use xlink:href="#s9" x="494"/>
+        </g>
+        <use xlink:href="#s18" x="988"/>
+        <use xlink:href="#s9" x="1976"/>
+        <use xlink:href="#s5" x="2470"/>
+    </g>
+</svg>

--- a/packages/vapor/scss/common/palette.scss
+++ b/packages/vapor/scss/common/palette.scss
@@ -70,7 +70,7 @@ $onahau-1: #b6eeff;
 $blue-purple-palette: category;
 $coveo-blue-purple: $mirage;
 $blue-purple-1: #3e5485;
-$blue-purple-2: #354878;
+$blue-purple-2: #354667;
 $blue-purple-3: #2d385e;
 $blue-purple-4: $coveo-blue-purple;
 $blue-purple-5: #101425;

--- a/packages/vapor/scss/components/menu.scss
+++ b/packages/vapor/scss/components/menu.scss
@@ -1,11 +1,11 @@
 .dropdown.mod-menu {
     &.header-section {
         &:hover {
-            background-color: $navigation-active-background-color;
+            background-color: $blue-purple-2;
         }
 
         &.open {
-            background-color: $navigation-active-background-color;
+            background-color: $blue-purple-2;
         }
     }
     .dropdown-toggle {
@@ -22,7 +22,7 @@
         }
     }
 
-    &.open > .dropdown-toggle .dropdown-toggle-arrow {
+    &.open .dropdown-toggle .dropdown-toggle-arrow {
         @include arrow-up-icon($pure-white);
     }
 

--- a/packages/vapor/scss/components/navigation.scss
+++ b/packages/vapor/scss/components/navigation.scss
@@ -57,11 +57,11 @@
                 .navigation-menu-section-link {
                     border-left: $navigation-active-border-width solid transparent;
                     &:hover {
-                        background-color: $navigation-active-background-color;
+                        background-color: $blue-purple-2;
                         opacity: 1;
                     }
                     &.state-active {
-                        background-color: $navigation-active-background-color;
+                        background-color: $blue-purple-2;
                         border-left-color: $orange;
                         opacity: 1;
                     }
@@ -144,7 +144,7 @@
                         }
 
                         &.state-active {
-                            background-color: $navigation-active-background-color;
+                            background-color: $blue-purple-2;
                             border-left-color: $orange;
                             .navigation-menu-section-item-link-name,
                             .navigation-menu-section-item-link-icon {
@@ -153,7 +153,7 @@
                         }
 
                         &:hover {
-                            background-color: $navigation-active-background-color;
+                            background-color: $blue-purple-2;
                             .navigation-menu-section-item-link-name,
                             .navigation-menu-section-item-link-icon {
                                 opacity: 1;

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -227,7 +227,7 @@ $navigation-menu-item-font-weight: 400;
 $navigation-width: 245px;
 $navigation-border-for-scroll-bar: 1px;
 $navigation-background-color: $purple-blue;
-$navigation-active-background-color: #354667;
+$navigation-active-background-color: $blue-purple-2;
 $navigation-active-border-width: 3px;
 $navigation-section-icon-size: 20px;
 $navigation-section-icon-margin-right: 10px;


### PR DESCRIPTION
### Proposed Changes

- Added the `customButton` prop on the `SingleSelectConnected` component. It allows to render a custom toggle for the SingleSelectConnected instead of the default white toggle.
- Added 2 new icons: `flagUs` and `flagEu`. SVGs were taken from Wikipedia
![image](https://user-images.githubusercontent.com/35579930/81971961-e6324d00-95ef-11ea-8c4c-e3866dfcc58e.png)
- Adjusted the `blue-purple-2` color so that it matches the color we use for active side navigation section and opened dropdowns.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
