### PR TITLE
test(tabselectors.spec.tsx): change getTabSelected

### DIFF
--- a/packages/react-vapor/src/components/tab/TabSelectors.ts
+++ b/packages/react-vapor/src/components/tab/TabSelectors.ts
@@ -9,9 +9,9 @@ const getTabGroup = (state: IReactVaporState, ownProps: ITabPaneOwnProps) => {
     return _.findWhere(state.tabs, {id: ownProps.groupId ?? DEFAULT_GROUP_ID});
 };
 
-const getTabSelected = () =>
-    createSelector(getTabGroup, (tabGroup: ITabGroupState) => _.findWhere(tabGroup.tabs, {isSelected: true}) ?? false);
+const getSelectedTab = () =>
+    createSelector(getTabGroup, (tabGroup: ITabGroupState) => _.findWhere(tabGroup.tabs, {isSelected: true}));
 export const TabSelectors = {
     getTabGroup,
-    getTabSelected,
+    getSelectedTab,
 };

--- a/packages/react-vapor/src/components/tab/TabSelectors.ts
+++ b/packages/react-vapor/src/components/tab/TabSelectors.ts
@@ -9,11 +9,8 @@ const getTabGroup = (state: IReactVaporState, ownProps: ITabPaneOwnProps) => {
     return _.findWhere(state.tabs, {id: ownProps.groupId ?? DEFAULT_GROUP_ID});
 };
 
-const getTabSelected = (tabId: string) =>
-    createSelector(
-        getTabGroup,
-        (tabGroup: ITabGroupState): boolean => !!_.findWhere(tabGroup.tabs, {id: tabId})?.isSelected
-    );
+const getTabSelected = () =>
+    createSelector(getTabGroup, (tabGroup: ITabGroupState) => _.findWhere(tabGroup.tabs, {isSelected: true}) ?? false);
 export const TabSelectors = {
     getTabGroup,
     getTabSelected,

--- a/packages/react-vapor/src/components/tab/tests/TabSelectors.spec.tsx
+++ b/packages/react-vapor/src/components/tab/tests/TabSelectors.spec.tsx
@@ -57,7 +57,7 @@ describe('TabSelector', () => {
                     {id: 'gros-boudesse', isSelected: false},
                 ],
             };
-            expect(TabSelectors.getTabSelected().resultFunc(tabGroupState)).toEqual({
+            expect(TabSelectors.getSelectedTab().resultFunc(tabGroupState)).toEqual({
                 id: 'coulili-zazou',
                 isSelected: true,
             });
@@ -71,7 +71,7 @@ describe('TabSelector', () => {
                     {id: 'gros-boudesse', isSelected: false},
                 ],
             };
-            expect(TabSelectors.getTabSelected().resultFunc(tabGroupState)).toBe(false);
+            expect(TabSelectors.getSelectedTab().resultFunc(tabGroupState)).toBe(undefined);
         });
     });
 });

--- a/packages/react-vapor/src/components/tab/tests/TabSelectors.spec.tsx
+++ b/packages/react-vapor/src/components/tab/tests/TabSelectors.spec.tsx
@@ -49,7 +49,7 @@ describe('TabSelector', () => {
         });
     });
     describe('getTabSelected', () => {
-        it('should return true if a tab is selected, false if not', () => {
+        it('should return the selected tab', () => {
             const tabGroupState = {
                 id: DEFAULT_GROUP_ID,
                 tabs: [
@@ -57,19 +57,21 @@ describe('TabSelector', () => {
                     {id: 'gros-boudesse', isSelected: false},
                 ],
             };
-            expect(TabSelectors.getTabSelected('coulili-zazou').resultFunc(tabGroupState)).toBe(true);
-            expect(TabSelectors.getTabSelected('gros-boudesse').resultFunc(tabGroupState)).toBe(false);
+            expect(TabSelectors.getTabSelected().resultFunc(tabGroupState)).toEqual({
+                id: 'coulili-zazou',
+                isSelected: true,
+            });
         });
 
-        it('should return false if the tab does not exist in the state', () => {
+        it('should return false if no tabs are selected', () => {
             const tabGroupState = {
                 id: DEFAULT_GROUP_ID,
                 tabs: [
-                    {id: 'coulili-zazou', isSelected: true},
+                    {id: 'coulili-zazou', isSelected: false},
                     {id: 'gros-boudesse', isSelected: false},
                 ],
             };
-            expect(TabSelectors.getTabSelected('who-am-i').resultFunc(tabGroupState)).toBe(false);
+            expect(TabSelectors.getTabSelected().resultFunc(tabGroupState)).toBe(false);
         });
     });
 });


### PR DESCRIPTION

### Proposed Changes

the selector now returns the selected tab (or false) instead of a boolea isSelected

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
