### PR TITLE
Adui 6097 multifacet is so pale that it s looking disabled

### DIFF
--- a/packages/demo/src/components/examples/MultiSelectExamples.tsx
+++ b/packages/demo/src/components/examples/MultiSelectExamples.tsx
@@ -146,7 +146,6 @@ export class MultiSelectExamples extends React.Component<null, IMultiSelectExamp
                         placeholder="Select something"
                         deselectAllTooltipText="Remove all"
                         sortable
-                        readOnly
                     />
                 </div>
                 <div className="form-group">
@@ -156,6 +155,13 @@ export class MultiSelectExamples extends React.Component<null, IMultiSelectExamp
                 </div>
                 <div className="form-group">
                     <label className="form-control-label">A Multi Select With Filter and Custom Values</label>
+                    <br />
+                    <MultiSelectWithFilter id={UUID.generate()} items={this.state.hoc} customValues />
+                </div>
+                <div className="form-group">
+                    <label className="form-control-label">
+                        A Multi Select With Filter and Custom Values in readonly
+                    </label>
                     <br />
                     <MultiSelectWithFilter id={UUID.generate()} items={this.state.hoc} customValues readOnly />
                 </div>

--- a/packages/demo/src/components/examples/MultiSelectExamples.tsx
+++ b/packages/demo/src/components/examples/MultiSelectExamples.tsx
@@ -13,9 +13,9 @@ import {
     ValidationMessage,
     withInitialValuesMultiSelectHOC,
     withNonEmptyMultiSelectHOC,
-    Tooltip,
 } from 'react-vapor';
 import * as _ from 'underscore';
+
 import {TooltipPlacement} from '../../../../react-vapor/src/utils/TooltipUtils';
 
 const defaultItems: IItemBoxProps[] = [
@@ -99,6 +99,7 @@ export class MultiSelectExamples extends React.Component<null, IMultiSelectExamp
             _.extend({}, item, {append: {content: () => <span className="text-medium-grey ml1">{item.value}</span>}})
         );
         hoc[0].selected = true;
+        hoc[1].selected = true;
 
         this.state = {
             first: _.clone(defaultItems),
@@ -141,10 +142,11 @@ export class MultiSelectExamples extends React.Component<null, IMultiSelectExamp
                     <br />
                     <MultiSelectConnected
                         id={UUID.generate()}
-                        items={this.state.first}
+                        items={this.state.hoc}
                         placeholder="Select something"
                         deselectAllTooltipText="Remove all"
                         sortable
+                        readOnly
                     />
                 </div>
                 <div className="form-group">
@@ -155,7 +157,7 @@ export class MultiSelectExamples extends React.Component<null, IMultiSelectExamp
                 <div className="form-group">
                     <label className="form-control-label">A Multi Select With Filter and Custom Values</label>
                     <br />
-                    <MultiSelectWithFilter id={UUID.generate()} items={this.state.hoc} customValues />
+                    <MultiSelectWithFilter id={UUID.generate()} items={this.state.hoc} customValues readOnly />
                 </div>
                 <div className="form-group">
                     <label className="form-control-label">A Multi Select With Filter, Custom Values and no items</label>

--- a/packages/demo/src/components/examples/MultiSelectExamples.tsx
+++ b/packages/demo/src/components/examples/MultiSelectExamples.tsx
@@ -160,6 +160,13 @@ export class MultiSelectExamples extends React.Component<null, IMultiSelectExamp
                 </div>
                 <div className="form-group">
                     <label className="form-control-label">
+                        A Multi Select With Filter and without selected values in readonly
+                    </label>
+                    <br />
+                    <MultiSelectWithFilter id={UUID.generate()} items={[]} customValues readOnly />
+                </div>
+                <div className="form-group">
+                    <label className="form-control-label">
                         A Multi Select With Filter and Custom Values in readonly
                     </label>
                     <br />

--- a/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/DraggableSelectedOption.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/DraggableSelectedOption.tsx
@@ -3,9 +3,9 @@ import {DragSource, DropTarget, IDragSource, IDropTarget} from 'react-dnd';
 import {findDOMNode} from 'react-dom';
 import {keys} from 'ts-transformer-keys';
 import * as _ from 'underscore';
-import {ITooltipProps} from '../../tooltip/Tooltip';
 
 import {Svg} from '../../svg/Svg';
+import {ITooltipProps} from '../../tooltip/Tooltip';
 import {ISelectedOptionProps, SelectedOption} from './SelectedOption';
 
 export interface IDraggableSelectedOptionOwnProps {
@@ -97,6 +97,7 @@ export class DraggableSelectedOption extends React.PureComponent<IDraggableSelec
                         {..._.omit(this.props, DraggableSelectedOptionPropsToOmit)}
                         label={this.props.isDragging ? null : this.props.label}
                         selectedTooltip={this.props.selectedTooltip}
+                        readOnly={this.props.readOnly}
                     >
                         <div className="inline-flex">
                             {this.props.connectDragSource(

--- a/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/DraggableSelectedOption.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/DraggableSelectedOption.tsx
@@ -100,11 +100,12 @@ export class DraggableSelectedOption extends React.PureComponent<IDraggableSelec
                         readOnly={this.props.readOnly}
                     >
                         <div className="inline-flex">
-                            {this.props.connectDragSource(
-                                <div className="move-option infline-flex cursor-move align-center">
-                                    <Svg svgName="drag-drop" svgClass="icon mod-small" />
-                                </div>
-                            )}
+                            {!this.props.readOnly &&
+                                this.props.connectDragSource(
+                                    <div className="move-option infline-flex cursor-move align-center">
+                                        <Svg svgName="drag-drop" svgClass="icon mod-small" />
+                                    </div>
+                                )}
                             {this.props.label}
                         </div>
                     </SelectedOption>

--- a/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/SelectedOption.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/SelectedOption.tsx
@@ -1,14 +1,16 @@
+import classNames from 'classnames';
 import * as React from 'react';
 
 import {TooltipPlacement} from '../../../utils/TooltipUtils';
 import {Svg} from '../../svg/Svg';
-import {Tooltip, ITooltipProps} from '../../tooltip/Tooltip';
+import {ITooltipProps, Tooltip} from '../../tooltip/Tooltip';
 
 export interface ISelectedOptionProps {
     value: string;
     label: React.ReactNode;
     selectedTooltip: ITooltipProps;
     onRemoveClick?: (value: string) => void;
+    readOnly?: boolean;
 }
 
 export class SelectedOption extends React.PureComponent<ISelectedOptionProps> {
@@ -28,14 +30,16 @@ export class SelectedOption extends React.PureComponent<ISelectedOptionProps> {
                     {...this.props.selectedTooltip}
                     title={tooltipCustomLabel ?? tooltipLabel}
                     placement={tooltipPosition ?? TooltipPlacement.Top}
-                    className="selected-option-value"
+                    className={classNames('selected-option-value', {readOnly: this.props.readOnly})}
                 >
                     {tooltipContent}
                 </Tooltip>
 
-                <div className="remove-option" onClick={this.handleOnRemove}>
-                    <Svg svgName="clear" svgClass="icon fill-medium-blue mod-small" />
-                </div>
+                {!this.props.readOnly && (
+                    <div className="remove-option" onClick={this.handleOnRemove}>
+                        <Svg svgName="clear" svgClass="icon fill-medium-blue mod-small" />
+                    </div>
+                )}
             </div>
         );
     }

--- a/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/tests/DraggableSelectedOption.spec.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/MultiSelectDropdownSearch/tests/DraggableSelectedOption.spec.tsx
@@ -2,8 +2,9 @@ import {mount, ReactWrapper} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
 
-import {Tooltip} from '../../../tooltip/Tooltip';
 import {TestUtils} from '../../../../utils/tests/TestUtils';
+import {Svg} from '../../../svg';
+import {Tooltip} from '../../../tooltip/Tooltip';
 import {DraggableSelectedOption, IDraggableSelectedOptionProps} from '../DraggableSelectedOption';
 
 describe('DraggableSelectedOption', () => {
@@ -71,6 +72,18 @@ describe('DraggableSelectedOption', () => {
             mountOption({label: 'helloworld', selectedTooltip: {title: customValue, placement: 'bottom'}});
 
             expect(selectedOption.find(Tooltip).prop('placement')).toBe('bottom');
+        });
+
+        it('should render the draggable icon and X icon if readOnly is false', () => {
+            mountOption();
+
+            expect(selectedOption.find(Svg).length).toBe(2);
+        });
+
+        it('should not render the draggable icon if readOnly is true', () => {
+            mountOption({readOnly: true});
+
+            expect(selectedOption.find(Svg).length).toBe(0);
         });
 
         it('should change the opacity when the element is dragged', () => {

--- a/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/MultiSelectConnected.tsx
@@ -26,6 +26,7 @@ export interface IMultiSelectOwnProps extends Omit<ISelectOwnProps, 'button'>, I
     sortable?: boolean;
     noDisabled?: boolean;
     multiSelectStyle?: React.CSSProperties;
+    readOnly?: boolean;
 }
 
 export interface IMultiSelectProps
@@ -100,6 +101,7 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps> {
                 value={item.value}
                 key={item.value}
                 onRemoveClick={() => this.props.onRemoveClick(item)}
+                readOnly={this.props.readOnly}
             >
                 {displayValue}
             </SelectedOption>
@@ -108,7 +110,12 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps> {
 
     private renderDraggableOption(item: IItemBoxProps, index: number): JSX.Element {
         return (
-            <div className="flex flex-row flex-center sortable-selected-option" key={item.value}>
+            <div
+                className={classNames('flex flex-row flex-center sortable-selected-option', {
+                    readOnly: this.props.readOnly,
+                })}
+                key={item.value}
+            >
                 <span className="mr1 text-medium-grey">{index + 1}</span>
                 <DraggableSelectedOption
                     label={item.selectedDisplayValue ?? item.displayValue ?? item.value}
@@ -117,6 +124,7 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps> {
                     onRemoveClick={() => this.props.onRemoveClick(item)}
                     index={index}
                     move={(dragIndex: number, hoverIndex: number) => this.move(dragIndex, hoverIndex)}
+                    readOnly={this.props.readOnly}
                 />
             </div>
         );
@@ -136,7 +144,7 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps> {
     }
 
     private getRemoveAllSelectedOptionsButton(): JSX.Element {
-        return this.getSelectedOptions().length > 1 ? (
+        return this.getSelectedOptions().length > 1 && !this.props.readOnly ? (
             <Tooltip title={this.props.deselectAllTooltipText} placement="top" noSpanWrapper>
                 <div className="remove-all-selected-options ml1" onClick={() => this.props.onRemoveAll()}>
                     <Svg svgName="clear" svgClass="icon fill-medium-blue" />
@@ -146,7 +154,9 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps> {
     }
 
     private Toggle = ({onClick, onKeyDown, onKeyUp}: ISelectButtonProps): JSX.Element => {
-        const classes = classNames('multiselect-input', {'mod-sortable': this.props.sortable});
+        const classes = classNames('multiselect-input', {
+            'mod-sortable': this.props.sortable,
+        });
         const buttonAttrs =
             !this.props.noDisabled && this.props.selected && this.props.selected.length === this.props.items.length
                 ? {disabled: true}
@@ -159,21 +169,29 @@ class MultiSelect extends React.PureComponent<IMultiSelectProps> {
             <div className={classes} style={this.props.multiSelectStyle}>
                 {this.props.connectDropTarget(
                     <div className="multiselect-selected flex flex-center flex-auto full-content">
-                        <div className="selected-options-container truncate">{this.getSelectedOptionComponents()}</div>
+                        <div
+                            className={classNames('selected-options-container truncate', {
+                                readOnly: this.props.readOnly,
+                            })}
+                        >
+                            {this.getSelectedOptionComponents()}
+                        </div>
                         {this.getRemoveAllSelectedOptionsButton()}
                     </div>
                 )}
-                <button
-                    className={buttonClasses}
-                    type="button"
-                    onKeyDown={onKeyDown}
-                    onKeyUp={onKeyUp}
-                    onClick={onClick}
-                    {...buttonAttrs}
-                >
-                    <span className="dropdown-no-value">{this.props.placeholder}</span>
-                    <span className="dropdown-toggle-arrow" />
-                </button>
+                {!this.props.readOnly && (
+                    <button
+                        className={buttonClasses}
+                        type="button"
+                        onKeyDown={onKeyDown}
+                        onKeyUp={onKeyUp}
+                        onClick={onClick}
+                        {...buttonAttrs}
+                    >
+                        <span className="dropdown-no-value">{this.props.placeholder}</span>
+                        <span className="dropdown-toggle-arrow" />
+                    </button>
+                )}
             </div>
         );
     };

--- a/packages/react-vapor/src/components/select/tests/MultiSelectConnected.spec.tsx
+++ b/packages/react-vapor/src/components/select/tests/MultiSelectConnected.spec.tsx
@@ -3,13 +3,13 @@ import * as React from 'react';
 import {Provider} from 'react-redux';
 import {Store} from 'redux';
 import * as _ from 'underscore';
-import {Tooltip} from '../../tooltip/Tooltip';
 
 import {IReactVaporState} from '../../../ReactVapor';
 import {clearState} from '../../../utils/ReduxUtils';
 import {TestUtils} from '../../../utils/tests/TestUtils';
 import {SelectedOption} from '../../dropdownSearch/MultiSelectDropdownSearch/SelectedOption';
 import {IItemBoxProps} from '../../itemBox/ItemBox';
+import {Tooltip} from '../../tooltip/Tooltip';
 import {IMultiSelectProps, MultiSelectConnected} from '../MultiSelectConnected';
 import {ISelectOwnProps, SelectConnected} from '../SelectConnected';
 import {SelectSelector} from '../SelectSelector';
@@ -212,6 +212,43 @@ describe('Select', () => {
             state = _.findWhere(store.getState().listBoxes, {id});
 
             expect(state.selected).toEqual([]);
+        });
+
+        it('should not render a X icon when readOnly is true', () => {
+            const firstSelected = 'dis 1';
+            const secondSelected = 'dis two';
+
+            mountMultiSelect(
+                [{value: 'a'}, {value: firstSelected, selected: true}, {value: secondSelected, selected: true}],
+                {readOnly: true}
+            );
+
+            expect(multiSelect.find(SelectedOption).at(0).find('.remove-option').length).toBe(0);
+            expect(multiSelect.find(SelectedOption).at(1).find('.remove-option').length).toBe(0);
+        });
+
+        it('should not render a X icon that remove all selected options when readOnly is true', () => {
+            const firstSelected = 'dis 1';
+            const secondSelected = 'dis two';
+
+            mountMultiSelect(
+                [{value: 'a'}, {value: firstSelected, selected: true}, {value: secondSelected, selected: true}],
+                {readOnly: true}
+            );
+
+            expect(multiSelect.find('.remove-all-selected-options').length).toBe(0);
+        });
+
+        it('should not render the dropdown if readOnly is true', () => {
+            mountMultiSelect(
+                [
+                    {value: 'a', selected: true},
+                    {value: 'b', selected: true},
+                ],
+                {readOnly: true}
+            );
+
+            expect(multiSelect.find('.multiselect-add').length).toBe(0);
         });
     });
 });

--- a/packages/vapor/scss/components/multiselect-input.scss
+++ b/packages/vapor/scss/components/multiselect-input.scss
@@ -36,6 +36,7 @@
     }
     &.readOnly {
         .selected-option,
+        .multiselect-empty,
         .sortable-selected-option:last-child {
             margin-bottom: 0;
         }

--- a/packages/vapor/scss/components/multiselect-input.scss
+++ b/packages/vapor/scss/components/multiselect-input.scss
@@ -34,6 +34,12 @@
     .sortable-selected-option {
         margin: 0 $dropdown-multiselect-margin $dropdown-multiselect-margin 0;
     }
+    &.readOnly {
+        .selected-option,
+        .sortable-selected-option:last-child {
+            margin-bottom: 0;
+        }
+    }
 }
 
 .multiselect-input.mod-sortable .selected-options-container {

--- a/packages/vapor/scss/components/selected-option.scss
+++ b/packages/vapor/scss/components/selected-option.scss
@@ -31,6 +31,9 @@
     text-overflow: ellipsis;
 
     @extend .selected-option-item;
+    &.readOnly {
+        margin-right: $dropdown-multiselect-items-margin;
+    }
 }
 
 .move-option {


### PR DESCRIPTION
### Proposed Changes

We will let the disabled component as it is, but we made some upgrade on it. We now make a distinction between a multiselect disabled and in readonly. I've added an example to the multiselectexamples file and added UTs for draggable component and selectedoption component

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
