### PR TITLE
feat(tab): include a children prop

### DIFF
--- a/packages/demo/src/components/examples/TabConnectedExample.tsx
+++ b/packages/demo/src/components/examples/TabConnectedExample.tsx
@@ -5,6 +5,7 @@ const TAB1_ID = 'tab1';
 const TAB2_ID = 'tab2';
 const TAB3_ID = 'tab3';
 const TAB4_ID = 'tab4';
+const TAB5_ID = 'tab5';
 
 const TAB11_ID = 'tab11';
 const TAB22_ID = 'tab22';
@@ -23,7 +24,12 @@ export class TabsExamples extends React.Component<any, any> {
                             <TabConnected id={TAB3_ID} title="Tab with an icon">
                                 <Svg svgName={'help'} svgClass={'icon fill-orange mod-16 mr1'} />
                             </TabConnected>
-                            <TabConnected id={TAB4_ID} title="A Disabled Tab" tooltip="I am a disabled tab" disabled />
+                            <TabConnected
+                                id={TAB4_ID}
+                                title=" Another Tab with an icon"
+                                children={<Svg svgName={'info'} svgClass={'icon fill-blue mod-16 mr1'} />}
+                            />
+                            <TabConnected id={TAB5_ID} title="A Disabled Tab" tooltip="I am a disabled tab" disabled />
                         </TabNavigation>
                         <TabContent>
                             <TabPaneConnected id={TAB1_ID}>
@@ -42,6 +48,11 @@ export class TabsExamples extends React.Component<any, any> {
                                 </div>
                             </TabPaneConnected>
                             <TabPaneConnected id={TAB4_ID}>
+                                <div className="mod-header-padding mod-form-top-bottom-padding">
+                                    Content of the other tab with an icon.
+                                </div>
+                            </TabPaneConnected>
+                            <TabPaneConnected id={TAB5_ID}>
                                 <div className="mod-header-padding mod-form-top-bottom-padding">
                                     Last tab. You shouldn't be able to see this because the tab is disabled.
                                 </div>

--- a/packages/react-vapor/src/components/tab/Tab.tsx
+++ b/packages/react-vapor/src/components/tab/Tab.tsx
@@ -10,6 +10,7 @@ export interface ITabOwnProps {
     title: string;
     disabled?: boolean;
     tooltip?: string;
+    children?: React.ReactNode;
 }
 
 export interface ITabStateProps {

--- a/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
+++ b/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
@@ -73,11 +73,20 @@ describe('Tab', () => {
         expect(tab.find(Tooltip).props().title).toBe(expectedTooltipText);
     });
 
-    it('should render a children component if it is not empty', () => {
+    it("should render a children component if it's included", () => {
         const tab = shallow(
             <Tab {...basicProps}>
                 <Svg svgName={'help'} svgClass={'icon fill-orange mod-16 mr1'} />
             </Tab>
+        );
+
+        expect(tab.find(Svg).exists()).toBe(true);
+        expect(tab.find(Svg).props().svgName).toBe('help');
+    });
+
+    it("should render a children component if it's set", () => {
+        const tab = shallow(
+            <Tab {...basicProps} children={<Svg svgName={'help'} svgClass={'icon fill-orange mod-16 mr1'} />} />
         );
 
         expect(tab.find(Svg).exists()).toBe(true);


### PR DESCRIPTION
### Proposed Changes

Take 2: this time I also included the children prop: in some instances, I need the children prop to be available, so I could set an icon. For example, if I assign an `ITabProps` array to the tab props of a `BreadcrumbHeader` component, I have to have this prop available. However, even if I included this prop, I also wanted to demonstrate that both ways are valid 
### Potential Breaking Changes


### Acceptance Criteria

-   [X ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
