### PR TITLE
feat(multivalue): can disabled

### DIFF
--- a/packages/demo/src/components/examples/InputExamples.tsx
+++ b/packages/demo/src/components/examples/InputExamples.tsx
@@ -121,9 +121,19 @@ const InputsConnected: React.FunctionComponent = () => {
                     <InputConnected
                         id="super-input-2"
                         labelTitle="I am the disabled input label."
-                        disabledOnMount={true}
+                        disabledOnMount
                         innerInputClasses="mb2"
                         defaultValue="I am disabled on mount."
+                    />
+                </Section>
+
+                <Section level={3} title="A simple input in state of readOnly.">
+                    <InputConnected
+                        id="super-input-read-only"
+                        labelTitle="I am a readOnly input label."
+                        innerInputClasses="mb2"
+                        defaultValue="I am in readOnly state"
+                        isReadOnly
                     />
                 </Section>
 
@@ -178,6 +188,7 @@ const MultiValuesInputId = 'multivalue-id';
 const mapStateToProps = (state) => ({
     values: MultiValuesInputSelectors.getValues(state, MultiValuesInputId),
 });
+
 const MultilineInputExampleDisconnected: React.FunctionComponent<ReturnType<typeof mapStateToProps>> = ({values}) => {
     const validate = (value: any) => !!value;
     const disabledInputInnerClasses = 'mod-no-border input-wider-text-box disabled-input';
@@ -213,6 +224,14 @@ const MultilineInputExampleDisconnected: React.FunctionComponent<ReturnType<type
                     id="multi-validate"
                     data={['Erase me to see the error']}
                     inputProps={validateInputProps}
+                />
+            </Section>
+            <Section level={3} title="Multi-value inputs disabled">
+                <MultiValuesInput
+                    id="multi-disabled"
+                    data={['First data!', 'second data']}
+                    inputProps={validateInputProps}
+                    disabled
                 />
             </Section>
         </>

--- a/packages/react-vapor/src/components/input/Input.tsx
+++ b/packages/react-vapor/src/components/input/Input.tsx
@@ -32,6 +32,7 @@ export interface IInputAdditionalOwnProps {
     maximum?: number /* @deprecated use max instead */;
     onBlur?: (value: string) => void;
     defaultValue?: string;
+    isReadOnly?: boolean;
 }
 
 export interface IInputNativeTagStateProps {
@@ -79,6 +80,7 @@ export class Input extends React.Component<IInputProps, IInputComponentState> {
         valid: true,
         labelTitle: '',
         required: true,
+        isReadOnly: false,
     };
 
     constructor(props: IInputProps, state: IInputState) {
@@ -182,6 +184,11 @@ export class Input extends React.Component<IInputProps, IInputComponentState> {
             this.props.innerInputClasses
         );
 
+        let additionalProps: {disabled?: boolean} = {};
+        if (this.props.isReadOnly) {
+            additionalProps = {disabled: true};
+        }
+
         const inputElements = [
             <input
                 key={this.props.id}
@@ -195,6 +202,7 @@ export class Input extends React.Component<IInputProps, IInputComponentState> {
                 min={this.props.minimum}
                 max={this.props.maximum}
                 {..._.omit(this.props, [...PropsToOmitUtils.input, ...inputPropsToOmit])}
+                {...additionalProps}
             />,
             this.getLabel(),
             this.props.children,

--- a/packages/react-vapor/src/components/multiValueInputs/MultiValuesInput.tsx
+++ b/packages/react-vapor/src/components/multiValueInputs/MultiValuesInput.tsx
@@ -36,6 +36,7 @@ export interface MultiValuesInputProps {
     disabledTooltipTitle?: string;
     disabledInputInnerClasses?: IClassName;
     disabledInputClasses?: IClassName;
+    disabled?: boolean;
 }
 
 export const MultiValuesInput: React.FunctionComponent<MultiValuesInputProps> = ({
@@ -47,6 +48,7 @@ export const MultiValuesInput: React.FunctionComponent<MultiValuesInputProps> = 
     disabledTooltipTitle,
     disabledInputInnerClasses,
     disabledInputClasses,
+    disabled,
 }) => (
     <MultilineBoxWithRemoveButton
         id={id}
@@ -63,6 +65,11 @@ export const MultiValuesInput: React.FunctionComponent<MultiValuesInputProps> = 
                 const classes = isInputLimitReached
                     ? classNames(inputProps?.classes, disabledInputClasses)
                     : inputProps?.classes;
+
+                if (cData.isLast && disabled) {
+                    return null;
+                }
+
                 return (
                     <InputConnected
                         key={cData.id}
@@ -76,6 +83,7 @@ export const MultiValuesInput: React.FunctionComponent<MultiValuesInputProps> = 
                                 parentProps.addNewBox();
                             }
                         }}
+                        isReadOnly={disabled || isInputLimitReached}
                         onBlur={(value: string) => {
                             inputProps?.onBlur?.(value);
                             if (value === '' && !cData.isLast) {
@@ -83,7 +91,6 @@ export const MultiValuesInput: React.FunctionComponent<MultiValuesInputProps> = 
                             }
                         }}
                         placeholder={isInputLimitReached ? reachedPlaceholder : inputProps?.placeholder}
-                        disabled={isInputLimitReached}
                         classes={classes}
                         innerInputClasses={innerInputClasses}
                         disabledTooltip={isTooltipRequired && disabledTooltipTitle ? disabledTooltipTitle : ''}
@@ -94,5 +101,6 @@ export const MultiValuesInput: React.FunctionComponent<MultiValuesInputProps> = 
             })
         }
         defaultProps=""
+        disabled={disabled}
     />
 );

--- a/packages/react-vapor/src/components/multiValueInputs/tests/MultiValuesInput.spec.tsx
+++ b/packages/react-vapor/src/components/multiValueInputs/tests/MultiValuesInput.spec.tsx
@@ -68,7 +68,7 @@ describe('MultiValuesInput', () => {
         );
         const lastInputConnectedProps = body.find(InputConnected).last().props();
 
-        expect(lastInputConnectedProps.disabled).toBe(true);
+        expect(lastInputConnectedProps.isReadOnly).toBe(true);
     });
 
     it('should display all data, even if the data length are above the dataLimit', () => {
@@ -98,7 +98,7 @@ describe('MultiValuesInput', () => {
         );
         const lastInputConnectedProps = body.find(InputConnected).last().props();
 
-        expect(lastInputConnectedProps.disabled).toBe(true);
+        expect(lastInputConnectedProps.isReadOnly).toBe(true);
     });
 
     it('should include the disabledInputInnerClasses if the inputs indexes are below the dataLimit', () => {
@@ -208,7 +208,7 @@ describe('MultiValuesInput', () => {
         );
         const oneInputConnectedBeforelastProps = body.find(InputConnected).first().props();
 
-        expect(oneInputConnectedBeforelastProps.disabled).toBe(false);
+        expect(oneInputConnectedBeforelastProps.isReadOnly).toBe(false);
     });
 
     it("should include a Tooltip if set to all data in which it's index are above the dataLimit", () => {

--- a/packages/react-vapor/src/components/multilineBox/MultilineBox.tsx
+++ b/packages/react-vapor/src/components/multilineBox/MultilineBox.tsx
@@ -37,6 +37,7 @@ export interface IMultilineBoxOwnProps<T = any> {
         boxProps: IMultilineSingleBoxProps<T>,
         parentProps: IMultilineParentProps
     ) => React.ReactNode;
+    disabled?: boolean;
 }
 
 export interface IMultilineBoxStateProps {

--- a/packages/react-vapor/src/components/multilineBox/hoc/MultilineBoxWithRemoveButton.tsx
+++ b/packages/react-vapor/src/components/multilineBox/hoc/MultilineBoxWithRemoveButton.tsx
@@ -1,9 +1,10 @@
 import classNames from 'classnames';
 import * as VaporSVG from 'coveo-styleguide';
 import * as React from 'react';
+import {connect} from 'react-redux';
 import {removeValueStringList} from '../../../reusableState/customList/StringListActions';
 import {ConfigSupplier, HocUtils} from '../../../utils/HocUtils';
-import {IDispatch, ReduxConnect} from '../../../utils/ReduxUtils';
+import {IDispatch} from '../../../utils/ReduxUtils';
 import {Button, IButtonProps} from '../../button/Button';
 import {Svg} from '../../svg/Svg';
 import {
@@ -46,15 +47,13 @@ export const defaultMultilineBoxRemoveButtonClasses: string = 'center-align mod-
 export const multilineBoxWithRemoveButton = (
     supplier: ConfigSupplier<IMultilineBoxWithRemoveButtonSupplierProps> = {containerNode: defaultContainerNode}
 ) => (Component: MultilineBoxWithRemoveButtonComponent): MultilineBoxWithRemoveButtonComponent => {
-    const mapDispatchToProps = (
-        dispatch: IDispatch,
-        ownProps: IMultilineBoxOwnProps
-    ): Partial<IMultilineBoxDispatchProps> => ({
+    const mapDispatchToProps = (dispatch: IDispatch, ownProps: IMultilineBoxOwnProps) => ({
         removeBox: (id: string) => dispatch(removeValueStringList(ownProps.id, id)),
     });
 
-    @ReduxConnect(null, mapDispatchToProps)
-    class MultilineBoxWithRemoveButton<T> extends React.PureComponent<IMultilineBoxWithRemoveButtonProps<T>> {
+    class MultilineBoxWithRemoveButton<T> extends React.PureComponent<
+        IMultilineBoxWithRemoveButtonProps<T> & ReturnType<typeof mapDispatchToProps>
+    > {
         static defaultProps = {
             renderBody: () => <div />,
         };
@@ -73,8 +72,8 @@ export const multilineBoxWithRemoveButton = (
                     style={{
                         visibility: !data.isLast ? 'visible' : 'hidden',
                     }}
-                    onClick={() => !data.isLast && this.props.removeBox(data.id)}
-                    enabled={!data.isLast}
+                    onClick={() => !data.isLast && !this.props.disabled && this.props.removeBox(data.id)}
+                    enabled={!this.props.disabled}
                     {...props}
                 >
                     <Svg
@@ -113,5 +112,5 @@ export const multilineBoxWithRemoveButton = (
         }
     }
 
-    return MultilineBoxWithRemoveButton;
+    return connect(undefined, mapDispatchToProps)(MultilineBoxWithRemoveButton);
 };


### PR DESCRIPTION
update input to handle readOnly to avoid confusion with the disabled from the state
Update multiValueInputs to use disabled as a props
Update MultilineBoxWithRemoveButton to use the disabled as a props
add input and multiValue examples

** Uts next PR

### Proposed Changes

Add "disabled" as a props for the MultiValuesInput.
The first problem was with the Input. we dont have any way to use the ownProps to set the component in disabled. We use the state to do that. I added a new props readOnly to avoid problem with the disabled from the state. I tried to use disabled in both case but it's to dangerous to get weird behaviour in the futur so I created the readOnly to set the component on render ou later in disabled state with his own props.

### Potential Breaking Changes

No breaking changes. The new props are optional and can modify the component only if we set the props manualy.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
