### PR TITLE
feat(validation): dirty + non empty single select

### DIFF
--- a/packages/demo/src/components/examples/SingleSelectExamples.tsx
+++ b/packages/demo/src/components/examples/SingleSelectExamples.tsx
@@ -22,6 +22,9 @@ import {
     IDispatch,
     withDirtySaveButtonHOC,
     withDirtySingleSelectHOC,
+    withNonEmptySingleSelectHOC,
+    LabeledInput,
+    ValidationMessage,
 } from 'react-vapor';
 
 import * as _ from 'underscore';
@@ -89,8 +92,8 @@ const matchPredicate = (predicate: string, item: IItemBoxProps) => {
     }
 };
 
+const SingleSelectWithNonEmptyValue = withNonEmptySingleSelectHOC(SingleSelectConnected);
 const SingleSelectWithDirty = withDirtySingleSelectHOC(SingleSelectConnected);
-
 const SaveButton = withDirtySaveButtonHOC(Button);
 
 const SingleSelectConnectedExamples: React.ComponentType = () => (
@@ -159,8 +162,14 @@ const SingleSelectConnectedExamples: React.ComponentType = () => (
         <Section level={3} title="A single select with an error message to show with a button">
             <SingleSelectWithMessageExample />
         </Section>
+        <Section level={3} title="A single select with non-empty validation">
+            <SingleSelectWithNonEmptyValue id="single-select-non-empty" items={defaultItems} canClear />
+            <div>
+                <ValidationMessage id="single-select-non-empty" />
+            </div>
+        </Section>
         <Section level={3} title="A single select with dirty management">
-            <SingleSelectWithDirty id="select-dirty" items={defaultItems} />
+            <SingleSelectWithDirty id="select-dirty" items={defaultItems} canClear />
             <SaveButton enabled validationIds={['select-dirty']} name="An example button bound to the select" />
         </Section>
     </Section>

--- a/packages/demo/src/components/examples/SingleSelectExamples.tsx
+++ b/packages/demo/src/components/examples/SingleSelectExamples.tsx
@@ -20,7 +20,10 @@ import {
     withValidationMessage,
     ValidationActions,
     IDispatch,
+    withDirtySaveButtonHOC,
+    withDirtySingleSelectHOC,
 } from 'react-vapor';
+
 import * as _ from 'underscore';
 
 import {IReactVaporExampleState} from '../../Reducers';
@@ -85,6 +88,10 @@ const matchPredicate = (predicate: string, item: IItemBoxProps) => {
         return true;
     }
 };
+
+const SingleSelectWithDirty = withDirtySingleSelectHOC(SingleSelectConnected);
+
+const SaveButton = withDirtySaveButtonHOC(Button);
 
 const SingleSelectConnectedExamples: React.ComponentType = () => (
     <Section level={2} title="Single selects connected to store">
@@ -151,6 +158,10 @@ const SingleSelectConnectedExamples: React.ComponentType = () => (
         </Section>
         <Section level={3} title="A single select with an error message to show with a button">
             <SingleSelectWithMessageExample />
+        </Section>
+        <Section level={3} title="A single select with dirty management">
+            <SingleSelectWithDirty id="select-dirty" items={defaultItems} />
+            <SaveButton enabled validationIds={['select-dirty']} name="An example button bound to the select" />
         </Section>
     </Section>
 );

--- a/packages/react-vapor/src/components/validation/hoc/WithDirtySingleSelectHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtySingleSelectHOC.tsx
@@ -19,7 +19,7 @@ const mapDispatchToProps = (dispatch: IDispatch) => ({
     clearIsDirty: (id: string) => dispatch(ValidationActions.clearDirty(id, ValidationTypes.wrongInitialValue)),
 });
 
-export type ISingleSelectWithDirtyOwnProps = {
+export type IWithDirtySingleSelectHOCProps = {
     initialValue?: string;
     resetDirtyOnUnmount?: boolean;
 };
@@ -28,7 +28,7 @@ export const withDirtySingleSelectHOC = <T extends ISingleSelectOwnProps>(Compon
     type StateProps = ReturnType<typeof mapStateToProps>;
     type DispatchProps = ReturnType<typeof mapDispatchToProps>;
     const WrapperSingleSelect: React.FunctionComponent<
-        T & ISingleSelectWithDirtyOwnProps & StateProps & DispatchProps
+        T & IWithDirtySingleSelectHOCProps & StateProps & DispatchProps
     > = ({initialValue, selectedValue, setIsDirty, clearIsDirty, resetDirtyOnUnmount, ...props}) => {
         React.useEffect(
             () => () => {

--- a/packages/react-vapor/src/components/validation/hoc/WithDirtySingleSelectHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtySingleSelectHOC.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+import {createStructuredSelector} from 'reselect';
+
+import {IDispatch} from '../../../utils/ReduxUtils';
+import {SelectSelector} from '../../select/SelectSelector';
+import {ISingleSelectOwnProps} from '../../select/SingleSelectConnected';
+import {ValidationActions} from '../ValidationActions';
+import {ValidationTypes} from '../ValidationTypes';
+import {InferableComponentEnhancer} from './connectHOC';
+
+const mapStateToProps = createStructuredSelector({
+    selectedValue: SelectSelector.getSelectedValue,
+});
+
+const mapDispatchToProps = (dispatch: IDispatch) => ({
+    setIsDirty: (id: string, isDirty: boolean) =>
+        dispatch(ValidationActions.setDirty(id, isDirty, ValidationTypes.wrongInitialValue)),
+    clearIsDirty: (id: string) => dispatch(ValidationActions.clearDirty(id, ValidationTypes.wrongInitialValue)),
+});
+
+export type ISingleSelectWithDirtyOwnProps = {
+    initialValue?: string;
+    resetDirtyOnUnmount?: boolean;
+};
+
+export const withDirtySingleSelectHOC = <T extends ISingleSelectOwnProps>(Component: React.ComponentType<T>) => {
+    type StateProps = ReturnType<typeof mapStateToProps>;
+    type DispatchProps = ReturnType<typeof mapDispatchToProps>;
+    const WrapperSingleSelect: React.FunctionComponent<
+        T & ISingleSelectWithDirtyOwnProps & StateProps & DispatchProps
+    > = ({initialValue, selectedValue, setIsDirty, clearIsDirty, resetDirtyOnUnmount, ...props}) => {
+        React.useEffect(
+            () => () => {
+                resetDirtyOnUnmount && clearIsDirty(props.id);
+            },
+            []
+        );
+
+        React.useEffect(() => {
+            setIsDirty(props.id, initialValue !== selectedValue);
+        }, [selectedValue]);
+
+        return <Component {...(props as T)} />;
+    };
+
+    const enhance = connect(mapStateToProps, mapDispatchToProps) as InferableComponentEnhancer<
+        StateProps & DispatchProps
+    >;
+
+    return enhance(WrapperSingleSelect);
+};

--- a/packages/react-vapor/src/components/validation/hoc/WithNonEmptySingleSelectHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithNonEmptySingleSelectHOC.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+import {createStructuredSelector} from 'reselect';
+
+import {IDispatch} from '../../../utils/ReduxUtils';
+import {SelectSelector} from '../../select/SelectSelector';
+import {ISingleSelectOwnProps} from '../../select/SingleSelectConnected';
+import {ValidationActions} from '../ValidationActions';
+import {ValidationTypes} from '../ValidationTypes';
+import {InferableComponentEnhancer} from './connectHOC';
+
+const mapStateToProps = createStructuredSelector({
+    selectedValue: SelectSelector.getSelectedValue,
+});
+
+const mapDispatchToProps = (dispatch: IDispatch) => ({
+    setError: (id: string, error: string) => dispatch(ValidationActions.setError(id, error, ValidationTypes.nonEmpty)),
+    clearError: (id: string) => dispatch(ValidationActions.clearError(id, ValidationTypes.nonEmpty)),
+});
+
+export interface IWithNonEmptySingleSelectHOCProps {
+    nonEmptyValidationMessage?: string;
+    resetNonEmptyErrorOnUnmount?: boolean;
+}
+
+export const withNonEmptySingleSelectHOC = <T extends ISingleSelectOwnProps>(Component: React.ComponentType<T>) => {
+    type StateProps = ReturnType<typeof mapStateToProps>;
+    type DispatchProps = ReturnType<typeof mapDispatchToProps>;
+    const WrappedSingleSelect: React.FunctionComponent<
+        T & IWithNonEmptySingleSelectHOCProps & StateProps & DispatchProps
+    > = ({
+        selectedValue,
+        setError,
+        clearError,
+        nonEmptyValidationMessage = 'Selection required',
+        resetNonEmptyErrorOnUnmount,
+        ...props
+    }) => {
+        React.useEffect(() => {
+            clearError(props.id);
+            return () => {
+                resetNonEmptyErrorOnUnmount && clearError(props.id);
+            };
+        }, [props.id, resetNonEmptyErrorOnUnmount]);
+
+        React.useEffect(() => {
+            setError(props.id, !selectedValue ? nonEmptyValidationMessage : '');
+        }, [selectedValue, props.id, nonEmptyValidationMessage]);
+
+        return <Component {...(props as T)} />;
+    };
+
+    const enhance = connect(mapStateToProps, mapDispatchToProps) as InferableComponentEnhancer<
+        StateProps & DispatchProps
+    >;
+    return enhance(WrappedSingleSelect);
+};

--- a/packages/react-vapor/src/components/validation/hoc/index.ts
+++ b/packages/react-vapor/src/components/validation/hoc/index.ts
@@ -1,5 +1,6 @@
 export * from './WithDirtyInputHOC';
 export * from './WithDirtyMultiSelectHOC';
+export * from './WithDirtySingleSelectHOC';
 export * from './WithDirtySaveButtonHOC';
 export * from './WithDirtyStickyFooter';
 export * from './WithInitialValuesMultiSelectHOC';

--- a/packages/react-vapor/src/components/validation/hoc/index.ts
+++ b/packages/react-vapor/src/components/validation/hoc/index.ts
@@ -7,3 +7,4 @@ export * from './WithInitialValuesMultiSelectHOC';
 export * from './WithNonEmptyValueInputValidationHOC';
 export * from './WithValidationMessageHOC';
 export * from './WithNonEmptyValueMultiSelectValidationHOC';
+export * from './WithNonEmptySingleSelectHOC';

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithDirtySingleSelectHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithDirtySingleSelectHOC.spec.tsx
@@ -1,14 +1,13 @@
-import { ShallowWrapper } from 'enzyme';
+import {ShallowWrapper} from 'enzyme';
 import {mountWithStore, shallowWithStore} from 'enzyme-redux';
 import * as React from 'react';
-import { act } from 'react-dom/test-utils';
-import { Store } from 'redux';
-import { ValidationActions, ValidationTypes } from '../..';
-import { IReactVaporState } from '../../../../Entry';
+import {act} from 'react-dom/test-utils';
+import {Store} from 'redux';
+import {ValidationActions, ValidationTypes} from '../..';
+import {IReactVaporState} from '../../../../Entry';
 import {composeMockStore, getStoreMock, withSelectedValues} from '../../../../utils/tests/TestUtils';
-import { ISingleSelectOwnProps, SingleSelectConnected } from '../../../select/SingleSelectConnected';
-import { withDirtySingleSelectHOC } from '../WithDirtySingleSelectHOC';
-
+import {ISingleSelectOwnProps, SingleSelectConnected} from '../../../select/SingleSelectConnected';
+import {withDirtySingleSelectHOC, IWithDirtySingleSelectHOCProps} from '../WithDirtySingleSelectHOC';
 
 describe('SingleSelectWithDirty', () => {
     const SingleSelectWithHOC = withDirtySingleSelectHOC(SingleSelectConnected);
@@ -17,7 +16,7 @@ describe('SingleSelectWithDirty', () => {
     const ONE_VALUE = '🐟';
     const ANOTHER_VALUE = '🐠';
 
-    const defaultProps: ISingleSelectOwnProps = {
+    const DEFAULT_PROPS: ISingleSelectOwnProps & IWithDirtySingleSelectHOCProps = {
         id: 'SOME_ID',
         items: [],
     };
@@ -32,46 +31,66 @@ describe('SingleSelectWithDirty', () => {
         store.clearActions();
     });
 
-    const mountSingleSelectWithHOC = (defaultProps: ISingleSelectOwnProps, store: Store<IReactVaporState>, initialValue?: string) => {
-        const component = mountWithStore(<SingleSelectWithHOC {...defaultProps} initialValue={initialValue}/>, store);
+    const mountSingleSelectWithHOC = (
+        props: Partial<typeof DEFAULT_PROPS> = {},
+        storeToUse: Store<IReactVaporState> = store
+    ) => {
+        const component = mountWithStore(<SingleSelectWithHOC {...DEFAULT_PROPS} {...props} />, storeToUse);
         act(() => {
             component.mount();
         });
-    }
-    
+    };
+
     it('should render without error', () => {
-        expect(() => shallowWithStore(<SingleSelectWithHOC {...defaultProps} />, store)).not.toThrow();
+        expect(() => shallowWithStore(<SingleSelectWithHOC {...DEFAULT_PROPS} />, store)).not.toThrow();
     });
 
     it('should mount and unmount/detach without error', () => {
         let singleSelectWrapper: ShallowWrapper<ISingleSelectOwnProps>;
+
         expect(() => {
-            singleSelectWrapper = shallowWithStore(<SingleSelectWithHOC {...defaultProps} />, store);
+            singleSelectWrapper = shallowWithStore(<SingleSelectWithHOC {...DEFAULT_PROPS} />, store);
             singleSelectWrapper.unmount();
         }).not.toThrow();
     });
 
     it('should trigger the dirty state when the user selects a new value', () => {
-        const store = composeMockStore(withSelectedValues(defaultProps.id, ONE_VALUE));
+        const storeWithInitialValue = composeMockStore(withSelectedValues(DEFAULT_PROPS.id, ONE_VALUE));
 
-        mountSingleSelectWithHOC(defaultProps, store)
+        mountSingleSelectWithHOC({}, storeWithInitialValue);
 
-        expect(store.getActions()).toContain(ValidationActions.setDirty(defaultProps.id, true, ValidationTypes.wrongInitialValue));
+        expect(storeWithInitialValue.getActions()).toContain(
+            ValidationActions.setDirty(DEFAULT_PROPS.id, true, ValidationTypes.wrongInitialValue)
+        );
     });
 
     it('should trigger the dirty state when the user selects a different value', () => {
-        const store = composeMockStore(withSelectedValues(defaultProps.id, ANOTHER_VALUE));
+        const storeWithInitialValue = composeMockStore(withSelectedValues(DEFAULT_PROPS.id, ANOTHER_VALUE));
 
-        mountSingleSelectWithHOC(defaultProps, store, ONE_VALUE);
+        mountSingleSelectWithHOC(
+            {
+                initialValue: ONE_VALUE,
+            },
+            storeWithInitialValue
+        );
 
-        expect(store.getActions()).toContain(ValidationActions.setDirty(defaultProps.id, true, ValidationTypes.wrongInitialValue));
+        expect(storeWithInitialValue.getActions()).toContain(
+            ValidationActions.setDirty(DEFAULT_PROPS.id, true, ValidationTypes.wrongInitialValue)
+        );
     });
 
     it('should not trigger the dirty state when the initial values are the same as the selected ones', () => {
-        const store = composeMockStore(withSelectedValues(defaultProps.id, ONE_VALUE));
+        const storeWithInitialValue = composeMockStore(withSelectedValues(DEFAULT_PROPS.id, ONE_VALUE));
 
-        mountSingleSelectWithHOC(defaultProps, store, ONE_VALUE);
+        mountSingleSelectWithHOC(
+            {
+                initialValue: ONE_VALUE,
+            },
+            storeWithInitialValue
+        );
 
-        expect(store.getActions()).not.toContain(ValidationActions.setDirty(defaultProps.id, true, ValidationTypes.wrongInitialValue));
+        expect(storeWithInitialValue.getActions()).not.toContain(
+            ValidationActions.setDirty(DEFAULT_PROPS.id, true, ValidationTypes.wrongInitialValue)
+        );
     });
 });

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithDirtySingleSelectHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithDirtySingleSelectHOC.spec.tsx
@@ -1,0 +1,77 @@
+import { ShallowWrapper } from 'enzyme';
+import {mountWithStore, shallowWithStore} from 'enzyme-redux';
+import * as React from 'react';
+import { act } from 'react-dom/test-utils';
+import { Store } from 'redux';
+import { ValidationActions, ValidationTypes } from '../..';
+import { IReactVaporState } from '../../../../Entry';
+import {composeMockStore, getStoreMock, withSelectedValues} from '../../../../utils/tests/TestUtils';
+import { ISingleSelectOwnProps, SingleSelectConnected } from '../../../select/SingleSelectConnected';
+import { withDirtySingleSelectHOC } from '../WithDirtySingleSelectHOC';
+
+
+describe('SingleSelectWithDirty', () => {
+    const SingleSelectWithHOC = withDirtySingleSelectHOC(SingleSelectConnected);
+    let store: ReturnType<typeof getStoreMock>;
+
+    const ONE_VALUE = '🐟';
+    const ANOTHER_VALUE = '🐠';
+
+    const defaultProps: ISingleSelectOwnProps = {
+        id: 'SOME_ID',
+        items: [],
+    };
+
+    beforeEach(() => {
+        store = getStoreMock({
+            validation: {},
+        });
+    });
+
+    afterEach(() => {
+        store.clearActions();
+    });
+
+    const mountSingleSelectWithHOC = (defaultProps: ISingleSelectOwnProps, store: Store<IReactVaporState>, initialValue?: string) => {
+        const component = mountWithStore(<SingleSelectWithHOC {...defaultProps} initialValue={initialValue}/>, store);
+        act(() => {
+            component.mount();
+        });
+    }
+    
+    it('should render without error', () => {
+        expect(() => shallowWithStore(<SingleSelectWithHOC {...defaultProps} />, store)).not.toThrow();
+    });
+
+    it('should mount and unmount/detach without error', () => {
+        let singleSelectWrapper: ShallowWrapper<ISingleSelectOwnProps>;
+        expect(() => {
+            singleSelectWrapper = shallowWithStore(<SingleSelectWithHOC {...defaultProps} />, store);
+            singleSelectWrapper.unmount();
+        }).not.toThrow();
+    });
+
+    it('should trigger the dirty state when the user selects a new value', () => {
+        const store = composeMockStore(withSelectedValues(defaultProps.id, ONE_VALUE));
+
+        mountSingleSelectWithHOC(defaultProps, store)
+
+        expect(store.getActions()).toContain(ValidationActions.setDirty(defaultProps.id, true, ValidationTypes.wrongInitialValue));
+    });
+
+    it('should trigger the dirty state when the user selects a different value', () => {
+        const store = composeMockStore(withSelectedValues(defaultProps.id, ANOTHER_VALUE));
+
+        mountSingleSelectWithHOC(defaultProps, store, ONE_VALUE);
+
+        expect(store.getActions()).toContain(ValidationActions.setDirty(defaultProps.id, true, ValidationTypes.wrongInitialValue));
+    });
+
+    it('should not trigger the dirty state when the initial values are the same as the selected ones', () => {
+        const store = composeMockStore(withSelectedValues(defaultProps.id, ONE_VALUE));
+
+        mountSingleSelectWithHOC(defaultProps, store, ONE_VALUE);
+
+        expect(store.getActions()).not.toContain(ValidationActions.setDirty(defaultProps.id, true, ValidationTypes.wrongInitialValue));
+    });
+});

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithNonEmptySingleSelectHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithNonEmptySingleSelectHOC.spec.tsx
@@ -1,0 +1,85 @@
+import {ShallowWrapper} from 'enzyme';
+import {mountWithStore, shallowWithStore} from 'enzyme-redux';
+import React from 'react';
+import {act} from 'react-dom/test-utils';
+import {Store} from 'redux';
+import {IReactVaporState} from '../../../../Entry';
+import {composeMockStore, getStoreMock, withSelectedValues} from '../../../../utils/tests/TestUtils';
+import {ISingleSelectOwnProps, SingleSelectConnected} from '../../../select/SingleSelectConnected';
+import {ValidationActions} from '../../ValidationActions';
+import {ValidationTypes} from '../../ValidationTypes';
+import {withNonEmptySingleSelectHOC, IWithNonEmptySingleSelectHOCProps} from '../WithNonEmptySingleSelectHOC';
+
+describe('SingleSelectWithNonEmpty', () => {
+    const SingleSelectWithNonEmpty = withNonEmptySingleSelectHOC(SingleSelectConnected);
+    let store: ReturnType<typeof getStoreMock>;
+
+    const ONE_VALUE = '🐟';
+
+    const DEFAULT_PROPS: ISingleSelectOwnProps & IWithNonEmptySingleSelectHOCProps = {
+        id: 'SOME_ID',
+        nonEmptyValidationMessage: 'ohno',
+        items: [],
+    };
+
+    beforeEach(() => {
+        store = getStoreMock({
+            validation: {},
+        });
+    });
+
+    afterEach(() => {
+        store.clearActions();
+    });
+
+    const mountSingleSelectWithHOC = (
+        props: Partial<typeof DEFAULT_PROPS> = {},
+        storeToUse: Store<IReactVaporState> = store
+    ) => {
+        const component = mountWithStore(<SingleSelectWithNonEmpty {...DEFAULT_PROPS} {...props} />, storeToUse);
+        act(() => {
+            component.mount();
+        });
+    };
+
+    it('should render without error', () => {
+        expect(() => shallowWithStore(<SingleSelectWithNonEmpty {...DEFAULT_PROPS} />, store)).not.toThrow();
+    });
+
+    it('should mount and unmount/detach without error', () => {
+        let singleSelectWrapper: ShallowWrapper<IWithNonEmptySingleSelectHOCProps & ISingleSelectOwnProps>;
+
+        expect(() => {
+            singleSelectWrapper = shallowWithStore(<SingleSelectWithNonEmpty {...DEFAULT_PROPS} />, store);
+            singleSelectWrapper.unmount();
+        }).not.toThrow();
+    });
+
+    it('should dispatch a setError action on mount if there are no values selected', () => {
+        const storeWithSelectedValue = composeMockStore(withSelectedValues(DEFAULT_PROPS.id));
+
+        mountSingleSelectWithHOC({}, storeWithSelectedValue);
+
+        expect(storeWithSelectedValue.getActions()).toContain(
+            ValidationActions.setError(
+                DEFAULT_PROPS.id,
+                DEFAULT_PROPS.nonEmptyValidationMessage,
+                ValidationTypes.nonEmpty
+            )
+        );
+    });
+
+    it('should not dispatch a setError action on mount if there is a value selected', () => {
+        const storeWithSelectedValue = composeMockStore(withSelectedValues(DEFAULT_PROPS.id, ONE_VALUE));
+
+        mountSingleSelectWithHOC({}, storeWithSelectedValue);
+
+        expect(storeWithSelectedValue.getActions()).not.toContain(
+            ValidationActions.setError(
+                DEFAULT_PROPS.id,
+                DEFAULT_PROPS.nonEmptyValidationMessage,
+                ValidationTypes.nonEmpty
+            )
+        );
+    });
+});


### PR DESCRIPTION
### Proposed Changes

Add dirty and non empty validation for single select

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
