### PR TITLE
feat(input): add input label with tooltip

### DIFF
--- a/packages/demo/src/components/examples/InputExamples.tsx
+++ b/packages/demo/src/components/examples/InputExamples.tsx
@@ -7,6 +7,7 @@ import {
     IMultilineSingleBoxProps,
     Input,
     InputConnected,
+    InputLabelWithTooltip,
     ISplitInput,
     Label,
     MultilineBox,
@@ -103,8 +104,13 @@ const InputsConnected: React.FunctionComponent = () => {
                     <InputConnected
                         id="super-input"
                         validate={validate}
-                        labelTitle="I am a connected input, and validated in real time."
-                        labelProps={{invalidMessage: 'Do not leave me empty'}}
+                        labelTitle={
+                            <InputLabelWithTooltip
+                                label="I am a connected input, and validated in real time."
+                                tooltip="This input is connected."
+                                invalidMessage="Do not leave me empty"
+                            />
+                        }
                         innerInputClasses="mb2"
                         validateOnChange
                     />

--- a/packages/react-vapor/src/components/input/InputLabelWithTooltip.tsx
+++ b/packages/react-vapor/src/components/input/InputLabelWithTooltip.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+import {TooltipPlacement} from '../../utils';
+import {Svg} from '../svg';
+import {Tooltip} from '../tooltip';
+import {Label} from './Label';
+
+export interface InputLabelWithTooltipProps {
+    label: string;
+    tooltip: string;
+    invalidMessage?: string;
+}
+
+export const InputLabelWithTooltip: React.FunctionComponent<InputLabelWithTooltipProps> = ({
+    label,
+    tooltip,
+    invalidMessage,
+}) => (
+    <Label invalidMessage={invalidMessage}>
+        {label}
+        <Tooltip title={tooltip} placement={TooltipPlacement.Right}>
+            <Svg svgName="info" svgClass="icon fill-medium-grey mod-16 ml1" />
+        </Tooltip>
+    </Label>
+);

--- a/packages/react-vapor/src/components/input/index.ts
+++ b/packages/react-vapor/src/components/input/index.ts
@@ -2,6 +2,7 @@ export * from './Input';
 export * from './InputActions';
 export * from './InputConnected';
 export * from './InputDescription';
+export * from './InputLabelWithTooltip';
 export * from './InputReducers';
 export * from './InputSelectors';
 export * from './Label';

--- a/packages/react-vapor/src/components/input/tests/InputLabelWithTooltip.spec.tsx
+++ b/packages/react-vapor/src/components/input/tests/InputLabelWithTooltip.spec.tsx
@@ -1,0 +1,40 @@
+import {shallow} from 'enzyme';
+import * as React from 'react';
+
+import {Tooltip} from '../../tooltip/Tooltip';
+import {InputLabelWithTooltip, InputLabelWithTooltipProps} from '../InputLabelWithTooltip';
+import {Label} from '../Label';
+
+describe('InputLabelWithTooltip', () => {
+    const defaultProps: InputLabelWithTooltipProps = {
+        label: '🥰',
+        tooltip: '😏',
+        invalidMessage: '🤨',
+    };
+
+    it('should render without errors', () => {
+        expect(() => {
+            shallow(<InputLabelWithTooltip {...defaultProps} />);
+        }).not.toThrow();
+    });
+
+    describe('<InputLabelWithTooltip />', () => {
+        it('should output specified label', () => {
+            const label = shallow(<InputLabelWithTooltip {...defaultProps} />);
+
+            expect(label.html()).toContain(defaultProps.label);
+        });
+
+        it('should render a tooltip with specified information', () => {
+            const label = shallow(<InputLabelWithTooltip {...defaultProps} />);
+
+            expect(label.find(Tooltip).prop('title')).toEqual(defaultProps.tooltip);
+        });
+
+        it('should output invalidMessage when specified', () => {
+            const label = shallow(<InputLabelWithTooltip {...defaultProps} />);
+
+            expect(label.find(Label).prop('invalidMessage')).toEqual(defaultProps.invalidMessage);
+        });
+    });
+});


### PR DESCRIPTION
### Proposed Changes

This component can be used a lot in forms, especially inside of an input, which needs a tooltip for its label.
https://bitbucket.org/coveord/admin-ui/pull-requests/830/feature-adui-5766-web-source-in-react-part#comment-169911868

![image](https://user-images.githubusercontent.com/52677246/89835932-b71a7180-db33-11ea-8d4b-d5852a4ce2ee.png)

Demo -> TextInput -> the second one

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
