### PR TITLE
fix(modal composite): openmodals array no duplication and clear

### DIFF
--- a/packages/react-vapor/src/components/modal/ModalReducers.ts
+++ b/packages/react-vapor/src/components/modal/ModalReducers.ts
@@ -60,9 +60,14 @@ export const modalsReducer = (
 export const openModalsReducer = (state: string[] = [], action: IReduxAction<IModalActionPayload>): string[] => {
     switch (action.type) {
         case ModalAction.openModal:
-            return [...state, action.payload.id];
+            if (!state.includes(action.payload.id)) {
+                return [...state, action.payload.id];
+            }
+            return state;
         case ModalAction.closeModals:
             return _.without(state, ...action.payload.ids);
+        case ModalAction.removeModal:
+            return _.without(state, action.payload.id);
         default:
             return state;
     }

--- a/packages/react-vapor/src/components/modal/tests/ModalCompositeConnected.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/ModalCompositeConnected.spec.tsx
@@ -84,4 +84,13 @@ describe('<ModalCompositeConnected />', () => {
         expect(modalCompositeConnected.find(ModalHeaderConnected).length).toBe(0, 'has modalHeaderConnected');
         expect(modalCompositeConnected.find(ModalHeader).length).toBe(0, 'has modalHeader');
     });
+
+    it('should dispatch a removeModal actions on destroy', () => {
+        const store = getStoreMock();
+        shallowWithStore(<ModalCompositeConnected id="id" isOpened />, store)
+            .dive()
+            .unmount();
+
+        expect(store.getActions()).toContain(removeModal('id'));
+    });
 });

--- a/packages/react-vapor/src/components/modal/tests/ModalReducers.spec.ts
+++ b/packages/react-vapor/src/components/modal/tests/ModalReducers.spec.ts
@@ -190,6 +190,27 @@ describe('Modal', () => {
                 expect(openModalsState[1]).toBe(action.payload.id);
             });
 
+            it('should not add the id to the openModals string array if the id of the opened modal is already there', () => {
+                let oldState: string[] = [];
+                const action: IReduxAction<IModalActionPayload> = {
+                    type: ModalAction.openModal,
+                    payload: {
+                        id: '🍑',
+                    },
+                };
+                let openModalsState: string[] = openModalsReducer(oldState, action);
+
+                expect(openModalsState.length).toBe(1);
+                expect(openModalsState[0]).toBe(action.payload.id);
+
+                oldState = openModalsState;
+                action.payload.id = '🍑';
+                openModalsState = openModalsReducer(oldState, action);
+
+                expect(openModalsState.length).toBe(1);
+                expect(openModalsState[0]).toBe(action.payload.id);
+            });
+
             it('should return the old state without all of the ids when the action is "ModalAction.closeModals"', () => {
                 const oldState: string[] = ['some-modal2', 'some-modal1', 'some-modal3'];
                 const action: IReduxAction<IModalActionPayload> = {
@@ -203,6 +224,20 @@ describe('Modal', () => {
                 expect(openModalsState.length).toBe(oldState.length - action.payload.ids.length);
                 expect(_.contains(openModalsState, action.payload.ids[0])).toBe(false);
                 expect(_.contains(openModalsState, action.payload.ids[1])).toBe(false);
+            });
+
+            it('should return the old state without all of the ids when the action is "ModalAction.removeModals"', () => {
+                const oldState: string[] = ['some-modal2', 'some-modal1', 'some-modal3'];
+                const action: IReduxAction<IModalActionPayload> = {
+                    type: ModalAction.removeModal,
+                    payload: {
+                        id: 'some-modal1',
+                    },
+                };
+                const openModalsState: string[] = openModalsReducer(oldState, action);
+
+                expect(openModalsState.length).toBe(oldState.length - 1);
+                expect(_.contains(openModalsState, action.payload.id)).toBe(false);
             });
         });
     });


### PR DESCRIPTION
### Proposed Changes

The openModals array in the store was emptying only if the modal was explicitaly closed. The modal Id will now be removed from the openModals array if the modal is symply removed.

Also, a condition in the reducer will prevent the same modal from being added in the openModals array many times

### Potential Breaking Changes

none

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
