### PR TITLE
fix(jenkinsfile.groovy): set the NEW VERSION var after version is bumped

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -100,6 +100,10 @@ pipeline {
             } else {
               sh "npx lerna version --no-commit-hooks --no-git-tag-version --no-push --force-publish=\"react-vapor\" --yes"
             }
+            NEW_VERSION = sh(
+              script: "node -p -e 'require(`./packages/react-vapor/package.json`).version;'",
+              returnStdout: true
+            ).trim()
             sh "git reset --hard"
           }
         }

--- a/packages/react-vapor/rollup.config.js
+++ b/packages/react-vapor/rollup.config.js
@@ -74,7 +74,7 @@ function tsPlugin() {
 function replacePlugin() {
     return replace({
         'process.env.NODE_ENV': JSON.stringify('production'),
-        'process.env.REACT_VAPOR_VERSION': JSON.stringify(require('./package.json').version),
+        'process.env.REACT_VAPOR_VERSION': JSON.stringify(process.env.NEW_VERSION || '0.0.0'),
     });
 }
 

--- a/packages/react-vapor/webpack.config.js
+++ b/packages/react-vapor/webpack.config.js
@@ -112,7 +112,7 @@ const config = {
     },
     plugins: [
         new webpack.DefinePlugin({
-            'process.env.REACT_VAPOR_VERSION': JSON.stringify(require('./package.json').version),
+            'process.env.REACT_VAPOR_VERSION': JSON.stringify(process.env.NEW_VERSION || '0.0.0'),
             'process.env.NODE_ENV': JSON.stringify('production'),
         }),
         new UnminifiedWebpackPlugin(),


### PR DESCRIPTION
### Proposed Changes
I'm trying to assign the bumped react-vapor version on the REACT_VAPOR_VERSION variable.

~~I still have to confirm if the NEW_VERSION variable contains the expected value, and to do so, I have to run to the jenkinfile, which explains why I open this PR to test it out.~~ Like Germain mentioned in his comment, because this command will only be run in master (or a branch named release-.*), I will be able to confirm if it worked or not only after this branch is merged in master.   

### Potential Breaking Changes

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
