### PR TITLE
fix(button): reset default text color to pure-white

### DIFF
--- a/packages/vapor/scss/redesign/variables.scss
+++ b/packages/vapor/scss/redesign/variables.scss
@@ -19,7 +19,7 @@
     // Button //
     // Primary
     --button-primary-color: var(--orange);
-    --button-primary-text-color: var(--white);
+    --button-primary-text-color: var(--pure-white);
     --button-primary-icon-color: var(--pure-white);
 
     --button-primary-hover-color: #{lighten($orange, 5%)};


### PR DESCRIPTION
### Proposed Changes

The default text color of buttons should be pure-white.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
