### PR TITLE
fix(validation): should not display tooltip with skipDirty

### DIFF
--- a/packages/react-vapor/src/components/validation/hoc/WithDirtySaveButtonHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtySaveButtonHOC.tsx
@@ -47,7 +47,7 @@ export const withDirtySaveButtonHOC = <T extends IButtonProps>(Component: React.
         const generatedTooltip =
             (hasErrors && errorMessage(errors.map((error) => error.value))) ||
             (hasWarnings && canSaveWhenDirty && warningMessage(warnings.map((warning) => warning.value))) ||
-            dirtyMessage(dirty.map((d) => d.value));
+            (skipDirty ? '' : dirtyMessage(dirty.map((d) => d.value)));
 
         return (
             <Component

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithDirtySaveButtonHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithDirtySaveButtonHOC.spec.tsx
@@ -195,6 +195,21 @@ describe('WithDirtySaveButtonHOC', () => {
                 expect(tooltip).toEqual(message);
             });
 
+            it('should not change the tooltip to the dirty message formatter if the skipDirty prop is set to true', () => {
+                const message = 'you must change stuff';
+                const buttonWrapper = shallowButton(
+                    {
+                        skipDirty: true,
+                        dirtyMessage: () => message,
+                    },
+                    getStoreMock()
+                );
+
+                const tooltip = buttonWrapper.find(Button).prop('tooltip');
+
+                expect(tooltip).not.toEqual(message);
+            });
+
             it('should not change the tooltip when there is a warning but the component is not dirty', () => {
                 const storeWithOnlyWarning = getStoreMock({
                     validation: {


### PR DESCRIPTION
[COM-575]

### Proposed Changes

The `skipDirty` prop allows bypassing the dirty check for Save Buttons. 

This is useful if you know the initial values can be valid and thus saveable without requiring the user to change any value.

However, the dirty tooltip was still displayed!

This removes the tooltip if `skipDirty` is set to true

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-575]: https://coveord.atlassian.net/browse/COM-575