### PR TITLE
fix(multi-values-input): remove tooltip if the placeholder is displayed

### DIFF
--- a/packages/react-vapor/src/components/multiValueInputs/MultiValuesInput.tsx
+++ b/packages/react-vapor/src/components/multiValueInputs/MultiValuesInput.tsx
@@ -56,8 +56,7 @@ export const MultiValuesInput: React.FunctionComponent<MultiValuesInputProps> = 
                 const isInputLimitReached = !!dataLimit && index >= dataLimit;
                 const isIndexEqualToDataLimit = !!dataLimit && index === dataLimit;
                 const reachedPlaceholder = !isIndexEqualToDataLimit ? reachedLimitPlaceholder : undefined;
-                const isTooltipRequired =
-                    isInputLimitReached && (!_.isEmpty(cData.props) || !_.isEmpty(reachedPlaceholder));
+                const isTooltipRequired = isInputLimitReached && !_.isEmpty(cData.props);
                 const innerInputClasses = isInputLimitReached
                     ? classNames(inputProps?.innerInputClasses, disabledInputInnerClasses)
                     : inputProps?.innerInputClasses;

--- a/packages/react-vapor/src/components/multiValueInputs/tests/MultiValuesInput.spec.tsx
+++ b/packages/react-vapor/src/components/multiValueInputs/tests/MultiValuesInput.spec.tsx
@@ -221,7 +221,10 @@ describe('MultiValuesInput', () => {
             <div>{(component.prop('renderBody') as any)(arrayOfMultilineSingleBoxAboveDataLimitProps)}</div>,
             {}
         );
-        const lastInputConnectedProps = body.find(InputConnected).last().props();
+        const lastInputConnectedProps = body
+            .find(InputConnected)
+            .at(defaultAboveDataLimitValues.length - 2)
+            .props();
 
         expect(lastInputConnectedProps.disabledTooltip).toBe(defaultProps.disabledTooltipTitle);
     });
@@ -237,6 +240,21 @@ describe('MultiValuesInput', () => {
             {}
         );
         const oneInputConnectedBeforelastProps = body.find(InputConnected).first().props();
+
+        expect(oneInputConnectedBeforelastProps.disabledTooltip).toBe('');
+    });
+
+    it("should NOT includes a Tooltip if the input value is empty even if it's index is above the dataLimit", () => {
+        const component = shallowWithState(
+            <MultiValuesInput {...defaultProps} data={defaultAboveDataLimitValues} />,
+            {}
+        ).dive();
+
+        const body = shallowWithState(
+            <div>{(component.prop('renderBody') as any)(arrayOfMultilineSingleBoxAboveDataLimitProps)}</div>,
+            {}
+        );
+        const oneInputConnectedBeforelastProps = body.find(InputConnected).last().props();
 
         expect(oneInputConnectedBeforelastProps.disabledTooltip).toBe('');
     });

--- a/packages/vapor/scss/controls/input-field.scss
+++ b/packages/vapor/scss/controls/input-field.scss
@@ -55,9 +55,19 @@
             color: $dark-grey;
             border-bottom-color: transparent;
 
-            @include placeholder($dark-grey);
+            &:not(.disabled-input) {
+                @include placeholder($dark-grey);
+                -webkit-text-fill-color: $dark-grey;
+            }
 
-            -webkit-text-fill-color: $dark-grey;
+            &.disabled-input {
+                margin-left: 1 * $spacing;
+                background-color: transparent;
+                &::placeholder {
+                    color: $red;
+                    font-size: 12px;
+                }
+            }
 
             & + label {
                 color: $lynch;


### PR DESCRIPTION
### Proposed Changes

Before a tooltip was shown if the cursor hovered the placeholder (if the number of input is above the limit), like this: 
![placeholderTooltipBug](https://user-images.githubusercontent.com/58052881/92043867-fb6fea80-ed4a-11ea-95ce-5ae2d41b061a.PNG)

Now, the tooltip will only be shown if the input has a default-value and if the index of the input is above the limit.

### Potential Breaking Changes

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
