### PR TITLE
feat(validation-message): clean state on unmout

### DIFF
--- a/packages/demo/src/components/examples/SingleSelectExamples.tsx
+++ b/packages/demo/src/components/examples/SingleSelectExamples.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {connect} from 'react-redux';
 import {
+    Button,
     FilterBoxSelectors,
     IFlatSelectOptionProps,
     IItemBoxProps,
@@ -8,14 +9,17 @@ import {
     ISingleSelectOwnProps,
     Section,
     selectWithFilter,
-    selectWithInfiniteScroll,
     SelectWithInfiniteScrollProps,
+    selectWithInfiniteScroll,
     SingleSelectConnected,
     SingleSelectWithFilter,
     SingleSelectWithPredicate,
     SingleSelectWithPredicateAndFilter,
     UUID,
     withServerSideProcessing,
+    withValidationMessage,
+    ValidationActions,
+    IDispatch,
 } from 'react-vapor';
 import * as _ from 'underscore';
 
@@ -58,6 +62,7 @@ const ids = [
     UUID.generate(),
     UUID.generate(),
     UUID.generate(),
+    UUID.generate(),
 ];
 
 const defaultFlatSelectOptions: IFlatSelectOptionProps[] = [
@@ -65,6 +70,8 @@ const defaultFlatSelectOptions: IFlatSelectOptionProps[] = [
     {id: UUID.generate(), option: {content: 'even'}},
     {id: UUID.generate(), option: {content: 'odd'}},
 ];
+
+const SingleSelectConnectedWithValidation = _.compose(withValidationMessage)(SingleSelectConnected);
 
 const matchPredicate = (predicate: string, item: IItemBoxProps) => {
     const value = parseInt(item.value, 10);
@@ -142,6 +149,9 @@ const SingleSelectConnectedExamples: React.ComponentType = () => (
                 options={defaultFlatSelectOptions}
             />
         </Section>
+        <Section level={3} title="A single select with an error message to show with a button">
+            <SingleSelectWithMessageExample />
+        </Section>
     </Section>
 );
 
@@ -159,6 +169,15 @@ const PER_PAGE = 10;
 const mapStateToProps = (state: IReactVaporExampleState, props: {id: string}) => ({
     filterValue: FilterBoxSelectors.getFilterText(state, props),
 });
+
+const SingleSelectWithMessageExample = connect(undefined, (dispatch: IDispatch) => ({
+    showMessage: () => dispatch(ValidationActions.setError(ids[8], 'error message!')),
+}))(({showMessage}: {showMessage: () => void}) => (
+    <>
+        <SingleSelectConnectedWithValidation id={ids[8]} items={defaultItems} placeholder="Select something" />
+        <Button name="Show message" classes="mt1" onClick={() => showMessage()} />
+    </>
+));
 
 const ServerSideSingleSelectExampleDisconnected: React.FunctionComponent<
     {id: string} & ReturnType<typeof mapStateToProps>

--- a/packages/react-vapor/src/components/validation/ValidationActions.ts
+++ b/packages/react-vapor/src/components/validation/ValidationActions.ts
@@ -4,6 +4,7 @@ export const ValidationActionsTypes = {
     updateError: 'UPDATE_VALIDATION_ERROR',
     updateWarning: 'UPDATE_VALIDATION_WARNING',
     updateDirty: 'UPDATE_VALIDATION_DIRTY',
+    cleanMessage: 'CLEAN_MESSAGE',
 };
 
 export const ValidationActions = {
@@ -37,4 +38,10 @@ export const ValidationActions = {
     }),
     clearDirty: (id: string, validationType: string = ValidationTypes.default) =>
         ValidationActions.setDirty(id, null, validationType),
+    cleanMessage: (id: string) => ({
+        type: ValidationActionsTypes.cleanMessage,
+        payload: {
+            id,
+        },
+    }),
 };

--- a/packages/react-vapor/src/components/validation/ValidationReducer.ts
+++ b/packages/react-vapor/src/components/validation/ValidationReducer.ts
@@ -2,10 +2,15 @@ import * as _ from 'underscore';
 import {ValidationActions, ValidationActionsTypes} from './ValidationActions';
 import {ValidationsState, ValidationState} from './ValidationState';
 
-type ValidationActions =
-    | ReturnType<typeof ValidationActions.setError>
-    | ReturnType<typeof ValidationActions.setWarning>
-    | ReturnType<typeof ValidationActions.setDirty>;
+type ValidationActions = {
+    type: string;
+    payload: {
+        id: string;
+        error?: string;
+        validationType?: string;
+        value?: any;
+    };
+};
 
 export const validationReducer = (state: ValidationsState = {}, action: ValidationActions): ValidationsState => {
     switch (action.type) {
@@ -15,6 +20,10 @@ export const validationReducer = (state: ValidationsState = {}, action: Validati
             return {
                 ...state,
                 [action.payload.id]: oneValidationReducer(state[action.payload.id], action),
+            };
+        case ValidationActionsTypes.cleanMessage:
+            return {
+                ..._.omit(state, action.payload.id),
             };
         default:
             return state;

--- a/packages/react-vapor/src/components/validation/components/ValidationMessage.tsx
+++ b/packages/react-vapor/src/components/validation/components/ValidationMessage.tsx
@@ -2,6 +2,8 @@ import classNames from 'classnames';
 import * as React from 'react';
 import {connect} from 'react-redux';
 import {IReactVaporState} from '../../../ReactVapor';
+import {IDispatch} from '../../../utils';
+import {ValidationActions} from '../ValidationActions';
 import {ValidationSelectors} from '../ValidationSelectors';
 
 export interface IValidationMessageProps {
@@ -13,14 +15,20 @@ const mapStateToProps = (state: IReactVaporState, ownProps: IValidationMessagePr
     warnings: ValidationSelectors.getWarnings(ownProps.id)(state),
 });
 
+const mapDispatchToProps = (dispatch: IDispatch, ownProps: IValidationMessageProps) => ({
+    cleanMessage: () => dispatch(ValidationActions.cleanMessage(ownProps.id)),
+});
+
 export const ValidationMessageClasses = {
     error: 'text-red',
     warning: 'text-yellow',
 };
 
 export const ValidationMessageDisconnect: React.FunctionComponent<
-    IValidationMessageProps & ReturnType<typeof mapStateToProps>
-> = ({errors, warnings}) => {
+    IValidationMessageProps & ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>
+> = ({errors, warnings, cleanMessage}) => {
+    React.useEffect(() => () => cleanMessage(), []);
+
     const hasErrors = errors.length > 0;
     const hasWarnings = warnings.length > 0;
     const eitherErrorsOrWarnings = hasErrors ? errors : warnings;
@@ -42,4 +50,4 @@ export const ValidationMessageDisconnect: React.FunctionComponent<
     );
 };
 
-export const ValidationMessage = connect(mapStateToProps)(ValidationMessageDisconnect);
+export const ValidationMessage = connect(mapStateToProps, mapDispatchToProps)(ValidationMessageDisconnect);

--- a/packages/react-vapor/src/components/validation/components/tests/ValidationMessage.spec.tsx
+++ b/packages/react-vapor/src/components/validation/components/tests/ValidationMessage.spec.tsx
@@ -1,5 +1,7 @@
-import {shallowWithState} from 'enzyme-redux';
+import {mountWithStore, shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
+import {getStoreMock} from '../../../../utils/tests/TestUtils';
+import {ValidationActions} from '../../ValidationActions';
 import {ValidationState} from '../../ValidationState';
 import {IValidationMessageProps, ValidationMessage, ValidationMessageClasses} from '../ValidationMessage';
 
@@ -27,6 +29,13 @@ describe('ValidationMessage', () => {
         const result = shallowWithState(<ValidationMessage {...defaultProps} />, {}).dive();
 
         expect(result.text()).toBe('');
+    });
+
+    it('should call the action cleanMessage on unmount to remove the message from the state', () => {
+        const store = getStoreMock({});
+        mountWithStore(<ValidationMessage {...defaultProps} />, store).unmount();
+
+        expect(store.getActions()).toContain(ValidationActions.cleanMessage(defaultProps.id));
     });
 
     it('should render nothing if the store does not contain errors for the given ID', () => {

--- a/packages/react-vapor/src/components/validation/tests/ValidationReducer.spec.ts
+++ b/packages/react-vapor/src/components/validation/tests/ValidationReducer.spec.ts
@@ -1,5 +1,6 @@
-import {ValidationActionsTypes} from '../ValidationActions';
+import {ValidationActions, ValidationActionsTypes} from '../ValidationActions';
 import {validationReducer} from '../ValidationReducer';
+import {ValidationTypes} from '../ValidationTypes';
 
 describe('ValidationReducer', () => {
     const componentId = '🐟';
@@ -246,6 +247,24 @@ describe('ValidationReducer', () => {
                 validationType: nonEmptyValidationType,
                 value: true,
             });
+        });
+    });
+
+    describe('clean', () => {
+        it('should remove the id from the state on cleanMessage', () => {
+            const id = '1';
+            const newState = validationReducer(
+                {
+                    [id]: {
+                        isDirty: [],
+                        error: [{validationType: ValidationTypes.default, value: 'error message'}],
+                        warning: [],
+                    },
+                },
+                ValidationActions.cleanMessage(id)
+            );
+
+            expect(newState[id]).toBeUndefined();
         });
     });
 });


### PR DESCRIPTION
add an action to clean all the state for a specific validationMessage
Add example to see when we remove the message from the state
Add uts

### Proposed Changes

Clean ValidationMessage from the state when we unmount the component

How to test: 
1. Open SingleSelect section
![image](https://user-images.githubusercontent.com/7167202/96309566-8f340800-0fd3-11eb-8c95-9e869d9512ec.png)
2. click on the button to show the error message
3. use the side navigation to change for an other example
4. comeback in SingleSelect and you shouldn't see the message.



### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
