### PR TITLE
build: remove validation of unexisting param

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -137,7 +137,6 @@ pipeline {
       when {
         allOf {
           expression { env.BRANCH_NAME ==~ /(master|release-.*)/ }
-          expression { params.SKIP_PUBLISH == false }
         }
       }
       steps {
@@ -172,7 +171,6 @@ pipeline {
       when {
         allOf {
           expression { env.BRANCH_NAME ==~ /(master|release-.*)/ }
-          expression { params.SKIP_PUBLISH == false }
           expression { COMMITS_BEHIND == 0 }
         }
       }


### PR DESCRIPTION
### Proposed Changes

params.SKIP_PUBLISH does not exists, so the step was ignored