### PR TITLE
fix(sfint-3610): consider whitespace string as empty

### DIFF
--- a/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
@@ -42,7 +42,7 @@ export const withNonEmptyValueInputValidationHOC = <T extends IInputOwnProps>(
             <Component
                 {...(props as T)}
                 validate={(value: string) => {
-                    const isEmpty = _.isEmpty(value);
+                    const isEmpty = !/\S/.test(value);
                     setError(props.id, isEmpty ? validationMessage : '');
                     return !isEmpty || (validate ? validate(value) : true);
                 }}

--- a/packages/react-vapor/src/components/validation/hoc/tests/WithNonEmptyValueInputValidationHOC.spec.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/tests/WithNonEmptyValueInputValidationHOC.spec.tsx
@@ -54,12 +54,21 @@ describe('WithNonEmptyValueInputValidationHOC', () => {
                 inputWrapper = shallowWithStore(<InputWithHOC {...INPUT_PROPS} validate={validateSpy} />, store).dive();
             });
 
-            it('should dispatch a set error action when the validation fails', () => {
-                inputWrapper.prop('validate')('');
+            [
+                {title: 'empty', value: ''},
+                {title: 'whitespace', value: ' '},
+            ].forEach((test) => {
+                it(`should dispatch a set error action when the validation fails (${test.title})`, () => {
+                    inputWrapper.prop('validate')(test.value);
 
-                expect(store.getActions()).toContain(
-                    ValidationActions.setError(INPUT_PROPS.id, INPUT_PROPS.validationMessage, ValidationTypes.nonEmpty)
-                );
+                    expect(store.getActions()).toContain(
+                        ValidationActions.setError(
+                            INPUT_PROPS.id,
+                            INPUT_PROPS.validationMessage,
+                            ValidationTypes.nonEmpty
+                        )
+                    );
+                });
             });
 
             it('should not dispatch a set error action when the validation succeeds', () => {


### PR DESCRIPTION
### Proposed Changes

When validating an input field containing only whitespaces, the value should be considered as empty.

### Potential Breaking Changes

One could be impacted if a field is wrapped with `withNonEmptyValueInputValidationHOC` and considers a string composed of whitespaces as valid. I can't think of a real-life scenario where it would be an issue.

### Acceptance Criteria

-   [X] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
