### PR TITLE
feat(redux utils): added a connected component props type

### DIFF
--- a/packages/react-vapor/src/utils/ReduxUtils.ts
+++ b/packages/react-vapor/src/utils/ReduxUtils.ts
@@ -1,9 +1,18 @@
-import {connect} from 'react-redux';
+import {connect, InferableComponentEnhancerWithProps} from 'react-redux';
 import * as Redux from 'redux';
 import {ThunkAction, ThunkDispatch} from 'redux-thunk';
 import {extend} from 'underscore';
 
 import {IReactVaporState} from '../ReactVapor';
+
+/**
+ * use this type with an enhance function containing the connecting functions like such:
+ *
+ * enhance = connect(mapStateToProps, mapDispatchToProps)
+ * const MyComponentBase: React.FC<ConnectedProps<typeof enhance>> = (props) => {}
+ * export const MyComponent = enhance(MyComponentBase)
+ */
+export type ConnectedProps<T> = T extends InferableComponentEnhancerWithProps<infer Props, infer _> ? Props : never;
 
 export type IThunkAction<R = any, S extends IReactVaporState = IReactVaporState> = ThunkAction<
     R,


### PR DESCRIPTION
### Proposed Changes
Added a new type in the reduxUtils
This new type can handle de connected component type in a clean way

ex: 

```
  enhance = connect(mapStateToProps, mapDispatchToProps)
  const MyComponentBase: React.FC<ConnectedProps<typeof enhance>> = (props) => {}
  export const MyComponent = enhance(MyComponentBase)
```

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
