### PR TITLE
fix(nonemptyhoc): clearError not clearing the right id

### DIFF
--- a/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
@@ -14,7 +14,7 @@ export interface IWithNonEmptyValueInputValidationProps {
 
 const mapDispatchToProps = (dispatch: IDispatch) => ({
     setError: (id: string, error: string) => dispatch(ValidationActions.setError(id, error, ValidationTypes.nonEmpty)),
-    clearError: (id: string) => dispatch(ValidationActions.clearError(id)),
+    clearError: (id: string) => dispatch(ValidationActions.clearError(id, ValidationTypes.nonEmpty)),
 });
 
 export const withNonEmptyValueInputValidationHOC = <T extends IInputOwnProps>(


### PR DESCRIPTION
[COM-453]

### Proposed Changes

Really quick thing I noticed when using the HOC. This wouldn't clear the right feature, so the error was still showing up.

I tried testing it, but `mount` (or anything else, in fact) doesn't call `React.useEffect`, and apparently the only way to test it is by using `jest.mock()`... 

I validated the other "clearX" and they are fine

### Potential Breaking Changes

No

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-453]: https://coveord.atlassian.net/browse/COM-453