### PR TITLE
feat(fonts): use css variables

### DIFF
--- a/packages/demo/src/demo-styling/_syntax-highlighting.scss
+++ b/packages/demo/src/demo-styling/_syntax-highlighting.scss
@@ -23,11 +23,11 @@
     }
     // Error
     .k {
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
     // Keyword
     .o {
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
     // Operator
     .cm {
@@ -37,7 +37,7 @@
     // Comment.Multiline
     .cp {
         color: #999;
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
     // Comment.Preproc
     .c1 {
@@ -47,7 +47,7 @@
     // Comment.Single
     .cs {
         color: #999;
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
         font-style: italic;
     }
     // Comment.Special
@@ -92,7 +92,7 @@
     }
     // Generic.Prompt
     .gs {
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
     // Generic.Strong
     .gu {
@@ -104,24 +104,24 @@
     }
     // Generic.Traceback
     .kc {
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
     // Keyword.Constant
     .kd {
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
     // Keyword.Declaration
     .kp {
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
     // Keyword.Pseudo
     .kr {
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
     // Keyword.Reserved
     .kt {
         color: #458;
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
     // Keyword.Type
     .m {
@@ -142,7 +142,7 @@
     // Name.Builtin
     .nc {
         color: #458;
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
     // Name.Class
     .no {
@@ -155,12 +155,12 @@
     // Name.Entity
     .ne {
         color: #900;
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
     // Name.Exception
     .nf {
         color: #900;
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
     // Name.Function
     .nn {
@@ -176,7 +176,7 @@
     }
     // Name.Variable
     .ow {
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
     // Operator.Word
     .w {

--- a/packages/demo/src/demo-styling/main.scss
+++ b/packages/demo/src/demo-styling/main.scss
@@ -25,7 +25,7 @@
         .navigation-menu-section-header {
             margin-left: -10px;
             color: var(--black);
-            font-weight: normal;
+            font-weight: var(--main-font-regular);
         }
 
         .navigation-menu-section-item-link {
@@ -35,11 +35,11 @@
         .navigation-menu-section-link,
         .navigation-menu-section-item {
             &.state-active {
-                font-weight: bold;
+                font-weight: var(--main-font-bold);
                 background-color: var(--grey-1);
 
                 .navigation-menu-section-header {
-                    font-weight: bold;
+                    font-weight: var(--main-font-bold);
                 }
             }
 
@@ -56,13 +56,13 @@
 
     .top-navigation .tab {
         color: var(--oxford-blue);
-        font-weight: normal;
+        font-weight: var(--main-font-regular);
         font-size: 14px;
         line-height: 17px;
         letter-spacing: 1.5px;
 
         &.active {
-            font-weight: bold;
+            font-weight: var(--main-font-bold);
         }
     }
 
@@ -98,7 +98,7 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-family: var(--main-font);
 
     li {
         display: inline-block;

--- a/packages/vapor/scss/common/common.scss
+++ b/packages/vapor/scss/common/common.scss
@@ -17,7 +17,7 @@ body {
     // Base font size for the entire app
     font-size: 13px;
 
-    font-family: $base-font-family;
+    font-family: var(--main-font);
     -webkit-font-smoothing: antialiased;
 }
 

--- a/packages/vapor/scss/common/font.scss
+++ b/packages/vapor/scss/common/font.scss
@@ -1,5 +1,5 @@
 @font-face {
-    font-weight: normal;
+    font-weight: var(--main-font-regular);
     font-family: 'source_code_pro_regular';
     font-style: normal;
 

--- a/packages/vapor/scss/components/calendar.scss
+++ b/packages/vapor/scss/components/calendar.scss
@@ -13,7 +13,7 @@
     }
 
     .dropdown-selected-value {
-        font-weight: normal;
+        font-weight: var(--main-font-regular);
     }
 }
 

--- a/packages/vapor/scss/components/facet.scss
+++ b/packages/vapor/scss/components/facet.scss
@@ -55,7 +55,7 @@
 
 .facet-header-title {
     font-size: $default-font-size;
-    font-family: $base-font-family;
+    font-family: var(--main-font);
 }
 
 .facet-values {

--- a/packages/vapor/scss/components/list-box.scss
+++ b/packages/vapor/scss/components/list-box.scss
@@ -35,7 +35,7 @@
 
     &.selected {
         color: var(--dark-blue);
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
 
     &.disabled {

--- a/packages/vapor/scss/components/markdown-documentation.scss
+++ b/packages/vapor/scss/components/markdown-documentation.scss
@@ -61,7 +61,7 @@
     }
 
     strong {
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
     }
 
     em {

--- a/packages/vapor/scss/components/member.scss
+++ b/packages/vapor/scss/components/member.scss
@@ -26,7 +26,7 @@
         margin-left: 14px;
 
         .member-info-name {
-            font-weight: 700;
+            font-weight: var(--main-font-bold);
             font-size: 13px;
             line-height: 16px;
             text-transform: uppercase;
@@ -34,7 +34,7 @@
 
         .member-info-email {
             margin-top: 2px;
-            font-weight: 400;
+            font-weight: var(--main-font-regular);
 
             font-size: 12px;
             line-height: 15px;

--- a/packages/vapor/scss/components/navigation.scss
+++ b/packages/vapor/scss/components/navigation.scss
@@ -72,7 +72,7 @@
                     align-items: center;
                     height: 55px;
                     color: var(--white);
-                    font-weight: $navigation-menu-header-font-weight;
+                    font-weight: var(--main-font-bolder);
 
                     font-size: $navigation-section-font-size;
                     cursor: pointer;
@@ -100,7 +100,7 @@
                     }
 
                     .navigation-menu-section-item {
-                        font-weight: $navigation-menu-item-font-weight;
+                        font-weight: var(--main-font-regular);
                         border-left: $navigation-active-border-width solid transparent;
 
                         cursor: pointer;

--- a/packages/vapor/scss/components/tab.scss
+++ b/packages/vapor/scss/components/tab.scss
@@ -10,7 +10,7 @@
         margin-right: $tab-margin-right;
         padding: $tab-padding;
         color: var(--medium-blue);
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
         font-size: $tab-font-size;
         line-height: 16px;
         letter-spacing: 0.3px;
@@ -37,7 +37,7 @@
 
     &.sub-tabs {
         .tab {
-            font-weight: 400;
+            font-weight: var(--main-font-regular);
             font-size: $sub-tab-font-size;
             border-bottom-width: 2px;
         }

--- a/packages/vapor/scss/controls/chosen.scss
+++ b/packages/vapor/scss/controls/chosen.scss
@@ -75,12 +75,12 @@
 
                 &.result-selected {
                     color: var(--medium-blue);
-                    font-weight: bold;
+                    font-weight: var(--main-font-bold);
                 }
 
                 em {
                     color: var(--dark-grey);
-                    font-weight: bold;
+                    font-weight: var(--main-font-bold);
                     font-style: normal;
                     text-decoration: underline;
                 }
@@ -115,7 +115,7 @@
         padding: 0 $button-padding-x;
         overflow: hidden;
         color: var(--medium-blue);
-        font-weight: 700;
+        font-weight: var(--main-font-bold);
         font-size: $dropdown-button-font-size;
         line-height: 34px;
         white-space: nowrap;
@@ -306,7 +306,7 @@
     .chosen-drop .chosen-results li.result-selected {
         display: list-item;
         color: var(--medium-grey);
-        font-weight: normal;
+        font-weight: var(--main-font-regular);
         cursor: default;
     }
 

--- a/packages/vapor/scss/controls/collapsable.scss
+++ b/packages/vapor/scss/controls/collapsable.scss
@@ -39,7 +39,7 @@
                 padding: 3px 0 3px 26px;
                 color: var(--medium-blue);
                 font-size: $default-font-size;
-                font-family: $base-font-family;
+                font-family: var(--main-font);
                 line-height: initial;
                 text-transform: uppercase;
                 text-decoration: none;

--- a/packages/vapor/scss/controls/dropdown.scss
+++ b/packages/vapor/scss/controls/dropdown.scss
@@ -175,7 +175,7 @@
 
             &.state-selected {
                 color: var(--dark-blue);
-                font-weight: bold;
+                font-weight: var(--main-font-bold);
             }
 
             &.disabled {

--- a/packages/vapor/scss/controls/filtering/filter-picker.scss
+++ b/packages/vapor/scss/controls/filtering/filter-picker.scss
@@ -17,7 +17,7 @@
         .filter-badge {
             box-sizing: border-box;
             height: $filter-badge-height;
-            font-weight: normal;
+            font-weight: var(--main-font-regular);
             text-transform: initial;
         }
 

--- a/packages/vapor/scss/controls/filtering/filters-values.scss
+++ b/packages/vapor/scss/controls/filtering/filters-values.scss
@@ -14,7 +14,7 @@
                 height: $selected-filter-height;
                 padding-left: $selected-filter-padding-left;
                 color: var(--medium-blue);
-                font-weight: bold;
+                font-weight: var(--main-font-bold);
                 font-size: $default-font-size;
                 line-height: $selected-filter-height;
             }

--- a/packages/vapor/scss/controls/filtering/multi-filter-picker.scss
+++ b/packages/vapor/scss/controls/filtering/multi-filter-picker.scss
@@ -34,10 +34,10 @@
                 display: inline-block;
                 margin: $pre-operator-margin;
                 padding: $pre-operator-padding;
-                font-weight: bold;
+                font-weight: var(--main-font-bold);
                 font-size: $pre-operator-font-size;
 
-                font-family: $base-font-family;
+                font-family: var(--main-font);
                 line-height: $pre-operator-line-height;
             }
 

--- a/packages/vapor/scss/controls/flat-select.scss
+++ b/packages/vapor/scss/controls/flat-select.scss
@@ -95,7 +95,7 @@
     &.mod-btn-group .flat-select-option {
         height: $button-height;
         padding: $button-padding-y $button-padding-x;
-        font-weight: $button-font-weight;
+        font-weight: var(--main-font-bold);
 
         font-size: $button-font-size;
         line-height: $button-line-height;

--- a/packages/vapor/scss/controls/inputs.scss
+++ b/packages/vapor/scss/controls/inputs.scss
@@ -19,7 +19,7 @@ input[type='color'] {
     padding: 3px 6px;
     color: var(--dark-grey);
     font-size: $title-font-size;
-    font-family: $base-font-family;
+    font-family: var(--main-font);
     border: 1px solid var(--medium-grey);
     border-radius: 2px;
 }
@@ -37,7 +37,7 @@ textarea {
     &:-ms-input-placeholder {
         color: var(--medium-grey);
         font-size: inherit;
-        font-family: $base-font-family;
+        font-family: var(--main-font);
         text-transform: none;
         transition: color 0.2s ease;
     }

--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -10,9 +10,9 @@
     height: $button-height;
     padding: $button-padding-y $button-padding-x;
     color: var(--medium-blue);
-    font-weight: $button-font-weight;
+    font-weight: var(--main-font-bold);
     font-size: $button-font-size;
-    font-family: $base-font-family;
+    font-family: var(--main-font);
     line-height: $button-line-height;
     white-space: nowrap;
     text-transform: uppercase;

--- a/packages/vapor/scss/forms/form-sections.scss
+++ b/packages/vapor/scss/forms/form-sections.scss
@@ -1,7 +1,7 @@
 .section-heading {
     .heading-title {
         color: var(--medium-blue);
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
         font-size: $title-font-size;
     }
 

--- a/packages/vapor/scss/forms/table-form.scss
+++ b/packages/vapor/scss/forms/table-form.scss
@@ -32,7 +32,7 @@
             padding: 0 10px;
             color: var(--medium-blue);
             font-size: $title-font-size;
-            font-family: $base-font-family;
+            font-family: var(--main-font);
             background-color: var(--pure-white);
         }
 
@@ -51,9 +51,9 @@
             background-color: var(--white);
 
             input:disabled:not([type='radio']) {
-                font-weight: 600;
+                font-weight: var(--main-font-bold);
                 font-size: $title-font-size;
-                font-family: $base-font-family;
+                font-family: var(--main-font);
                 background-color: var(--pure-white);
 
                 opacity: 0.4;

--- a/packages/vapor/scss/lib/_mixins.scss
+++ b/packages/vapor/scss/lib/_mixins.scss
@@ -23,7 +23,7 @@
     }
 }
 
-@mixin placeholder($text-color: var(--medium-grey), $font-family: $base-font-family) {
+@mixin placeholder($text-color: var(--medium-grey), $font-family: var(--main-font)) {
     &::placeholder {
         color: $text-color;
         font-size: inherit;

--- a/packages/vapor/scss/lib/datepicker.scss
+++ b/packages/vapor/scss/lib/datepicker.scss
@@ -50,7 +50,7 @@ div.datepicker table td {
 div.datepicker th {
     padding: 0;
     color: #666666;
-    font-weight: normal;
+    font-weight: var(--main-font-regular);
     text-align: center;
 }
 
@@ -199,13 +199,13 @@ div.datepicker tbody.datepickerDays td.datepickerSpecial.datepickerSelected a {
 
 div.datepicker th a.datepickerMonth {
     color: #008ed6;
-    font-weight: normal;
+    font-weight: var(--main-font-regular);
 }
 
 /* style the day of week header cells */
 div.datepicker th {
     color: black;
-    font-weight: bold;
+    font-weight: var(--main-font-bold);
 }
 
 /* grey underline beneath day of week row */
@@ -241,7 +241,7 @@ div.datepicker tbody.datepickerDays td:hover {
 
 /* Bold today's date */
 div.datepicker td.datepickerToday a {
-    font-weight: bold;
+    font-weight: var(--main-font-bold);
 }
 
 /* cells are wider in the clean style */

--- a/packages/vapor/scss/redesign/fonts.scss
+++ b/packages/vapor/scss/redesign/fonts.scss
@@ -1,36 +1,40 @@
 :root {
-  // General
-  --default-margin: $default-margin;
-  --default-line-height: $default-line-height;
-  --banner-height: $banner-height;
-  --header-line-height: $header-line-height;
-  --spacing: $spacing;
+    --main-font: Lato, Arial, Helvetica, sans-serif;
+    --main-font-regular: normal;
+    --main-font-bold: bold;
+    --main-font-bolder: 900;
 
-  // Typography
-  --small-font-size: $small-font-size;
-  --default-font-size: $default-font-size;
-  --title-font-size: $title-font-size;
-  --navigation-section-font-size: $navigation-section-font-size;
-  --medium-title-font-size: $medium-title-font-size;
-  --big-font-size: $big-font-size;
-  --big-title-font-size: $big-title-font-size;
-  --default-line-height: $default-line-height;
-  --big-line-height: $big-line-height;
-  --code-font-size: $code-font-size;
-  --base-font-family: $base-font-family;
-  --code-font-family: $code-font-family;
-  --standard-line-height: $standard-line-height;
-  --help-text-font-size: $help-text-font-size;
-  --help-text-line-height: $help-text-line-height;
-  --text-max-width: $text-max-width;
+    // General
+    --default-margin: $default-margin;
+    --default-line-height: $default-line-height;
+    --banner-height: $banner-height;
+    --header-line-height: $header-line-height;
+    --spacing: $spacing;
 
-  // Button
-  --button-font-size: $button-font-size;
-  --button-line-height: $button-line-height;
-  --button-font-weight: $button-font-weight;
-  --button-small-font-size: $button-small-font-size;
-  --button-small-line-height: $button-small-line-height;
+    // Typography
+    --small-font-size: $small-font-size;
+    --default-font-size: $default-font-size;
+    --title-font-size: $title-font-size;
+    --navigation-section-font-size: $navigation-section-font-size;
+    --medium-title-font-size: $medium-title-font-size;
+    --big-font-size: $big-font-size;
+    --big-title-font-size: $big-title-font-size;
+    --default-line-height: $default-line-height;
+    --big-line-height: $big-line-height;
+    --code-font-size: $code-font-size;
+    --base-font-family: $base-font-family;
+    --code-font-family: $code-font-family;
+    --standard-line-height: $standard-line-height;
+    --help-text-font-size: $help-text-font-size;
+    --help-text-line-height: $help-text-line-height;
+    --text-max-width: $text-max-width;
 
-  // Input and textarea
-  --input-font-size: $input-font-size;
+    // Button
+    --button-font-size: $button-font-size;
+    --button-line-height: $button-line-height;
+    --button-small-font-size: $button-small-font-size;
+    --button-small-line-height: $button-small-line-height;
+
+    // Input and textarea
+    --input-font-size: $input-font-size;
 }

--- a/packages/vapor/scss/tables/table-actions.scss
+++ b/packages/vapor/scss/tables/table-actions.scss
@@ -77,7 +77,7 @@
             margin-top: 1px; // Hack to fix label vertical alignment...
             margin-left: $table-action-margin-left;
             color: var(--medium-blue);
-            font-weight: bold;
+            font-weight: var(--main-font-bold);
             font-size: 13px;
             line-height: 11px;
             text-transform: uppercase;

--- a/packages/vapor/scss/tables/table-collapsible-rows.scss
+++ b/packages/vapor/scss/tables/table-collapsible-rows.scss
@@ -39,7 +39,7 @@ table {
                     .section-title {
                         padding-top: $collapsible-title-padding;
                         color: var(--medium-blue);
-                        font-weight: bold;
+                        font-weight: var(--main-font-bold);
                         font-size: $collapsible-content-font-size;
                         text-transform: uppercase;
                     }
@@ -62,7 +62,7 @@ table {
                             line-height: 15px;
 
                             b {
-                                font-weight: bold;
+                                font-weight: var(--main-font-bold);
                             }
 
                             i {
@@ -77,7 +77,7 @@ table {
 
                         .label {
                             padding: 5px 0;
-                            font-weight: normal;
+                            font-weight: var(--main-font-regular);
 
                             font-size: 12px;
                         }

--- a/packages/vapor/scss/tables/table.scss
+++ b/packages/vapor/scss/tables/table.scss
@@ -28,7 +28,7 @@
     thead tr {
         height: $table-header-height;
         color: var(--medium-blue);
-        font-weight: bold;
+        font-weight: var(--main-font-bold);
         font-size: $table-header-font-size;
         line-height: $table-header-line-height;
         background-color: transparent;
@@ -222,7 +222,7 @@
 
         & .mod-card-header {
             color: var(--medium-blue);
-            font-weight: bold;
+            font-weight: var(--main-font-bold);
             font-size: $medium-title-font-size;
             border-bottom: 2px solid var(--light-grey);
         }

--- a/packages/vapor/scss/typography/headings.scss
+++ b/packages/vapor/scss/typography/headings.scss
@@ -5,7 +5,7 @@ h4,
 h5,
 h6 {
     color: var(--medium-blue);
-    font-family: $base-font-family;
+    font-family: var(--main-font);
     line-height: $standard-line-height;
 }
 

--- a/packages/vapor/scss/typography/utility.scss
+++ b/packages/vapor/scss/typography/utility.scss
@@ -2,15 +2,15 @@
 // Source: https://github.com/basscss/utility-typography
 
 .bold {
-    font-weight: bold;
+    font-weight: var(--main-font-bold);
 }
 
 .semibold {
-    font-weight: 600;
+    font-weight: var(--main-font-bold);
 }
 
 .regular {
-    font-weight: normal;
+    font-weight: var(--main-font-regular);
 }
 
 .italic {

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -35,7 +35,7 @@ $big-title-font-size: 32px;
 $default-line-height: 16px;
 $big-line-height: 21px;
 $code-font-size: 14px;
-$base-font-family: 'Lato', Arial, Helvetica, sans-serif;
+$base-font-family: var(--main-font);
 $code-font-family: source_code_pro_regular, 'Courier New', Courier, monospace;
 $standard-line-height: 1.35em;
 $help-text-font-size: 14px;
@@ -48,7 +48,6 @@ $list-padding: 20px;
 // Button
 $button-font-size: 12px;
 $button-line-height: 15px;
-$button-font-weight: 700;
 $button-padding-x: 16px;
 $button-padding-y: 8.5px;
 $button-border-width: 1px;
@@ -222,8 +221,6 @@ $card-minimum-width: 160px;
 $card-minimum-height: 70px;
 
 // Navigation
-$navigation-menu-header-font-weight: 900;
-$navigation-menu-item-font-weight: 400;
 $navigation-width: 245px;
 $navigation-border-for-scroll-bar: 1px;
 $navigation-background-color: var(--purple-blue);


### PR DESCRIPTION
### Proposed Changes

Created CSS variables for the font-family and font-weight, and replaced current values with these global variables. Confirmed with UX, for the new rebranding style, we will need a third font-weight, 500/bolder, but only for a few specific cases. For instance, we want to use bolder for button text, since Gibson 400/bold is not very visible. 

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
