### PR TITLE
improvement(tablehoc): add showBorderBottom prop

### DIFF
--- a/packages/demo/src/components/examples/TableHOCExamples.tsx
+++ b/packages/demo/src/components/examples/TableHOCExamples.tsx
@@ -197,6 +197,7 @@ const TableWithActionsAndDataFilteringDisconnected: React.FunctionComponent<
             renderBody={(Alldata: IExampleRowData[]) => generateTableRow(Alldata, id)}
             tableHeader={renderHeader(id)}
             showBorderTop
+            showBorderBottom
         />
     );
 };

--- a/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
@@ -24,6 +24,7 @@ export interface ITableHOCOwnProps {
     containerClassName?: string;
     tbodyClassName?: string;
     showBorderTop?: boolean;
+    showBorderBottom?: boolean;
     loading?: {
         isCard?: boolean;
         numberOfColumns?: number;
@@ -40,6 +41,7 @@ export class TableHOC extends React.PureComponent<ITableHOCProps & React.HTMLAtt
         hasActionButtons: false,
         actions: [],
         showBorderTop: false,
+        showBorderBottom: false,
         loading: {
             isCard: false,
             numberOfColumns: 5,
@@ -91,6 +93,7 @@ export class TableHOC extends React.PureComponent<ITableHOCProps & React.HTMLAtt
                         'mod-align-header',
                         {
                             'mod-border-top': this.props.showBorderTop,
+                            'mod-border-bottom': this.props.showBorderBottom,
                         }
                     ).split(' ')}
                     disabled={this.props.isLoading}

--- a/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
@@ -52,7 +52,7 @@ export class TableHOC extends React.PureComponent<ITableHOCProps & React.HTMLAtt
 
     render() {
         const table = (
-            <table className={classNames(this.props.className)}>
+            <table className={classNames(this.props.className)} style={{marginTop: this.hasActions() ? -1 : 0}}>
                 {this.props.tableHeader}
                 <tbody
                     key={`table-body-${this.props.id}`}
@@ -81,8 +81,12 @@ export class TableHOC extends React.PureComponent<ITableHOCProps & React.HTMLAtt
         );
     }
 
+    private hasActions() {
+        return this.props.hasActionButtons || this.props.actions.length;
+    }
+
     private renderActions() {
-        if (this.props.hasActionButtons || this.props.actions.length) {
+        if (this.hasActions()) {
             return (
                 <ActionBarConnected
                     id={this.props.id}

--- a/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
@@ -84,10 +84,16 @@ describe('TableHOC', () => {
             expect(wrapper.find(ActionBarConnected).exists()).toBe(true);
         });
 
-        it('should render an ActionBarConnected with a top border if the "hasBorderTop" is set to true', () => {
+        it('should render an ActionBarConnected with a top border if the "showBorderTop" is set to true', () => {
             const wrapper = shallow(<TableHOC {...defaultProps} hasActionButtons showBorderTop />);
 
             expect(wrapper.find(ActionBarConnected).prop('extraContainerClasses')).toContain('mod-border-top');
+        });
+
+        it('should render an ActionBarConnected with a top border if the "showBorderBottom" is set to true', () => {
+            const wrapper = shallow(<TableHOC {...defaultProps} hasActionButtons showBorderBottom />);
+
+            expect(wrapper.find(ActionBarConnected).prop('extraContainerClasses')).toContain('mod-border-bottom');
         });
 
         it('should render an ActionBarConnected if the table prop hasActionButtons is false but the table have some actions', () => {

--- a/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
@@ -129,5 +129,17 @@ describe('TableHOC', () => {
 
             expect(wrapper.find(ActionBarConnected).props().disabled).toBe(false);
         });
+
+        it('should render a negative top margin on the table if there is an ActionBar', () => {
+            const wrapper = shallow(<TableHOC {...defaultProps} hasActionButtons />);
+
+            expect(wrapper.find('table').prop('style').marginTop).toBe(-1);
+        });
+
+        it('should not render a negative top margin on the table if there is an ActionBar', () => {
+            const wrapper = shallow(<TableHOC {...defaultProps} />);
+
+            expect(wrapper.find('table').prop('style').marginTop).toBe(0);
+        });
     });
 });


### PR DESCRIPTION
The tablehoc component only had showBorderTop but no option for showBorderBottom so I added that

### Proposed Changes

The tablehoc component uses the actionbar component. It never passed mod-border-bottom to it in the first place. I copied the functionality of the top border by adding a showBorderBottom prop that would pass the mod-border-bottom class to ActionBar.