### PR TITLE
fix(snyk): remove incompatible argument projectName

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -181,7 +181,6 @@ pipeline {
 
           runSnyk(
             org: "coveo-admin-ui",
-            projectName: "react-vapor",
             directory: ".",
             archiveArtifacts: true,
             scanDevDependencies: false,


### PR DESCRIPTION
>18:43:13  UnsupportedOptionCombinationError: The following option combination is not currently supported: project-name + all-projects