### PR TITLE
fix(validation): automatically select initial value in single select

### DIFF
--- a/packages/demo/src/components/examples/SingleSelectExamples.tsx
+++ b/packages/demo/src/components/examples/SingleSelectExamples.tsx
@@ -170,7 +170,18 @@ const SingleSelectConnectedExamples: React.ComponentType = () => (
         </Section>
         <Section level={3} title="A single select with dirty management">
             <SingleSelectWithDirty id="select-dirty" items={defaultItems} canClear />
-            <SaveButton enabled validationIds={['select-dirty']} name="An example button bound to the select" />
+            <SingleSelectWithDirty
+                id="select-dirty-with-initial-value"
+                items={defaultItems}
+                initialValue={defaultItems[1].value}
+                canClear
+                footer={<div className="select-footer">This one already has an initial value</div>}
+            />
+            <SaveButton
+                enabled
+                validationIds={['select-dirty', 'select-dirty-with-initial-value']}
+                name="An example button bound to the select"
+            />
         </Section>
     </Section>
 );

--- a/packages/react-vapor/src/components/validation/hoc/WithDirtySingleSelectHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtySingleSelectHOC.tsx
@@ -29,7 +29,7 @@ export const withDirtySingleSelectHOC = <T extends ISingleSelectOwnProps>(Compon
     type DispatchProps = ReturnType<typeof mapDispatchToProps>;
     const WrapperSingleSelect: React.FunctionComponent<
         T & IWithDirtySingleSelectHOCProps & StateProps & DispatchProps
-    > = ({initialValue, selectedValue, setIsDirty, clearIsDirty, resetDirtyOnUnmount, ...props}) => {
+    > = ({initialValue, selectedValue, setIsDirty, clearIsDirty, resetDirtyOnUnmount, items, ...props}) => {
         React.useEffect(
             () => () => {
                 resetDirtyOnUnmount && clearIsDirty(props.id);
@@ -41,7 +41,9 @@ export const withDirtySingleSelectHOC = <T extends ISingleSelectOwnProps>(Compon
             setIsDirty(props.id, initialValue !== selectedValue);
         }, [selectedValue]);
 
-        return <Component {...(props as T)} />;
+        const itemsWithSelectedInitialValue = items.map((item) => ({...item, selected: item.value === initialValue}));
+
+        return <Component {...(props as T)} items={itemsWithSelectedInitialValue} />;
     };
 
     const enhance = connect(mapStateToProps, mapDispatchToProps) as InferableComponentEnhancer<

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithDirtySingleSelectHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithDirtySingleSelectHOC.spec.tsx
@@ -18,7 +18,14 @@ describe('SingleSelectWithDirty', () => {
 
     const DEFAULT_PROPS: ISingleSelectOwnProps & IWithDirtySingleSelectHOCProps = {
         id: 'SOME_ID',
-        items: [],
+        items: [
+            {
+                value: '0',
+            },
+            {
+                value: '1',
+            },
+        ],
     };
 
     beforeEach(() => {
@@ -52,6 +59,21 @@ describe('SingleSelectWithDirty', () => {
             singleSelectWrapper = shallowWithStore(<SingleSelectWithHOC {...DEFAULT_PROPS} />, store);
             singleSelectWrapper.unmount();
         }).not.toThrow();
+    });
+
+    it('should update the items prop to select the initial value', () => {
+        const initialValue = DEFAULT_PROPS.items[1].value;
+        const singleSelectWrapper = shallowWithStore(
+            <SingleSelectWithHOC {...DEFAULT_PROPS} initialValue={initialValue} />,
+            store
+        );
+        const selectedItem = singleSelectWrapper
+            .dive()
+            .find(SingleSelectConnected)
+            .prop('items')
+            .find((item) => item.selected);
+
+        expect(selectedItem.value).toBe(initialValue);
     });
 
     it('should trigger the dirty state when the user selects a new value', () => {


### PR DESCRIPTION
[COM-702]

### Proposed Changes

Small improvement to the `withDirtySingleSelectHOC`, it will automatically select the `initialValue`.

This is mostly for convenience, I think it makes sense to expose an `initialValue` prop and use it that way, even though it is not strictly a "dirty" feature.

### Potential Breaking Changes

No

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-702]: https://coveord.atlassian.net/browse/COM-702