### PR TITLE
fix(radioselectconnected): invalid HTML props

### DIFF
--- a/packages/demo/src/demo-building-blocs/Code.tsx
+++ b/packages/demo/src/demo-building-blocs/Code.tsx
@@ -36,7 +36,6 @@ export const Code: React.FunctionComponent<{language: string}> = ({language, chi
             style={theme}
             showLineNumbers
             customStyle={{fontFamily: 'source_code_pro_regular, monospace', fontSize: '16px', lineHeight: '1.2'}}
-            lineNumberContainerStyle={{paddingRight: '2rem', float: 'left'}}
         >
             {formattedCode}
         </SyntaxHighlighter>

--- a/packages/react-vapor/src/components/radio/Radio.tsx
+++ b/packages/react-vapor/src/components/radio/Radio.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
+import {omit} from 'underscore';
 import {IInputProps, Input} from '../input/Input';
 
 export interface RadioOwnProps {
@@ -22,12 +23,15 @@ export const Radio: React.FunctionComponent<RadioProps> = (props) => {
     );
 };
 
-const RadioInputContent: React.FunctionComponent<{props: RadioProps; classes: string}> = ({props, classes}) => (
-    <>
-        <Input {...props} classes={[classes]} type="radio" />
-        {props.outerElementInContainer}
-    </>
-);
+const RadioInputContent: React.FunctionComponent<{props: RadioProps; classes: string}> = ({props, classes}) => {
+    const inputProps = omit(props, 'outerContainerClass', 'outerElementInContainer');
+    return (
+        <>
+            <Input {...inputProps} classes={[classes]} type="radio" />
+            {props.outerElementInContainer}
+        </>
+    );
+};
 
 Radio.defaultProps = {
     ...Input.defaultProps,


### PR DESCRIPTION
### Proposed Changes

**Whats Going on**

- Some new props added to manage the Radio container were passed to the HTML element.
- Same think was happening in the `Code.tsx` file.

### Potential Breaking Changes

:man_shrugging:  I dont know what the `lineNumberContainerStyle` Was doing in the `Code.tsx` but removing it doesn't seem to change anything.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
