### PR TITLE
feat(radio-button): add an optional wrapper for radio buttons

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,9 +6,7 @@
     "command": {
         "publish": {
             "conventionalCommits": true,
-            "allowBranch": [
-                "master"
-            ]
+            "allowBranch": ["master"]
         },
         "version": {
             "conventionalCommits": true,
@@ -16,12 +14,7 @@
         },
         "bootstrap": {
             "hoist": true,
-            "nohoist": [
-                "unidiff",
-                "query-string",
-                "strict-uri-encode",
-                "split-on-first"
-            ]
+            "nohoist": ["unidiff", "query-string", "strict-uri-encode", "split-on-first"]
         }
     }
 }

--- a/packages/demo/src/components/examples/RadioExamples.tsx
+++ b/packages/demo/src/components/examples/RadioExamples.tsx
@@ -42,20 +42,22 @@ const radioSelectConnectedId = 'radioselectconnected';
 
 // start-print
 
-const blueRadioButtonProps = {
-    id: 'blue',
+const radioButtonProps = {
     name: 'rankingResult',
-    value: 'blue',
     outerContainerClass: 'modal-radio-button',
     outerElementInContainer: <img src="https://via.placeholder.com/150x100" />,
 };
 
+const blueRadioButtonProps = {
+    id: 'blue',
+    value: 'blue',
+    ...radioButtonProps,
+};
+
 const redRadioButtonProps = {
     id: 'red',
-    name: 'rankingResult',
     value: 'red',
-    outerContainerClass: 'modal-radio-button',
-    outerElementInContainer: <img src="https://via.placeholder.com/150x100" />,
+    ...radioButtonProps,
 };
 
 const RadioSelectExample: React.FunctionComponent = () => (
@@ -122,7 +124,7 @@ const RadioSelectWithDivWrapAroundRadioButtonExample: React.FunctionComponent = 
         <RadioSelectConnected id="addRankingResult" valueOnMount={'blue'}>
             <Radio {...blueRadioButtonProps}>
                 <Label>
-                    <span style={{fontWeight: 'bold'}}>{'Blue color'}</span>
+                    <span className="bold">{'Blue color'}</span>
                 </Label>
                 <InputDescription>
                     <div style={{...paragraphStyle}}>{'Blue is the best color.'}</div>
@@ -130,7 +132,7 @@ const RadioSelectWithDivWrapAroundRadioButtonExample: React.FunctionComponent = 
             </Radio>
             <Radio {...redRadioButtonProps}>
                 <Label>
-                    <span style={{fontWeight: 'bold'}}>{'Red color'}</span>
+                    <span className="bold">{'Red color'}</span>
                 </Label>
                 <InputDescription>
                     <div style={{...paragraphStyle}}>{'Red is the best color.'}</div>

--- a/packages/demo/src/components/examples/RadioExamples.tsx
+++ b/packages/demo/src/components/examples/RadioExamples.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
     Button,
+    InputDescription,
     IRadioSelectProps,
     Label,
     LabeledInput,
@@ -25,8 +26,35 @@ export const RadioButtonExamples: ExampleComponent = () => (
     <Section title="Radio set">
         <RadioSelectExample />
         <RadioSelectDisabledExample />
+        <RadioSelectWithDivWrapAroundRadioButtonExample />
     </Section>
 );
+
+const generateRadioDivision = (id: string, value: string, label: string, description: string) => {
+    const radioProps = {
+        id: id,
+        name: 'rankingResult',
+        value: value,
+        outerContainerClass: 'modal-radio-button',
+        outerElementInContainer: <img src="https://via.placeholder.com/150x100" />,
+    };
+    const paragraphStyle = {
+        marginLeft: 36,
+        marginTop: 10,
+        marginRight: 36,
+    };
+
+    return (
+        <Radio {...radioProps}>
+            <Label>
+                <span style={{fontWeight: 'bold'}}>{label}</span>
+            </Label>
+            <InputDescription>
+                <div style={{...paragraphStyle}}>{description}</div>
+            </InputDescription>
+        </Radio>
+    );
+};
 
 RadioButtonExamples.description = 'Radio Buttons allow for the selection of a single option among a set of options.';
 
@@ -90,5 +118,14 @@ const RadioSelectDisabledExample: React.FunctionComponent = () => (
                 </Radio>
             </RadioSelectConnected>
         </LabeledInput>
+    </Section>
+);
+
+const RadioSelectWithDivWrapAroundRadioButtonExample: React.FunctionComponent = () => (
+    <Section level={3} title="A radio select with radio button that has a container.">
+        <RadioSelectConnected id="addRankingResult" valueOnMount={'blue'}>
+            {generateRadioDivision('blue', 'blue', 'Blue color', 'The color I like the most is blue.')}
+            {generateRadioDivision('red', 'red', 'Red color', 'The color I like the most is red.')}
+        </RadioSelectConnected>
     </Section>
 );

--- a/packages/demo/src/components/examples/RadioExamples.tsx
+++ b/packages/demo/src/components/examples/RadioExamples.tsx
@@ -26,7 +26,7 @@ export const RadioButtonExamples: ExampleComponent = () => (
     <Section title="Radio set">
         <RadioSelectExample />
         <RadioSelectDisabledExample />
-        <RadioSelectWithDivWrapAroundRadioButtonExample />
+        <RadioSelectWrappedExample />
     </Section>
 );
 
@@ -119,7 +119,7 @@ const RadioSelectDisabledExample: React.FunctionComponent = () => (
     </Section>
 );
 
-const RadioSelectWithDivWrapAroundRadioButtonExample: React.FunctionComponent = () => (
+const RadioSelectWrappedExample: React.FunctionComponent = () => (
     <Section level={3} title="A radio select with a wrapped radio button.">
         <RadioSelectConnected id="addRankingResult" valueOnMount={'blue'}>
             <Radio {...blueRadioButtonProps}>

--- a/packages/demo/src/components/examples/RadioExamples.tsx
+++ b/packages/demo/src/components/examples/RadioExamples.tsx
@@ -30,30 +30,10 @@ export const RadioButtonExamples: ExampleComponent = () => (
     </Section>
 );
 
-const generateRadioDivision = (id: string, value: string, label: string, description: string) => {
-    const radioProps = {
-        id: id,
-        name: 'rankingResult',
-        value: value,
-        outerContainerClass: 'modal-radio-button',
-        outerElementInContainer: <img src="https://via.placeholder.com/150x100" />,
-    };
-    const paragraphStyle = {
-        marginLeft: 36,
-        marginTop: 10,
-        marginRight: 36,
-    };
-
-    return (
-        <Radio {...radioProps}>
-            <Label>
-                <span style={{fontWeight: 'bold'}}>{label}</span>
-            </Label>
-            <InputDescription>
-                <div style={{...paragraphStyle}}>{description}</div>
-            </InputDescription>
-        </Radio>
-    );
+const paragraphStyle = {
+    marginLeft: 36,
+    marginTop: 10,
+    marginRight: 36,
 };
 
 RadioButtonExamples.description = 'Radio Buttons allow for the selection of a single option among a set of options.';
@@ -61,6 +41,22 @@ RadioButtonExamples.description = 'Radio Buttons allow for the selection o
 const radioSelectConnectedId = 'radioselectconnected';
 
 // start-print
+
+const blueRadioButtonProps = {
+    id: 'blue',
+    name: 'rankingResult',
+    value: 'blue',
+    outerContainerClass: 'modal-radio-button',
+    outerElementInContainer: <img src="https://via.placeholder.com/150x100" />,
+};
+
+const redRadioButtonProps = {
+    id: 'red',
+    name: 'rankingResult',
+    value: 'red',
+    outerContainerClass: 'modal-radio-button',
+    outerElementInContainer: <img src="https://via.placeholder.com/150x100" />,
+};
 
 const RadioSelectExample: React.FunctionComponent = () => (
     <Section level={2} title="Radio select with redux store">
@@ -124,8 +120,22 @@ const RadioSelectDisabledExample: React.FunctionComponent = () => (
 const RadioSelectWithDivWrapAroundRadioButtonExample: React.FunctionComponent = () => (
     <Section level={3} title="A radio select with radio button that has a container.">
         <RadioSelectConnected id="addRankingResult" valueOnMount={'blue'}>
-            {generateRadioDivision('blue', 'blue', 'Blue color', 'The color I like the most is blue.')}
-            {generateRadioDivision('red', 'red', 'Red color', 'The color I like the most is red.')}
+            <Radio {...blueRadioButtonProps}>
+                <Label>
+                    <span style={{fontWeight: 'bold'}}>{'Blue color'}</span>
+                </Label>
+                <InputDescription>
+                    <div style={{...paragraphStyle}}>{'Blue is the best color.'}</div>
+                </InputDescription>
+            </Radio>
+            <Radio {...redRadioButtonProps}>
+                <Label>
+                    <span style={{fontWeight: 'bold'}}>{'Red color'}</span>
+                </Label>
+                <InputDescription>
+                    <div style={{...paragraphStyle}}>{'Red is the best color.'}</div>
+                </InputDescription>
+            </Radio>
         </RadioSelectConnected>
     </Section>
 );

--- a/packages/demo/src/components/examples/RadioExamples.tsx
+++ b/packages/demo/src/components/examples/RadioExamples.tsx
@@ -118,7 +118,7 @@ const RadioSelectDisabledExample: React.FunctionComponent = () => (
 );
 
 const RadioSelectWithDivWrapAroundRadioButtonExample: React.FunctionComponent = () => (
-    <Section level={3} title="A radio select with radio button that has a container.">
+    <Section level={3} title="A radio select with a wrapped radio button.">
         <RadioSelectConnected id="addRankingResult" valueOnMount={'blue'}>
             <Radio {...blueRadioButtonProps}>
                 <Label>

--- a/packages/react-vapor/src/components/childForm/tests/ToggleForm.spec.tsx
+++ b/packages/react-vapor/src/components/childForm/tests/ToggleForm.spec.tsx
@@ -60,7 +60,7 @@ describe('ToggleForm', () => {
                 .update();
             expect(
                 toggleForm
-                    .find('Radio')
+                    .find(Radio)
                     .first()
                     .prop('checked')
             ).toBe(false);
@@ -71,7 +71,7 @@ describe('ToggleForm', () => {
                 .update();
             expect(
                 toggleForm
-                    .find('Radio')
+                    .find(Radio)
                     .first()
                     .prop('checked')
             ).toBe(true);

--- a/packages/react-vapor/src/components/radio/Radio.tsx
+++ b/packages/react-vapor/src/components/radio/Radio.tsx
@@ -9,32 +9,28 @@ export interface RadioOwnProps {
 
 export interface RadioProps extends RadioOwnProps, IInputProps {}
 
-export class Radio extends React.PureComponent<RadioProps> {
-    static defaultProps: Partial<RadioProps> = {
-        ...Input.defaultProps,
-        checked: false,
-        disabled: false,
-    };
+export const Radio: React.FunctionComponent<RadioProps> = (props) => {
+    const outerContainerClasses: string =
+        !!props.outerContainerClass && classNames('radio-option', props.outerContainerClass);
+    const classes: string = classNames('radio-option', props.classes);
+    return outerContainerClasses ? (
+        <div className={outerContainerClasses}>
+            <RadioInputContent props={props} classes={classes} />
+        </div>
+    ) : (
+        <RadioInputContent props={props} classes={classes} />
+    );
+};
 
-    private getRadioInputContent = (props: RadioProps, classes: string): React.ReactNode => {
-        type InputProps = Omit<RadioProps, 'elementOuterContainer | outerContainerClasses'>;
-        const inputProps: InputProps = {...props};
-        return (
-            <>
-                <Input {...inputProps} classes={[classes]} type="radio" />
-                {props.outerElementInContainer}
-            </>
-        );
-    };
+const RadioInputContent: React.FunctionComponent<{props: RadioProps; classes: string}> = ({props, classes}) => (
+    <>
+        <Input {...props} classes={[classes]} type="radio" />
+        {props.outerElementInContainer}
+    </>
+);
 
-    render() {
-        const outerContainerClasses: string =
-            !!this.props.outerContainerClass && classNames('radio-option', this.props.outerContainerClass);
-        const classes: string = classNames('radio-option', this.props.classes);
-        return outerContainerClasses ? (
-            <div className={outerContainerClasses}>{this.getRadioInputContent({...this.props}, classes)}</div>
-        ) : (
-            <>{this.getRadioInputContent({...this.props}, classes)}</>
-        );
-    }
-}
+Radio.defaultProps = {
+    ...Input.defaultProps,
+    checked: false,
+    disabled: false,
+};

--- a/packages/react-vapor/src/components/radio/Radio.tsx
+++ b/packages/react-vapor/src/components/radio/Radio.tsx
@@ -2,15 +2,39 @@ import classNames from 'classnames';
 import * as React from 'react';
 import {IInputProps, Input} from '../input/Input';
 
-export class Radio extends Input {
-    static defaultProps: Partial<IInputProps> = {
+export interface RadioOwnProps {
+    outerContainerClass?: string;
+    outerElementInContainer?: React.ReactNode;
+}
+
+export interface RadioProps extends RadioOwnProps, IInputProps {}
+
+export class Radio extends React.PureComponent<RadioProps> {
+    static defaultProps: Partial<RadioProps> = {
         ...Input.defaultProps,
         checked: false,
         disabled: false,
     };
 
+    private getRadioInputContent = (props: RadioProps, classes: string): React.ReactNode => {
+        type InputProps = Omit<RadioProps, 'elementOuterContainer | outerContainerClasses'>;
+        const inputProps: InputProps = {...props};
+        return (
+            <>
+                <Input {...inputProps} classes={[classes]} type="radio" />
+                {props.outerElementInContainer}
+            </>
+        );
+    };
+
     render() {
+        const outerContainerClasses: string =
+            !!this.props.outerContainerClass && classNames('radio-option', this.props.outerContainerClass);
         const classes: string = classNames('radio-option', this.props.classes);
-        return <Input {...this.props} classes={[classes]} type="radio" />;
+        return outerContainerClasses ? (
+            <div className={outerContainerClasses}>{this.getRadioInputContent({...this.props}, classes)}</div>
+        ) : (
+            <>{this.getRadioInputContent({...this.props}, classes)}</>
+        );
     }
 }

--- a/packages/react-vapor/src/components/radio/RadioSelect.tsx
+++ b/packages/react-vapor/src/components/radio/RadioSelect.tsx
@@ -16,7 +16,7 @@ export interface IRadioSelectProps extends IRadioSelectOnChangeCallback {
     value?: string;
     disabled?: boolean;
     disabledTooltip?: string;
-    children?: Array<React.ReactElement<Radio>> | Array<React.ReactElement<ToggleForm>>;
+    children?: Array<React.ReactElement<typeof Radio>> | Array<React.ReactElement<ToggleForm>>;
     onChangeCallback?: (value: string, id?: string, e?: React.MouseEvent<HTMLElement>) => void;
 }
 

--- a/packages/react-vapor/src/components/radio/RadioSelect.tsx
+++ b/packages/react-vapor/src/components/radio/RadioSelect.tsx
@@ -57,6 +57,8 @@ export class RadioSelect extends React.PureComponent<IRadioSelectAllProps> {
                 checked: this.props.value === child.props.value,
                 disabled: this.isValueDisabled(child.props.value),
                 disabledTooltip: this.props.disabledTooltip,
+                outerContainerClass: child.props.outerContainerClass,
+                outerElementInContainer: child.props.outerElementInContainer,
                 onClick: (e: React.MouseEvent<HTMLElement>) => {
                     child.props.onClick && child.props.onClick(e);
                     this.handleToggle(child.props.value, e);

--- a/packages/react-vapor/src/components/radio/tests/Radio.spec.tsx
+++ b/packages/react-vapor/src/components/radio/tests/Radio.spec.tsx
@@ -1,8 +1,7 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 
-import {IInputProps} from '../../input/Input';
-import {Radio} from '../Radio';
+import {Radio, RadioProps} from '../Radio';
 
 describe('Radio', () => {
     const anId = 'patate';
@@ -16,7 +15,7 @@ describe('Radio', () => {
     });
 
     describe('<Radio />', () => {
-        let radio: ReactWrapper<IInputProps, any>;
+        let radio: ReactWrapper<RadioProps, any>;
 
         beforeEach(() => {
             radio = mount(<Radio id={anId} />, {attachTo: document.getElementById('App')});
@@ -98,6 +97,51 @@ describe('Radio', () => {
                 .mount()
                 .update();
             expect(radio.find('div').hasClass(innerClass)).toBe(true);
+        });
+
+        it('should set outerClasses when specified', () => {
+            const outerContainerClass = 'salut-externe';
+            expect(
+                radio
+                    .find('div')
+                    .first()
+                    .hasClass(outerContainerClass)
+            ).toBe(false);
+
+            radio
+                .setProps({outerContainerClass})
+                .mount()
+                .update();
+            expect(
+                radio
+                    .find('div')
+                    .first()
+                    .hasClass(outerContainerClass)
+            ).toBe(true);
+        });
+
+        it('should set two div tags when the outerContainerClass is set', () => {
+            const outerContainerClass = 'salut-externe';
+            radio
+                .setProps({outerContainerClass})
+                .mount()
+                .update();
+            expect(radio.find('div').length).toBe(2);
+        });
+
+        it('should set only one div tag when the outerContainerClass is not set', () => {
+            radio.mount().update();
+            expect(radio.find('div').length).toBe(1);
+        });
+
+        it('should includes the element set in the outerElementInContainer props if its set', () => {
+            const outerElementInContainer = <img src="https://via.placeholder.com/150x100" />;
+            expect(radio.find('img').length).toBe(0);
+            radio
+                .setProps({outerElementInContainer})
+                .mount()
+                .update();
+            expect(radio.find('img').length).toBe(1);
         });
 
         it('should call prop onChange when specified on click', () => {

--- a/packages/vapor/scss/components/modal.scss
+++ b/packages/vapor/scss/components/modal.scss
@@ -247,3 +247,10 @@ $icon-size: (4em / 3);
         padding: $modal-footer-small-padding;
     }
 }
+
+.modal-radio-button {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 21px;
+}


### PR DESCRIPTION
### Proposed Changes

A radio button can now be wrapped inside a div container or a fragment container. Which means that an element could be in the same node level in the DOM as the radio button and a CSS class could affect both components. For instance the following image display a radio button that share the same CSS class with an image, and it's consider inside the same row. 

![partOfTheSameContainer](https://user-images.githubusercontent.com/58052881/86055190-69392680-ba29-11ea-9bdd-622ec18a33f1.PNG)

### Potential Breaking Changes


### Acceptance Criteria

-   [X] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
