### PR TITLE
fix(table.scss): ADUI-6283 collapsible row animation fix

### DIFF
--- a/packages/vapor/scss/tables/table.scss
+++ b/packages/vapor/scss/tables/table.scss
@@ -96,6 +96,8 @@
         height: $table-row-height;
         font-size: $table-row-font-size;
         line-height: $table-row-line-height;
+        -webkit-transform: translate3d(0, 0, 0);
+        transform: translate3d(0, 0, 0);
 
         &.disabled div.wrapper {
             opacity: 0.4;


### PR DESCRIPTION
The collapsible row leaves a trail of bottom border as it expands and collapses. This fix will force
the hardware acceleration. Problem only isolated to Windows machines with Chrome and Edge

### Proposed Changes

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
