### PR TITLE
fix(selectwithpredicate): make matchPredicate prop optional

### DIFF
--- a/packages/react-vapor/src/components/select/hoc/SelectWithPredicate.tsx
+++ b/packages/react-vapor/src/components/select/hoc/SelectWithPredicate.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
 import {connect} from 'react-redux';
 import {keys} from 'ts-transformer-keys';
@@ -13,7 +14,7 @@ import {ISelectOwnProps} from '../SelectConnected';
 
 export interface ISelectWithPredicateOwnProps {
     options: IFlatSelectOptionProps[];
-    matchPredicate: (predicate: string, item: IItemBoxProps) => boolean;
+    matchPredicate?: (predicate: string, item: IItemBoxProps) => boolean;
 }
 const SelectWithPredicatePropsToOmit = keys<ISelectWithPredicateOwnProps>();
 
@@ -49,7 +50,7 @@ export const selectWithPredicate = <P extends Omit<ISelectOwnProps, 'button'> & 
             <Component {..._.omit(props, SelectWithPredicatePropsToOmit)}>
                 <FlatSelectConnected
                     id={props.id}
-                    classes={['full-content-x']}
+                    classes={[classNames('full-content-x', {mb2: !!props.children})]}
                     options={props.options}
                     group
                     optionPicker


### PR DESCRIPTION
### Proposed Changes

`matchPredicate` isn't used when `isServer` is set to true, so it is optional.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
