### PR TITLE
fix(svg): update svgmin config to avoid collision in svg ids

### DIFF
--- a/packages/vapor/gulpfile.js
+++ b/packages/vapor/gulpfile.js
@@ -3,6 +3,7 @@
 // --gzip                       Flag to enable gziphication                                         Default: false
 // --all                        Flag to remove all compiled files                                   Default: false
 
+const path = require('path');
 const del = require('del');
 const pngSprite = require('coveo-png-sprite');
 const gulp = require('gulp');
@@ -161,20 +162,29 @@ gulp.task('svg:concat', () => {
 
     return src
         .pipe(
-            svgmin({
-                plugins: [
-                    {
-                        removeAttrs: {
-                            attrs: ['xmlns:*', 'xmlns'],
+            svgmin((file) => {
+                var prefix = path.basename(file.relative, path.extname(file.relative));
+                return {
+                    plugins: [
+                        {
+                            removeAttrs: {
+                                attrs: ['xmlns:*', 'xmlns'],
+                            },
                         },
-                    },
-                    {
-                        removeUselessDefs: true,
-                    },
-                    {
-                        removeComments: true,
-                    },
-                ],
+                        {
+                            removeUselessDefs: true,
+                        },
+                        {
+                            removeComments: true,
+                        },
+                        {
+                            cleanupIDs: {
+                                prefix: prefix + '-',
+                                minify: true,
+                            },
+                        },
+                    ],
+                };
             })
         )
         .pipe(


### PR DESCRIPTION
### Proposed Changes

Added configuration as [listed here](https://www.npmjs.com/package/gulp-svgmin#per-file-options) to make sure all the ids of the definitions are unique

You'll be able to see the effect on the flag icons of the [demo](https://vaporqa.cloud.coveo.com/feature/fix-ADUI-6034-svg-id-collision/index.html#/styles/icons/list) vs [current](https://vapor.cloud.coveo.com/#/styles/icons/list)