### PR TITLE
fix(commonjs): remove transpileOnly option in webpack build

### DIFF
--- a/packages/react-vapor/rollup.config.js
+++ b/packages/react-vapor/rollup.config.js
@@ -58,8 +58,14 @@ function tsPlugin() {
                 after: [],
             }),
         ],
-        tsconfig: 'tsconfig.build.json',
         useTsconfigDeclarationDir: true,
+        tsconfig: 'tsconfig.build.json',
+        tsconfigOverride: {
+            compilerOptions: {
+                declaration: true,
+                declarationDir: 'dist/definitions',
+            },
+        },
     });
 }
 

--- a/packages/react-vapor/tsconfig.build.json
+++ b/packages/react-vapor/tsconfig.build.json
@@ -3,8 +3,6 @@
     "compilerOptions": {
         "removeComments": false,
         "sourceMap": true,
-        "declaration": true,
-        "declarationDir": "dist/definitions",
         "baseUrl": "./",
         "paths": {
             "*": ["types/*", "*"]

--- a/packages/react-vapor/webpack.config.js
+++ b/packages/react-vapor/webpack.config.js
@@ -75,7 +75,6 @@ const config = {
                 test: /\.tsx?$/,
                 loader: 'ts-loader',
                 options: {
-                    transpileOnly: true,
                     configFile: 'tsconfig.build.json',
                     getCustomTransformers: (program) => ({
                         before: [keysTransformer(program)],


### PR DESCRIPTION
### Proposed Changes

With `transpileOnly: true` in the webpack.config, the react-vapor.js build was broken because the custom typescript keys transformer was skipped.

With the changes made, here is what is happening:
- `webpack` build: generates the UMD build (`react-vapor.js`) + source maps
![image](https://user-images.githubusercontent.com/35579930/83297393-7cee3480-a1c0-11ea-878b-eb892ec9f6a6.png)

- `rollup` build: generates the ES modules build (`react-vapor.esm.js`) + the type declarations
![image](https://user-images.githubusercontent.com/35579930/83297444-93948b80-a1c0-11ea-866c-9c3279db29e7.png)

When running `npm run build` it runs the rollup and webpack build concurently so that we have everything at once.
![image](https://user-images.githubusercontent.com/35579930/83297626-e40be900-a1c0-11ea-88f7-b2ab21a83d7b.png)


### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
