### PR TITLE
fix(code editor): no cursor option replaced by css

### DIFF
--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -10,6 +10,7 @@ import * as CodeMirror from 'codemirror';
 import * as React from 'react';
 import * as ReactCodeMirror from 'react-codemirror2';
 
+import classNames from 'classnames';
 import {CodeMirrorGutters} from './EditorConstants';
 
 export interface ICodeEditorProps {
@@ -81,17 +82,13 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
                 onChange={(editor, data, value: string) => this.props.onChange?.(value)}
                 options={{
                     ...CodeEditor.defaultOptions,
-                    readOnly: this.removeCursorWhenEditorIsReadOnly(),
+                    readOnly: this.props.readOnly,
                     mode: this.props.mode,
                     ...this.props.options,
                 }}
-                className={this.props.className}
+                className={classNames(this.props.className, {'code-editor-no-cursor': this.props.readOnly})}
             />
         );
-    }
-
-    private removeCursorWhenEditorIsReadOnly() {
-        return this.props.readOnly ? 'nocursor' : this.props.readOnly;
     }
 
     private addExtraKeywords() {

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -52,17 +52,15 @@ describe('CodeEditor', () => {
             expect(readOnlyProp).toBe(true);
         });
 
-        it('should set readOnly to `nocursor` when receiving true from props, else keep props', () => {
+        it('should set the code-editor-no-cursor className when in readOnly to hide the cursor', () => {
             mountWithProps({readOnly: true});
 
-            expect((codeEditorInstance as any).removeCursorWhenEditorIsReadOnly(codeEditor.props().readOnly)).toBe(
-                'nocursor'
-            );
+            expect(codeEditor.find(ReactCodeMirror.Controlled).props().className).toContain('code-editor-no-cursor');
 
             codeEditor.setProps({readOnly: false});
 
-            expect((codeEditorInstance as any).removeCursorWhenEditorIsReadOnly(codeEditor.props().readOnly)).toBe(
-                codeEditor.props().readOnly
+            expect(codeEditor.find(ReactCodeMirror.Controlled).props().className).not.toContain(
+                'code-editor-no-cursor'
             );
         });
 
@@ -115,7 +113,7 @@ describe('CodeEditor', () => {
         });
 
         it('should have a border by default', () => {
-            expect(codeEditor.find(ReactCodeMirror.Controlled).props().className).toBe('mod-border');
+            expect(codeEditor.find(ReactCodeMirror.Controlled).props().className).toContain('mod-border');
         });
     });
 });

--- a/packages/vapor/scss/components/code-editor.scss
+++ b/packages/vapor/scss/components/code-editor.scss
@@ -1,0 +1,5 @@
+.code-editor-no-cursor {
+    .CodeMirror-cursor {
+        display: none !important;
+    }
+}

--- a/packages/vapor/scss/guide.scss
+++ b/packages/vapor/scss/guide.scss
@@ -108,6 +108,7 @@
     @import 'components/step-progress-bar';
     @import 'components/badge';
     @import 'components/corner-ribbon';
+    @import 'components/code-editor.scss';
     @import 'components/logo-card';
     @import 'components/flippable';
     @import 'components/material-card';


### PR DESCRIPTION
### Proposed Changes

The no cursor option that was implemented a year ago by a wonderfull but newbie developper is preventing the selection of text.
So no ctrl+a, ctrl+c ctrl+v

I changed the implementation to css-ly hide the cursor instead.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
