### PR TITLE
fix(listbox): switched prop from selected to active

### DIFF
--- a/packages/react-vapor/src/components/listBox/ListBox.tsx
+++ b/packages/react-vapor/src/components/listBox/ListBox.tsx
@@ -91,7 +91,7 @@ export class ListBox extends React.Component<IListBoxProps> {
                     key={item.value}
                     {...item}
                     onOptionClick={(option: IItemBoxProps) => this.onSelectItem(item, item.index)}
-                    selected={_.contains(this.props.selected, item.value)}
+                    active={_.contains(this.props.selected, item.value)} // here
                 />
             ))
             .value();


### PR DESCRIPTION
### Proposed Changes

Switched the `ListBox` prop from `selected` to `active` as the first child was always being rendered as selected 

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)

![image](https://user-images.githubusercontent.com/22773767/92499940-7c573800-f1ca-11ea-8a2f-82c8e4d29b6d.png)

[Jira](https://coveord.atlassian.net/browse/ADUI-5929)