### PR TITLE
fix: linewrapping for react-vapor code editor

### DIFF
--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -15,6 +15,7 @@ import {CodeMirrorGutters} from './EditorConstants';
 export interface ICodeEditorProps {
     value: string;
     mode: any;
+    lineWrapping?: boolean;
     readOnly?: boolean;
     onChange?: (code: string) => void;
     onMount?: (codemirror: ReactCodeMirror.Controlled) => void;
@@ -81,6 +82,7 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
                 onChange={(editor, data, value: string) => this.props.onChange?.(value)}
                 options={{
                     ...CodeEditor.defaultOptions,
+                    lineWrapping: this.props.lineWrapping,
                     readOnly: this.removeCursorWhenEditorIsReadOnly(),
                     mode: this.props.mode,
                     ...this.props.options,

--- a/packages/react-vapor/src/components/editor/JSONEditor.tsx
+++ b/packages/react-vapor/src/components/editor/JSONEditor.tsx
@@ -9,6 +9,7 @@ import {CodeMirrorModes} from './EditorConstants';
 
 export interface IJSONEditorProps {
     value: string;
+    lineWrapping?: boolean;
     readOnly?: boolean;
     onChange?: (json: string, inError: boolean) => void;
     errorMessage?: string;
@@ -42,6 +43,7 @@ export class JSONEditor extends React.Component<IJSONEditorProps, IJSONEditorSta
                     value={this.props.value}
                     onChange={(json: string) => this.handleChange(json)}
                     mode={CodeMirrorModes.JSON}
+                    lineWrapping={this.props.lineWrapping}
                     readOnly={this.props.readOnly}
                 />
                 {this.getValidationDetails()}

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -52,6 +52,18 @@ describe('CodeEditor', () => {
             expect(readOnlyProp).toBe(true);
         });
 
+        it('should get the linewrapping state as a prop', () => {
+            let lineWrapping: boolean = codeEditor.props().lineWrapping;
+
+            expect(lineWrapping).toBeUndefined();
+
+            mountWithProps({lineWrapping: true});
+
+            lineWrapping = codeEditor.props().lineWrapping;
+
+            expect(lineWrapping).toBe(true);
+        });
+
         it('should set readOnly to `nocursor` when receiving true from props, else keep props', () => {
             mountWithProps({readOnly: true});
             expect((codeEditorInstance as any).removeCursorWhenEditorIsReadOnly(codeEditor.props().readOnly)).toBe(

--- a/packages/react-vapor/src/components/editor/tests/JSONEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/JSONEditor.spec.tsx
@@ -49,6 +49,18 @@ describe('JSONEditor', () => {
             expect(readOnlyProp).toBe(true);
         });
 
+        it('should get the linewrapping state as a prop', () => {
+            let lineWrapping: boolean = jsonEditor.props().lineWrapping;
+
+            expect(lineWrapping).toBeUndefined();
+
+            mountWithProps({lineWrapping: true});
+
+            lineWrapping = jsonEditor.props().lineWrapping;
+
+            expect(lineWrapping).toBe(true);
+        });
+
         it('should get what to do on change state as a prop if set', () => {
             let onChangeProp: (json: string, inError: boolean) => void = jsonEditor.props().onChange;
 


### PR DESCRIPTION
### Proposed Changes

Exposed line wrapping options for code editor and json editor.

### Potential Breaking Changes

Should not break anything since its a not required exposed prop.

### Acceptance Criteria

-   The proposed changes are covered by unit tests
-   No breaking changes
