### PR TITLE
feat(multiselect): com-435 create non empty validation for multi select

### DIFF
--- a/packages/demo/src/components/examples/MultiSelectExamples.tsx
+++ b/packages/demo/src/components/examples/MultiSelectExamples.tsx
@@ -3,11 +3,14 @@ import {
     getReactNodeTextContent,
     IFlatSelectOptionProps,
     IItemBoxProps,
+    LabeledInput,
     MultiSelectConnected,
     MultiSelectWithFilter,
     MultiSelectWithPredicate,
     MultiSelectWithPredicateAndFilter,
     UUID,
+    ValidationMessage,
+    withNonEmptyMultiSelectHOC,
 } from 'react-vapor';
 import * as _ from 'underscore';
 
@@ -27,6 +30,24 @@ const defaultFlatSelectOptions: IFlatSelectOptionProps[] = [
     {id: UUID.generate(), option: {content: 'even'}},
     {id: UUID.generate(), option: {content: 'odd'}},
 ];
+
+const WithNonEmptyMultiSelect = withNonEmptyMultiSelectHOC(MultiSelectConnected);
+
+const WithNonEmptyMultiSelectExample = () => {
+    return (
+        <LabeledInput
+            label="A Multi Select with Non Empty Validation"
+            message={
+                <div>
+                    <ValidationMessage id="multi-select-non-empty" />
+                </div>
+            }
+        >
+            <br />
+            <WithNonEmptyMultiSelect id="multi-select-non-empty" items={defaultItems} />
+        </LabeledInput>
+    );
+};
 
 export interface IMultiSelectExamplesState {
     first: IItemBoxProps[];
@@ -223,6 +244,9 @@ export class MultiSelectExamples extends React.Component<{}, IMultiSelectExample
                         items={[{value: 'a'.repeat(100)}]}
                         customValues
                     />
+                </div>
+                <div className="form-group">
+                    <WithNonEmptyMultiSelectExample />
                 </div>
             </div>
         );

--- a/packages/react-vapor/src/components/select/hoc/tests/SingleSelectWithFilter.spec.tsx
+++ b/packages/react-vapor/src/components/select/hoc/tests/SingleSelectWithFilter.spec.tsx
@@ -232,8 +232,6 @@ describe('Select', () => {
         });
 
         describe('With CustomValue Props', () => {
-            const items = [{value: 'a'}, {value: 'b', selected: true}, {value: 'c'}];
-
             const mountSingleSelectCustomValues = (
                 props: Partial<ISelectWithFilterOwnProps & ISingleSelectOwnProps> = {}
             ) => {

--- a/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueMultiSelectValidationHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueMultiSelectValidationHOC.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+import {createStructuredSelector} from 'reselect';
+import {IDispatch} from '../../../utils/ReduxUtils';
+import {IMultiSelectOwnProps} from '../../select/MultiSelectConnected';
+import {SelectSelector} from '../../select/SelectSelector';
+import {ValidationActions} from '../ValidationActions';
+import {ValidationTypes} from '../ValidationTypes';
+import {InferableComponentEnhancer} from './connectHOC';
+
+const mapStateToProps = createStructuredSelector({
+    selectedValues: SelectSelector.getMultiSelectSelectedValues,
+});
+
+const mapDispatchToProps = (dispatch: IDispatch) => ({
+    setError: (id: string, error: string) => dispatch(ValidationActions.setError(id, error, ValidationTypes.nonEmpty)),
+    clearError: (id: string) => dispatch(ValidationActions.clearError(id, ValidationTypes.nonEmpty)),
+});
+
+export interface WithNonEmptyValueMultiSelectValidationProps {
+    nonEmptyValidationMessage?: string;
+    resetNonEmptyMultiSelectErrorOnUnmount?: boolean;
+}
+
+export const withNonEmptyMultiSelectHOC = <T extends IMultiSelectOwnProps>(Component: React.ComponentType<T>) => {
+    type NewOwnProps = T & WithNonEmptyValueMultiSelectValidationProps;
+    type StateProps = ReturnType<typeof mapStateToProps>;
+    type DispatchProps = ReturnType<typeof mapDispatchToProps>;
+    const WrappedMultiSelect: React.FunctionComponent<NewOwnProps & StateProps & DispatchProps> = ({
+        selectedValues,
+        setError,
+        clearError,
+        nonEmptyValidationMessage = 'Selection required',
+        resetNonEmptyMultiSelectErrorOnUnmount,
+        ...props
+    }) => {
+        const hasValuesSelected = selectedValues.length > 0;
+
+        React.useEffect(() => {
+            clearError(props.id);
+            return () => {
+                resetNonEmptyMultiSelectErrorOnUnmount && clearError(props.id);
+            };
+        }, [props.id, resetNonEmptyMultiSelectErrorOnUnmount]);
+
+        React.useEffect(() => {
+            setError(props.id, !hasValuesSelected ? nonEmptyValidationMessage : '');
+        }, [hasValuesSelected, props.id, nonEmptyValidationMessage]);
+
+        return <Component {...(props as T)} />;
+    };
+
+    const enhance = connect(mapStateToProps, mapDispatchToProps) as InferableComponentEnhancer<
+        StateProps & DispatchProps
+    >;
+    return enhance(WrappedMultiSelect);
+};

--- a/packages/react-vapor/src/components/validation/hoc/index.ts
+++ b/packages/react-vapor/src/components/validation/hoc/index.ts
@@ -4,3 +4,4 @@ export * from './WithDirtySaveButtonHOC';
 export * from './WithDirtyStickyFooter';
 export * from './WithNonEmptyValueInputValidationHOC';
 export * from './WithValidationMessageHOC';
+export * from './WithNonEmptyValueMultiSelectValidationHOC';

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithDirtyMultiSelectHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithDirtyMultiSelectHOC.spec.tsx
@@ -1,8 +1,7 @@
 import {mountWithStore} from 'enzyme-redux';
 import * as React from 'react';
 import {act} from 'react-dom/test-utils';
-import {IReactVaporState} from '../../../../ReactVapor';
-import {composeMockStore} from '../../../../utils/tests/TestUtils';
+import {composeMockStore, withSelectedValues} from '../../../../utils/tests/TestUtils';
 import {IMultiSelectOwnProps, MultiSelectConnected} from '../../../select/MultiSelectConnected';
 import {ValidationActions} from '../../ValidationActions';
 import {withDirtyMultiSelectHOC} from '../WithDirtyMultiSelectHOC';
@@ -18,22 +17,8 @@ describe('MultiSelectWithDirty', () => {
     const ONE_VALUE = '🐟';
     const ANOTHER_VALUE = '🐠';
 
-    const withSelectedValues = (...values: string[]) => (state: IReactVaporState) => ({
-        ...state,
-        listBoxes: [
-            ...(state.listBoxes || []),
-            {
-                active: 0,
-                ...{
-                    id: defaultProps.id,
-                    selected: values,
-                },
-            },
-        ],
-    });
-
     it('should trigger the dirty state when the user selects a new value', () => {
-        const store = composeMockStore(withSelectedValues(ONE_VALUE));
+        const store = composeMockStore(withSelectedValues(defaultProps.id, ONE_VALUE));
 
         const component = mountWithStore(<MultiSelectWithDirty {...defaultProps} initialValues={[]} />, store);
 
@@ -45,7 +30,7 @@ describe('MultiSelectWithDirty', () => {
     });
 
     it('should trigger the dirty state when the user removes a value', () => {
-        const store = composeMockStore(withSelectedValues(ONE_VALUE));
+        const store = composeMockStore(withSelectedValues(defaultProps.id, ONE_VALUE));
 
         const component = mountWithStore(
             <MultiSelectWithDirty {...defaultProps} initialValues={[ONE_VALUE, ANOTHER_VALUE]} />,
@@ -60,7 +45,7 @@ describe('MultiSelectWithDirty', () => {
     });
 
     it('should not trigger the dirty state when the initial values are the same as the selected ones', () => {
-        const store = composeMockStore(withSelectedValues(ONE_VALUE));
+        const store = composeMockStore(withSelectedValues(defaultProps.id, ONE_VALUE));
 
         const component = mountWithStore(<MultiSelectWithDirty {...defaultProps} initialValues={[ONE_VALUE]} />, store);
 
@@ -72,7 +57,7 @@ describe('MultiSelectWithDirty', () => {
     });
 
     it('should not trigger the dirty state when there is no initial value and selected value', () => {
-        const store = composeMockStore(withSelectedValues());
+        const store = composeMockStore(withSelectedValues(defaultProps.id));
 
         const component = mountWithStore(<MultiSelectWithDirty {...defaultProps} initialValues={[]} />, store);
 

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithNonEmptyValueMultiSelectValidationHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithNonEmptyValueMultiSelectValidationHOC.spec.tsx
@@ -1,0 +1,76 @@
+import {ShallowWrapper} from 'enzyme';
+import {mountWithStore, shallowWithStore} from 'enzyme-redux';
+import React from 'react';
+import {act} from 'react-dom/test-utils';
+import {composeMockStore, getStoreMock, withSelectedValues} from '../../../../utils/tests/TestUtils';
+import {IMultiSelectOwnProps, MultiSelectConnected} from '../../../select/MultiSelectConnected';
+import {ValidationActions} from '../../ValidationActions';
+import {ValidationTypes} from '../../ValidationTypes';
+import {
+    withNonEmptyMultiSelectHOC,
+    WithNonEmptyValueMultiSelectValidationProps,
+} from '../WithNonEmptyValueMultiSelectValidationHOC';
+
+const MultiSelectWithNonEmpty = withNonEmptyMultiSelectHOC(MultiSelectConnected);
+let multiSelectWrapper: ShallowWrapper<WithNonEmptyValueMultiSelectValidationProps & IMultiSelectOwnProps>;
+
+describe('MultiSelectWithNonEmpty', () => {
+    const defaultProps: IMultiSelectOwnProps & WithNonEmptyValueMultiSelectValidationProps = {
+        id: 'SOME_ID',
+        nonEmptyValidationMessage: 'ohno',
+        items: [],
+    };
+
+    let store: ReturnType<typeof getStoreMock>;
+
+    afterEach(() => {
+        store.clearActions();
+    });
+
+    const ONE_VALUE = '🐟';
+
+    it('should dispatch a setError action on mount if there are no values selected', () => {
+        store = composeMockStore(withSelectedValues(defaultProps.id));
+        const component = mountWithStore(<MultiSelectWithNonEmpty {...defaultProps} />, store);
+
+        act(() => {
+            component.mount();
+        });
+
+        expect(store.getActions()).toContain(
+            ValidationActions.setError(
+                defaultProps.id,
+                defaultProps.nonEmptyValidationMessage,
+                ValidationTypes.nonEmpty
+            )
+        );
+    });
+
+    it('should not dispatch a setError action on mount if there is a value selected', () => {
+        store = composeMockStore(withSelectedValues(defaultProps.id, ONE_VALUE));
+        const component = mountWithStore(<MultiSelectWithNonEmpty {...defaultProps} />, store);
+
+        act(() => {
+            component.mount();
+        });
+
+        expect(store.getActions()).not.toContain(
+            ValidationActions.setError(
+                defaultProps.id,
+                defaultProps.nonEmptyValidationMessage,
+                ValidationTypes.nonEmpty
+            )
+        );
+    });
+
+    it('should render without error', () => {
+        expect(() => shallowWithStore(<MultiSelectWithNonEmpty {...defaultProps} />, store)).not.toThrow();
+    });
+
+    it('should mount and unmount/detach without error', () => {
+        expect(() => {
+            multiSelectWrapper = shallowWithStore(<MultiSelectWithNonEmpty {...defaultProps} />, store);
+            multiSelectWrapper.unmount();
+        }).not.toThrow();
+    });
+});

--- a/packages/react-vapor/src/utils/tests/TestUtils.ts
+++ b/packages/react-vapor/src/utils/tests/TestUtils.ts
@@ -99,6 +99,22 @@ export const triggerAlertFunction = () => {
     alert(`Alert function triggered`);
 };
 
+export const withSelectedValues = (id: string, ...values: string[]) => {
+    return (state: IReactVaporState) => ({
+        ...state,
+        listBoxes: [
+            ...(state.listBoxes || []),
+            {
+                active: 0,
+                ...{
+                    id: id,
+                    selected: values,
+                },
+            },
+        ],
+    });
+};
+
 export type ReactVaporMockStore = MockStoreEnhanced<IReactVaporState, IDispatch<IReactVaporState>>;
 export const getStoreMock = createMockStore<Partial<IReactVaporState>, IDispatch<IReactVaporState>>([thunk]);
 export const composeMockStore = (


### PR DESCRIPTION
https://coveord.atlassian.net/browse/COM-435

### Proposed Changes

Created a validation for non empty multi select

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
