### PR TITLE
fix(action row): if disabled no double click

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableRowConnected.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableRowConnected.tsx
@@ -5,6 +5,7 @@ import * as _ from 'underscore';
 
 import {SlideY} from '../../animations/SlideY';
 import {IReactVaporState} from '../../ReactVapor';
+import {UrlUtils} from '../../utils';
 import {EventUtils} from '../../utils/EventUtils';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
 import {IActionOptions} from '../actions/Action';
@@ -197,11 +198,12 @@ class TableRowConnected extends React.PureComponent<
     private handleDoubleClick = () => {
         _.chain(this.props.actions)
             .filter((action: IActionOptions) => action.callOnDoubleClick)
+            .filter((action: IActionOptions) => action.enabled)
             .forEach((action: IActionOptions) => {
                 if (action.link) {
-                    window.location.href = action.link;
-                } else if (action.trigger) {
-                    action.trigger();
+                    UrlUtils.redirectToUrl(action.link);
+                } else {
+                    action.trigger?.();
                 }
             });
     };

--- a/packages/react-vapor/src/components/table-hoc/tests/TableRowConnected.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableRowConnected.spec.tsx
@@ -2,6 +2,7 @@ import {ShallowWrapper} from 'enzyme';
 import {mountWithStore, shallowWithStore} from 'enzyme-redux';
 import * as React from 'react';
 
+import {UrlUtils} from '../../../utils';
 import {getStoreMock, ReactVaporMockStore} from '../../../utils/tests/TestUtils';
 import {addActionsToActionBar} from '../../actions/ActionBarActions';
 import {CollapsibleToggle} from '../../collapsible/CollapsibleToggle';
@@ -203,20 +204,67 @@ describe('Table HOC', () => {
             expect(store.getActions()).toContain(expectedActionWithoutMulti);
         });
 
-        it('should dispatch trigger actions with callOnDoubleClick=true when double clicking the row', () => {
-            const triggerActionSpy = jasmine.createSpy('triggerAction');
+        describe('double click', () => {
+            it('should dispatch trigger actions with callOnDoubleClick=true when double clicking the row', () => {
+                const triggerActionSpy = jasmine.createSpy('triggerAction');
 
-            const wrapper = shallowWithStore(
-                <TableRowConnected
-                    {...defaultProps}
-                    actions={[{enabled: true, name: 'action', callOnDoubleClick: true, trigger: triggerActionSpy}]}
-                />,
-                store
-            ).dive();
+                const wrapper = shallowWithStore(
+                    <TableRowConnected
+                        {...defaultProps}
+                        actions={[{enabled: true, name: 'action', callOnDoubleClick: true, trigger: triggerActionSpy}]}
+                    />,
+                    store
+                ).dive();
 
-            wrapper.find('tr').simulate('doubleclick');
+                wrapper.find('tr').simulate('doubleclick');
 
-            expect(triggerActionSpy).toHaveBeenCalledTimes(1);
+                expect(triggerActionSpy).toHaveBeenCalledTimes(1);
+            });
+
+            it('should navigate to the link if a link is defined instead of the trigger', () => {
+                const triggerActionSpy = jasmine.createSpy('triggerAction');
+                const redirectionSpy = spyOn(UrlUtils, 'redirectToUrl');
+                const wrapper = shallowWithStore(
+                    <TableRowConnected
+                        {...defaultProps}
+                        actions={[
+                            {
+                                enabled: true,
+                                name: 'action',
+                                callOnDoubleClick: true,
+                                trigger: triggerActionSpy,
+                                link: 'http://perdu.com/',
+                            },
+                        ]}
+                    />,
+                    store
+                ).dive();
+                wrapper.find('tr').simulate('doubleclick');
+
+                expect(triggerActionSpy).not.toHaveBeenCalled();
+                expect(redirectionSpy).toHaveBeenCalledWith('http://perdu.com/');
+            });
+
+            it('should not be triggered in any way when the action is not enabled', () => {
+                const triggerActionSpy = jasmine.createSpy('triggerAction');
+                const wrapper = shallowWithStore(
+                    <TableRowConnected
+                        {...defaultProps}
+                        actions={[
+                            {
+                                enabled: false,
+                                name: 'action',
+                                callOnDoubleClick: true,
+                                trigger: triggerActionSpy,
+                            },
+                        ]}
+                    />,
+                    store
+                ).dive();
+                wrapper.find('tr').simulate('doubleclick');
+
+                expect(triggerActionSpy).not.toHaveBeenCalled();
+            });
         });
 
         describe('when the row is collapsible', () => {

--- a/packages/react-vapor/src/utils/UrlUtils.ts
+++ b/packages/react-vapor/src/utils/UrlUtils.ts
@@ -20,7 +20,12 @@ const toQueryString = (obj: Record<string, unknown>): string => QueryString.stri
 
 const getSearchParams = (): {[key: string]: any} => UrlUtils.toObject(UrlUtils.getQuery());
 
+const redirectToUrl = (link: string) => {
+    window.location.href = link;
+};
+
 export const UrlUtils = {
+    redirectToUrl,
     getQuery,
     getSearchParams,
     getPathName,


### PR DESCRIPTION
### Proposed Changes

The row call on double click should not be triggered if the row is disabled.

### Potential Breaking Changes

The American gouvernement administration change. Although probably not.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
