### PR TITLE
fix(select): remove dotted loading from select infinite scroll

### DIFF
--- a/packages/react-vapor/src/components/select/hoc/SelectWithInfiniteScroll.tsx
+++ b/packages/react-vapor/src/components/select/hoc/SelectWithInfiniteScroll.tsx
@@ -17,7 +17,7 @@ export function selectWithInfiniteScroll<P extends Omit<ISelectOwnProps, 'button
         const dataLength = _.size(props.items);
         const hasMore = props.totalEntries - dataLength > 0;
 
-        function itemsWrapper(items: React.ReactNode): React.ReactNode {
+        function itemsWrapper(items: React.ReactNode[]): React.ReactNode {
             return (
                 <InfiniteScroll
                     dataLength={dataLength}
@@ -27,6 +27,7 @@ export function selectWithInfiniteScroll<P extends Omit<ISelectOwnProps, 'button
                     scrollableTarget={props.id}
                     scrollThreshold={1}
                     style={{overflow: 'initial'}}
+                    hasChildren={items.length > 0 || props.isLoading}
                 >
                     {items}
                 </InfiniteScroll>

--- a/packages/react-vapor/src/components/select/hoc/tests/SelectWithInfiniteScroll.spec.tsx
+++ b/packages/react-vapor/src/components/select/hoc/tests/SelectWithInfiniteScroll.spec.tsx
@@ -32,7 +32,7 @@ describe('SelectWithInfiniteScroll', () => {
             getStoreMock()
         ).dive();
 
-        return shallow(<div>{component.prop('wrapItems')(items)}</div>);
+        return shallow(<div>{component.prop('wrapItems')(props.items)}</div>);
     };
 
     it('should not throw when rendering and unmounting', () => {
@@ -57,6 +57,25 @@ describe('SelectWithInfiniteScroll', () => {
 
         expect(wrappedItems.find(InfiniteScroll).exists()).toBe(true);
         expect(wrappedItems.find(InfiniteScroll).contains(items)).toBe(true);
+    });
+
+    it('should set the hasChildren prop to true if there is at least one item', () => {
+        const wrappedItems = renderInfiniteScroll({totalEntries: 3, items: itemsProps});
+
+        expect(wrappedItems.find(InfiniteScroll).prop('hasChildren')).toBe(true);
+    });
+
+    it('should set the hasChildren prop to true if the select is loading', () => {
+        // this is because the skeleton loading is shown while loading
+        const wrappedItems = renderInfiniteScroll({totalEntries: 3, items: [], isLoading: true});
+
+        expect(wrappedItems.find(InfiniteScroll).prop('hasChildren')).toBe(true);
+    });
+
+    it('should set the hasChildren prop to false if the select is not loading and it has no items', () => {
+        const wrappedItems = renderInfiniteScroll({totalEntries: 3, items: [], isLoading: false});
+
+        expect(wrappedItems.find(InfiniteScroll).prop('hasChildren')).toBe(false);
     });
 
     it('should set hasMore prop to false on the infinite scroll component when the total number of items is less than the totalEntries prop', () => {


### PR DESCRIPTION
### Proposed Changes

The select with infinite scroll was displaying its loading (the one with orange dots) while the skeleton loading was already displayed.
![image](https://user-images.githubusercontent.com/35579930/83912737-58540880-a73c-11ea-95fd-b729c4907b54.png)

The changes made here remove the loading with orange dots when the skeleton loading is already there.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
