### PR TITLE
feat(multiselect): implement dirty hoc

### DIFF
--- a/packages/react-vapor/src/components/validation/hoc/WithDirtyMultiSelectHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtyMultiSelectHOC.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+import {createStructuredSelector} from 'reselect';
+import * as _ from 'underscore';
+import {IDispatch} from '../../../utils/ReduxUtils';
+import {IMultiSelectOwnProps} from '../../select/MultiSelectConnected';
+import {SelectSelector} from '../../select/SelectSelector';
+import {ValidationActions} from '../ValidationActions';
+import {InferableComponentEnhancer} from './connectHOC';
+
+const mapStateToProps = createStructuredSelector({
+    selectedValues: SelectSelector.getMultiSelectSelectedValues,
+});
+
+const mapDispatchToProps = (dispatch: IDispatch, {id}: IMultiSelectOwnProps) => ({
+    toggleIsDirty: (isDirty: boolean) => dispatch(ValidationActions.setDirty(id, isDirty)),
+});
+
+export type IMultiSelectWithDirtyOwnProps = {
+    initialValues: string[];
+};
+
+export const withDirtyMultiSelectHOC = <T extends IMultiSelectOwnProps>(Component: React.ComponentType<T>) => {
+    type StateProps = ReturnType<typeof mapStateToProps>;
+    type DispatchProps = ReturnType<typeof mapDispatchToProps>;
+    const WrappedMultiSelect: React.FunctionComponent<T &
+        IMultiSelectWithDirtyOwnProps &
+        StateProps &
+        DispatchProps> = ({initialValues = [], selectedValues, toggleIsDirty, ...props}) => {
+        const hasDifferentValuesSelected =
+            _.difference(initialValues, selectedValues).length > 0 ||
+            _.difference(selectedValues, initialValues).length > 0;
+
+        React.useEffect(() => {
+            toggleIsDirty(hasDifferentValuesSelected);
+        }, [hasDifferentValuesSelected]);
+
+        return <Component {...(props as T)} />;
+    };
+
+    const enhance = connect(mapStateToProps, mapDispatchToProps) as InferableComponentEnhancer<
+        StateProps & DispatchProps
+    >;
+    return enhance(WrappedMultiSelect);
+};

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithDirtyMultiSelectHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithDirtyMultiSelectHOC.spec.tsx
@@ -1,0 +1,85 @@
+import {mountWithStore} from 'enzyme-redux';
+import * as React from 'react';
+import {act} from 'react-dom/test-utils';
+import {IReactVaporState} from '../../../../ReactVapor';
+import {composeMockStore} from '../../../../utils/tests/TestUtils';
+import {IMultiSelectOwnProps, MultiSelectConnected} from '../../../select/MultiSelectConnected';
+import {ValidationActions} from '../../ValidationActions';
+import {withDirtyMultiSelectHOC} from '../WithDirtyMultiSelectHOC';
+
+const MultiSelectWithDirty = withDirtyMultiSelectHOC(MultiSelectConnected);
+
+describe('MultiSelectWithDirty', () => {
+    const defaultProps: IMultiSelectOwnProps = {
+        id: 'SOME_ID',
+        items: [],
+    };
+
+    const ONE_VALUE = '🐟';
+    const ANOTHER_VALUE = '🐠';
+
+    const withSelectedValues = (...values: string[]) => (state: IReactVaporState) => ({
+        ...state,
+        listBoxes: [
+            ...(state.listBoxes || []),
+            {
+                active: 0,
+                ...{
+                    id: defaultProps.id,
+                    selected: values,
+                },
+            },
+        ],
+    });
+
+    it('should trigger the dirty state when the user selects a new value', () => {
+        const store = composeMockStore(withSelectedValues(ONE_VALUE));
+
+        const component = mountWithStore(<MultiSelectWithDirty {...defaultProps} initialValues={[]} />, store);
+
+        act(() => {
+            component.mount();
+        });
+
+        expect(store.getActions()).toContain(ValidationActions.setDirty(defaultProps.id, true));
+    });
+
+    it('should trigger the dirty state when the user removes a value', () => {
+        const store = composeMockStore(withSelectedValues(ONE_VALUE));
+
+        const component = mountWithStore(
+            <MultiSelectWithDirty {...defaultProps} initialValues={[ONE_VALUE, ANOTHER_VALUE]} />,
+            store
+        );
+
+        act(() => {
+            component.mount();
+        });
+
+        expect(store.getActions()).toContain(ValidationActions.setDirty(defaultProps.id, true));
+    });
+
+    it('should not trigger the dirty state when the initial values are the same as the selected ones', () => {
+        const store = composeMockStore(withSelectedValues(ONE_VALUE));
+
+        const component = mountWithStore(<MultiSelectWithDirty {...defaultProps} initialValues={[ONE_VALUE]} />, store);
+
+        act(() => {
+            component.mount();
+        });
+
+        expect(store.getActions()).toContain(ValidationActions.setDirty(defaultProps.id, false));
+    });
+
+    it('should not trigger the dirty state when there is no initial value and selected value', () => {
+        const store = composeMockStore(withSelectedValues());
+
+        const component = mountWithStore(<MultiSelectWithDirty {...defaultProps} initialValues={[]} />, store);
+
+        act(() => {
+            component.mount();
+        });
+
+        expect(store.getActions()).toContain(ValidationActions.setDirty(defaultProps.id, false));
+    });
+});

--- a/packages/react-vapor/src/utils/tests/TestUtils.ts
+++ b/packages/react-vapor/src/utils/tests/TestUtils.ts
@@ -101,3 +101,6 @@ export const triggerAlertFunction = () => {
 
 export type ReactVaporMockStore = MockStoreEnhanced<IReactVaporState, IDispatch<IReactVaporState>>;
 export const getStoreMock = createMockStore<Partial<IReactVaporState>, IDispatch<IReactVaporState>>([thunk]);
+export const composeMockStore = (
+    ...functions: Array<(state: Partial<IReactVaporState>) => Partial<IReactVaporState>>
+) => getStoreMock(_.compose(...functions) as IReactVaporState);


### PR DESCRIPTION
[COM-453]

### Proposed Changes

I brought back this implementation on Gael's suggestion, so here it is :)

It registers a dirty state if there is a difference between the initial values and the selected values.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-453]: https://coveord.atlassian.net/browse/COM-453