### PR TITLE
Fix childform disabled issues

### DIFF
--- a/packages/demo/src/components/examples/InputExamples.tsx
+++ b/packages/demo/src/components/examples/InputExamples.tsx
@@ -22,6 +22,10 @@ import {
     SplitMultilineInput,
     ValidationSelectors,
     withDirtyInputHOC,
+    RadioSelectConnected,
+    Radio,
+    SlideY,
+    ChildForm,
 } from 'react-vapor';
 import {createStructuredSelector} from 'reselect';
 import * as _ from 'underscore';
@@ -203,36 +207,33 @@ const MultilineInputExampleDisconnected: React.FunctionComponent<ReturnType<type
     };
     return (
         <>
-            <Section level={3} title="Multi-value inputs">
-                <MultiValuesInput id={MultiValuesInputId} data={['hello', 'world']} />
-                <p className="small transparency-2">Values in the state: {JSON.stringify(values, null, 2)}</p>
-            </Section>
-            <Section level={3} title="Multi-value inputs with a data limit">
-                <MultiValuesInput
-                    id="multi-data"
-                    data={['enabled', 'disabled']}
-                    dataLimit={1}
-                    inputProps={limitInputProps}
-                    reachedLimitPlaceholder={"this is a placeholder when you've reached the limit"}
-                    disabledTooltipTitle="this input can't edited"
-                    disabledInputInnerClasses={disabledInputInnerClasses}
-                    disabledInputClasses={disabledInputClasse}
-                />
-            </Section>
-            <Section level={3} title="Multi-value inputs with a validation">
-                <MultiValuesInput
-                    id="multi-validate"
-                    data={['Erase me to see the error']}
-                    inputProps={validateInputProps}
-                />
-            </Section>
-            <Section level={3} title="Multi-value inputs disabled">
-                <MultiValuesInput
-                    id="multi-disabled"
-                    data={['First data!', 'second data']}
-                    inputProps={validateInputProps}
-                    disabled
-                />
+            <Section level={3} title="Multi-value inputs disabled with a Radio">
+                <RadioSelectConnected id="radio-test-1" valueOnMount={'a'} disabled>
+                    <Radio value="a" key="radio-1">
+                        <Label>Choice 1</Label>
+                        <p
+                            className="mod-align-with-radio-label text-lynch my1"
+                            dangerouslySetInnerHTML={{__html: 'allo'}}
+                        />
+                    </Radio>
+                    <SlideY in>
+                        <ChildForm className="mb1">
+                            <MultiValuesInput
+                                id="multi-disabled-2"
+                                data={['Im first!', 'last one!']}
+                                inputProps={validateInputProps}
+                                disabled
+                            />
+                        </ChildForm>
+                    </SlideY>
+                    <Radio value="b" key="radio-2">
+                        <Label>Choice 1</Label>
+                        <p
+                            className="mod-align-with-radio-label text-lynch my1"
+                            dangerouslySetInnerHTML={{__html: 'allo'}}
+                        />
+                    </Radio>
+                </RadioSelectConnected>
             </Section>
         </>
     );

--- a/packages/demo/src/components/examples/InputExamples.tsx
+++ b/packages/demo/src/components/examples/InputExamples.tsx
@@ -22,10 +22,6 @@ import {
     SplitMultilineInput,
     ValidationSelectors,
     withDirtyInputHOC,
-    RadioSelectConnected,
-    Radio,
-    SlideY,
-    ChildForm,
 } from 'react-vapor';
 import {createStructuredSelector} from 'reselect';
 import * as _ from 'underscore';
@@ -207,33 +203,36 @@ const MultilineInputExampleDisconnected: React.FunctionComponent<ReturnType<type
     };
     return (
         <>
-            <Section level={3} title="Multi-value inputs disabled with a Radio">
-                <RadioSelectConnected id="radio-test-1" valueOnMount={'a'} disabled>
-                    <Radio value="a" key="radio-1">
-                        <Label>Choice 1</Label>
-                        <p
-                            className="mod-align-with-radio-label text-lynch my1"
-                            dangerouslySetInnerHTML={{__html: 'allo'}}
-                        />
-                    </Radio>
-                    <SlideY in>
-                        <ChildForm className="mb1">
-                            <MultiValuesInput
-                                id="multi-disabled-2"
-                                data={['Im first!', 'last one!']}
-                                inputProps={validateInputProps}
-                                disabled
-                            />
-                        </ChildForm>
-                    </SlideY>
-                    <Radio value="b" key="radio-2">
-                        <Label>Choice 1</Label>
-                        <p
-                            className="mod-align-with-radio-label text-lynch my1"
-                            dangerouslySetInnerHTML={{__html: 'allo'}}
-                        />
-                    </Radio>
-                </RadioSelectConnected>
+            <Section level={3} title="Multi-value inputs">
+                <MultiValuesInput id={MultiValuesInputId} data={['hello', 'world']} />
+                <p className="small transparency-2">Values in the state: {JSON.stringify(values, null, 2)}</p>
+            </Section>
+            <Section level={3} title="Multi-value inputs with a data limit">
+                <MultiValuesInput
+                    id="multi-data"
+                    data={['enabled', 'disabled']}
+                    dataLimit={1}
+                    inputProps={limitInputProps}
+                    reachedLimitPlaceholder={"this is a placeholder when you've reached the limit"}
+                    disabledTooltipTitle="this input can't edited"
+                    disabledInputInnerClasses={disabledInputInnerClasses}
+                    disabledInputClasses={disabledInputClasse}
+                />
+            </Section>
+            <Section level={3} title="Multi-value inputs with a validation">
+                <MultiValuesInput
+                    id="multi-validate"
+                    data={['Erase me to see the error']}
+                    inputProps={validateInputProps}
+                />
+            </Section>
+            <Section level={3} title="Multi-value inputs disabled">
+                <MultiValuesInput
+                    id="multi-disabled"
+                    data={['First data!', 'second data']}
+                    inputProps={validateInputProps}
+                    disabled
+                />
             </Section>
         </>
     );

--- a/packages/react-vapor/src/components/childForm/ChildForm.tsx
+++ b/packages/react-vapor/src/components/childForm/ChildForm.tsx
@@ -1,27 +1,11 @@
 import classNames from 'classnames';
 import * as React from 'react';
-import * as _ from 'underscore';
-import {ValidComponentChildren} from '../../utils/ValidComponentChildren';
 
 export interface IChildFormProps extends React.HTMLAttributes<HTMLDivElement> {
+    className?: string;
     disabled?: boolean;
 }
 
-export class ChildForm extends React.Component<IChildFormProps> {
-    render() {
-        const children = ValidComponentChildren.map(
-            this.props.children,
-            (child: React.ReactElement<any>) =>
-                React.cloneElement(child, {
-                    disabled: !!this.props.disabled,
-                }),
-            null
-        );
-
-        return (
-            <div {..._.omit(this.props, 'disabled')} className={classNames('coveo-child', this.props.className)}>
-                {children}
-            </div>
-        );
-    }
-}
+export const ChildForm: React.FunctionComponent<IChildFormProps> = ({className, children}) => (
+    <div className={classNames('coveo-child', className)}>{children}</div>
+);

--- a/packages/react-vapor/src/components/childForm/ChildForm.tsx
+++ b/packages/react-vapor/src/components/childForm/ChildForm.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 export interface IChildFormProps extends React.HTMLAttributes<HTMLDivElement> {
     className?: string;
-    disabled?: boolean;
+    disabled?: boolean; // @deprecated set your disabled state on each child component instead
 }
 
 export const ChildForm: React.FunctionComponent<IChildFormProps> = ({className, children}) => (

--- a/packages/react-vapor/src/components/childForm/ToggleForm.tsx
+++ b/packages/react-vapor/src/components/childForm/ToggleForm.tsx
@@ -3,6 +3,10 @@ import * as React from 'react';
 import {Input} from '../input/Input';
 import {ChildForm} from './ChildForm';
 
+/**
+ * @deprecated Use a form or the class coveo-parent for the style instead
+ */
+
 export interface IToggleFormProps {
     classes?: string[];
     checked?: boolean;

--- a/packages/react-vapor/src/components/childForm/ToggleForm.tsx
+++ b/packages/react-vapor/src/components/childForm/ToggleForm.tsx
@@ -6,7 +6,7 @@ import {ChildForm} from './ChildForm';
 export interface IToggleFormProps {
     classes?: string[];
     checked?: boolean;
-    children?: React.ReactElement<Input | ChildForm> | Array<React.ReactElement<Input | ChildForm>>;
+    children?: React.ReactElement<Input | typeof ChildForm> | Array<React.ReactElement<Input | typeof ChildForm>>;
     onClick?: (e: React.MouseEvent<HTMLElement>) => void;
     value?: string;
 }

--- a/packages/react-vapor/src/components/childForm/tests/ChildForm.spec.tsx
+++ b/packages/react-vapor/src/components/childForm/tests/ChildForm.spec.tsx
@@ -1,42 +1,12 @@
-import {mount, ReactWrapper, shallow} from 'enzyme';
+import {shallow} from 'enzyme';
 import * as React from 'react';
-
-import {Radio} from '../../radio/Radio';
-import {ChildForm, IChildFormProps} from '../ChildForm';
+import {ChildForm} from '../ChildForm';
 
 describe('ChildForm', () => {
     it('should render without errors', () => {
         expect(() => {
-            shallow(<ChildForm />);
+            const component = shallow(<ChildForm />);
+            component.unmount();
         }).not.toThrow();
-    });
-
-    describe('<ChildForm />', () => {
-        let childForm: ReactWrapper<IChildFormProps, any>;
-
-        beforeEach(() => {
-            childForm = mount(
-                <ChildForm>
-                    <Radio id="id" />
-                </ChildForm>,
-                {attachTo: document.getElementById('App')}
-            );
-        });
-
-        afterEach(() => {
-            childForm.detach();
-        });
-
-        it('should disable children when disabled property is true', () => {
-            expect(childForm.find(Radio).first().prop('disabled')).toBe(false);
-
-            childForm.setProps({disabled: false}).mount().update();
-
-            expect(childForm.find(Radio).first().prop('disabled')).toBe(false);
-
-            childForm.setProps({disabled: true}).mount().update();
-
-            expect(childForm.find(Radio).first().prop('disabled')).toBe(true);
-        });
     });
 });

--- a/packages/react-vapor/src/components/childForm/tests/ToggleForm.spec.tsx
+++ b/packages/react-vapor/src/components/childForm/tests/ToggleForm.spec.tsx
@@ -68,17 +68,5 @@ describe('ToggleForm', () => {
 
             expect(clickSpy.calls.count()).toBe(1);
         });
-
-        it('should disable ChildForm children when checked property is false', () => {
-            expect(toggleForm.find('ChildForm').first().prop('disabled')).toBe(true);
-
-            toggleForm.setProps({checked: false}).mount().update();
-
-            expect(toggleForm.find('ChildForm').first().prop('disabled')).toBe(true);
-
-            toggleForm.setProps({checked: true}).mount().update();
-
-            expect(toggleForm.find('ChildForm').first().prop('disabled')).toBe(false);
-        });
     });
 });


### PR DESCRIPTION
### Proposed Changes

Fix ChildForm
1. do not override the disabled prop on each child on mount
2. only set the coveo-child class 

### Potential Breaking Changes

ToggleForm deprecated
Remove Disabled prop set on ChildForm

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
