### PR TITLE
fix(validations): only dispatch dirty and error when input changes

### DIFF
--- a/packages/react-vapor/src/components/validation/hoc/WithDirtyInputHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtyInputHOC.tsx
@@ -26,6 +26,8 @@ export const withDirtyInputHOC = <T extends IInputOwnProps>(Component: React.Com
         resetDirtyOnUnmount,
         ...props
     }) => {
+        const [lastState, setLastState] = React.useState<boolean | null>(null);
+
         React.useEffect(
             () => () => {
                 resetDirtyOnUnmount && clearIsDirty(props.id);
@@ -37,7 +39,11 @@ export const withDirtyInputHOC = <T extends IInputOwnProps>(Component: React.Com
             <Component
                 {...(props as T)}
                 validate={(value: string) => {
-                    setIsDirty(props.id, value !== (props.defaultValue || ''));
+                    const isDirty = value !== (props.defaultValue || '');
+                    if (isDirty !== lastState) {
+                        setLastState(isDirty);
+                        setIsDirty(props.id, isDirty);
+                    }
                     return validate ? validate(value) : true;
                 }}
                 validateOnChange

--- a/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithNonEmptyValueInputValidationHOC.tsx
@@ -31,6 +31,8 @@ export const withNonEmptyValueInputValidationHOC = <T extends IInputOwnProps>(
         validate,
         ...props
     }) => {
+        const [lastState, setLastState] = React.useState<boolean | null>(null);
+
         React.useEffect(
             () => () => {
                 resetErrorOnUnmount && clearError(props.id);
@@ -43,7 +45,10 @@ export const withNonEmptyValueInputValidationHOC = <T extends IInputOwnProps>(
                 {...(props as T)}
                 validate={(value: string) => {
                     const isEmpty = !/\S/.test(value);
-                    setError(props.id, isEmpty ? validationMessage : '');
+                    if (isEmpty !== lastState) {
+                        setLastState(isEmpty);
+                        setError(props.id, isEmpty ? validationMessage : '');
+                    }
                     return !isEmpty || (validate ? validate(value) : true);
                 }}
             />


### PR DESCRIPTION
[COM-703]

While profiling, I noticed that an input that validates both "non-empty" and `dirty" would dispatch 3 actions per keystroke.

Here is a quick and easy optimization that will only dispatch the action when the value actually changes.

You can validate the change in the demo, in the "Input with dirty management" example.

<!-- Explain what are your changes. -->

None

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-703]: https://coveord.atlassian.net/browse/COM-703