### PR TITLE
fix(btn): fix extra margin when using tooltip

### DIFF
--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -193,6 +193,7 @@
 .btn-container {
     display: inline-block;
     margin: 0;
+    vertical-align: middle;
 
     .btn[disabled] {
         pointer-events: none;


### PR DESCRIPTION
[COM-700]

I put two buttons side-by-side, one with a tooltip, the other without, and there was a difference in margin!

I found out that the `vertical-align: middle` that is *only* on the `btn` class and not on `btn-container`  was responsible for that! See here:

![Peek 2020-11-17 11-16](https://user-images.githubusercontent.com/8355585/99418356-ee35b700-28c8-11eb-9baa-9ce76ae158c8.gif)

The issue only occurs when the button is included **inline** and another component is in the same block.

<!-- Explain what are your changes. -->

It should not cause any issue, if anything, it will repair margins in some places

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-700]: https://coveord.atlassian.net/browse/COM-700