### PR TITLE
Fix adui 5838 code editor with validation quickly shows the invalid icon upon mounting

### DIFF
--- a/packages/demo/src/components/examples/CodeEditorExamples.tsx
+++ b/packages/demo/src/components/examples/CodeEditorExamples.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {CodeEditor, CodeMirrorModes} from 'react-vapor';
+import {CodeEditor, CodeMirrorModes, Loading} from 'react-vapor';
 
 export class CodeEditorExamples extends React.Component {
     render() {
@@ -18,6 +18,10 @@ export class CodeEditorExamples extends React.Component {
                 <div className="form-group">
                     <label className="form-control-label">Code Editor using codemirror with an action on change</label>
                     <CodeEditor value="" mode={CodeMirrorModes.Python} onChange={(code: string) => alert(code)} />
+                </div>
+                <div className="form-group">
+                    <label className="form-control-label">Code Editor using the default value prop</label>
+                    <CodeEditor mode={CodeMirrorModes.Python} options={{lineWrapping: true}} />
                 </div>
             </div>
         );

--- a/packages/demo/src/components/examples/CodeEditorExamples.tsx
+++ b/packages/demo/src/components/examples/CodeEditorExamples.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {CodeEditor, CodeMirrorModes, Loading} from 'react-vapor';
+import {CodeEditor, CodeMirrorModes} from 'react-vapor';
 
 export class CodeEditorExamples extends React.Component {
     render() {

--- a/packages/demo/src/components/examples/JSONEditorExamples.tsx
+++ b/packages/demo/src/components/examples/JSONEditorExamples.tsx
@@ -21,6 +21,17 @@ export class JSONEditorExamples extends React.Component {
                     <label className="form-control-label">JSON Editor using codemirror with an action on change</label>
                     <JSONEditor value={JSONToString(fakeJSON)} onChange={(json: string) => alert(json)} />
                 </div>
+                <div className="form-group">
+                    <label className="form-control-label">
+                        JSON Editor without set codeMirror's lint option to false
+                    </label>
+                    <JSONEditor
+                        value={JSONToString(fakeJSON)}
+                        options={{
+                            lint: false,
+                        }}
+                    />
+                </div>
             </div>
         );
     }

--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -31,6 +31,7 @@ export interface CodeEditorState {
 export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorState> {
     static defaultProps: Partial<ICodeEditorProps> = {
         className: 'mod-border',
+        value: '{}',
     };
 
     static defaultOptions: CodeMirror.EditorConfiguration = {
@@ -65,7 +66,6 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
             this.editor.getDoc().clearHistory();
         }
     }
-
     render() {
         return (
             <ReactCodeMirror.Controlled


### PR DESCRIPTION
### Proposed Changes

To resolve[ ADUI-5838](https://coveord.atlassian.net/browse/ADUI-5838)

It seems that the icon that briefly appears in all instances of the implemented JSONEditorConnected component in the Admin-UI is due to a slight delay between the render of the JSONEditor container and the JSON text. After a troubleshooting with PO, it might be caused by the codemirror's lint addon (same error icon is displayed in this [demo](https://codemirror.net/demo/lint.html) ).

We thought of two possible solutions for this bug: 
1) If we set a default value for the CodeEditor component _value_ prop, we might avoid this kind of issue. 
2) We could set the lint addon option to `false`. For example, I set this option to false in the AssociationJSONEditor component in the Admin-UI repo, in which the appearance of the error icon didn't occur. Also, I included an example in the JSONEditorExample component, showing that even if the lint addon option is set to false, the validation details will still be displayed (simply remove one of the bracket in the last JSONEditor example to validate the behavior). 

AssociationJSONEditor component modification (if you want to test it out on your end):
![lintIsFalse](https://user-images.githubusercontent.com/58052881/90444940-cdcd4500-e0ac-11ea-9e76-b4bfa61cff01.PNG)


### Potential Breaking Changes

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
