### PR TITLE
fix(demo): vul in the react-syntax-highlighter given by prism-js

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -34,7 +34,7 @@
         "react-markdown": "4.3.1",
         "react-redux": "5.1.2",
         "react-router-dom": "5.2.0",
-        "react-syntax-highlighter": "12.2.1",
+        "react-syntax-highlighter": "^13.5.1",
         "react-vapor": "^7.6.0",
         "redux": "4.0.5",
         "redux-devtools-extension": "2.13.8",


### PR DESCRIPTION
Exploitable in the Demo from Safari or IE browsers.

### Proposed Changes

Bumbed the `react-syntax-highlighter` package in the `package.json` of the react-vapor package.

Used `npm install react-syntax-highlighter@latest` to make sure the `package-lock` got updated accordingly

### Potential Breaking Changes

~is there any ? gotta look at the code editor demo to make sure.~ 
Did not spot any 

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
