### PR TITLE
feat(tab): add the possibility to include a svg to a tab

### DIFF
--- a/packages/demo/src/components/examples/TabConnectedExample.tsx
+++ b/packages/demo/src/components/examples/TabConnectedExample.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {TabConnected, TabContent, TabNavigation, TabPaneConnected} from 'react-vapor';
+import {Svg, TabConnected, TabContent, TabNavigation, TabPaneConnected} from 'react-vapor';
 
 const TAB1_ID = 'tab1';
 const TAB2_ID = 'tab2';
@@ -23,8 +23,7 @@ export class TabsExamples extends React.Component<any, any> {
                             <TabConnected
                                 id={TAB3_ID}
                                 title="Tab with an icon"
-                                svgName="help"
-                                svgClass="icon fill-orange mod-16 mr1"
+                                children={<Svg svgName={'help'} svgClass={'icon fill-orange mod-16 mr1'} />}
                             />
                             <TabConnected id={TAB4_ID} title="A Disabled Tab" tooltip="I am a disabled tab" disabled />
                         </TabNavigation>

--- a/packages/demo/src/components/examples/TabConnectedExample.tsx
+++ b/packages/demo/src/components/examples/TabConnectedExample.tsx
@@ -4,6 +4,7 @@ import {TabConnected, TabContent, TabNavigation, TabPaneConnected} from 'react-v
 const TAB1_ID = 'tab1';
 const TAB2_ID = 'tab2';
 const TAB3_ID = 'tab3';
+const TAB4_ID = 'tab4';
 
 const TAB11_ID = 'tab11';
 const TAB22_ID = 'tab22';
@@ -19,7 +20,13 @@ export class TabsExamples extends React.Component<any, any> {
                         <TabNavigation>
                             <TabConnected id={TAB1_ID} title="A Tab" />
                             <TabConnected id={TAB2_ID} title="Another Tab" tooltip="I am an enabled tab" />
-                            <TabConnected id={TAB3_ID} title="A Disabled Tab" tooltip="I am a disabled tab" disabled />
+                            <TabConnected
+                                id={TAB3_ID}
+                                title="Tab with an icon"
+                                svgName="help"
+                                svgClass="icon fill-orange mod-16 mr1"
+                            />
+                            <TabConnected id={TAB4_ID} title="A Disabled Tab" tooltip="I am a disabled tab" disabled />
                         </TabNavigation>
                         <TabContent>
                             <TabPaneConnected id={TAB1_ID}>
@@ -33,6 +40,11 @@ export class TabsExamples extends React.Component<any, any> {
                                 </div>
                             </TabPaneConnected>
                             <TabPaneConnected id={TAB3_ID}>
+                                <div className="mod-header-padding mod-form-top-bottom-padding">
+                                    Content of the tab with an icon.
+                                </div>
+                            </TabPaneConnected>
+                            <TabPaneConnected id={TAB4_ID}>
                                 <div className="mod-header-padding mod-form-top-bottom-padding">
                                     Last tab. You shouldn't be able to see this because the tab is disabled.
                                 </div>

--- a/packages/demo/src/components/examples/TabConnectedExample.tsx
+++ b/packages/demo/src/components/examples/TabConnectedExample.tsx
@@ -20,11 +20,9 @@ export class TabsExamples extends React.Component<any, any> {
                         <TabNavigation>
                             <TabConnected id={TAB1_ID} title="A Tab" />
                             <TabConnected id={TAB2_ID} title="Another Tab" tooltip="I am an enabled tab" />
-                            <TabConnected
-                                id={TAB3_ID}
-                                title="Tab with an icon"
-                                children={<Svg svgName={'help'} svgClass={'icon fill-orange mod-16 mr1'} />}
-                            />
+                            <TabConnected id={TAB3_ID} title="Tab with an icon">
+                                <Svg svgName={'help'} svgClass={'icon fill-orange mod-16 mr1'} />
+                            </TabConnected>
                             <TabConnected id={TAB4_ID} title="A Disabled Tab" tooltip="I am a disabled tab" disabled />
                         </TabNavigation>
                         <TabContent>

--- a/packages/react-vapor/src/components/tab/Tab.tsx
+++ b/packages/react-vapor/src/components/tab/Tab.tsx
@@ -10,7 +10,6 @@ export interface ITabOwnProps {
     title: string;
     disabled?: boolean;
     tooltip?: string;
-    children?: React.ReactNode;
 }
 
 export interface ITabStateProps {
@@ -35,7 +34,7 @@ export class Tab extends React.Component<ITabProps, any> {
 
         return (
             <div className={className} onClick={this.handleSelect}>
-                {!!this.props.children && this.props.children}
+                {this.props.children}
                 <Tooltip title={this.props.tooltip} placement={TooltipPlacement.Top}>
                     {this.props.title}
                 </Tooltip>

--- a/packages/react-vapor/src/components/tab/Tab.tsx
+++ b/packages/react-vapor/src/components/tab/Tab.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import * as React from 'react';
 
 import {TooltipPlacement} from '../../utils/TooltipUtils';
+import {Svg} from '../svg';
 import {Tooltip} from '../tooltip/Tooltip';
 
 export interface ITabOwnProps {
@@ -10,6 +11,8 @@ export interface ITabOwnProps {
     title: string;
     disabled?: boolean;
     tooltip?: string;
+    svgName?: string;
+    svgClass?: string;
 }
 
 export interface ITabStateProps {
@@ -34,6 +37,7 @@ export class Tab extends React.Component<ITabProps, any> {
 
         return (
             <div className={className} onClick={this.handleSelect}>
+                {!!this.props.svgName && <Svg svgName={this.props.svgName} svgClass={this.props.svgClass} />}
                 <Tooltip title={this.props.tooltip} placement={TooltipPlacement.Top}>
                     {this.props.title}
                 </Tooltip>

--- a/packages/react-vapor/src/components/tab/Tab.tsx
+++ b/packages/react-vapor/src/components/tab/Tab.tsx
@@ -2,7 +2,6 @@ import classNames from 'classnames';
 import * as React from 'react';
 
 import {TooltipPlacement} from '../../utils/TooltipUtils';
-import {Svg} from '../svg';
 import {Tooltip} from '../tooltip/Tooltip';
 
 export interface ITabOwnProps {
@@ -11,8 +10,7 @@ export interface ITabOwnProps {
     title: string;
     disabled?: boolean;
     tooltip?: string;
-    svgName?: string;
-    svgClass?: string;
+    children?: React.ReactNode;
 }
 
 export interface ITabStateProps {
@@ -37,7 +35,7 @@ export class Tab extends React.Component<ITabProps, any> {
 
         return (
             <div className={className} onClick={this.handleSelect}>
-                {!!this.props.svgName && <Svg svgName={this.props.svgName} svgClass={this.props.svgClass} />}
+                {!!this.props.children && this.props.children}
                 <Tooltip title={this.props.tooltip} placement={TooltipPlacement.Top}>
                     {this.props.title}
                 </Tooltip>

--- a/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
+++ b/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
@@ -1,5 +1,6 @@
 import {shallow} from 'enzyme';
 import * as React from 'react';
+import {Svg} from '../../svg';
 
 import {Tooltip} from '../../tooltip/Tooltip';
 import {ITabProps, Tab} from '../Tab';
@@ -70,5 +71,12 @@ describe('Tab', () => {
 
         expect(tab.find(Tooltip).exists()).toBe(true);
         expect(tab.find(Tooltip).props().title).toBe(expectedTooltipText);
+    });
+
+    it('should render a Svg component if the svgName is not empty', () => {
+        const tab = shallow(<Tab {...basicProps} svgName="help" />);
+
+        expect(tab.find(Svg).exists()).toBe(true);
+        expect(tab.find(Svg).props().svgName).toBe('help');
     });
 });

--- a/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
+++ b/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
@@ -75,7 +75,9 @@ describe('Tab', () => {
 
     it('should render a children component if it is not empty', () => {
         const tab = shallow(
-            <Tab {...basicProps} children={<Svg svgName={'help'} svgClass={'icon fill-orange mod-16 mr1'} />} />
+            <Tab {...basicProps}>
+                <Svg svgName={'help'} svgClass={'icon fill-orange mod-16 mr1'} />
+            </Tab>
         );
 
         expect(tab.find(Svg).exists()).toBe(true);

--- a/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
+++ b/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
@@ -73,8 +73,10 @@ describe('Tab', () => {
         expect(tab.find(Tooltip).props().title).toBe(expectedTooltipText);
     });
 
-    it('should render a Svg component if the svgName is not empty', () => {
-        const tab = shallow(<Tab {...basicProps} svgName="help" />);
+    it('should render a children component if it is not empty', () => {
+        const tab = shallow(
+            <Tab {...basicProps} children={<Svg svgName={'help'} svgClass={'icon fill-orange mod-16 mr1'} />} />
+        );
 
         expect(tab.find(Svg).exists()).toBe(true);
         expect(tab.find(Svg).props().svgName).toBe('help');


### PR DESCRIPTION
### Proposed Changes
I added the possibility to include a Svg icon to an Tab component. You could see an example in the Tab section.
![new_tab_with_icon](https://user-images.githubusercontent.com/58052881/101418591-30488c00-38bc-11eb-9390-ee7cf73023aa.png)


### Potential Breaking Changes


### Acceptance Criteria

-   [X ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
