### PR TITLE
fix(json-editor): set the default prop options lint=false

### DIFF
--- a/packages/demo/src/components/examples/JSONEditorExamples.tsx
+++ b/packages/demo/src/components/examples/JSONEditorExamples.tsx
@@ -21,17 +21,6 @@ export class JSONEditorExamples extends React.Component {
                     <label className="form-control-label">JSON Editor using codemirror with an action on change</label>
                     <JSONEditor value={JSONToString(fakeJSON)} onChange={(json: string) => alert(json)} />
                 </div>
-                <div className="form-group">
-                    <label className="form-control-label">
-                        JSON Editor without set codeMirror's lint option to false
-                    </label>
-                    <JSONEditor
-                        value={JSONToString(fakeJSON)}
-                        options={{
-                            lint: false,
-                        }}
-                    />
-                </div>
             </div>
         );
     }

--- a/packages/react-vapor/src/components/editor/JSONEditor.tsx
+++ b/packages/react-vapor/src/components/editor/JSONEditor.tsx
@@ -73,6 +73,12 @@ export const JSONEditor: React.FunctionComponent<JSONEditorProps & JSONEditorSta
     );
 };
 
+JSONEditor.defaultProps = {
+    options: {
+        lint: false,
+    },
+};
+
 const ValidationDetails: React.FunctionComponent<{errorMessage?: string}> = ({errorMessage}) => (
     <div className="input-validation-error-details">
         <Svg className="input-validation-error-icon" svgName="message-alert" svgClass="icon fill-white" />

--- a/packages/react-vapor/src/components/editor/tests/JSONEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/JSONEditor.spec.tsx
@@ -67,4 +67,10 @@ describe('<JSONEditor />', () => {
     it('should not throw on change if the onChange prop is undefined', () => {
         expect(() => shallowComponent({onChange: undefined})).not.toThrow();
     });
+
+    it('should set the lint option to false by default', () => {
+        shallowComponent();
+
+        expect(component.find(CodeEditor).props().options.lint).toBe(false);
+    });
 });


### PR DESCRIPTION
### Proposed Changes

Second attempt to resolve [ADUI-5838](https://coveord.atlassian.net/browse/ADUI-5838)

It seems that the icon that briefly appears in all instances of the implemented JSONEditorConnected component in the Admin-UI is due to a slight delay between the render of the JSONEditor container and the JSON text. After a troubleshooting with PO, it might be caused by the codemirror's lint addon (same error icon is displayed in this demo ).

This time, I suggest to add a default prop to set the lint addon to false to resolve this issue.

### Potential Breaking Changes

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
