### PR TITLE
ci(jenkins): prevent builds on version bump

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -64,6 +64,12 @@ pipeline {
           env.PATH = "${nodeHome}/bin:${env.PATH}"
           sh "npm config set //registry.npmjs.org/:_authToken=${env.NPM_TOKEN}"
 
+          // TODO: remove this once DT-3364 is fixed, set parameter `excludeJenkinsCommit=true` in the webhook instead
+          commitMessage = sh(returnStdout: true, script: "git log -1 --pretty=%B").trim()
+          if(commitMessage.contains("[version bump]")) {
+              return
+          }
+
           sh "npm cache clean --force"
           sh "rm -rf node_modules"
           sh "npm run setup"

--- a/lerna.json
+++ b/lerna.json
@@ -1,27 +1,18 @@
 {
     "version": "8.0.10",
-    "packages": [
-        "packages/*"
-    ],
+    "packages": ["packages/*"],
     "command": {
         "publish": {
             "conventionalCommits": true,
-            "allowBranch": [
-                "master"
-            ]
+            "allowBranch": ["master"]
         },
         "version": {
             "conventionalCommits": true,
-            "message": "chore(release): publish %s [skip travis]"
+            "message": "chore(release): [version bump] - %s"
         },
         "bootstrap": {
             "hoist": true,
-            "nohoist": [
-                "unidiff",
-                "query-string",
-                "strict-uri-encode",
-                "split-on-first"
-            ]
+            "nohoist": ["unidiff", "query-string", "strict-uri-encode", "split-on-first"]
         }
     }
 }


### PR DESCRIPTION
### Proposed Changes

Prevent Jenkins from triggering builds when the last commit was a version bump.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
