### PR TITLE
fix(numericinput): type error in selectors

### DIFF
--- a/packages/react-vapor/src/components/numericInput/NumericInputSelectors.ts
+++ b/packages/react-vapor/src/components/numericInput/NumericInputSelectors.ts
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import {createSelector} from 'reselect';
+
 import {IReactVaporState} from '../../ReactVapor';
 import {initialNumericInputState, INumericInputState} from './NumericInputReducers';
 
 const getNumericInput = (state: IReactVaporState, ownProps: {id: string}): INumericInputState =>
-    (state && state.numericInputs[ownProps.id]) || initialNumericInputState;
+    state?.numericInputs?.[ownProps.id] || initialNumericInputState;
 
 const getValue: (state: IReactVaporState, ownProps: {id: string}) => React.ReactText = createSelector(
     getNumericInput,


### PR DESCRIPTION
### Proposed Changes

Add optional chaining to fix type error when using `NumericInputSelectors`.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
