### PR TITLE
feat(multi-select): supporting the selectDisplayValue prop

### DIFF
--- a/packages/demo/src/components/examples/MultiSelectExamples.tsx
+++ b/packages/demo/src/components/examples/MultiSelectExamples.tsx
@@ -24,7 +24,7 @@ const defaultItems: IItemBoxProps[] = [
     {displayValue: 'Four', value: '4'},
     {displayValue: 'Five', value: '5'},
     {displayValue: 'Six', value: '6'},
-    {displayValue: 'Seven', value: '7'},
+    {displayValue: 'Seven', value: '7', selectedDisplayValue: 'James Bond 007'},
 ];
 
 const defaultFlatSelectOptions: IFlatSelectOptionProps[] = [

--- a/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
@@ -92,7 +92,8 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps> {
     }
 
     private renderOption(item: IItemBoxProps): JSX.Element {
-        const displayValue = item.displayValue || item.value;
+        const displayValue = item.selectedDisplayValue || item.displayValue || item.value;
+
         return (
             <SelectedOption
                 label={displayValue}
@@ -110,7 +111,7 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps> {
             <div className="flex flex-row flex-center sortable-selected-option" key={item.value}>
                 <span className="mr1 text-medium-grey">{index + 1}</span>
                 <DraggableSelectedOption
-                    label={item.displayValue || item.value}
+                    label={item.selectedDisplayValue || item.displayValue || item.value}
                     value={item.value}
                     onRemoveClick={() => this.props.onRemoveClick(item)}
                     index={index}


### PR DESCRIPTION
Adding the support for the selectDisplayValue prop for the multi-select component, similar to the
SingleSelect component

Test for this feature seems to be completed in `MultiSelectConnected.spec.tsx` lines 87-92 with `selectedDisplayValue`

### Proposed Changes

The value to show `selectedDisplayValue` if it is passed in as a prop. This will allow flexibility for users who want to display a different value when an item is selected versus when the item is shown on the dropdown

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
