### PR TITLE
fix(react-vapor.version): set react vapor version even if not new

### DIFF
--- a/packages/react-vapor/rollup.config.js
+++ b/packages/react-vapor/rollup.config.js
@@ -74,7 +74,7 @@ function tsPlugin() {
 function replacePlugin() {
     return replace({
         'process.env.NODE_ENV': JSON.stringify('production'),
-        'process.env.REACT_VAPOR_VERSION': JSON.stringify(process.env.NEW_VERSION || '0.0.0'),
+        'process.env.REACT_VAPOR_VERSION': JSON.stringify(process.env.NEW_VERSION || require('./package.json').version),
     });
 }
 

--- a/packages/react-vapor/webpack.config.js
+++ b/packages/react-vapor/webpack.config.js
@@ -112,7 +112,9 @@ const config = {
     },
     plugins: [
         new webpack.DefinePlugin({
-            'process.env.REACT_VAPOR_VERSION': JSON.stringify(process.env.NEW_VERSION || '0.0.0'),
+            'process.env.REACT_VAPOR_VERSION': JSON.stringify(
+                process.env.NEW_VERSION || require('./package.json').version
+            ),
             'process.env.NODE_ENV': JSON.stringify('production'),
         }),
         new UnminifiedWebpackPlugin(),


### PR DESCRIPTION
### Proposed Changes

**Second attempt to solve this issue:**
Set the react vapor version variable to the current version from the package.json if the NEW_VERSION is empty. 

The reasoning for this change is as follow:
- it would seems that the version contained in the package.json is currently up to date with the release version. So I wonder if the package.json version is actually bumped after a new version is set.
- Because the current result when running the `CoveoJsAdmin.versions` is '0.0.0'. I want to observe what would be the result if we set the to the current version contained in the package.json (which will either confirm my theory explained in the previous statement, or it will display the prior version, just like before).

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
