### PR TITLE
fix(slider): make the sliders fit into their parent container

### DIFF
--- a/packages/react-vapor/src/components/slider/Slider.tsx
+++ b/packages/react-vapor/src/components/slider/Slider.tsx
@@ -1,6 +1,7 @@
+import 'rc-slider/assets/index.css';
+
 import classNames from 'classnames';
 import RCSlider, {createSliderWithTooltip, SliderProps, WithTooltipProps} from 'rc-slider';
-import 'rc-slider/assets/index.css';
 import * as React from 'react';
 
 export interface ISliderProps {
@@ -18,7 +19,11 @@ const Slider: React.SFC<ISliderProps> = ({hasTooltip, slider, classes}) => {
         };
     }
 
-    return <HtmlTag className={classNames('vapor-slider input-wrapper input-field', classes)} {...slider} />;
+    return (
+        <div className="flex">
+            <HtmlTag className={classNames('vapor-slider input-wrapper input-field', classes)} {...slider} />
+        </div>
+    );
 };
 
 Slider.defaultProps = {

--- a/packages/vapor/scss/controls/slider.scss
+++ b/packages/vapor/scss/controls/slider.scss
@@ -10,14 +10,23 @@ div.slider-container {
     }
     div.slider-value {
         flex: 2;
-        align-items: flex-end;
+        margin: auto;
 
-        justify-content: center;
-        padding-top: 1.2em;
+        &:first-child {
+            justify-content: flex-start;
+            padding-left: 1rem;
+        }
+
+        &:last-child {
+            justify-content: flex-end;
+            padding-right: 1rem;
+        }
     }
 }
 
 .vapor-slider.rc-slider {
+    margin: 1.5rem $slider-handle-width / 2;
+
     .rc-slider-rail {
         height: $slider-rail-height;
         margin-top: $slider-rail-margin-top;


### PR DESCRIPTION
### Proposed Changes

The slider components were spilling out of their container which made them awkward to style in any layout.

#### Before
![image](https://user-images.githubusercontent.com/35579930/84403433-b1f08300-abd3-11ea-87c5-e67b25482a86.png)
- As you can see, the slider handle stretches outside of the slider container to the left.
![image](https://user-images.githubusercontent.com/35579930/84403830-22979f80-abd4-11ea-9b53-6a9703788c86.png)
- The marks spill out on the bottom too.
![image](https://user-images.githubusercontent.com/35579930/84404045-5ecb0000-abd4-11ea-83a2-b7c1011cb799.png)

#### After
![image](https://user-images.githubusercontent.com/35579930/84403491-c2a0f900-abd3-11ea-92c6-a38169d29378.png)
- Now it is contained in the container.
![image](https://user-images.githubusercontent.com/35579930/84404231-93d75280-abd4-11ea-927a-52155a032c38.png)
- Marks are ok too
![image](https://user-images.githubusercontent.com/35579930/84404343-b2d5e480-abd4-11ea-9bd1-2e4d6554efbf.png)

### Potential Breaking Changes

It might change the slider appearance in some places where workaround were applied to make it fit.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
