### PR TITLE
feat(validation): shorter save button tooltip with mutliple warnings

### DIFF
--- a/packages/demo/src/components/examples/ButtonExamples.tsx
+++ b/packages/demo/src/components/examples/ButtonExamples.tsx
@@ -109,7 +109,7 @@ export class ButtonExamples extends React.Component<any, any> {
                     <SaveButton
                         enabled
                         name="Save Button"
-                        validationIds={['inputId']}
+                        validationIds={[FIRST_INPUT_ID, SECOND_INPUT_ID]}
                         onClick={() => alert('Saving!')}
                     />
                 </Section>
@@ -200,35 +200,55 @@ export class ButtonExamples extends React.Component<any, any> {
 
 // stop-print
 
+const FIRST_INPUT_ID = 'firstInputId';
+const SECOND_INPUT_ID = 'secondInputId';
 const StatefulCheckboxesForSaveButtonDisconnect: React.FunctionComponent<ReturnType<typeof mapDispatchToProps>> = ({
     setDirty,
     setWarning,
     setError,
 }) => (
     <LabeledInput label="Toggles to test the Save Button">
-        <CheckboxConnected id="saveCheckboxDirty" handleOnClick={(checked) => setDirty(!checked)} clearSides>
+        <CheckboxConnected
+            id="saveCheckboxDirty"
+            handleOnClick={(checked) => setDirty(FIRST_INPUT_ID, !checked)}
+            clearSides
+        >
             <Label>Click on me to set the component as dirty</Label>
         </CheckboxConnected>
         <CheckboxConnected
             id="saveCheckboxWarning"
-            handleOnClick={(checked) => setWarning(!checked ? 'WARNING' : '')}
+            handleOnClick={(checked) => setWarning(FIRST_INPUT_ID, !checked ? 'WARNING' : '')}
             clearSides
         >
             <Label>Click on me to set a warning</Label>
         </CheckboxConnected>
         <CheckboxConnected
+            id="saveCheckboxSecondWarning"
+            handleOnClick={(checked) => setWarning(SECOND_INPUT_ID, !checked ? 'SECOND WARNING' : '')}
+            clearSides
+        >
+            <Label>Click on me to set a second warning (activate both to change the message)</Label>
+        </CheckboxConnected>
+        <CheckboxConnected
             id="saveCheckboxError"
-            handleOnClick={(checked) => setError(!checked ? 'ERROR' : '')}
+            handleOnClick={(checked) => setError(FIRST_INPUT_ID, !checked ? 'ERROR' : '')}
             clearSides
         >
             <Label>Click on me to set an error</Label>
+        </CheckboxConnected>
+        <CheckboxConnected
+            id="saveCheckboxSecondError"
+            handleOnClick={(checked) => setError(SECOND_INPUT_ID, !checked ? 'SECOND ERROR' : '')}
+            clearSides
+        >
+            <Label>Click on me to set a second error (activate both to change the message)</Label>
         </CheckboxConnected>
     </LabeledInput>
 );
 
 const mapDispatchToProps = (dispatch: IDispatch) => ({
-    setDirty: (value: boolean) => dispatch(ValidationActions.setDirty('inputId', value)),
-    setWarning: (value: string) => dispatch(ValidationActions.setWarning('inputId', value)),
-    setError: (value: string) => dispatch(ValidationActions.setError('inputId', value)),
+    setDirty: (id: string, value: boolean) => dispatch(ValidationActions.setDirty(id, value)),
+    setWarning: (id: string, value: string) => dispatch(ValidationActions.setWarning(id, value)),
+    setError: (id: string, value: string) => dispatch(ValidationActions.setError(id, value)),
 });
 const DirtyCheckboxesForSaveButton = connect(null, mapDispatchToProps)(StatefulCheckboxesForSaveButtonDisconnect);

--- a/packages/react-vapor/src/components/validation/hoc/WithDirtySaveButtonHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtySaveButtonHOC.tsx
@@ -31,7 +31,10 @@ export const withDirtySaveButtonHOC = <T extends IButtonProps>(Component: React.
             e?.length > 1
                 ? `Some required fields are missing. Please complete them.`
                 : `Cannot save because of the following error: ${e}`,
-        warningMessage = (w) => `Can save but with warnings: ${w.join('\n')}`,
+        warningMessage = (w) =>
+            w?.length > 1
+                ? `Some fields have warnings. Please validate them before saving.`
+                : `Can save, but with the following warning: ${w}`,
         dirtyMessage = (d) => d.length === 0 && `Cannot save when there are no changes`,
         enabled,
         tooltip,


### PR DESCRIPTION
[COM-170]

### Proposed Changes

The warning tooltip did not match the behavior of the error tooltip, so here it is!

I have also added two other checkboxes in the examples so that you can test out what happens when multiple components are outputting warnings and errors

### Potential Breaking Changes

No

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-170]: https://coveord.atlassian.net/browse/COM-170