### PR TITLE
improvement(filepicker): add redux state for the filepicker

### DIFF
--- a/packages/react-vapor/src/ReactVapor.ts
+++ b/packages/react-vapor/src/ReactVapor.ts
@@ -15,6 +15,7 @@ import {IDropdownSearchState} from './components/dropdownSearch/DropdownSearchRe
 import {JSONEditorState} from './components/editor/JSONEditorReducers';
 import {IFacet} from './components/facets/Facet';
 import {IFacetState} from './components/facets/FacetReducers';
+import {FilepickerState} from './components/filepicker/FilepickerReducers';
 import {IFilterState} from './components/filterBox/FilterBoxReducers';
 import {IFlatSelectState} from './components/flatSelect/FlatSelectReducers';
 import {IFlippableState} from './components/flippable/FlippableReducers';
@@ -65,6 +66,7 @@ export interface IReactVaporState {
     dropdowns?: IDropdownState[];
     dropdownSearch?: IDropdownSearchState[];
     facets?: IFacetState[];
+    filepickers?: FilepickerState;
     filters?: IFilterState[];
     flatSelect?: IFlatSelectState[];
     flippables?: IFlippableState[];

--- a/packages/react-vapor/src/ReactVaporReducers.ts
+++ b/packages/react-vapor/src/ReactVaporReducers.ts
@@ -12,6 +12,7 @@ import {dropdownsReducer} from './components/dropdown/DropdownReducers';
 import {dropdownsSearchReducer} from './components/dropdownSearch/DropdownSearchReducers';
 import {jsonEditorsReducer} from './components/editor/JSONEditorReducers';
 import {facetsReducer} from './components/facets/FacetReducers';
+import {filepickersReducer} from './components/filepicker/FilepickerReducers';
 import {filterBoxesReducer} from './components/filterBox/FilterBoxReducers';
 import {flatSelectsReducer} from './components/flatSelect/FlatSelectReducers';
 import {flippablesReducer} from './components/flippable/FlippableReducers';
@@ -63,6 +64,7 @@ export const ReactVaporReducers: ReducersMapObject = {
     dropdowns: dropdownsReducer,
     dropdownSearch: dropdownsSearchReducer,
     facets: facetsReducer,
+    filepickers: filepickersReducer,
     filters: filterBoxesReducer,
     flatSelect: flatSelectsReducer,
     flippables: flippablesReducer,

--- a/packages/react-vapor/src/components/filepicker/Filepicker.tsx
+++ b/packages/react-vapor/src/components/filepicker/Filepicker.tsx
@@ -1,36 +1,62 @@
 import classNames from 'classnames';
 import * as VaporSVG from 'coveo-styleguide';
 import * as React from 'react';
+import {connect} from 'react-redux';
 
+import {IReactVaporState} from '../../ReactVapor';
+import {IDispatch} from '../../utils';
+import {FileMetadata, FileUtils} from '../../utils/FileUtils';
 import {Svg} from '../svg';
+import {FilepickerActions} from './FilepickerActions';
+import {FilepickerSelectors} from './FilepickerSelectors';
 
 export interface FilepickerProps {
     id: string;
 }
 
-export const Filepicker: React.FunctionComponent<FilepickerProps & React.HTMLProps<HTMLInputElement>> = (props) => {
-    const {placeholder, ...inputProps} = props;
-    const [fileName, setFileName] = React.useState(null);
+const mapStateToProps = (state: IReactVaporState, ownProps: FilepickerProps) => ({
+    selectedFile: FilepickerSelectors.getFileMetadata(state, ownProps),
+    isEmpty: FilepickerSelectors.isEmpty(state, ownProps),
+});
+
+const mapDispatchToProps = (dispatch: IDispatch, {id}: FilepickerProps) => ({
+    addFilepicker: () => dispatch(FilepickerActions.add(id)),
+    setFile: (file: FileMetadata) => dispatch(FilepickerActions.setFile(id, file)),
+    clear: () => dispatch(FilepickerActions.clear(id)),
+});
+
+const FilepickerDisconnected: React.FunctionComponent<
+    FilepickerProps &
+        React.HTMLProps<HTMLInputElement> &
+        ReturnType<typeof mapDispatchToProps> &
+        ReturnType<typeof mapStateToProps>
+> = (props) => {
+    const {addFilepicker, setFile, clear, isEmpty, selectedFile, placeholder, ...inputProps} = props;
     const input = React.useRef<HTMLInputElement>();
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setFileName(e.target.files[0]?.name ?? null);
+        setFile(FileUtils.serialize(e.target.files[0]));
     };
 
     const handleClear = (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
         e.preventDefault();
         e.stopPropagation();
-        setFileName(null);
+        setFile(null);
         if (input.current) {
             input.current.value = null;
         }
     };
 
+    React.useEffect(() => {
+        addFilepicker();
+        return clear;
+    }, []);
+
     return (
         <>
             <input ref={input} type="file" {...inputProps} className="filepicker" onChange={handleChange} />
-            <label htmlFor={props.id} className={classNames('btn', {'mod-append': !!fileName})}>
-                {fileName ?? placeholder}
-                {!!fileName && (
+            <label htmlFor={props.id} className={classNames('btn', {'mod-append reset-text-transform': !isEmpty})}>
+                {selectedFile?.name ?? placeholder}
+                {!isEmpty && (
                     <Svg
                         className="btn-append mod-icon"
                         svgName={VaporSVG.svg.clear.name}
@@ -42,3 +68,5 @@ export const Filepicker: React.FunctionComponent<FilepickerProps & React.HTMLPro
         </>
     );
 };
+
+export const Filepicker = connect(mapStateToProps, mapDispatchToProps)(FilepickerDisconnected);

--- a/packages/react-vapor/src/components/filepicker/FilepickerActions.ts
+++ b/packages/react-vapor/src/components/filepicker/FilepickerActions.ts
@@ -1,0 +1,30 @@
+import {IReduxAction} from '../../utils';
+import {FileMetadata} from '../../utils/FileUtils';
+import {FilepickerActionsTypes, FilepickerState} from './FilepickerReducers';
+
+const addFilepicker = (id: string): IReduxAction<{id: keyof FilepickerState}> => ({
+    type: FilepickerActionsTypes.Add,
+    payload: {id},
+});
+
+const setSelectedFile = (
+    id: string,
+    selectedFile: FileMetadata
+): IReduxAction<{id: string; selectedFile: FileMetadata}> => ({
+    type: FilepickerActionsTypes.SetValue,
+    payload: {
+        id,
+        selectedFile,
+    },
+});
+
+const clearFilepicker = (id: string): IReduxAction<{id: keyof FilepickerState}> => ({
+    type: FilepickerActionsTypes.Clear,
+    payload: {id},
+});
+
+export const FilepickerActions = {
+    add: addFilepicker,
+    setFile: setSelectedFile,
+    clear: clearFilepicker,
+};

--- a/packages/react-vapor/src/components/filepicker/FilepickerReducers.ts
+++ b/packages/react-vapor/src/components/filepicker/FilepickerReducers.ts
@@ -1,0 +1,55 @@
+import * as _ from 'underscore';
+
+import {IReduxAction} from '../../utils';
+import {FileMetadata} from '../../utils/FileUtils';
+
+export const FilepickerActionsTypes = {
+    Add: 'ADD_FILE_PICKER',
+    SetValue: 'SET_FILE_PICKER',
+    Clear: 'CLEAR_FILE_PICKER',
+};
+
+export type FilepickerState = Record<string, {id: string; isEmpty: boolean; selectedFile: FileMetadata}>;
+
+const addFilepicker = (state: FilepickerState, action: IReduxAction<{id: string}>): FilepickerState => {
+    if (action?.payload?.id) {
+        return {
+            ...state,
+            [action.payload.id]: {id: action.payload.id, isEmpty: true, selectedFile: null},
+        };
+    }
+    return state;
+};
+
+const setSelectedFile = (
+    state: FilepickerState,
+    action: IReduxAction<{id: string; selectedFile: FileMetadata}>
+): FilepickerState => {
+    if (action?.payload?.id) {
+        return {
+            ...state,
+            [action.payload.id]: {
+                id: action.payload.id,
+                isEmpty: !action.payload.selectedFile,
+                selectedFile: action.payload.selectedFile ?? null,
+            },
+        };
+    }
+    return state;
+};
+
+const clearFilepicker = (state: FilepickerState, action: IReduxAction<{id: string}>): FilepickerState =>
+    state[action?.payload?.id] ? _.omit(state, action.payload.id) : state;
+
+const Reducers = {
+    [FilepickerActionsTypes.Add]: addFilepicker,
+    [FilepickerActionsTypes.SetValue]: setSelectedFile,
+    [FilepickerActionsTypes.Clear]: clearFilepicker,
+};
+
+export const filepickersReducer = (state: FilepickerState = {}, action: IReduxAction<{id: keyof FilepickerState}>) => {
+    if (Reducers[action.type]) {
+        return Reducers[action.type](state, action);
+    }
+    return state;
+};

--- a/packages/react-vapor/src/components/filepicker/FilepickerSelectors.ts
+++ b/packages/react-vapor/src/components/filepicker/FilepickerSelectors.ts
@@ -1,0 +1,27 @@
+import {createSelector} from 'reselect';
+
+import {IReactVaporState} from '../../ReactVapor';
+import {FilepickerState} from './FilepickerReducers';
+
+const getFile = (inputId: string): File => {
+    const input = document.getElementById(inputId) as HTMLInputElement;
+    return input?.files[0];
+};
+
+const getFilePicker = (state: IReactVaporState, {id}: {id: string}) => state.filepickers[id];
+
+const getFileMetadata = createSelector(
+    getFilePicker,
+    (filepicker: FilepickerState[keyof FilepickerState]) => filepicker?.selectedFile
+);
+
+const isEmpty = createSelector(
+    getFilePicker,
+    (filepicker: FilepickerState[keyof FilepickerState]) => filepicker?.isEmpty
+);
+
+export const FilepickerSelectors = {
+    getFile,
+    getFileMetadata,
+    isEmpty,
+};

--- a/packages/react-vapor/src/components/filepicker/FilepikcerSelectors.ts
+++ b/packages/react-vapor/src/components/filepicker/FilepikcerSelectors.ts
@@ -1,8 +1,0 @@
-const getFile = (inputId: string): File => {
-    const input = document.getElementById(inputId) as HTMLInputElement;
-    return input?.files[0];
-};
-
-export const FilepickerSelectors = {
-    getFile,
-};

--- a/packages/react-vapor/src/components/filepicker/index.ts
+++ b/packages/react-vapor/src/components/filepicker/index.ts
@@ -1,2 +1,3 @@
 export * from './Filepicker';
-export * from './FilepikcerSelectors';
+export * from './FilepickerActions';
+export * from './FilepickerSelectors';

--- a/packages/react-vapor/src/components/filepicker/tests/Filepicker.spec.tsx
+++ b/packages/react-vapor/src/components/filepicker/tests/Filepicker.spec.tsx
@@ -1,22 +1,31 @@
-import {shallow} from 'enzyme';
+import {mount} from 'enzyme';
+import {shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
+import {act} from 'react-dom/test-utils';
+import {Provider} from 'react-redux';
 
+import {getStoreMock} from '../../../utils/tests/TestUtils';
+import {Svg} from '../../svg';
 import {Filepicker, FilepickerProps} from '../Filepicker';
+import {FilepickerActions} from '../FilepickerActions';
+import {FilepickerSelectors} from '../FilepickerSelectors';
 
 describe('Filepicker', () => {
     const basicProps: FilepickerProps = {
         id: '🐟',
     };
+    const now = new Date().valueOf();
 
     it('should render and unmount without throwing errors', () => {
         expect(() => {
-            const filepicker = shallow(<Filepicker {...basicProps} />);
+            const filepicker = shallowWithState(<Filepicker {...basicProps} />, {filepickers: {}}).dive();
             filepicker.unmount();
         }).not.toThrow();
     });
 
     it('should render an input of type "file"', () => {
-        const filepicker = shallow(<Filepicker {...basicProps} />)
+        const filepicker = shallowWithState(<Filepicker {...basicProps} />, {filepickers: {}})
+            .dive()
             .children()
             .first();
 
@@ -25,10 +34,91 @@ describe('Filepicker', () => {
     });
 
     it('should render the placeholder in the input label when no file is selected', () => {
-        const inputLabel = shallow(<Filepicker {...basicProps} placeholder="🔥" />)
+        spyOn(FilepickerSelectors, 'isEmpty').and.returnValue(true);
+        const inputLabel = shallowWithState(<Filepicker {...basicProps} placeholder="🔥" />, {filepickers: {}})
+            .dive()
             .children()
             .last();
 
         expect(inputLabel.text()).toBe('🔥');
+    });
+
+    it('should add the filepicker in the state on mount', () => {
+        const store = getStoreMock({filepickers: {}});
+        const addFilepickerSpy = spyOn(FilepickerActions, 'add').and.callThrough();
+        act(() => {
+            mount(
+                <Provider store={store}>
+                    <Filepicker {...basicProps} />
+                </Provider>
+            );
+        });
+
+        expect(addFilepickerSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should remove the filepicker from the state on unmount', () => {
+        const store = getStoreMock({filepickers: {}});
+        const clearFilepickerSpy = spyOn(FilepickerActions, 'clear').and.callThrough();
+        const filepicker = mount(
+            <Provider store={store}>
+                <Filepicker {...basicProps} />
+            </Provider>
+        );
+        filepicker.unmount();
+
+        expect(clearFilepickerSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should set the selected file metadata in the state when it changes in the input', () => {
+        const setFileMetadataSpy = spyOn(FilepickerActions, 'setFile').and.callThrough();
+        const filepicker = shallowWithState(<Filepicker {...basicProps} />, {filepickers: {}})
+            .dive()
+            .children()
+            .first();
+
+        filepicker.prop('onChange')({
+            target: {files: [new File(['content of my file'], 'my file', {type: 'text/plain', lastModified: now})]},
+        });
+
+        expect(setFileMetadataSpy).toHaveBeenCalledTimes(1);
+        expect(setFileMetadataSpy).toHaveBeenCalledWith(basicProps.id, {
+            name: 'my file',
+            type: 'text/plain',
+            size: 18,
+            lastModified: now,
+        });
+    });
+
+    it('should render a clear button when a file is selected', () => {
+        spyOn(FilepickerSelectors, 'isEmpty').and.returnValue(false);
+        const cancelButton = shallowWithState(<Filepicker {...basicProps} />, {filepickers: {}})
+            .dive()
+            .find(Svg);
+
+        expect(cancelButton.exists()).toBe(true);
+    });
+
+    it('should not render a clear button when no file is selected', () => {
+        spyOn(FilepickerSelectors, 'isEmpty').and.returnValue(true);
+        const cancelButton = shallowWithState(<Filepicker {...basicProps} />, {filepickers: {}})
+            .dive()
+            .find(Svg);
+
+        expect(cancelButton.exists()).toBe(false);
+    });
+
+    it('should set the selected file to null in the state when clicking on the clear button', () => {
+        const setFileMetadataSpy = spyOn(FilepickerActions, 'setFile').and.callThrough();
+        spyOn(FilepickerSelectors, 'isEmpty').and.returnValue(false);
+        const cancelButton = shallowWithState(<Filepicker {...basicProps} />, {filepickers: {}})
+            .dive()
+            .find(Svg);
+        cancelButton.prop('onClick')(
+            (new MouseEvent('click') as unknown) as React.MouseEvent<HTMLSpanElement, MouseEvent>
+        );
+
+        expect(setFileMetadataSpy).toHaveBeenCalledTimes(1);
+        expect(setFileMetadataSpy).toHaveBeenCalledWith(basicProps.id, null);
     });
 });

--- a/packages/react-vapor/src/components/filepicker/tests/FilepickerReducers.spec.ts
+++ b/packages/react-vapor/src/components/filepicker/tests/FilepickerReducers.spec.ts
@@ -1,0 +1,136 @@
+import {FileMetadata} from '../../../utils/FileUtils';
+import {FilepickerActions} from '../FilepickerActions';
+import {filepickersReducer, FilepickerState} from '../FilepickerReducers';
+
+describe('FilepickerReducers', () => {
+    it('should return an empty object if the current state is undefined', () => {
+        expect(filepickersReducer(undefined, {type: 'UNKOWN_ACTION'})).toEqual({});
+    });
+
+    it('should return the old state if the action type is unknown by the reducer', () => {
+        const oldState: FilepickerState = {};
+
+        expect(filepickersReducer(oldState, {type: 'UNKOWN_ACTION'})).toBe(oldState);
+    });
+
+    describe('adding a filepicker', () => {
+        it('should return the old state if no id is specified', () => {
+            const oldState: FilepickerState = {};
+
+            expect(filepickersReducer(oldState, FilepickerActions.add(''))).toBe(oldState);
+        });
+
+        it('should add a new entry at the specified id with an empty filepicker state as value', () => {
+            const oldState: FilepickerState = {};
+            const newState = filepickersReducer(oldState, FilepickerActions.add('📜'));
+
+            expect(newState).not.toBe(oldState);
+            expect(newState).toEqual({'📜': {id: '📜', isEmpty: true, selectedFile: null}});
+        });
+
+        it('should not remove other existing entries', () => {
+            const otherFilePicker: FilepickerState[keyof FilepickerState] = {
+                id: 'other-filepicker',
+                isEmpty: true,
+                selectedFile: null,
+            };
+
+            const oldState: FilepickerState = {[otherFilePicker.id]: otherFilePicker};
+            const newState = filepickersReducer(oldState, FilepickerActions.add('📜'));
+
+            expect(newState[otherFilePicker.id]).toBe(otherFilePicker);
+        });
+    });
+
+    describe('selecting a file in a filepicker', () => {
+        it('should return the old state if no id is specified', () => {
+            const oldState: FilepickerState = {};
+
+            expect(filepickersReducer(oldState, FilepickerActions.setFile('', null))).toBe(oldState);
+        });
+
+        it('should set "isEmpty" field to true and the "selectedFile" field to null if the specified file is null', () => {
+            const oldState: FilepickerState = {
+                '📜': {
+                    id: '📜',
+                    isEmpty: false,
+                    selectedFile: {
+                        name: 'whatever.txt',
+                        size: 12,
+                        type: 'text/plain',
+                        lastModified: new Date().valueOf(),
+                    },
+                },
+            };
+
+            expect(filepickersReducer(oldState, FilepickerActions.setFile('📜', null))).toEqual({
+                '📜': {id: '📜', isEmpty: true, selectedFile: null},
+            });
+        });
+
+        it('should set "isEmpty" field to false if the specified file is null', () => {
+            const file: FileMetadata = {
+                name: 'whatever.txt',
+                size: 12,
+                type: 'text/plain',
+                lastModified: new Date().valueOf(),
+            };
+            const oldState: FilepickerState = {
+                '📜': {id: '📜', isEmpty: true, selectedFile: null},
+            };
+
+            expect(filepickersReducer(oldState, FilepickerActions.setFile('📜', file))).toEqual({
+                '📜': {
+                    id: '📜',
+                    isEmpty: false,
+                    selectedFile: file,
+                },
+            });
+        });
+
+        it('should not change the other existing entries', () => {
+            const otherFilePicker: FilepickerState[keyof FilepickerState] = {
+                id: 'other-filepicker',
+                isEmpty: false,
+                selectedFile: {
+                    name: 'whatever.txt',
+                    size: 12,
+                    type: 'text/plain',
+                    lastModified: new Date().valueOf(),
+                },
+            };
+
+            const oldState: FilepickerState = {[otherFilePicker.id]: otherFilePicker};
+            const newState = filepickersReducer(oldState, FilepickerActions.setFile('📜', null));
+
+            expect(newState[otherFilePicker.id]).toBe(otherFilePicker);
+        });
+    });
+
+    describe('removing a filepicker', () => {
+        it('should return the old state if no id is specified', () => {
+            const oldState: FilepickerState = {};
+
+            expect(filepickersReducer(oldState, FilepickerActions.clear(''))).toBe(oldState);
+        });
+
+        it('should return the old state if there is no entry in the state at the specified id', () => {
+            const oldState: FilepickerState = {
+                'other-filepicker': {id: 'other-filepicker', isEmpty: true, selectedFile: null},
+            };
+
+            expect(filepickersReducer(oldState, FilepickerActions.clear('📜'))).toBe(oldState);
+        });
+
+        it('should remove the entry at the specified id', () => {
+            const oldState: FilepickerState = {
+                '📜': {id: '📜', isEmpty: true, selectedFile: null},
+                'other-filepicker': {id: 'other-filepicker', isEmpty: true, selectedFile: null},
+            };
+
+            expect(filepickersReducer(oldState, FilepickerActions.clear('📜'))).toEqual({
+                'other-filepicker': {id: 'other-filepicker', isEmpty: true, selectedFile: null},
+            });
+        });
+    });
+});

--- a/packages/react-vapor/src/components/filepicker/tests/FilepickerSelectors.spec.ts
+++ b/packages/react-vapor/src/components/filepicker/tests/FilepickerSelectors.spec.ts
@@ -1,0 +1,111 @@
+import {IReactVaporState} from '../../../ReactVapor';
+import {FilepickerSelectors} from '../FilepickerSelectors';
+
+describe('FilepickerSelectors', () => {
+    describe('getFile', () => {
+        // This selector cannot be tested, because for security reasons the browser won't allow to select a file programmatically.
+    });
+
+    describe('isEmpty', () => {
+        it('should return undefined if no filepicker match the specified id', () => {
+            expect(FilepickerSelectors.isEmpty({filepickers: {}} as IReactVaporState, {id: '📜'})).toBeUndefined();
+            expect(
+                FilepickerSelectors.isEmpty(
+                    {filepickers: {'🍩': {id: '🍩', isEmpty: true, selectedFile: null}}} as IReactVaporState,
+                    {id: '📜'}
+                )
+            ).toBeUndefined();
+        });
+
+        it('should return true if no file is selected in the filepicker at the specified id', () => {
+            expect(
+                FilepickerSelectors.isEmpty(
+                    {
+                        filepickers: {
+                            '🍩': {id: '🍩', isEmpty: true, selectedFile: null},
+                            '📜': {id: '📜', isEmpty: true, selectedFile: null},
+                        },
+                    } as IReactVaporState,
+                    {id: '📜'}
+                )
+            ).toBe(true);
+        });
+
+        it('should return false if a file is selected in the file picker at the specified id', () => {
+            expect(
+                FilepickerSelectors.isEmpty(
+                    {
+                        filepickers: {
+                            '🍩': {id: '🍩', isEmpty: true, selectedFile: null},
+                            '📜': {
+                                id: '📜',
+                                isEmpty: false,
+                                selectedFile: {
+                                    name: 'whatever',
+                                    size: 12,
+                                    type: 'text/plain',
+                                    lastModified: new Date().valueOf(),
+                                },
+                            },
+                        },
+                    } as IReactVaporState,
+                    {id: '📜'}
+                )
+            ).toBe(false);
+        });
+    });
+
+    describe('getFileMetadata', () => {
+        it('should return undefined if no filepicker match the specified id', () => {
+            expect(
+                FilepickerSelectors.getFileMetadata({filepickers: {}} as IReactVaporState, {id: '📜'})
+            ).toBeUndefined();
+
+            expect(
+                FilepickerSelectors.getFileMetadata(
+                    {filepickers: {'🍩': {id: '🍩', isEmpty: true, selectedFile: null}}} as IReactVaporState,
+                    {id: '📜'}
+                )
+            ).toBeUndefined();
+        });
+
+        it('should return null if there is no file selected in the filepicker at the specified id', () => {
+            expect(
+                FilepickerSelectors.getFileMetadata(
+                    {
+                        filepickers: {
+                            '🍩': {id: '🍩', isEmpty: true, selectedFile: null},
+                            '📜': {id: '📜', isEmpty: true, selectedFile: null},
+                        },
+                    } as IReactVaporState,
+                    {id: '📜'}
+                )
+            ).toBeNull();
+        });
+
+        it('should return the file metadata if a file is selected in the file picker at the specified id', () => {
+            const fileMetaData = {
+                name: 'whatever',
+                size: 12,
+                type: 'text/plain',
+                lastModified: new Date().valueOf(),
+            };
+
+            expect(
+                FilepickerSelectors.getFileMetadata(
+                    {
+                        filepickers: {
+                            '🍩': {id: '🍩', isEmpty: true, selectedFile: null},
+                            '📜': {
+                                id: '📜',
+                                isEmpty: false,
+                                selectedFile: fileMetaData,
+                            },
+                        },
+                    } as IReactVaporState,
+                    {id: '📜'}
+                )
+            ).toEqual(fileMetaData);
+        });
+    });
+});

--- a/packages/react-vapor/src/components/filepicker/tests/Filepickerelectors.spec.ts
+++ b/packages/react-vapor/src/components/filepicker/tests/Filepickerelectors.spec.ts
@@ -1,1 +1,0 @@
-// The filepicker selector cannot be tested, because for security reasons the browser won't allow to select a file programmatically.

--- a/packages/react-vapor/src/utils/FileUtils.spec.ts
+++ b/packages/react-vapor/src/utils/FileUtils.spec.ts
@@ -1,0 +1,28 @@
+import {FileUtils} from './FileUtils';
+
+describe('FileUtils', () => {
+    describe('serialize', () => {
+        const now = new Date().valueOf();
+        const file = new File(['this is a nice file you got there'], '🤓', {type: 'text/plain', lastModified: now});
+
+        it('should return undefined if no file is specified', () => {
+            expect(FileUtils.serialize(null)).toBeUndefined();
+        });
+
+        it('should return an object containing the specified file name', () => {
+            expect(FileUtils.serialize(file)).toEqual(jasmine.objectContaining({name: '🤓'}));
+        });
+
+        it('should return an object containing the specified file type', () => {
+            expect(FileUtils.serialize(file)).toEqual(jasmine.objectContaining({type: 'text/plain'}));
+        });
+
+        it('should return an object containing the specified file size', () => {
+            expect(FileUtils.serialize(file)).toEqual(jasmine.objectContaining({size: 33}));
+        });
+
+        it('should return an object containing the specified file last modified date', () => {
+            expect(FileUtils.serialize(file)).toEqual(jasmine.objectContaining({lastModified: now}));
+        });
+    });
+});

--- a/packages/react-vapor/src/utils/FileUtils.ts
+++ b/packages/react-vapor/src/utils/FileUtils.ts
@@ -1,0 +1,18 @@
+export type FileMetadata = {
+    name: string;
+    type: string;
+    size: number;
+    lastModified: number;
+};
+
+const serialize = (file: File): FileMetadata =>
+    file
+        ? {
+              name: file.name,
+              type: file.type,
+              size: file.size,
+              lastModified: file.lastModified,
+          }
+        : undefined;
+
+export const FileUtils = {serialize};


### PR DESCRIPTION
### Proposed Changes

The filepicker was previously unconnected, meaning there were no information about it in the redux
state. Now it will have information about whether there is a file currently selected or not.

Structure of its state:
```js
{
    ... // react-vapor state
    filepickers: {
        'my-file-picker-id': {. // has a file selected
            id: 'my-file-picker-id',
            isEmpty: false,
            selectedFile: {
                name: 'whatever.txt',
                size: 12,
                type: 'text/plain',
                lastModified: 1600184137067,
            },
        },
        'my-other-file-picker-id': { // has no file selected
            id: 'my-other-file-picker-id',
            isEmpty: true,
            selectedFile: null,
        }
    },
}
```

New selectors:

- `FilepickerSelectors.isEmpty()`
- `FilepickerSelectors.getFileMetadata()`

### Potential Breaking Changes

Filepicker is now a connected component so it must be wrapped inside a store
provider

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
