### PR TITLE
feat(linksvg): add a prop for text

### DIFF
--- a/packages/demo/src/components/examples/LinkSvgExamples.tsx
+++ b/packages/demo/src/components/examples/LinkSvgExamples.tsx
@@ -46,6 +46,18 @@ export class LinkSvgExamples extends React.Component<any, any> {
                         <LinkSvg tooltip={defaultTooltipProps} svg={defaultSvgProps} />
                     </div>
                 </div>
+                <div className="form-group">
+                    <label className="form-control-label">LinkSvg with a custom label</label>
+                    <div className="form-control">
+                        <LinkSvg
+                            url={defaultProps.url}
+                            svg={{svgName: 'external', svgClass: 'icon mod-16 fill-blue ml1'}}
+                            linkClasses={['bold', 'caps']}
+                        >
+                            Learn more on Google
+                        </LinkSvg>
+                    </div>
+                </div>
             </div>
         );
     }

--- a/packages/react-vapor/src/components/svg/LinkSvg.tsx
+++ b/packages/react-vapor/src/components/svg/LinkSvg.tsx
@@ -8,6 +8,7 @@ export interface ILinkSvgProps extends React.ClassAttributes<LinkSvg> {
     target?: string;
     linkClasses?: string[];
     svg?: ISvgProps;
+    text?: string;
     tooltip?: ITooltipProps;
 }
 
@@ -23,6 +24,7 @@ export class LinkSvg extends React.Component<ILinkSvgProps, {}> {
         const href = this.props.url ? {href: this.props.url} : null;
         return (
             <a {...href} target={this.props.target} className={classes}>
+                {this.props.text}
                 <Tooltip {...this.props.tooltip}>
                     <Svg {...this.props.svg} />
                 </Tooltip>

--- a/packages/react-vapor/src/components/svg/LinkSvg.tsx
+++ b/packages/react-vapor/src/components/svg/LinkSvg.tsx
@@ -8,7 +8,6 @@ export interface ILinkSvgProps extends React.ClassAttributes<LinkSvg> {
     target?: string;
     linkClasses?: string[];
     svg?: ISvgProps;
-    text?: string;
     tooltip?: ITooltipProps;
 }
 
@@ -24,7 +23,7 @@ export class LinkSvg extends React.Component<ILinkSvgProps, {}> {
         const href = this.props.url ? {href: this.props.url} : null;
         return (
             <a {...href} target={this.props.target} className={classes}>
-                {this.props.text}
+                {this.props.children}
                 <Tooltip {...this.props.tooltip}>
                     <Svg {...this.props.svg} />
                 </Tooltip>

--- a/packages/react-vapor/src/components/svg/tests/LinkSvg.spec.tsx
+++ b/packages/react-vapor/src/components/svg/tests/LinkSvg.spec.tsx
@@ -9,6 +9,7 @@ import {Svg} from '../Svg';
 describe('<LinkSvg>', () => {
     let linkSvgComponent: ReactWrapper<ILinkSvgProps, any>;
     let linkSvgProps: ILinkSvgProps;
+    const linkSvgLabel = '🍦';
 
     beforeEach(() => {
         linkSvgProps = {
@@ -37,7 +38,7 @@ describe('<LinkSvg>', () => {
         });
 
         const renderLinkSvg = (props: Partial<ILinkSvgProps> = {}) => {
-            linkSvgComponent = mount(<LinkSvg {..._.extend(linkSvgProps, props)} />, {
+            linkSvgComponent = mount(<LinkSvg {..._.extend(linkSvgProps, props)}>{linkSvgLabel}</LinkSvg>, {
                 attachTo: document.getElementById('App'),
             });
         };
@@ -84,6 +85,12 @@ describe('<LinkSvg>', () => {
             });
 
             expect(linkSvgComponent.find('a').props().href).toBeUndefined();
+        });
+
+        it('should render a custom label as child', () => {
+            renderLinkSvg();
+
+            expect(linkSvgComponent.html()).toContain(linkSvgLabel);
         });
     });
 });


### PR DESCRIPTION
### Proposed Changes

Add a prop `text` to the component `LinkSvg` in order to allow displaying customized texts under hyperlink.

### Potential Breaking Changes

nope

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
