### PR TITLE
feat(datepicker): add class for next and previous year

### DIFF
--- a/packages/react-vapor/src/components/calendar/Calendar.tsx
+++ b/packages/react-vapor/src/components/calendar/Calendar.tsx
@@ -201,6 +201,7 @@ export class Calendar extends React.Component<ICalendarProps, any> {
         const yearPickerProps: IOptionsCycleProps = {
             options: this.props.years,
             isInline: true,
+            className: 'mod-year',
         };
 
         const orderedDays: string[] = [


### PR DESCRIPTION
### Proposed Changes

Added a class selector for the FTs. The month arrows in DatePicker have a class named `.mod-month`, now we want the class `.mod-year` for year arrows.

![image](https://user-images.githubusercontent.com/52677246/99987399-69421600-2d7e-11eb-8bef-bb19e12ac198.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
