### PR TITLE
fix(banner): set default padding to 40px

### DIFF
--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -621,7 +621,7 @@ $diff-separator-margin: 10px;
 $color-dot-size: $default-line-height;
 
 // Banners
-$banner-padding: 25px 40px;
+$banner-padding: 40px;
 $full-banner-height: 300px;
 $banner-content-height: 165px;
 $banner-content-padding: 50px;


### PR DESCRIPTION
### Proposed Changes

Set default padding of BannerContainer to `40px`.
![image](https://user-images.githubusercontent.com/52677246/93931177-7bef8e80-fcec-11ea-9eb8-6b06ff1221e5.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
