### PR TITLE
fix(middle slider): initial range value uselessly rounded

### DIFF
--- a/packages/react-vapor/src/components/slider/SliderUtils.ts
+++ b/packages/react-vapor/src/components/slider/SliderUtils.ts
@@ -18,7 +18,7 @@ export const getValuesPositionOnRange = (value: number[], crossingPoint: number)
 export const getCrossingPoint = (min: number, max: number): number => Math.round(((0 - min) / (max - min)) * 100);
 
 export const convertInitialValuetoRangeValue = (min: number, max: number, initialValue: number): number =>
-    Math.round(((initialValue - min) / (max - min)) * 100);
+    ((initialValue - min) / (max - min)) * 100;
 
 export const handleIsAtCrossingPoint = (
     lowRange: number,


### PR DESCRIPTION
### Proposed Changes

The value was rounded to an integer so it was loosing the required precision to convert a big range (like 0 to 30 000) to the slider range (0 to 100) and get the correct range again.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
