### PR TITLE
improvement(save button hoc): change error message if more than 1

### DIFF
--- a/packages/react-vapor/src/components/validation/hoc/WithDirtySaveButtonHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtySaveButtonHOC.tsx
@@ -27,7 +27,10 @@ export const withDirtySaveButtonHOC = <T extends IButtonProps>(Component: React.
         warnings,
         validationIds,
         skipDirty,
-        errorMessage = (e) => `Cannot save because of the following errors: ${e.join('\n')}`,
+        errorMessage = (e) =>
+            e?.length > 1
+                ? `Some required fields are missing. Please complete them.`
+                : `Cannot save because of the following error: ${e}`,
         warningMessage = (w) => `Can save but with warnings: ${w.join('\n')}`,
         dirtyMessage = (d) => d.length === 0 && `Cannot save when there are no changes`,
         enabled,

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithDirtySaveButtonHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithDirtySaveButtonHOC.spec.tsx
@@ -47,6 +47,18 @@ describe('WithDirtySaveButtonHOC', () => {
                 },
             },
         });
+        const storeWithMultipleErrorsAndDirty: ReturnType<typeof getStoreMock> = getStoreMock({
+            validation: {
+                [buttonValidationId]: {
+                    error: [
+                        {validationType: 'something', value: 'bad'},
+                        {validationType: 'somethingElse', value: 'veryBad'},
+                    ],
+                    warning: [],
+                    isDirty: [{validationType: 'something', value: true}],
+                },
+            },
+        });
         const storeWithWarningsAndDirty: ReturnType<typeof getStoreMock> = getStoreMock({
             validation: {
                 [buttonValidationId]: {
@@ -127,9 +139,10 @@ describe('WithDirtySaveButtonHOC', () => {
         describe('button tooltip prop', () => {
             it('should change the tooltip to the error message formatter', () => {
                 const message = 'this is bad';
+                const messageMultipleError = 'this is really bad';
                 const buttonWrapper = shallowButton(
                     {
-                        errorMessage: () => message,
+                        errorMessage: (e) => (e?.length > 1 ? messageMultipleError : message),
                     },
                     storeWithErrorsAndDirty
                 );
@@ -137,6 +150,21 @@ describe('WithDirtySaveButtonHOC', () => {
                 const tooltip = buttonWrapper.find(Button).prop('tooltip');
 
                 expect(tooltip).toEqual(message);
+            });
+
+            it('should change the tooltip to the error message formatter for multiple errors', () => {
+                const message = 'this is bad';
+                const messageMultipleErrors = 'this is really bad';
+                const buttonWrapper = shallowButton(
+                    {
+                        errorMessage: (e) => (e?.length > 1 ? messageMultipleErrors : message),
+                    },
+                    storeWithMultipleErrorsAndDirty
+                );
+
+                const tooltip = buttonWrapper.find(Button).prop('tooltip');
+
+                expect(tooltip).toEqual(messageMultipleErrors);
             });
 
             it('should change the tooltip to the warning message formatter', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/COM-435

### Proposed Changes

Update error message when there are multiple. This will avoid a long list of errors log and there should be validationMessages near the input to properly identify missing fields

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
