### PR TITLE
fix: remove useless border radius on application-container

### DIFF
--- a/packages/vapor/scss/components/application-container.scss
+++ b/packages/vapor/scss/components/application-container.scss
@@ -5,7 +5,6 @@
 
     max-width: 100vw;
     overflow: auto;
-    border-top-left-radius: 2px;
 }
 
 .application-wrapper {


### PR DESCRIPTION
### Proposed Changes

Before: 

![image](https://user-images.githubusercontent.com/260007/102255724-70b99280-3ed8-11eb-95d7-a68f86c07aee.png)



After:

![image](https://user-images.githubusercontent.com/260007/102255643-55e71e00-3ed8-11eb-9b65-5f8eefe151f1.png)
