### PR TITLE
feat(labeledinput): change default tooltip placement

### DIFF
--- a/packages/react-vapor/src/components/input/LabeledInput.tsx
+++ b/packages/react-vapor/src/components/input/LabeledInput.tsx
@@ -12,7 +12,6 @@ export interface ILabeledInputProps {
     helpText?: React.ReactNode;
     headerClassName?: string;
     optionalInformation?: string;
-    informationPlacement?: TooltipPlacement;
 }
 
 export const LabeledInput: React.FunctionComponent<ILabeledInputProps> = ({
@@ -22,18 +21,13 @@ export const LabeledInput: React.FunctionComponent<ILabeledInputProps> = ({
     helpText: description,
     headerClassName,
     optionalInformation: information,
-    informationPlacement,
 }) => {
     const header =
         !!label || !!information ? (
             <header className={classNames('label', 'text-light-blue', headerClassName)}>
                 {!!label ? <span>{label}</span> : null}
                 {!!information ? (
-                    <Tooltip
-                        title={information}
-                        placement={informationPlacement || TooltipPlacement.Top}
-                        className="ml1"
-                    >
+                    <Tooltip title={information} placement={TooltipPlacement.Right} className="ml1">
                         <Svg svgName="info-14" svgClass="icon fill-medium-grey" />
                     </Tooltip>
                 ) : null}

--- a/packages/react-vapor/src/components/input/LabeledInput.tsx
+++ b/packages/react-vapor/src/components/input/LabeledInput.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
+
 import {TooltipPlacement} from '../../utils/TooltipUtils';
 import {Svg} from '../svg/Svg';
 import {Tooltip} from '../tooltip/Tooltip';
@@ -11,6 +12,7 @@ export interface ILabeledInputProps {
     helpText?: React.ReactNode;
     headerClassName?: string;
     optionalInformation?: string;
+    informationPlacement?: TooltipPlacement;
 }
 
 export const LabeledInput: React.FunctionComponent<ILabeledInputProps> = ({
@@ -20,13 +22,18 @@ export const LabeledInput: React.FunctionComponent<ILabeledInputProps> = ({
     helpText: description,
     headerClassName,
     optionalInformation: information,
+    informationPlacement,
 }) => {
     const header =
         !!label || !!information ? (
             <header className={classNames('label', 'text-light-blue', headerClassName)}>
                 {!!label ? <span>{label}</span> : null}
                 {!!information ? (
-                    <Tooltip title={information} placement={TooltipPlacement.Top} className="ml1">
+                    <Tooltip
+                        title={information}
+                        placement={informationPlacement || TooltipPlacement.Top}
+                        className="ml1"
+                    >
                         <Svg svgName="info-14" svgClass="icon fill-medium-grey" />
                     </Tooltip>
                 ) : null}


### PR DESCRIPTION
### Proposed Changes

The tooltip placement was set to `top`, if we want to display information/helper in the label title. Since we use this component mostly in forms, it could be changed to `right` according to current design.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
