### PR TITLE
fix(infinite-loop): use effect bad watch

### DIFF
--- a/packages/demo/src/components/examples/SingleSelectExamples.tsx
+++ b/packages/demo/src/components/examples/SingleSelectExamples.tsx
@@ -168,7 +168,7 @@ const ServerSideSingleSelectExampleDisconnected: React.FunctionComponent<
 
     React.useEffect(() => {
         fetchPhotos({_page: 1, _limit: PER_PAGE});
-    }, [fetchPhotos]);
+    }, []);
 
     const fetchNextPage = () => {
         fetchPhotos({_page: pageNbr + 1, _limit: PER_PAGE, q: filterValue}, false);

--- a/packages/react-vapor/src/components/collapsible/CollapsibleConnected.tsx
+++ b/packages/react-vapor/src/components/collapsible/CollapsibleConnected.tsx
@@ -58,7 +58,7 @@ export const CollapsibleDisconnected: React.FunctionComponent<
     React.useEffect(() => {
         onMount();
         return () => onUnmount();
-    }, [onMount, onUnmount]);
+    }, []);
 
     const headerClassesCombine = classNames('cursor-pointer flex space-between center-align', headerClasses, {
         'mod-border-bottom mod-border-top': withBorders,

--- a/packages/react-vapor/src/components/editor/JSONEditor.tsx
+++ b/packages/react-vapor/src/components/editor/JSONEditor.tsx
@@ -48,7 +48,7 @@ export const JSONEditor: React.FunctionComponent<JSONEditorProps & JSONEditorSta
         onMount?.();
 
         return onUnmount;
-    }, [onMount, onUnmount]);
+    }, []);
 
     const handleChange = (json: string) => {
         const hasError = !JSONEditorUtils.validateValue(json);

--- a/packages/react-vapor/src/components/flatSelect/FlatSelect.tsx
+++ b/packages/react-vapor/src/components/flatSelect/FlatSelect.tsx
@@ -41,7 +41,7 @@ export const FlatSelect: React.FunctionComponent<IFlatSelectProps> = ({
     React.useEffect(() => {
         onRender?.();
         return onDestroy;
-    }, [onRender, onDestroy]);
+    }, []);
 
     const handleClick = (option: IFlatSelectOptionProps) => {
         onOptionClick?.(option);

--- a/packages/react-vapor/src/components/select/hoc/SelectWithPredicate.tsx
+++ b/packages/react-vapor/src/components/select/hoc/SelectWithPredicate.tsx
@@ -46,7 +46,7 @@ export const selectWithPredicate = <P extends Omit<ISelectOwnProps, 'button'> & 
         const {onUpdate, predicate} = props;
         React.useEffect(() => {
             onUpdate?.();
-        }, [predicate, onUpdate]);
+        }, [predicate]);
 
         return (
             <Component {..._.omit(props, SelectWithPredicatePropsToOmit)}>

--- a/packages/react-vapor/src/components/slider/Slider.tsx
+++ b/packages/react-vapor/src/components/slider/Slider.tsx
@@ -54,11 +54,8 @@ const SliderDisconnected: React.FunctionComponent<SliderOwnProps & ReturnType<ty
 
     React.useEffect(() => {
         onChange?.(outputValue);
-    }, [onChange, outputValue]);
-
-    React.useEffect(() => {
         setOutputValue(outputValue);
-    }, [outputValue, setOutputValue]);
+    }, [outputValue]);
 
     const jumpValueFromHighToLowRange = React.useCallback(
         (handlePositions: number[]) => {

--- a/packages/react-vapor/src/components/textarea/TextArea.tsx
+++ b/packages/react-vapor/src/components/textarea/TextArea.tsx
@@ -83,13 +83,13 @@ export const TextArea: React.FunctionComponent<ITextAreaProps> = ({
 
     React.useEffect(() => {
         setIsValid(validate?.(debouncedValue));
-    }, [debouncedValue, validate]);
+    }, [debouncedValue]);
 
     React.useEffect(() => {
         onMount?.();
         setIsValid(true);
         return onUnmount;
-    }, [onMount, onUnmount]);
+    }, []);
 
     const getValidationLabel = () =>
         !isValid && <div className="full-content-x generic-form-error my1">{validationMessage}</div>;

--- a/packages/react-vapor/src/components/validation/hoc/WithDirtyInputHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtyInputHOC.tsx
@@ -30,7 +30,7 @@ export const withDirtyInputHOC = <T extends IInputOwnProps>(Component: React.Com
             () => () => {
                 resetDirtyOnUnmount && clearIsDirty(props.id);
             },
-            [props.id, clearIsDirty, resetDirtyOnUnmount]
+            []
         );
 
         return (

--- a/packages/react-vapor/src/components/validation/hoc/WithDirtyMultiSelectHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtyMultiSelectHOC.tsx
@@ -33,7 +33,7 @@ export const withDirtyMultiSelectHOC = <T extends IMultiSelectOwnProps>(Componen
 
         React.useEffect(() => {
             toggleIsDirty(hasDifferentValuesSelected);
-        }, [hasDifferentValuesSelected, toggleIsDirty]);
+        }, [hasDifferentValuesSelected]);
 
         return <Component {...(props as T)} />;
     };

--- a/packages/react-vapor/src/components/validation/hoc/WithInitialValuesMultiSelectHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithInitialValuesMultiSelectHOC.tsx
@@ -49,13 +49,13 @@ export const withInitialValuesMultiSelectHOC = <T extends IMultiSelectOwnProps>(
             () => () => {
                 props.resetInitialValueWarningOnUnmount && clearWarning();
             },
-            [clearWarning, props.resetInitialValueWarningOnUnmount]
+            []
         );
 
         React.useEffect(() => {
             const message = invalidInitialValuesMessage?.(notFoundInitialValues) || '';
             setWarning(notFoundInitialValues.length > 0 ? message : '');
-        }, [invalidInitialValuesMessage, notFoundInitialValues, setWarning]);
+        }, [invalidInitialValuesMessage, notFoundInitialValues.length]);
 
         return <Component {...(props as T)} items={newItems} />;
     };

--- a/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
@@ -36,7 +36,7 @@ export const withNonEmptyValueInputValidationHOC = <T extends IInputOwnProps>(
             return () => {
                 resetErrorOnUnmount && clearError(props.id);
             };
-        }, [props.id, clearError, resetErrorOnUnmount]);
+        }, []);
 
         return (
             <Component

--- a/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueMultiSelectValidationHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueMultiSelectValidationHOC.tsx
@@ -42,7 +42,7 @@ export const withNonEmptyMultiSelectHOC = <T extends IMultiSelectOwnProps>(Compo
             return () => {
                 resetNonEmptyMultiSelectErrorOnUnmount && clearError(props.id);
             };
-        }, [props.id, resetNonEmptyMultiSelectErrorOnUnmount, clearError]);
+        }, [props.id, resetNonEmptyMultiSelectErrorOnUnmount]);
 
         React.useEffect(() => {
             setError(props.id, !hasValuesSelected ? nonEmptyValidationMessage : '');


### PR DESCRIPTION
Update every variable to watch on useEffect. we cant watch on a function from mapDispatchToProps redefine every time.

### Proposed Changes

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
