### PR TITLE
tableWithPrepend HOC

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableWithPrepend.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithPrepend.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+
+import {IReactVaporState} from '../../ReactVapor';
+import {ITableHOCOwnProps} from './TableHOC';
+import {TableSelectors} from './TableSelectors';
+
+export interface TableWithPrependProps {
+    prepend?: React.ReactNode;
+}
+
+export const tableWithPrepend = <P extends ITableHOCOwnProps & React.HTMLAttributes<HTMLTableElement>>(
+    Component: React.ComponentClass<P>
+) => {
+    const mapStateToProps = (state: IReactVaporState, ownProps: P & TableWithPrependProps) => ({
+        isTruelyEmpty: TableSelectors.getIsTruelyEmpty(state, ownProps),
+    });
+
+    const TableWithPrepend: React.FunctionComponent<
+        ITableHOCOwnProps &
+            React.HTMLAttributes<HTMLTableElement> &
+            TableWithPrependProps &
+            ReturnType<typeof mapStateToProps>
+    > = (props) => {
+        const {prepend, isTruelyEmpty, ...tableProps} = props;
+        return (
+            <>
+                {!isTruelyEmpty ? prepend : null}
+                <Component {...(tableProps as P)} />
+            </>
+        );
+    };
+
+    return connect(mapStateToProps)(TableWithPrepend);
+};

--- a/packages/react-vapor/src/components/table-hoc/index.ts
+++ b/packages/react-vapor/src/components/table-hoc/index.ts
@@ -17,3 +17,4 @@ export * from './TableWithUrlState';
 export * from './actions';
 export * from './reducers';
 export * from './TableRowHeader';
+export * from './TableWithPrepend';

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithPrepend.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithPrepend.spec.tsx
@@ -1,0 +1,46 @@
+import {shallowWithState} from 'enzyme-redux';
+import * as React from 'react';
+
+import {TableHOC} from '../TableHOC';
+import {TableSelectors} from '../TableSelectors';
+import {tableWithPrepend} from '../TableWithPrepend';
+
+describe('TableWithPrepend', () => {
+    const TableWithPrepend = tableWithPrepend(TableHOC);
+
+    const basicProps = {
+        id: 'table-id',
+        renderBody: (): null => null,
+    };
+
+    it('should render and unmount without throwing errors', () => {
+        expect(() => {
+            const wrapper = shallowWithState(<TableWithPrepend {...basicProps} data={[]} />, {}).dive();
+            wrapper.unmount();
+        }).not.toThrow();
+    });
+
+    it('should not render prepended content if the table is truely empty', () => {
+        spyOn(TableSelectors, 'getIsTruelyEmpty').and.returnValue(true);
+        const Prepend = () => <span>ink!</span>;
+        const wrapper = shallowWithState(
+            <TableWithPrepend {...basicProps} data={[]} prepend={<Prepend />} />,
+            {}
+        ).dive();
+
+        expect(wrapper.children().first().type()).not.toBe(Prepend);
+        expect(wrapper.children().first().type()).toBe(TableHOC);
+    });
+
+    it('should render prepended content if the table is not truely empty', () => {
+        spyOn(TableSelectors, 'getIsTruelyEmpty').and.returnValue(false);
+        const Prepend = () => <span>ink!</span>;
+        const wrapper = shallowWithState(
+            <TableWithPrepend {...basicProps} data={[]} prepend={<Prepend />} />,
+            {}
+        ).dive();
+
+        expect(wrapper.children().first().type()).not.toBe(TableHOC);
+        expect(wrapper.children().first().type()).toBe(Prepend);
+    });
+});


### PR DESCRIPTION
### Proposed Changes

Sometimes we need something to be displayed above the table only if there is data in the table. For example, if we want to display an info box that gives explanation about the columns. This is what the new `tableWithPrepend` HOC is for.

#### Usage

```tsx
const TableWithPrepend = tableWithPrepend(TableHOC);

const SomePanel = () => (
    <TableWithPrepend
        // standard table props here (id, data, renderBody, etc.)
        prepend={
            // Will only be rendered if there is data
            <InfoBox>Some information about the current component.</InfoBox>
        }
    />
);
```

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
