### PR TITLE
fix(tablehoc): set the showBorderBottom to true by default

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
@@ -41,7 +41,7 @@ export class TableHOC extends React.PureComponent<ITableHOCProps & React.HTMLAtt
         hasActionButtons: false,
         actions: [],
         showBorderTop: false,
-        showBorderBottom: false,
+        showBorderBottom: true,
         loading: {
             isCard: false,
             numberOfColumns: 5,

--- a/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
@@ -90,10 +90,10 @@ describe('TableHOC', () => {
             expect(wrapper.find(ActionBarConnected).prop('extraContainerClasses')).toContain('mod-border-top');
         });
 
-        it('should render an ActionBarConnected with a top border if the "showBorderBottom" is set to true', () => {
-            const wrapper = shallow(<TableHOC {...defaultProps} hasActionButtons showBorderBottom />);
+        it('should render an ActionBarConnected without a top border if the "showBorderBottom" is set to false', () => {
+            const wrapper = shallow(<TableHOC {...defaultProps} hasActionButtons showBorderBottom={false} />);
 
-            expect(wrapper.find(ActionBarConnected).prop('extraContainerClasses')).toContain('mod-border-bottom');
+            expect(wrapper.find(ActionBarConnected).prop('extraContainerClasses')).not.toContain('mod-border-bottom');
         });
 
         it('should render an ActionBarConnected if the table prop hasActionButtons is false but the table have some actions', () => {

--- a/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
@@ -90,6 +90,12 @@ describe('TableHOC', () => {
             expect(wrapper.find(ActionBarConnected).prop('extraContainerClasses')).toContain('mod-border-top');
         });
 
+        it('should render an ActionBarConnected with a top border if the "showBorderBottom" is set to true (default)', () => {
+            const wrapper = shallow(<TableHOC {...defaultProps} hasActionButtons />);
+
+            expect(wrapper.find(ActionBarConnected).prop('extraContainerClasses')).toContain('mod-border-bottom');
+        });
+
         it('should render an ActionBarConnected without a top border if the "showBorderBottom" is set to false', () => {
             const wrapper = shallow(<TableHOC {...defaultProps} hasActionButtons showBorderBottom={false} />);
 


### PR DESCRIPTION
### Proposed Changes

By doing this, the missing border bottom of the table-actions-container will be fixed

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
