### PR TITLE
fix: exposed the options parameter

### DIFF
--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -15,7 +15,6 @@ import {CodeMirrorGutters} from './EditorConstants';
 export interface ICodeEditorProps {
     value: string;
     mode: any;
-    lineWrapping?: boolean;
     readOnly?: boolean;
     onChange?: (code: string) => void;
     onMount?: (codemirror: ReactCodeMirror.Controlled) => void;
@@ -82,7 +81,6 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
                 onChange={(editor, data, value: string) => this.props.onChange?.(value)}
                 options={{
                     ...CodeEditor.defaultOptions,
-                    lineWrapping: this.props.lineWrapping,
                     readOnly: this.removeCursorWhenEditorIsReadOnly(),
                     mode: this.props.mode,
                     ...this.props.options,

--- a/packages/react-vapor/src/components/editor/JSONEditor.tsx
+++ b/packages/react-vapor/src/components/editor/JSONEditor.tsx
@@ -11,12 +11,12 @@ import {JSONEditorUtils} from './JSONEditorUtils';
 export interface JSONEditorProps {
     id?: string;
     value: string;
-    lineWrapping?: boolean;
     readOnly?: boolean;
     onChange?: (json: string, inError: boolean) => void;
     errorMessage?: string;
     containerClasses?: string[];
     className?: string;
+    options?: CodeMirror.EditorConfiguration;
     ref?: React.Ref<any>;
 }
 
@@ -32,12 +32,12 @@ export interface JSONEditorDispatchProps {
 
 export const JSONEditor: React.FunctionComponent<JSONEditorProps & JSONEditorStateProps & JSONEditorDispatchProps> = ({
     value,
-    lineWrapping,
     readOnly,
     onChange,
     errorMessage,
     containerClasses,
     className,
+    options,
     onMount,
     onUnmount,
     ref,
@@ -63,9 +63,9 @@ export const JSONEditor: React.FunctionComponent<JSONEditorProps & JSONEditorSta
                 value={value}
                 onChange={handleChange}
                 mode={CodeMirrorModes.JSON}
-                lineWrapping={lineWrapping}
                 readOnly={readOnly}
                 className={className}
+                options={options}
                 ref={ref}
             />
             {isInError && <ValidationDetails errorMessage={errorMessage} />}

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -52,18 +52,6 @@ describe('CodeEditor', () => {
             expect(readOnlyProp).toBe(true);
         });
 
-        it('should get the linewrapping state as a prop', () => {
-            let lineWrapping: boolean = codeEditor.props().lineWrapping;
-
-            expect(lineWrapping).toBeUndefined();
-
-            mountWithProps({lineWrapping: true});
-
-            lineWrapping = codeEditor.props().lineWrapping;
-
-            expect(lineWrapping).toBe(true);
-        });
-
         it('should set readOnly to `nocursor` when receiving true from props, else keep props', () => {
             mountWithProps({readOnly: true});
             expect((codeEditorInstance as any).removeCursorWhenEditorIsReadOnly(codeEditor.props().readOnly)).toBe(

--- a/packages/react-vapor/src/components/editor/tests/JSONEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/JSONEditor.spec.tsx
@@ -43,12 +43,6 @@ describe('<JSONEditor />', () => {
         expect(component.find(CodeEditor).prop('readOnly')).toBe(true);
     });
 
-    it('should pass the lineWrapping prop', () => {
-        shallowComponent({lineWrapping: true});
-
-        expect(component.find(CodeEditor).prop('lineWrapping')).toBe(true);
-    });
-
     it('should validate value when editing json', () => {
         const expectedValue = '{}';
         const validateSpy = spyOn(JSONEditorUtils, 'validateValue');


### PR DESCRIPTION
### Proposed Changes

Initially the changes for the JSONEditor only exposed linewrapping but after another feature request for place holders for a V2 feature I decided to expose the options param instead of also just exposing the placeholder param. (@gdostie this was a discussion in the other PR: https://github.com/coveo/react-vapor/pull/1632#discussion_r456636800)

### Potential Breaking Changes

There are no potential breaking changes.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
