### PR TITLE
feat(listbox): remove active

### DIFF
--- a/packages/demo/src/components/examples/ButtonExamples.tsx
+++ b/packages/demo/src/components/examples/ButtonExamples.tsx
@@ -163,7 +163,7 @@ export class ButtonExamples extends React.Component<any, any> {
                                     primary: true,
                                 }}
                             >
-                                <ListBox items={[{value: 'option 1'}, {value: 'option 2'}]} />
+                                <ListBox items={[{value: 'option 1'}, {value: 'option 2'}]} noActive />
                             </MenuConnected>
                         </div>
                     </Section>
@@ -188,6 +188,7 @@ export class ButtonExamples extends React.Component<any, any> {
                                         {value: 'option 2'},
                                         {value: 'option with very long value 3'},
                                     ]}
+                                    noActive
                                 />
                             </MenuConnected>
                         </div>

--- a/packages/react-vapor/src/components/listBox/ListBox.tsx
+++ b/packages/react-vapor/src/components/listBox/ListBox.tsx
@@ -17,6 +17,7 @@ export interface IListBoxOwnProps {
     wrapItems?: (items: React.ReactNode) => React.ReactNode;
     footer?: React.ReactNode;
     isLoading?: boolean;
+    noActive?: boolean;
 }
 
 export interface IListBoxStateProps {
@@ -38,6 +39,7 @@ export class ListBox extends React.Component<IListBoxProps> {
             value: 'No Items',
         },
         wrapItems: _.identity,
+        noActive: false,
     };
 
     componentDidMount() {
@@ -75,13 +77,14 @@ export class ListBox extends React.Component<IListBoxProps> {
 
                     itemWithIndex.index = realIndex;
                     itemWithIndex.active = active;
+
                     realIndex++;
                 }
                 return itemWithIndex;
             })
             .map((itemWithIndex: IItemBoxPropsWithIndex) => {
                 if (!itemWithIndex.disabled && activeSet === false) {
-                    itemWithIndex.active = true;
+                    itemWithIndex.active = !this.props.noActive;
                     activeSet = true;
                 }
                 return itemWithIndex;

--- a/packages/react-vapor/src/components/listBox/tests/ListBox.spec.tsx
+++ b/packages/react-vapor/src/components/listBox/tests/ListBox.spec.tsx
@@ -163,5 +163,16 @@ describe('ListBox', () => {
                 expect(item.type()).toBe(ItemBoxLoading);
             });
         });
+
+        it('should render without active on any item if noActive is set as a prop', (done) => {
+            renderListBox({
+                noActive: true,
+            });
+
+            listBoxComponent.find(ItemBox).forEach((itemBox) => {
+                expect(itemBox.prop('active')).toBe(false);
+            });
+            done();
+        });
     });
 });


### PR DESCRIPTION
Add a prop to remove the state active for the list rendered by the ListBox component

For the MenuConnected, we use the ListBox to show the list of item when the menu open.
Before, we had the first item active but the active state make no sens for a menu because we dont have a item selected like the dropdown.

before:
![image](https://user-images.githubusercontent.com/7167202/96312204-20f24400-0fd9-11eb-8c19-784116b8b79d.png)

after: 
![image](https://user-images.githubusercontent.com/7167202/96312176-13d55500-0fd9-11eb-9bdf-bb4ac14ccce7.png)

On hover, we continue to see the grey background.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
