### PR TITLE
feat(package): bump typescript version

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -74,7 +74,7 @@
         "style-loader": "1.1.3",
         "ts-loader": "6.2.1",
         "ts-transformer-keys": "0.4.1",
-        "typescript": "3.7.5",
+        "typescript": "3.9.6",
         "webpack": "4.41.6",
         "webpack-cli": "3.3.11",
         "webpack-dev-server": "3.10.3"

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -74,7 +74,7 @@
         "style-loader": "1.1.3",
         "ts-loader": "6.2.1",
         "ts-transformer-keys": "0.4.1",
-        "typescript": "3.9.6",
+        "typescript": "3.8.3",
         "webpack": "4.41.6",
         "webpack-cli": "3.3.11",
         "webpack-dev-server": "3.10.3"

--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -159,7 +159,7 @@
         "ts-transformer-keys": "0.4.1",
         "tslint": "6.0.0",
         "tslint-loader": "3.5.4",
-        "typescript": "3.9.6",
+        "typescript": "3.8.3",
         "underscore": "1.9.2",
         "underscore.string": "3.3.5",
         "unminified-webpack-plugin": "2.0.0",

--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -159,7 +159,7 @@
         "ts-transformer-keys": "0.4.1",
         "tslint": "6.0.0",
         "tslint-loader": "3.5.4",
-        "typescript": "3.7.5",
+        "typescript": "3.9.6",
         "underscore": "1.9.2",
         "underscore.string": "3.3.5",
         "unminified-webpack-plugin": "2.0.0",

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithUrlState.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithUrlState.spec.tsx
@@ -49,17 +49,32 @@ describe('Table HOC', () => {
         });
 
         it('should not throw when rendering the HOC component', () => {
+            const onUpdateUrlSpy = jasmine.createSpy('onUpdateUrl');
+            const renderBodySpy = jasmine.createSpy('renderBody');
+
             expect(() => {
                 const TableWithUrlState = tableWithUrlState(TableHOC);
-                table = shallowWithStore(<TableWithUrlState />, store).dive();
+                table = shallowWithStore(
+                    <TableWithUrlState
+                        id={'table'}
+                        data={[]}
+                        onUpdateUrl={onUpdateUrlSpy}
+                        renderBody={renderBodySpy}
+                    />,
+                    store
+                ).dive();
                 table.unmount();
             }).not.toThrow();
         });
 
         it('should call the "onUpdateUrl" prop with the query string representing the current state when the table needs to update', () => {
             const onUpdateUrlSpy = jasmine.createSpy('onUpdateUrl');
+            const renderBodySpy = jasmine.createSpy('renderBody');
             const TableWithUrlState = tableWithUrlState(TableHOC);
-            table = shallowWithStore(<TableWithUrlState onUpdateUrl={onUpdateUrlSpy} />, store).dive();
+            table = shallowWithStore(
+                <TableWithUrlState id={'table'} data={[]} onUpdateUrl={onUpdateUrlSpy} renderBody={renderBodySpy} />,
+                store
+            ).dive();
 
             expect(onUpdateUrlSpy).not.toHaveBeenCalled();
             table.prop('onUpdate')();


### PR DESCRIPTION
### Proposed Changes

Bump Typescript to _latest version_ (To Discuss)

After investigating all the errors, I'm not sure if it's a good idea to bump the latest version/3.9.6. The principal reason is that we cannot use jasmine `spyOn` anymore. For more details https://github.com/jasmine/jasmine/issues/1817

Here are 2 solutions that I see at this moment:
- Use the version `3.8.3` until replacing jasmine with Jest
- There is a workaround https://github.com/jasmine/jasmine/issues/1817#issuecomment-630110087 but personally I think it's a little bit hacky.

### Potential Breaking Changes

See above

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
