### PR TITLE
fix(labeledvalue-labeledinput): changed the css of the tooltip container

### DIFF
--- a/packages/demo/src/components/examples/SectionExamples.tsx
+++ b/packages/demo/src/components/examples/SectionExamples.tsx
@@ -62,7 +62,7 @@ export class SectionExamples extends React.Component<any, any> {
                                     <Svg
                                         svgName="info"
                                         className="ml1 icon mod-align-with-text"
-                                        svgClass="fill-light-grey"
+                                        svgClass="fill-medium-grey"
                                     />
                                 </Tooltip>
                             </div>

--- a/packages/react-vapor/src/components/input/LabeledInput.tsx
+++ b/packages/react-vapor/src/components/input/LabeledInput.tsx
@@ -24,14 +24,16 @@ export const LabeledInput: React.FunctionComponent<ILabeledInputProps> = ({
 }) => {
     const header =
         !!label || !!information ? (
-            <header className={classNames('label', 'text-light-blue', headerClassName)}>
-                {!!label ? <span>{label}</span> : null}
+            <div className="flex">
+                <header className={classNames('label', 'text-light-blue', headerClassName)}>
+                    {!!label ? <span>{label}</span> : null}
+                </header>
                 {!!information ? (
-                    <Tooltip title={information} placement={TooltipPlacement.Right} className="ml1">
+                    <Tooltip title={information} placement={TooltipPlacement.Right} className="ml1 labeled-tooltip">
                         <Svg svgName="info-14" svgClass="icon fill-medium-grey" />
                     </Tooltip>
                 ) : null}
-            </header>
+            </div>
         ) : null;
 
     return (

--- a/packages/react-vapor/src/components/labeledValue/LabeledValue.tsx
+++ b/packages/react-vapor/src/components/labeledValue/LabeledValue.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
+
 import {TooltipPlacement} from '../../utils/TooltipUtils';
 import {Svg} from '../svg/Svg';
 import {Tooltip} from '../tooltip/Tooltip';
@@ -22,7 +23,11 @@ export class LabeledValue extends React.PureComponent<ILabeledValueProps> {
 
     render() {
         const informationSVG = !!this.props.information ? (
-            <Tooltip title={this.props.information} placement={this.props.informationPlacement || TooltipPlacement.Top}>
+            <Tooltip
+                title={this.props.information}
+                placement={this.props.informationPlacement || TooltipPlacement.Top}
+                className="labeled-tooltip"
+            >
                 <Svg svgName="info-14" svgClass="icon fill-medium-grey" />
             </Tooltip>
         ) : null;
@@ -35,10 +40,12 @@ export class LabeledValue extends React.PureComponent<ILabeledValueProps> {
                     this.props.className
                 )}
             >
-                <header className={classNames('label', {'inline-block': this.props.singleLine})}>
-                    <span className={classNames({mr1: !!this.props.information})}>{this.props.label}</span>
+                <div className="flex flex-center">
+                    <header className={classNames('label', {'inline-block': this.props.singleLine})}>
+                        <span className={classNames({mr1: !!this.props.information})}>{this.props.label}</span>
+                    </header>
                     {informationSVG}
-                </header>
+                </div>
                 <section className={classNames('value', {'inline-block': this.props.singleLine})}>
                     {this.props.value}
                 </section>

--- a/packages/vapor/scss/components/labeled-value.scss
+++ b/packages/vapor/scss/components/labeled-value.scss
@@ -5,17 +5,18 @@
 
     .label,
     .value {
-        padding: 5px;
         overflow: hidden;
         text-overflow: ellipsis;
     }
 
     .label {
+        padding: 5px 0px 5px 5px;
         color: $light-blue;
         font-size: $small-font-size;
     }
 
     .value {
+        padding: 5px;
         font-size: $default-font-size;
         line-height: $default-line-height;
     }

--- a/packages/vapor/scss/forms/block-form.scss
+++ b/packages/vapor/scss/forms/block-form.scss
@@ -50,6 +50,11 @@ form {
             }
         }
 
+        .labeled-tooltip {
+            width: 15px;
+            height: 15px;
+        }
+
         &.coveo-checkbox-label,
         &.coveo-slide-toggle-label {
             display: flex;


### PR DESCRIPTION
### Proposed Changes

Made a bigger tooltip sontainer so icon container and tooltip don't overlap when hovering the svg
info. Still not very experimented with all the class we already have. Fixed it with my knowledge.. I'm opened to alternatives if this doesn't respect react-vapor's rules

Note: Same buggy behavior was found in LabeledValue.tsx

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
