### PR TITLE
fix(tabselectors.ts): added the safe operator

### DIFF
--- a/packages/react-vapor/src/components/tab/TabSelectors.ts
+++ b/packages/react-vapor/src/components/tab/TabSelectors.ts
@@ -10,7 +10,7 @@ const getTabGroup = (state: IReactVaporState, ownProps: ITabPaneOwnProps) => {
 };
 
 const getSelectedTab = createSelector(getTabGroup, (tabGroup: ITabGroupState) =>
-    _.findWhere(tabGroup.tabs, {isSelected: true})
+    _.findWhere(tabGroup?.tabs, {isSelected: true})
 );
 export const TabSelectors = {
     getTabGroup,


### PR DESCRIPTION

### Proposed Changes

added the safe operator, that way, it doesn't throw when unmounting

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
