### PR TITLE
fix(tablewithdatepicker): prevent from throwing errors with null dates

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableWithDatePicker.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithDatePicker.tsx
@@ -76,8 +76,8 @@ export const tableWithDatePicker = (supplier: ConfigSupplier<ITableWithDatePicke
 
         componentDidUpdate(prevProps: ITableWithDatePickerProps) {
             if (
-                prevProps.lowerLimit.valueOf() !== this.props.lowerLimit.valueOf() ||
-                prevProps.upperLimit.valueOf() !== this.props.upperLimit.valueOf()
+                prevProps.lowerLimit?.valueOf() !== this.props.lowerLimit?.valueOf() ||
+                prevProps.upperLimit?.valueOf() !== this.props.upperLimit?.valueOf()
             ) {
                 this.props.onUpdate?.();
             }

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithDatePicker.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithDatePicker.spec.tsx
@@ -37,6 +37,13 @@ describe('Table HOC', () => {
             expect(wrapper.find(TableHOC).exists()).toBe(true);
         });
 
+        it('renders without throwing errors when no dates are initially selected and the table updates', () => {
+            expect(() => {
+                const table = shallowWithState(<TableWithDatePicker {...defaultProps} />, {}).dive();
+                table.setProps({}); // triggering an update
+            }).not.toThrow();
+        });
+
         it('should not filter the rows if no function is sent in the config', () => {
             const wrapper = shallowWithState(
                 <TableWithDatePicker {...defaultProps} />,


### PR DESCRIPTION
### Proposed Changes

The TableWithDatePicker HOC would throw on update when no `initialDateRange` is provided. Since this option is optional in the HOC config it shouldn't.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
