### PR TITLE
fix(multiselect): fix the selected custom value option box from demo

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,14 +1,10 @@
 {
-    "packages": [
-        "packages/*"
-    ],
+    "packages": ["packages/*"],
     "version": "5.50.1",
     "command": {
         "publish": {
             "conventionalCommits": true,
-            "allowBranch": [
-                "master"
-            ]
+            "allowBranch": ["master"]
         },
         "version": {
             "conventionalCommits": true,
@@ -16,12 +12,7 @@
         },
         "bootstrap": {
             "hoist": true,
-            "nohoist": [
-                "unidiff",
-                "query-string",
-                "strict-uri-encode",
-                "split-on-first"
-            ]
+            "nohoist": ["unidiff", "query-string", "strict-uri-encode", "split-on-first"]
         }
     }
 }

--- a/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
@@ -5,6 +5,7 @@ import {createStructuredSelector} from 'reselect';
 import {keys} from 'ts-transformer-keys';
 import * as _ from 'underscore';
 
+import {convertItemsBoxToStringList, convertStringListToItemsBox} from '../../reusableState';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
 import {DnDUtils} from '../dragAndDrop/DnDUtils';
 import {
@@ -183,7 +184,15 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps> {
                 .value();
         }
 
-        return this.props.items.filter((option: IItemBoxProps) => _.contains(this.props.selected, option.value));
+        const selectedItemsWithoutCustom: IItemBoxProps[] = this.props.items.filter((option: IItemBoxProps) =>
+            _.contains(this.props.selected, option.value)
+        );
+        const selectedItemsWithoutCustomItems: string[] = convertItemsBoxToStringList(selectedItemsWithoutCustom);
+        const customItemsValues: string[] = _.difference(this.props.selected, selectedItemsWithoutCustomItems);
+        const customItems: IItemBoxProps[] = convertStringListToItemsBox(customItemsValues);
+        const selectedItems: IItemBoxProps[] = selectedItemsWithoutCustom.concat(customItems);
+
+        return selectedItems;
     }
 }
 


### PR DESCRIPTION
Fix the selected custom value option box that was not visible, as the custom value is not included
in the array of items availables from the previous method

### Proposed Changes
(Due to some format issue, I had to create a new pull request),

Before this modification, all displayed selected option box are items that would normally be suggested from the filter. However, as a custom value might be suggested to be added for the end-user and because it is not part of the items' list,  this selected option is not displayed in the selected option box section. To resolve this issue, all the selected items are now checked and included in the returned list, which includes the custom values. In doing, we first checked the selected items from the "items" list, so we can get the displayValue from them, then we included the selected custom values.
 
<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
