### PR TITLE
fix(table hoc): missing filterBlankslate in the ownProps interface

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
@@ -4,6 +4,7 @@ import * as _ from 'underscore';
 
 import {WithServerSideProcessingProps} from '../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {ActionBarConnected} from '../actions/ActionBar';
+import {IBlankSlateProps} from '../blankSlate';
 import {TableLoading} from '../loading/components/TableLoading';
 import {PER_PAGE_NUMBERS} from '../navigation/perPage/NavigationPerPage';
 
@@ -24,6 +25,7 @@ export interface ITableHOCOwnProps {
     containerClassName?: string;
     tbodyClassName?: string;
     showBorderTop?: boolean;
+    filterBlankslate: IBlankSlateProps;
     loading?: {
         isCard?: boolean;
         numberOfColumns?: number;


### PR DESCRIPTION
### Proposed Changes

**What is going on:**

- The filterBlankslate was missing in the table hoc interface

### Potential Breaking Changes

none

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
