### PR TITLE
fix(non-empty validation): Do not clear error immediately

### DIFF
--- a/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
@@ -31,12 +31,12 @@ export const withNonEmptyValueInputValidationHOC = <T extends IInputOwnProps>(
         validate,
         ...props
     }) => {
-        React.useEffect(() => {
-            clearError(props.id);
-            return () => {
+        React.useEffect(
+            () => () => {
                 resetErrorOnUnmount && clearError(props.id);
-            };
-        }, [props.id, resetErrorOnUnmount]);
+            },
+            [props.id, resetErrorOnUnmount]
+        );
 
         return (
             <Component

--- a/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
@@ -36,7 +36,7 @@ export const withNonEmptyValueInputValidationHOC = <T extends IInputOwnProps>(
             return () => {
                 resetErrorOnUnmount && clearError(props.id);
             };
-        }, []);
+        }, [props.id, resetErrorOnUnmount]);
 
         return (
             <Component


### PR DESCRIPTION
`withNonEmptyValueInputValidationHOC` was not showing errors for required fields in their initial state.

Turns out that the validation was occurring onMount, however the useEffect hook runs after that, so it was clearing the error set during validation.

The initial clear is not required, and should only be called on cleanup (unmount)