### PR TITLE
fix(sub navigation): fixed the link prop and small refactor

### DIFF
--- a/packages/react-vapor/src/components/limit/Limit.tsx
+++ b/packages/react-vapor/src/components/limit/Limit.tsx
@@ -2,11 +2,12 @@ import classNames from 'classnames';
 import * as VaporSVG from 'coveo-styleguide';
 import * as React from 'react';
 import {connect} from 'react-redux';
-import {InputConnected, Svg} from 'react-vapor';
 import {IReactVaporState} from '../../ReactVapor';
 import {IDispatch} from '../../utils/ReduxUtils';
+import {InputConnected} from '../input';
 import {changeInputValue} from '../input/InputActions';
 import {InputSelectors} from '../input/InputSelectors';
+import {Svg} from '../svg';
 
 export interface LimitOwnProps {
     id?: string;

--- a/packages/react-vapor/src/components/limit/tests/Limit.spec.tsx
+++ b/packages/react-vapor/src/components/limit/tests/Limit.spec.tsx
@@ -2,11 +2,11 @@ import {mount, ReactWrapper} from 'enzyme';
 import {shallowWithStore} from 'enzyme-redux';
 import * as React from 'react';
 import {Provider} from 'react-redux';
-import {InputConnected} from 'react-vapor';
 import {any} from 'underscore';
 import _ from 'underscore';
 import {clearState} from '../../../utils';
 import {getStoreMock, ReactVaporMockStore} from '../../../utils/tests/TestUtils';
+import {InputConnected} from '../../input';
 import {Limit, LimitProps} from '../Limit';
 
 describe('Limit', () => {

--- a/packages/react-vapor/src/components/subNavigation/tests/SubNavigation.spec.tsx
+++ b/packages/react-vapor/src/components/subNavigation/tests/SubNavigation.spec.tsx
@@ -1,7 +1,8 @@
-import {shallow, ShallowWrapper} from 'enzyme';
+import {mount, shallow, ShallowWrapper} from 'enzyme';
 import * as React from 'react';
 import {noop} from 'underscore';
 
+import {act} from 'react-dom/test-utils';
 import {ISubNavigationProps, SubNavigation} from '../SubNavigation';
 
 describe('SubNavigation', () => {
@@ -27,14 +28,17 @@ describe('SubNavigation', () => {
 
     it('should call onRender when the element is created', () => {
         const spy = jasmine.createSpy('onRender');
-        shallow(<SubNavigation items={[]} defaultSelected="" onRender={spy} />);
+        const wrapper = mount(<SubNavigation items={[]} defaultSelected="" onRender={spy} />);
+        act(() => {
+            wrapper.update();
+        });
 
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should call onDestroy when the element is created', () => {
         const spy = jasmine.createSpy('onDestroy');
-        const subNav = shallow(<SubNavigation items={[]} defaultSelected="" onDestroy={spy} />);
+        const subNav = mount(<SubNavigation items={[]} defaultSelected="" onDestroy={spy} />);
         subNav.unmount();
 
         expect(spy).toHaveBeenCalledTimes(1);

--- a/packages/react-vapor/src/components/subNavigation/tests/SubNavigationConnected.spec.tsx
+++ b/packages/react-vapor/src/components/subNavigation/tests/SubNavigationConnected.spec.tsx
@@ -1,6 +1,7 @@
 import {mount, ReactWrapper} from 'enzyme';
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
+import {act} from 'react-dom/test-utils';
 import {Provider} from 'react-redux';
 import {Store} from 'redux';
 import {findWhere} from 'underscore';
@@ -33,6 +34,9 @@ describe('SubNavigation', () => {
                 </Provider>,
                 {attachTo: document.getElementById('App')}
             );
+            act(() => {
+                wrapper.update();
+            });
             subNavigation = wrapper.find(SubNavigation);
         });
 
@@ -99,6 +103,9 @@ describe('SubNavigation', () => {
                 </Provider>,
                 {attachTo: document.getElementById('App')}
             );
+            act(() => {
+                wrapper.update();
+            });
 
             expect(findWhere(store.getState().subNavigations, {id: props.id}).selected).toBe(props.items[0].id);
             wrapper.unmount();


### PR DESCRIPTION
### Proposed Changes

The onclick html property was in conflict with the link property. in order to access the link, the function passed to onlclick must return true. 

I also refactored the component to get rid of the deprecated class component lifeCycle methods.

Fixed the broken uts.

### Potential Breaking Changes

No breaking change intented

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
