### PR TITLE
feat(tablerowconnected): +noBorderBottom props

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableRowConnected.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableRowConnected.tsx
@@ -19,6 +19,7 @@ export interface CollapsibleRowProps {
     content?: React.ReactNode;
     className?: string;
     expandOnMount?: boolean;
+    noBorderBottom?: boolean;
     renderCustomToggleCell?: (opened: boolean) => React.ReactNode;
     onToggleCollapsible?: (open: boolean) => void;
 }
@@ -146,7 +147,11 @@ class TableRowConnected extends React.PureComponent<
                 collapsibleRowToggle = React.isValidElement(customToggle) ? (
                     customToggle
                 ) : (
-                    <td className="table-row-collapsible-btn">
+                    <td
+                        className={classNames('table-row-collapsible-btn', {
+                            'mod-no-border-bottom': this.props.collapsible.noBorderBottom,
+                        })}
+                    >
                         <CollapsibleToggle
                             onClick={this.onToggleCollapsible}
                             expanded={this.props.opened}

--- a/packages/react-vapor/src/components/table-hoc/tests/TableRowConnected.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableRowConnected.spec.tsx
@@ -308,6 +308,7 @@ describe('Table HOC', () => {
 
                 expect(wrapper.find('tr').length).toBe(2);
                 expect(wrapper.find('tr').at(0).hasClass('heading-row')).toBe(true);
+
                 expect(wrapper.find('tr').at(1).hasClass('collapsible-row')).toBe(true);
             });
 
@@ -334,6 +335,18 @@ describe('Table HOC', () => {
 
                 expect(wrapper.find(CollapsibleToggle).exists()).toBe(true);
                 expect(wrapper.find(CollapsibleToggle).props().expanded).toBe(true);
+            });
+
+            it('should add mod-no-border-bottom when specified using the prop noBorderBottom', () => {
+                shallowComponent();
+                wrapper.setProps({
+                    collapsible: {
+                        content: collapsibleContent,
+                        noBorderBottom: true,
+                    },
+                });
+
+                expect(wrapper.find('tr.heading-row td').last().hasClass('mod-no-border-bottom')).toBe(true);
             });
 
             it('should render a collapsible row custom toggle when specified using the prop renderCustomToggleCell', () => {


### PR DESCRIPTION
### Proposed Changes

when we toggle the collapsible, now we can display or not the borderbottom of the row, which would
give a better feeling of expanding content

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
