### PR TITLE
feat(demo): enable esm react-vapor sourcemaps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4166,6 +4166,11 @@
 				"through": ">=2.2.7 <3"
 			}
 		},
+		"abab": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
+		},
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -21598,6 +21603,52 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 		},
+		"source-map-loader": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-1.1.0.tgz",
+			"integrity": "sha512-Kj7rXntLhAsEjZlqGz85Mbnu8N4gcxj5qZI1XyLQjqAI/p92ckRXwErb3jVYL5JxlFJnD4VgwybpB1h6NlETRg==",
+			"requires": {
+				"abab": "^2.0.4",
+				"iconv-lite": "^0.6.2",
+				"loader-utils": "^2.0.0",
+				"schema-utils": "^2.7.0",
+				"source-map": "^0.6.1",
+				"whatwg-mimetype": "^2.3.0"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.6.2",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+					"integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3.0.0"
+					}
+				},
+				"json5": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+					"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
+				"loader-utils": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+					"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^2.1.2"
+					}
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+				}
+			}
+		},
 		"source-map-resolve": {
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -25526,6 +25577,11 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
 			"integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
+		},
+		"whatwg-mimetype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
 		},
 		"whatwg-url": {
 			"version": "7.1.0",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -73,6 +73,7 @@
         "sass": "1.25.0",
         "sass-loader": "10.1.0",
         "sass-variable-loader": "0.1.2",
+        "source-map-loader": "1.1.0",
         "style-loader": "1.1.3",
         "ts-loader": "6.2.1",
         "ts-transformer-keys": "0.4.1",

--- a/packages/demo/src/components/examples/DatePickerExamples.tsx
+++ b/packages/demo/src/components/examples/DatePickerExamples.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import {
     CalendarConnected,
+    ChildForm,
     DatePickerBox,
     DatePickerDropdownConnected,
     DatesSelectionConnected,
     Section,
 } from 'react-vapor';
 import * as _ from 'underscore';
-import {ChildForm} from '../../../../react-vapor/src/components/childForm/ChildForm';
 
 import {ExampleComponent} from '../ComponentsInterface';
 import {

--- a/packages/demo/tsconfig.json
+++ b/packages/demo/tsconfig.json
@@ -6,8 +6,7 @@
         "experimentalDecorators": true,
         "downlevelIteration": true,
         "esModuleInterop": true,
-        "importsNotUsedAsValues": "preserve"
+        "importHelpers": true
     },
-    "exclude": ["node_modules", "dist", "*.js"],
     "include": ["src", "types"]
 }

--- a/packages/demo/webpack.config.js
+++ b/packages/demo/webpack.config.js
@@ -44,6 +44,11 @@ module.exports = {
     module: {
         rules: [
             {
+                test: /\.js$/,
+                enforce: 'pre',
+                use: ['source-map-loader'],
+            },
+            {
                 test: /\.tsx?$/,
                 use: [
                     {

--- a/packages/react-vapor/rollup.config.js
+++ b/packages/react-vapor/rollup.config.js
@@ -13,6 +13,7 @@ export default {
     output: {
         file: 'dist/react-vapor.esm.js',
         format: 'es',
+        sourcemap: true,
     },
     external: [
         'codemirror',


### PR DESCRIPTION
The sourcemaps for the esm build were not produced, making it very hard to debug react-vapor
components from the demo.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
