### PR TITLE
Revert "fix(table.scss): aDUI-6283 collapsible row animation fix"

### DIFF
--- a/packages/vapor/scss/tables/table.scss
+++ b/packages/vapor/scss/tables/table.scss
@@ -96,8 +96,6 @@
         height: $table-row-height;
         font-size: $table-row-font-size;
         line-height: $table-row-line-height;
-        -webkit-transform: translate3d(0, 0, 0);
-        transform: translate3d(0, 0, 0);
 
         &.disabled div.wrapper {
             opacity: 0.4;


### PR DESCRIPTION
This reverts commit 9c81b4c94d679250d351bf8f54bafde156ce57d6.

### Proposed Changes

This fix, efficent for the case of the trailing lines. breaks the z-index of the rows.

### Potential Breaking Changes

revert back to normal behavior so in very specific cases you will see trailling lines from the border of a collablible row.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
