### PR TITLE
feat(table): implement tableWithEmptyState HOC

### DIFF
--- a/packages/demo/src/components/examples/TableHOCExampleUtils.tsx
+++ b/packages/demo/src/components/examples/TableHOCExampleUtils.tsx
@@ -53,6 +53,7 @@ const tablePredicates = [
         values: [
             {displayValue: 'All', value: '', selected: true},
             {displayValue: 'Lebsackbury', value: 'Lebsackbury'},
+            {displayValue: 'Wakanda', value: 'Wakanda'},
         ],
     },
     {

--- a/packages/demo/src/components/examples/TableHOCServerExamples.tsx
+++ b/packages/demo/src/components/examples/TableHOCServerExamples.tsx
@@ -100,25 +100,11 @@ class TableExampleDisconnected extends React.PureComponent<TableHOCServerProps, 
     private ServerTableComposed = _.compose(
         withServerSideProcessing,
         tableWithUrlState,
-        tableWithBlankSlate({
-            title: 'No data fetched from the server',
-            description: 'Try reviewing the specified filters above or clearing all filters.',
-            buttons: [
-                {
-                    name: 'Clear filter',
-                    enabled: true,
-                    onClick: () => this.props.resetFilter(),
-                },
-            ],
-        }),
+        tableWithBlankSlate({title: 'No data fetched from the server'}),
         tableWithPredicate(TableHOCExampleUtils.tablePredicates[0]),
         tableWithPredicate(TableHOCExampleUtils.tablePredicates[1]),
-        tableWithFilter({
-            placeholder: 'Filter all',
-            blankSlate: {
-                title: 'No results found',
-            },
-        }),
+        tableWithBlankSlate({title: 'No users match the selected predicates'}),
+        tableWithFilter(),
         tableWithSort(),
         tableWithDatePicker({...(TableHOCExampleUtils.tableDatePickerConfig as any)}),
         tableWithNewPagination({perPageNumbers: [3, 5, 10]}),
@@ -168,6 +154,18 @@ class TableExampleDisconnected extends React.PureComponent<TableHOCServerProps, 
                         onUpdateUrl={this.updateUrl}
                         isLoading={this.state.isLoading}
                         loading={{numberOfColumns: 6}}
+                        filterPlaceholder="Filter all"
+                        filterBlankslate={{
+                            title: 'No result match the specified filter',
+                            description: 'Try reviewing the specified filters above or clearing all filters.',
+                            buttons: [
+                                {
+                                    name: 'Clear filter',
+                                    enabled: true,
+                                    onClick: this.props.resetFilter,
+                                },
+                            ],
+                        }}
                     >
                         <LastUpdated time={new Date()} />
                     </this.ServerTableComposed>

--- a/packages/react-vapor/src/components/table-hoc/TableSelectors.ts
+++ b/packages/react-vapor/src/components/table-hoc/TableSelectors.ts
@@ -18,9 +18,9 @@ const initialTableSort: ITableWithSortState = {
 };
 
 const getIsEmpty = (state: IReactVaporState, props: TableSelectorsProps): boolean =>
-    props.data !== null && (!props.data || props.data.length === 0);
+    props.isServer ? !props.data?.length : props.data !== null && !props.data?.length;
 
-const getIsTruelyEmpty = (state: IReactVaporState, props: TableSelectorsProps): boolean => {
+const getIsTrulyEmpty = (state: IReactVaporState, props: TableSelectorsProps): boolean => {
     const compositeState = TableHOCUtils.getCompositeState(props.id, state);
     const isEmpty = getIsEmpty(state, props);
 
@@ -52,7 +52,11 @@ const getSelectedRows = (state: IReactVaporState, {id}: {id: string}): HOCTableR
 
 export const TableSelectors = {
     getIsEmpty,
-    getIsTruelyEmpty,
+    getIsTrulyEmpty,
+    /**
+     * @deprecated renamed to getIsTrulyEmpty
+     */
+    getIsTruelyEmpty: getIsTrulyEmpty,
     getDataCount,
     getSort,
     getTableRow,

--- a/packages/react-vapor/src/components/table-hoc/TableWithBlankSlate.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithBlankSlate.tsx
@@ -9,7 +9,13 @@ import {ITableHOCOwnProps} from './TableHOC';
 import {TableSelectors} from './TableSelectors';
 
 export interface ITableWithBlankSlateStateProps {
+    /**
+     * @deprecated Use TableWithEmptyState instead
+     */
     renderBlankSlate?: JSX.Element;
+    /**
+     * @deprecated Use TableWithEmptyState instead
+     */
     renderBlankSlateOnly?: boolean;
 }
 
@@ -21,11 +27,10 @@ export const tableWithBlankSlate = (supplier: ConfigSupplier<IBlankSlateWithTabl
     const config = HocUtils.supplyConfig(supplier);
     const defaultRenderBlankSlateMethod = <BlankSlateWithTable {...config} />;
     const mapStateToProps = (state: IReactVaporState, ownProps: ITableHOCOwnProps & ITableWithBlankSlateProps) => {
-        const isEmpty = ownProps.renderBlankSlateOnly
-            ? TableSelectors.getIsTruelyEmpty(state, ownProps)
-            : TableSelectors.getIsEmpty(state, ownProps);
+        const isEmpty = TableSelectors.getIsEmpty(state, ownProps);
         return {
             isEmpty,
+            isTrulyEmpty: TableSelectors.getIsTrulyEmpty(state, ownProps),
             data: isEmpty ? null : ownProps.data,
         };
     };
@@ -33,11 +38,11 @@ export const tableWithBlankSlate = (supplier: ConfigSupplier<IBlankSlateWithTabl
     const TableWithBlankSlate: React.FunctionComponent<
         ITableHOCOwnProps & ITableWithBlankSlateProps & ReturnType<typeof mapStateToProps>
     > = (props) => {
-        const {renderBlankSlate, renderBlankSlateOnly, isEmpty, ...tableProps} = props;
+        const {renderBlankSlate, renderBlankSlateOnly, isEmpty, isTrulyEmpty, ...tableProps} = props;
 
         const blankSlateToRender = renderBlankSlate || defaultRenderBlankSlateMethod;
 
-        if (isEmpty && renderBlankSlateOnly && !props.isLoading) {
+        if (renderBlankSlateOnly && isTrulyEmpty && !props.isLoading) {
             return blankSlateToRender;
         }
 

--- a/packages/react-vapor/src/components/table-hoc/TableWithEmptyState.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithEmptyState.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+import * as _ from 'underscore';
+
+import {IReactVaporState} from '../../ReactVapor';
+import {ITableHOCOwnProps} from './TableHOC';
+import {TableSelectors} from './TableSelectors';
+
+export interface TableWithEmptyStateProps {
+    emptyState: JSX.Element;
+}
+
+const UPDATE_DELAY = 50; // ms
+
+export const tableWithEmptyState = (
+    Component: React.ComponentClass<ITableHOCOwnProps & React.HTMLAttributes<HTMLTableElement>>
+): React.ComponentType<ITableHOCOwnProps & React.HTMLAttributes<HTMLTableElement> & TableWithEmptyStateProps> => {
+    const mapStateToProps = (state: IReactVaporState, ownProps: ITableHOCOwnProps) => {
+        const isTrulyEmpty = TableSelectors.getIsTrulyEmpty(state, ownProps);
+        return {
+            isTrulyEmpty,
+            data: isTrulyEmpty ? null : ownProps.data,
+        };
+    };
+
+    const TableEmptyState: React.FunctionComponent<
+        ITableHOCOwnProps & TableWithEmptyStateProps & ReturnType<typeof mapStateToProps>
+    > = (props) => {
+        const {emptyState, isTrulyEmpty: isTrulyEmpty, ...tableProps} = props;
+        const [shouldRenderEmptyState, setShouldRenderEmptyState_immediate] = React.useState(false);
+
+        const setShouldRenderEmptyState_debounced = React.useRef(
+            _.debounce((value: boolean) => setShouldRenderEmptyState_immediate(value), UPDATE_DELAY)
+        ).current;
+
+        // Cancelling the debounced function on unmount to prevent calling setState on an unmounted component
+        React.useEffect(() => setShouldRenderEmptyState_debounced.cancel, []);
+
+        React.useEffect(() => {
+            setShouldRenderEmptyState_debounced(isTrulyEmpty && !props.isLoading);
+        }, [isTrulyEmpty, props.isLoading]);
+
+        return shouldRenderEmptyState ? emptyState : <Component {...tableProps} />;
+    };
+
+    return connect(mapStateToProps)(TableEmptyState);
+};

--- a/packages/react-vapor/src/components/table-hoc/TableWithPrepend.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithPrepend.tsx
@@ -13,7 +13,7 @@ export const tableWithPrepend = <P extends ITableHOCOwnProps & React.HTMLAttribu
     Component: React.ComponentClass<P>
 ) => {
     const mapStateToProps = (state: IReactVaporState, ownProps: P & TableWithPrependProps) => ({
-        isTruelyEmpty: TableSelectors.getIsTruelyEmpty(state, ownProps),
+        isTrulyEmpty: TableSelectors.getIsTrulyEmpty(state, ownProps),
     });
 
     const TableWithPrepend: React.FunctionComponent<
@@ -22,10 +22,10 @@ export const tableWithPrepend = <P extends ITableHOCOwnProps & React.HTMLAttribu
             TableWithPrependProps &
             ReturnType<typeof mapStateToProps>
     > = (props) => {
-        const {prepend, isTruelyEmpty, ...tableProps} = props;
+        const {prepend, isTrulyEmpty, ...tableProps} = props;
         return (
             <>
-                {!isTruelyEmpty ? prepend : null}
+                {!isTrulyEmpty ? prepend : null}
                 <Component {...(tableProps as P)} />
             </>
         );

--- a/packages/react-vapor/src/components/table-hoc/index.ts
+++ b/packages/react-vapor/src/components/table-hoc/index.ts
@@ -8,6 +8,7 @@ export * from './TableSelectors';
 export * from './TableWithActions';
 export * from './TableWithBlankSlate';
 export * from './TableWithDatePicker';
+export * from './TableWithEmptyState';
 export * from './TableWithFilter';
 export * from './TableWithPagination';
 export * from './TableWithNewPagination';

--- a/packages/react-vapor/src/components/table-hoc/tests/TableSelectors.spec.ts
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableSelectors.spec.ts
@@ -3,11 +3,49 @@ import {TableSelectors} from '../TableSelectors';
 import {ITableHOCCompositeState, TableHOCUtils} from '../utils/TableHOCUtils';
 
 describe('TableSelectors', () => {
-    describe('getIsTruelyEmpty', () => {
+    describe('getIsEmpty', () => {
+        describe('when the "isServer" prop is true', () => {
+            it('returns true if the "data" prop is undefined', () => {
+                expect(TableSelectors.getIsEmpty({}, {id: '🌶', isServer: true, data: undefined})).toBe(true);
+            });
+
+            it('returns true if the "data" prop is null', () => {
+                expect(TableSelectors.getIsEmpty({}, {id: '🌶', isServer: true, data: null})).toBe(true);
+            });
+
+            it('returns true if the "data" prop is an empty array', () => {
+                expect(TableSelectors.getIsEmpty({}, {id: '🌶', isServer: true, data: []})).toBe(true);
+            });
+
+            it('returns false if the "data" prop is a non-empty array', () => {
+                expect(TableSelectors.getIsEmpty({}, {id: '🌶', isServer: true, data: [1, 2, 3]})).toBe(false);
+            });
+        });
+
+        describe('when the "isServer" prop is false', () => {
+            it('returns true if the "data" prop is undefined', () => {
+                expect(TableSelectors.getIsEmpty({}, {id: '🌶', isServer: false, data: undefined})).toBe(true);
+            });
+
+            it('returns true if the "data" prop is an empty array', () => {
+                expect(TableSelectors.getIsEmpty({}, {id: '🌶', isServer: false, data: []})).toBe(true);
+            });
+
+            it('returns false if the "data" prop is null', () => {
+                expect(TableSelectors.getIsEmpty({}, {id: '🌶', isServer: false, data: null})).toBe(false);
+            });
+
+            it('returns false if the "data" prop is a non-empty array', () => {
+                expect(TableSelectors.getIsEmpty({}, {id: '🌶', isServer: false, data: [1, 2, 3]})).toBe(false);
+            });
+        });
+    });
+
+    describe('getIsTrulyEmpty', () => {
         it('should return true if the data is empty, there is no filter, predicate or date limit applied', () => {
             spyOn(TableHOCUtils, 'getCompositeState').and.returnValue({});
 
-            expect(TableSelectors.getIsTruelyEmpty({} as IReactVaporState, {id: 'table-id', data: []})).toBe(true);
+            expect(TableSelectors.getIsTrulyEmpty({} as IReactVaporState, {id: 'table-id', data: []})).toBe(true);
         });
 
         it('should return true if the data is empty, there is no filter, predicate or date limit applied (null dates)', () => {
@@ -16,7 +54,7 @@ describe('TableSelectors', () => {
             };
             spyOn(TableHOCUtils, 'getCompositeState').and.returnValue(tableState);
 
-            expect(TableSelectors.getIsTruelyEmpty({} as IReactVaporState, {id: 'table-id', data: []})).toBe(true);
+            expect(TableSelectors.getIsTrulyEmpty({} as IReactVaporState, {id: 'table-id', data: []})).toBe(true);
         });
 
         it('should return false if the data is empty but a filter is applied', () => {
@@ -25,7 +63,7 @@ describe('TableSelectors', () => {
             };
             spyOn(TableHOCUtils, 'getCompositeState').and.returnValue(tableState);
 
-            expect(TableSelectors.getIsTruelyEmpty({} as IReactVaporState, {id: 'table-id', data: []})).toBe(false);
+            expect(TableSelectors.getIsTrulyEmpty({} as IReactVaporState, {id: 'table-id', data: []})).toBe(false);
         });
 
         it('should return false if the data is empty but a predicate is applied', () => {
@@ -34,7 +72,7 @@ describe('TableSelectors', () => {
             };
             spyOn(TableHOCUtils, 'getCompositeState').and.returnValue(tableState);
 
-            expect(TableSelectors.getIsTruelyEmpty({} as IReactVaporState, {id: 'table-id', data: []})).toBe(false);
+            expect(TableSelectors.getIsTrulyEmpty({} as IReactVaporState, {id: 'table-id', data: []})).toBe(false);
         });
 
         it('should return false if the data is empty but a date limit is applied', () => {
@@ -44,7 +82,7 @@ describe('TableSelectors', () => {
             };
             spyOn(TableHOCUtils, 'getCompositeState').and.returnValue(tableState);
 
-            expect(TableSelectors.getIsTruelyEmpty({} as IReactVaporState, {id: 'table-id', data: []})).toBe(false);
+            expect(TableSelectors.getIsTrulyEmpty({} as IReactVaporState, {id: 'table-id', data: []})).toBe(false);
         });
     });
 });

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithBlankslate.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithBlankslate.spec.tsx
@@ -107,22 +107,23 @@ describe('TableWithBlankSlate', () => {
     });
 
     describe('when "renderBlankSlateOnly" prop is set to true', () => {
-        it('should not render anything else than the blankslate if the table is truely empty', () => {
-            spyOn(TableSelectors, 'getIsTruelyEmpty').and.returnValue(true);
+        it('should not render anything else than the blankslate if the table is truly empty', () => {
+            spyOn(TableSelectors, 'getIsTrulyEmpty').and.returnValue(true);
             const wrapper = shallowWithState(<TableWithBlankSlate {...basicProps} renderBlankSlateOnly />, {}).dive();
 
             expect(wrapper.type()).toBe(BlankSlateWithTable);
         });
 
-        it('should render the blank slate in the table body if the table is not truely empty', () => {
-            spyOn(TableSelectors, 'getIsTruelyEmpty').and.returnValue(false);
+        it('should render the blank slate in the table body if the table is not truly empty', () => {
+            spyOn(TableSelectors, 'getIsTrulyEmpty').and.returnValue(false);
             const wrapper = shallowWithState(<TableWithBlankSlate {...basicProps} renderBlankSlateOnly />, {}).dive();
 
             expect(wrapper.type()).toBe(TableHOC);
+            expect(wrapper.prop<() => JSX.Element>('renderBody')().type).toBe(BlankSlateWithTable);
         });
 
-        it('does not render the blank slate in the table body when the table is loading', () => {
-            spyOn(TableSelectors, 'getIsTruelyEmpty').and.returnValue(false);
+        it('does not render the blank slate instead of the table when the table is loading', () => {
+            spyOn(TableSelectors, 'getIsTrulyEmpty').and.returnValue(true);
             const wrapper = shallowWithState(
                 <TableWithBlankSlate {...basicProps} renderBlankSlateOnly isLoading />,
                 {}

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithEmptyState.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithEmptyState.spec.tsx
@@ -1,0 +1,80 @@
+import {ReactWrapper} from 'enzyme';
+import {mountWithStore} from 'enzyme-redux';
+import * as React from 'react';
+import {act} from 'react-dom/test-utils';
+import * as _ from 'underscore';
+
+import {getStoreMock} from '../../../utils/tests/TestUtils';
+import {TableHOC} from '../TableHOC';
+import {tableWithEmptyState} from '../TableWithEmptyState';
+
+describe('TableWithEmptyState', () => {
+    const TableWithEmptyState = tableWithEmptyState(TableHOC);
+    const EmptyState: React.FunctionComponent = () => <div>No data!</div>;
+
+    it('renders and unmounts without throwing errors', () => {
+        expect(() => {
+            const table = mountWithStore(
+                <TableWithEmptyState id="🌶" data={[]} renderBody={() => null} emptyState={<EmptyState />} />,
+                getStoreMock()
+            );
+            table.unmount();
+        }).not.toThrow();
+    });
+
+    it('renders the empty state if the table is empty after waiting 50 ms', () => {
+        jasmine.clock().install();
+        let table: ReactWrapper;
+        act(() => {
+            table = mountWithStore(
+                <TableWithEmptyState id="🌶" data={[]} renderBody={() => null} emptyState={<EmptyState />} />,
+                getStoreMock()
+            );
+        });
+
+        expect(table.children().children().type()).toBe(TableHOC);
+
+        jasmine.clock().tick(50);
+        table.update();
+
+        expect(table.children().children().type()).toBe(EmptyState);
+
+        jasmine.clock().uninstall();
+    });
+
+    it('renders the table if the table is empty after waiting 50 ms but still loading', () => {
+        jasmine.clock().install();
+        let table: ReactWrapper;
+        act(() => {
+            table = mountWithStore(
+                <TableWithEmptyState id="🌶" data={[]} renderBody={() => null} emptyState={<EmptyState />} isLoading />,
+                getStoreMock()
+            );
+        });
+
+        jasmine.clock().tick(50);
+        table.update();
+
+        expect(table.children().children().type()).toBe(TableHOC);
+
+        jasmine.clock().uninstall();
+    });
+
+    it('renders the table if the table is not empty after waiting 50 ms', () => {
+        jasmine.clock().install();
+        let table: ReactWrapper;
+        act(() => {
+            table = mountWithStore(
+                <TableWithEmptyState id="🌶" data={['🤓']} renderBody={() => null} emptyState={<EmptyState />} />,
+                getStoreMock()
+            );
+        });
+
+        jasmine.clock().tick(50);
+        table.update();
+
+        expect(table.children().children().type()).toBe(TableHOC);
+
+        jasmine.clock().uninstall();
+    });
+});

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithPrepend.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithPrepend.spec.tsx
@@ -20,8 +20,8 @@ describe('TableWithPrepend', () => {
         }).not.toThrow();
     });
 
-    it('should not render prepended content if the table is truely empty', () => {
-        spyOn(TableSelectors, 'getIsTruelyEmpty').and.returnValue(true);
+    it('should not render prepended content if the table is truly empty', () => {
+        spyOn(TableSelectors, 'getIsTrulyEmpty').and.returnValue(true);
         const Prepend = () => <span>ink!</span>;
         const wrapper = shallowWithState(
             <TableWithPrepend {...basicProps} data={[]} prepend={<Prepend />} />,
@@ -29,11 +29,12 @@ describe('TableWithPrepend', () => {
         ).dive();
 
         expect(wrapper.children().first().type()).not.toBe(Prepend);
+
         expect(wrapper.children().first().type()).toBe(TableHOC);
     });
 
-    it('should render prepended content if the table is not truely empty', () => {
-        spyOn(TableSelectors, 'getIsTruelyEmpty').and.returnValue(false);
+    it('should render prepended content if the table is not truly empty', () => {
+        spyOn(TableSelectors, 'getIsTrulyEmpty').and.returnValue(false);
         const Prepend = () => <span>ink!</span>;
         const wrapper = shallowWithState(
             <TableWithPrepend {...basicProps} data={[]} prepend={<Prepend />} />,
@@ -41,6 +42,7 @@ describe('TableWithPrepend', () => {
         ).dive();
 
         expect(wrapper.children().first().type()).not.toBe(TableHOC);
+
         expect(wrapper.children().first().type()).toBe(Prepend);
     });
 });


### PR DESCRIPTION
Empty state: displayed when no data exist for the resource bound to the table. 
Blankslate: displayed when no data match the current configuration of the table (filter, predicates, date picker, etc)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
