### PR TITLE
feat(validation): allow checkbox dirty tracking

### DIFF
--- a/packages/demo/src/components/examples/CheckboxExamples.tsx
+++ b/packages/demo/src/components/examples/CheckboxExamples.tsx
@@ -8,6 +8,8 @@ import {
     LabeledInput,
     Section,
     toggleDisabledAllGroupedCheckbox,
+    withDirtyCheckboxHOC,
+    withDirtySaveButtonHOC,
 } from 'react-vapor';
 
 import {Store} from '../../Store';
@@ -22,7 +24,11 @@ export const CheckboxExamples: ExampleComponent = () => (
 
 CheckboxExamples.description = 'Checkboxes allow users to select multiple options from a set.';
 
+const SaveButton = withDirtySaveButtonHOC(Button);
+
 // start-print
+
+const CheckboxWithDirty = withDirtyCheckboxHOC(CheckboxConnected);
 
 const Checkboxset: React.FunctionComponent = () => {
     const [checked, setChecked] = React.useState(false);
@@ -43,9 +49,22 @@ const Checkboxset: React.FunctionComponent = () => {
                     <CheckboxConnected id="checkbox4" indeterminate={true} clearSides>
                         <Label>A force checked and indeterminate (partially selected) checkbox</Label>
                     </CheckboxConnected>
-                    <Checkbox id="checkbox5" checked={checked} onClick={() => setChecked(!checked)}>
+                    <Checkbox id="checkbox5" checked={checked} onClick={() => setChecked(!checked)} clearSides>
                         <Label>A checkbox with local state</Label>
                     </Checkbox>
+                </LabeledInput>
+                <LabeledInput label="The checkbox set with dirty management">
+                    <CheckboxWithDirty id="checkbox-dirty" clearSides>
+                        <Label>A checkbox with a validation dirty state</Label>
+                    </CheckboxWithDirty>
+                    <CheckboxWithDirty id="checkbox-dirty-true" defaultChecked={true}>
+                        <Label>A checkbox with a validation dirty state that starts with a default value</Label>
+                    </CheckboxWithDirty>
+                    <SaveButton
+                        enabled
+                        validationIds={['checkbox-dirty', 'checkbox-dirty-true']}
+                        name="An example button bound to the checkboxes"
+                    />
                 </LabeledInput>
             </Section>
             <Section level={2}>

--- a/packages/react-vapor/src/components/validation/hoc/WithDirtyCheckboxHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtyCheckboxHOC.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+
+import {IDispatch} from '../../../utils/ReduxUtils';
+import {ICheckboxOwnProps} from '../../checkbox/Checkbox';
+import {IInputOwnProps} from '../../input/Input';
+import {ValidationActions} from '../ValidationActions';
+import {ValidationTypes} from '../ValidationTypes';
+import {InferableComponentEnhancer} from './connectHOC';
+
+export interface IWithDirtyCheckboxOwnProps {
+    resetDirtyOnUnmount?: boolean;
+}
+
+const mapDispatchToProps = (dispatch: IDispatch) => ({
+    setIsDirty: (id: string, isDirty: boolean) =>
+        dispatch(ValidationActions.setDirty(id, isDirty, ValidationTypes.wrongInitialValue)),
+    clearIsDirty: (id: string) => dispatch(ValidationActions.clearDirty(id, ValidationTypes.wrongInitialValue)),
+});
+
+export const withDirtyCheckboxHOC = <T extends ICheckboxOwnProps & IInputOwnProps>(
+    Component: React.ComponentType<T>
+) => {
+    type DispatchProps = ReturnType<typeof mapDispatchToProps>;
+    const WrappedCheckbox: React.FunctionComponent<T & IWithDirtyCheckboxOwnProps & DispatchProps> = ({
+        setIsDirty,
+        clearIsDirty,
+        handleOnClick,
+        resetDirtyOnUnmount,
+        ...props
+    }) => {
+        React.useEffect(
+            () => () => {
+                resetDirtyOnUnmount && clearIsDirty(props.id);
+            },
+            []
+        );
+
+        return (
+            <Component
+                {...(props as T)}
+                handleOnClick={(wasChecked: boolean) => {
+                    const isNowChecked = !wasChecked;
+                    setIsDirty(props.id, isNowChecked !== !!props.defaultChecked);
+                    handleOnClick?.(wasChecked);
+                }}
+            />
+        );
+    };
+
+    const enhance = connect(null, mapDispatchToProps) as InferableComponentEnhancer<DispatchProps>;
+    return enhance(WrappedCheckbox);
+};

--- a/packages/react-vapor/src/components/validation/hoc/index.ts
+++ b/packages/react-vapor/src/components/validation/hoc/index.ts
@@ -1,3 +1,4 @@
+export * from './WithDirtyCheckboxHOC';
 export * from './WithDirtyInputHOC';
 export * from './WithDirtyMultiSelectHOC';
 export * from './WithDirtySaveButtonHOC';

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithDirtyCheckboxHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithDirtyCheckboxHOC.spec.tsx
@@ -1,0 +1,108 @@
+import {ShallowWrapper} from 'enzyme';
+import {shallowWithStore} from 'enzyme-redux';
+import * as React from 'react';
+import * as _ from 'underscore';
+import {getStoreMock} from '../../../../utils/tests/TestUtils';
+import {ICheckboxOwnProps} from '../../../checkbox/Checkbox';
+import {CheckboxConnected} from '../../../checkbox/CheckboxConnected';
+import {IInputOwnProps} from '../../../input';
+import {ValidationActions} from '../../ValidationActions';
+import {ValidationTypes} from '../../ValidationTypes';
+import {withDirtyCheckboxHOC} from '../WithDirtyCheckboxHOC';
+
+describe('WithDirtyCheckboxHOC', () => {
+    const CheckboxWithHOC = withDirtyCheckboxHOC(CheckboxConnected);
+
+    let store: ReturnType<typeof getStoreMock>;
+    let checkboxWrapper: ShallowWrapper<ICheckboxOwnProps & IInputOwnProps>;
+
+    const CHECKBOX_PROPS: ICheckboxOwnProps & IInputOwnProps = {
+        id: '🥔',
+        title: 'ok',
+    };
+
+    const triggerUncheck = () => checkboxWrapper.prop('handleOnClick')(true);
+    const triggerCheck = () => checkboxWrapper.prop('handleOnClick')(false);
+
+    beforeEach(() => {
+        store = getStoreMock({
+            validation: {},
+        });
+    });
+
+    afterEach(() => {
+        store.clearActions();
+    });
+
+    describe('<CheckboxWithHOC />', () => {
+        it('should render without error', () => {
+            expect(() => shallowWithStore(<CheckboxWithHOC {...CHECKBOX_PROPS} />, store)).not.toThrow();
+        });
+
+        it('should mount and unmount/detach without error', () => {
+            expect(() => {
+                checkboxWrapper = shallowWithStore(<CheckboxWithHOC {...CHECKBOX_PROPS} />, store);
+                checkboxWrapper.unmount();
+            }).not.toThrow();
+        });
+
+        describe('after mount', () => {
+            let handleOnClickSpy: jasmine.Spy;
+
+            const shallowCheckbox = (props?: Partial<ICheckboxOwnProps & IInputOwnProps>) =>
+                shallowWithStore<typeof CheckboxWithHOC>(
+                    <CheckboxWithHOC {...CHECKBOX_PROPS} {...props} handleOnClick={handleOnClickSpy} />,
+                    store
+                ).dive();
+
+            beforeEach(() => {
+                handleOnClickSpy = jasmine.createSpy('handleOnClick');
+                checkboxWrapper = shallowCheckbox();
+            });
+
+            it('should dispatch a set dirty action with true when the value is different from the initial value (undefined, evaluated as false)', () => {
+                triggerCheck();
+
+                expect(store.getActions()).toContain(
+                    ValidationActions.setDirty(CHECKBOX_PROPS.id, true, ValidationTypes.wrongInitialValue)
+                );
+            });
+
+            it('should dispatch a set dirty action with false when the value is the same as the initial value (undefined, evaluated as false)', () => {
+                triggerUncheck();
+
+                expect(store.getActions()).toContain(
+                    ValidationActions.setDirty(CHECKBOX_PROPS.id, false, ValidationTypes.wrongInitialValue)
+                );
+            });
+
+            it('should dispatch a set dirty action with true when the value is different from the initial value (true)', () => {
+                checkboxWrapper = shallowCheckbox({
+                    defaultChecked: true,
+                });
+                triggerUncheck();
+
+                expect(store.getActions()).toContain(
+                    ValidationActions.setDirty(CHECKBOX_PROPS.id, true, ValidationTypes.wrongInitialValue)
+                );
+            });
+
+            it('should dispatch a set dirty action with false when the value is the same as the initial value (true)', () => {
+                checkboxWrapper = shallowCheckbox({
+                    defaultChecked: true,
+                });
+                triggerCheck();
+
+                expect(store.getActions()).toContain(
+                    ValidationActions.setDirty(CHECKBOX_PROPS.id, false, ValidationTypes.wrongInitialValue)
+                );
+            });
+
+            it('should call the original handleOnClick function', () => {
+                triggerUncheck();
+
+                expect(handleOnClickSpy).toHaveBeenCalledWith(true);
+            });
+        });
+    });
+});


### PR DESCRIPTION
[COM-700]

### Proposed Changes

We already have a couple of `withDirty` implementation, but now we needed it for the Checkbox.

Here it is!

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-700]: https://coveord.atlassian.net/browse/COM-700