### PR TITLE
fix(table-with-blankslate): check for table is loading

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableWithBlankSlate.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithBlankSlate.tsx
@@ -37,7 +37,7 @@ export const tableWithBlankSlate = (supplier: ConfigSupplier<IBlankSlateWithTabl
 
         const blankSlateToRender = renderBlankSlate || defaultRenderBlankSlateMethod;
 
-        if (isEmpty && renderBlankSlateOnly) {
+        if (isEmpty && renderBlankSlateOnly && !props.isLoading) {
             return blankSlateToRender;
         }
 

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithBlankslate.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithBlankslate.spec.tsx
@@ -120,5 +120,15 @@ describe('TableWithBlankSlate', () => {
 
             expect(wrapper.type()).toBe(TableHOC);
         });
+
+        it('does not render the blank slate in the table body when the table is loading', () => {
+            spyOn(TableSelectors, 'getIsTruelyEmpty').and.returnValue(false);
+            const wrapper = shallowWithState(
+                <TableWithBlankSlate {...basicProps} renderBlankSlateOnly isLoading />,
+                {}
+            ).dive();
+
+            expect(wrapper.type()).toBe(TableHOC);
+        });
     });
 });


### PR DESCRIPTION
The tableWithBlankSlate shouldn't render its blankslate if the table is loading.

### Proposed Changes

Before
https://screencast-o-matic.com/watch/cYXeDvs9B7
After
![Search Pages - Administration Console - Coveo Cloud Platform (1)](https://user-images.githubusercontent.com/35579930/98565775-00d23f80-227c-11eb-8815-20c337fa338a.gif)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
