### PR TITLE
fix(multiselect): remove + button beside the filter box

### DIFF
--- a/packages/react-vapor/src/components/select/hoc/SelectWithFilter.tsx
+++ b/packages/react-vapor/src/components/select/hoc/SelectWithFilter.tsx
@@ -10,13 +10,11 @@ import {IReactVaporState} from '../../../ReactVapor';
 import {addStringList, addValueStringList, removeStringList} from '../../../reusableState/customList/StringListActions';
 import {IDispatch} from '../../../utils/ReduxUtils';
 import {UUID} from '../../../utils/UUID';
-import {Button, IButtonProps} from '../../button/Button';
 import {IFilterBoxOwnProps} from '../../filterBox/FilterBox';
 import {FilterBoxConnected} from '../../filterBox/FilterBoxConnected';
 import {FilterBoxSelectors} from '../../filterBox/FilterBoxSelectors';
 import {MatchFilter} from '../../filterBox/FilterBoxUtils';
 import {IItemBoxProps} from '../../itemBox/ItemBox';
-import {Svg} from '../../svg/Svg';
 import {ISelectOwnProps} from '../SelectConnected';
 import {SelectSelector} from '../SelectSelector';
 
@@ -28,7 +26,6 @@ export interface ISelectWithFilterOwnProps {
     duplicateText?: string;
     noResultFilterText?: (filterText: string) => string;
     noItemsText?: string;
-    filterButton?: IButtonProps;
     filter?: IFilterBoxOwnProps;
 }
 
@@ -62,11 +59,6 @@ export function selectWithFilter<P extends Omit<ISelectOwnProps, 'button'> & Wit
             noResultFilterText: (filterText: string) => `No results match "${filterText}"`,
             noItemsText: 'No items, enter a new value',
             addValueText: (filterText: string) => `Add "${filterText}"`,
-            filterButton: {
-                enabled: true,
-                tooltip: 'Add',
-                tooltipPlacement: 'top',
-            },
             defaultCustomValues: [],
         };
 
@@ -117,24 +109,6 @@ export function selectWithFilter<P extends Omit<ISelectOwnProps, 'button'> & Wit
                 value: this.props.noItemsText,
                 disabled: true,
             };
-        }
-
-        private handleOnClick = () => {
-            if (!_.isEmpty(this.props.filterValue)) {
-                this.props.onSelectCustomValue(this.props.filterValue);
-            }
-        };
-
-        private getAddValueButton(): React.ReactNode {
-            return (
-                this.props.customValues && (
-                    <div className="ml1">
-                        <Button classes={['p1']} onClick={this.handleOnClick} {...this.props.filterButton}>
-                            <Svg svgName={'add'} className="icon mod-lg mod-align-with-text" />
-                        </Button>
-                    </div>
-                )
-            );
         }
 
         private isDuplicateValue(): boolean {
@@ -194,9 +168,7 @@ export function selectWithFilter<P extends Omit<ISelectOwnProps, 'button'> & Wit
                         onKeyUp={(this.props as any).onKeyUp}
                         className={filterBoxClassNames}
                         isAutoFocus
-                    >
-                        {this.getAddValueButton()}
-                    </FilterBoxConnected>
+                    ></FilterBoxConnected>
                     {this.props.children}
                 </Component>
             );

--- a/packages/react-vapor/src/components/select/hoc/tests/SingleSelectWithFilter.spec.tsx
+++ b/packages/react-vapor/src/components/select/hoc/tests/SingleSelectWithFilter.spec.tsx
@@ -249,51 +249,6 @@ describe('Select', () => {
                 wrapper.update();
             };
 
-            it('should not add a button with the filter if customValue is false', () => {
-                mountSingleSelect({items, matchFilter: () => false});
-
-                expect(wrapper.find(Button).length).toBe(0);
-            });
-
-            it('should add a button with the filter', () => {
-                mountSingleSelectCustomValues({items, matchFilter: () => false});
-
-                expect(wrapper.find(Button).length).toBe(1);
-            });
-
-            it('should not add the value in the store list on click button if the filter value is empty', () => {
-                mountSingleSelectCustomValues({items, matchFilter: () => false});
-
-                expect(store.getState().selectWithFilter[id].list.length).toBe(0);
-                store.dispatch(filterThrough(id, ''));
-
-                wrapper
-                    .find(SelectConnected)
-                    .find(Button)
-                    .find('button')
-                    .simulate('click');
-
-                expect(store.getState().selectWithFilter[id].list.length).toBe(0);
-            });
-
-            it('should add the value in the store list on click button if the filterValue is not empty', () => {
-                const filterValue: string = 'wontmatchanything';
-
-                mountSingleSelectCustomValues({items, matchFilter: () => false});
-
-                expect(store.getState().selectWithFilter[id].list.length).toBe(0);
-                store.dispatch(filterThrough(id, filterValue));
-
-                wrapper
-                    .find(SelectConnected)
-                    .find(Button)
-                    .find('button')
-                    .simulate('click');
-
-                expect(store.getState().selectWithFilter[id].list.length).toBe(1);
-                expect(store.getState().selectWithFilter[id].list[0]).toBe(filterValue);
-            });
-
             it('should add an itemBox with the filter value in the list if it is not already in the initial list', () => {
                 const complexItems: IItemBoxProps[] = [{value: 'abc'}, {value: 'afg'}];
                 const filterValue: string = 'a';


### PR DESCRIPTION
### Proposed Changes
As the ( + ) icon beside the filter box doesn't seem to add a value for the end-user experience,
this item is remove of the code + the tests relevant to the latter.

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
