### PR TITLE
fix(navigationitems): make margin bottom optional

### DIFF
--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationMenuSection.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationMenuSection.tsx
@@ -24,6 +24,7 @@ export interface ISideNavigationSectionProps extends SideNavigationHeaderProps {
     expanded?: boolean;
     isActive?: boolean;
     onClick?: () => void;
+    itemsClassName?: string;
 }
 
 const HeaderIcon: React.FunctionComponent<SideNavigationHeaderProps> = ({svgName, svgClass}) =>
@@ -63,6 +64,7 @@ export const SideNavigationMenuSection: React.FunctionComponent<ISideNavigationS
     children,
     isActive,
     isLink,
+    itemsClassName,
     ...headerProps
 }) => {
     const ref = React.useRef(null);
@@ -86,7 +88,9 @@ export const SideNavigationMenuSection: React.FunctionComponent<ISideNavigationS
         </SideNavigationHeader>
     );
 
-    const items = children ? <div className="navigation-menu-section-items">{children}</div> : null;
+    const items = children ? (
+        <div className={classNames('navigation-menu-section-items', itemsClassName)}>{children}</div>
+    ) : null;
     const sectionLink = isLink ? (
         <div className={sectionClasses} ref={ref}>
             {sectionHeader}

--- a/packages/vapor/scss/components/navigation.scss
+++ b/packages/vapor/scss/components/navigation.scss
@@ -93,8 +93,11 @@
                 }
 
                 .navigation-menu-section-items {
-                    margin-bottom: 1em;
                     overflow-x: auto;
+
+                    &:not(.mb0) {
+                        margin-bottom: 1em;
+                    }
 
                     .navigation-menu-section-item {
                         font-weight: $navigation-menu-item-font-weight;


### PR DESCRIPTION
### Proposed Changes

![image](https://user-images.githubusercontent.com/52677246/94305602-6f16a900-ff3f-11ea-9f1b-de0a99fc1e61.png)
`.navigation-menu-section-items` has a margin bottom, however, we don't always need this.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
