### PR TITLE
refactor(components): remove UNSAFE_componentWillMount lifecycle methods

### DIFF
--- a/packages/demo/src/components/examples/ListBoxExampleConnected.tsx
+++ b/packages/demo/src/components/examples/ListBoxExampleConnected.tsx
@@ -59,7 +59,7 @@ const mapDispatchToProps = (dispatch: IDispatch, ownProps: IListBoxExamplesProps
 
 @ReduxConnect(mapStateToProps, mapDispatchToProps, ReduxUtils.defaultMergeProps)
 export class ListBoxExampleConnected extends React.Component<IListBoxExamplesProps> {
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         this.props.addListBoxExample();
     }
 

--- a/packages/demo/src/components/examples/PaginationConnectedExamples.tsx
+++ b/packages/demo/src/components/examples/PaginationConnectedExamples.tsx
@@ -10,7 +10,7 @@ const navigationConnectedExampleLoadingIds = ['loading-' + navigationConnectedEx
 export class PaginationConnectedExamples extends React.PureComponent {
     static title: string = 'PaginationConnected';
     // Remove loading after a few seconds
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         Store.subscribe(() => {
             if (_.contains([LoadingActions.turnOn, LoadingActions.add], Store.getState().lastAction.type)) {
                 setTimeout(() => {

--- a/packages/react-vapor/src/components/autocomplete/AutocompleteConnected.tsx
+++ b/packages/react-vapor/src/components/autocomplete/AutocompleteConnected.tsx
@@ -108,7 +108,7 @@ export class AutocompleteConnected extends React.Component<
         inline: false,
     };
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         this.props.onRender();
         document.addEventListener('mousedown', this.handleDocumentClick);
     }

--- a/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
@@ -68,7 +68,7 @@ export class DatePickerBox extends React.Component<IDatePickerBoxProps, any> {
 
     private id: string;
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         this.id = DatePickerBox.getCalendarId(this.props.id);
     }
 

--- a/packages/react-vapor/src/components/datePicker/DatesSelection.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatesSelection.tsx
@@ -76,7 +76,7 @@ export class DatesSelection extends React.Component<IDatesSelectionProps, any> {
         }
     }
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         if (this.props.onRender) {
             this.props.onRender();
         }

--- a/packages/react-vapor/src/components/datePicker/tests/DatesSelection.spec.tsx
+++ b/packages/react-vapor/src/components/datePicker/tests/DatesSelection.spec.tsx
@@ -146,7 +146,7 @@ describe('Date picker', () => {
         it('should call onRender prop if set when mounting', () => {
             const onRenderSpy: jasmine.Spy = jasmine.createSpy('onRender');
 
-            expect(() => datesSelectionInstance.UNSAFE_componentWillMount()).not.toThrow();
+            expect(() => datesSelectionInstance.componentDidMount()).not.toThrow();
 
             datesSelection.unmount();
             datesSelection.setProps({onRender: onRenderSpy});

--- a/packages/react-vapor/src/components/dropdown/Dropdown.tsx
+++ b/packages/react-vapor/src/components/dropdown/Dropdown.tsx
@@ -42,7 +42,7 @@ export class Dropdown extends React.Component<IDropdownProps, any> {
         }
     };
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         if (this.props.onRender) {
             this.props.onRender();
         }

--- a/packages/react-vapor/src/components/dropdownSearch/DropdownSearch.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/DropdownSearch.tsx
@@ -124,7 +124,7 @@ export class DropdownSearch extends React.Component<IDropdownSearchProps> {
         }
     }
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         if (this.props.onMount) {
             this.props.onMount();
         }

--- a/packages/react-vapor/src/components/dropdownSearch/DropdownSearchInfiniteScrollOptions.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/DropdownSearchInfiniteScrollOptions.tsx
@@ -12,7 +12,7 @@ export interface DropdownSearchInfiniteScrollOptionsProps {
 export class DropdownSearchInfiniteScrollOptions extends React.Component<DropdownSearchInfiniteScrollOptionsProps> {
     private id: string;
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         this.id = _.uniqueId('infinite-dropdown');
     }
 

--- a/packages/react-vapor/src/components/dropdownSearch/tests/DropdownSearch.spec.tsx
+++ b/packages/react-vapor/src/components/dropdownSearch/tests/DropdownSearch.spec.tsx
@@ -101,7 +101,7 @@ describe('DropdownSearch', () => {
             it('should call onMountCallBack prop if set when mounting', () => {
                 const onMountCallBack = jasmine.createSpy('onMountCallBack');
 
-                expect(() => dropdownSearchInstance.UNSAFE_componentWillMount()).not.toThrow();
+                expect(() => dropdownSearchInstance.componentDidMount()).not.toThrow();
 
                 dropdownSearch.unmount();
                 dropdownSearch.setProps({onMountCallBack});
@@ -113,7 +113,7 @@ describe('DropdownSearch', () => {
             it('should call onMount prop if set when mounting', () => {
                 const onMountSpy = jasmine.createSpy('onMount');
 
-                expect(() => dropdownSearchInstance.UNSAFE_componentWillMount()).not.toThrow();
+                expect(() => dropdownSearchInstance.componentDidMount()).not.toThrow();
 
                 dropdownSearch.unmount();
                 dropdownSearch.setProps({onMount: onMountSpy});

--- a/packages/react-vapor/src/components/facets/Facet.tsx
+++ b/packages/react-vapor/src/components/facets/Facet.tsx
@@ -75,7 +75,7 @@ export class Facet extends React.Component<IFacetProps, any> {
         return _.sortBy(facetRows, (facetRow: IFacet) => facetRow.formattedName.toLowerCase());
     }
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         if (this.props.onRender) {
             this.props.onRender(this.props.facet.name);
         }

--- a/packages/react-vapor/src/components/facets/FacetMoreRows.tsx
+++ b/packages/react-vapor/src/components/facets/FacetMoreRows.tsx
@@ -34,7 +34,7 @@ export interface IFacetMoreRowsProps
 export class FacetMoreRows extends React.Component<IFacetMoreRowsProps, any> {
     private facetSearch: HTMLDivElement;
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         if (this.props.onDocumentClick) {
             document.addEventListener('click', this.handleDocumentClick);
         }

--- a/packages/react-vapor/src/components/facets/tests/Facet.spec.tsx
+++ b/packages/react-vapor/src/components/facets/tests/Facet.spec.tsx
@@ -55,7 +55,7 @@ describe('Facets', () => {
             const renderSpy = jasmine.createSpy('onRender');
             const newFacetAttributes = _.extend({}, facetBasicAttributes, {onRender: renderSpy});
 
-            expect(() => facetInstance.UNSAFE_componentWillMount()).not.toThrow();
+            expect(() => facetInstance.componentDidMount()).not.toThrow();
 
             facetComponent.unmount();
             facetComponent.setProps(newFacetAttributes);

--- a/packages/react-vapor/src/components/flippable/Flippable.tsx
+++ b/packages/react-vapor/src/components/flippable/Flippable.tsx
@@ -47,7 +47,7 @@ export class Flippable extends React.Component<IFlippableProps & React.HTMLProps
     private backside: HTMLDivElement;
     private frontside: HTMLDivElement;
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         if (this.props.onRender) {
             this.props.onRender();
         }

--- a/packages/react-vapor/src/components/flippable/tests/Flippable.spec.tsx
+++ b/packages/react-vapor/src/components/flippable/tests/Flippable.spec.tsx
@@ -26,7 +26,7 @@ describe('Flippable', () => {
         it('should call onRender prop if set when mounting', () => {
             const onRenderSpy = jasmine.createSpy('onRender');
 
-            expect(() => flippable.instance().UNSAFE_componentWillMount()).not.toThrow();
+            expect(() => flippable.instance().componentDidMount()).not.toThrow();
 
             flippable.unmount();
             flippable.setProps({onRender: onRenderSpy});

--- a/packages/react-vapor/src/components/input/Input.tsx
+++ b/packages/react-vapor/src/components/input/Input.tsx
@@ -90,7 +90,7 @@ export class Input extends React.Component<IInputProps, IInputComponentState> {
         };
     }
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         if (this.props.onRender) {
             // undefined validOnMount will default to true in the state
             const validOnMount =

--- a/packages/react-vapor/src/components/lastUpdated/LastUpdated.tsx
+++ b/packages/react-vapor/src/components/lastUpdated/LastUpdated.tsx
@@ -22,7 +22,7 @@ export interface ILastUpdatedProps extends ILastUpdatedOwnProps, ILastUpdatedSta
 export const LAST_UPDATE_LABEL: string = 'Last update:';
 
 export class LastUpdated extends React.Component<ILastUpdatedProps, any> {
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         if (this.props.onRender) {
             this.props.onRender();
         }

--- a/packages/react-vapor/src/components/lastUpdated/tests/LastUpdated.spec.tsx
+++ b/packages/react-vapor/src/components/lastUpdated/tests/LastUpdated.spec.tsx
@@ -59,7 +59,7 @@ describe('LastUpdated', () => {
             const renderSpy = jasmine.createSpy('onRender');
             lastUpdated = mount(<LastUpdated />, {attachTo: document.getElementById('App')});
 
-            expect(() => (lastUpdated.instance() as LastUpdated).UNSAFE_componentWillMount()).not.toThrow();
+            expect(() => (lastUpdated.instance() as LastUpdated).componentDidMount()).not.toThrow();
 
             lastUpdated.unmount();
             lastUpdated.setProps({onRender: renderSpy});

--- a/packages/react-vapor/src/components/menu/MenuConnected.tsx
+++ b/packages/react-vapor/src/components/menu/MenuConnected.tsx
@@ -60,7 +60,7 @@ export class MenuConnected extends React.Component<IMenuProps> {
         customOffset: 0,
     };
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         this.props.onRender();
         document.addEventListener('mousedown', this.handleDocumentClick);
     }

--- a/packages/react-vapor/src/components/modal/Modal.tsx
+++ b/packages/react-vapor/src/components/modal/Modal.tsx
@@ -38,7 +38,7 @@ export class Modal extends React.Component<IModalProps> {
 
     private timeoutId: number;
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         if (this.props.onRender) {
             this.props.onRender();
         }

--- a/packages/react-vapor/src/components/modal/tests/Modal.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/Modal.spec.tsx
@@ -29,7 +29,7 @@ describe('Modal', () => {
         it('should call prop onRender on mounting if set', () => {
             const renderSpy = jasmine.createSpy('onRender');
 
-            expect(() => modalInstance.UNSAFE_componentWillMount()).not.toThrow();
+            expect(() => modalInstance.componentDidMount()).not.toThrow();
 
             modal.setProps({id: id, onRender: renderSpy});
             modal.unmount();

--- a/packages/react-vapor/src/components/navigation/perPage/NavigationPerPage.tsx
+++ b/packages/react-vapor/src/components/navigation/perPage/NavigationPerPage.tsx
@@ -36,7 +36,6 @@ export class NavigationPerPage extends React.Component<INavigationPerPageProps> 
         perPageNumbers: PER_PAGE_NUMBERS,
         label: PER_PAGE_LABEL,
     };
-    private initialPosition: number;
 
     private handleClick(newPerPage: number) {
         if (this.props.onPerPageClick && this.props.currentPerPage !== newPerPage) {
@@ -44,10 +43,13 @@ export class NavigationPerPage extends React.Component<INavigationPerPageProps> 
         }
     }
 
-    UNSAFE_componentWillMount() {
-        this.initialPosition = !_.isUndefined(this.props.initialPosition)
+    private get initialPosition(): number {
+        return !_.isUndefined(this.props.initialPosition)
             ? this.props.initialPosition
             : Math.ceil(this.props.perPageNumbers.length / 2) - 1;
+    }
+
+    componentDidMount() {
         this.props.onRender?.(this.props.perPageNumbers[this.initialPosition]);
     }
 

--- a/packages/react-vapor/src/components/navigation/perPage/tests/NavigationPerPage.spec.tsx
+++ b/packages/react-vapor/src/components/navigation/perPage/tests/NavigationPerPage.spec.tsx
@@ -85,7 +85,7 @@ describe('NavigationPerPage', () => {
             const onRenderSpy = jasmine.createSpy('onRender');
 
             expect(() => {
-                navigationPerPageInstance.UNSAFE_componentWillMount();
+                navigationPerPageInstance.componentDidMount();
             }).not.toThrow();
 
             navigationPerPage = mount(
@@ -100,7 +100,7 @@ describe('NavigationPerPage', () => {
             const onDestroySpy = jasmine.createSpy('onDestroy');
 
             expect(() => {
-                navigationPerPageInstance.UNSAFE_componentWillMount();
+                navigationPerPageInstance.componentDidMount();
             }).not.toThrow();
 
             navigationPerPage = mount(

--- a/packages/react-vapor/src/components/optionPicker/OptionPicker.tsx
+++ b/packages/react-vapor/src/components/optionPicker/OptionPicker.tsx
@@ -29,7 +29,7 @@ export class OptionPicker extends React.Component<IOptionPickerProps, any> {
         }
     }
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         if (this.props.onRender) {
             this.props.onRender();
         }

--- a/packages/react-vapor/src/components/optionPicker/tests/OptionPicker.spec.tsx
+++ b/packages/react-vapor/src/components/optionPicker/tests/OptionPicker.spec.tsx
@@ -68,7 +68,7 @@ describe('Option picker', () => {
             const renderSpy: jasmine.Spy = jasmine.createSpy('onRender');
             const withRenderProps: IOptionPickerProps = _.extend({}, OPTION_PICKER_BASIC_PROPS, {onRender: renderSpy});
 
-            expect(() => optionPickerInstance.UNSAFE_componentWillMount()).not.toThrow();
+            expect(() => optionPickerInstance.componentDidMount()).not.toThrow();
 
             optionPicker.setProps(withRenderProps);
             optionPicker.unmount();

--- a/packages/react-vapor/src/components/searchBar/SearchBar.tsx
+++ b/packages/react-vapor/src/components/searchBar/SearchBar.tsx
@@ -46,7 +46,7 @@ export class SearchBar extends React.Component<ISearchBarProps> {
         maxWidth: '500px',
     };
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         if (this.props.onMount) {
             this.props.onMount();
         }

--- a/packages/react-vapor/src/components/tables/TableHeadingRow.tsx
+++ b/packages/react-vapor/src/components/tables/TableHeadingRow.tsx
@@ -34,7 +34,7 @@ export interface ITableHeadingRowProps
         ITableHeadingRowDispatchProps {}
 
 export class TableHeadingRow extends React.Component<ITableHeadingRowProps, any> {
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         this.props.onRender?.();
     }
 

--- a/packages/react-vapor/src/components/tables/tests/TableHeadingRow.spec.tsx
+++ b/packages/react-vapor/src/components/tables/tests/TableHeadingRow.spec.tsx
@@ -84,7 +84,7 @@ describe('Tables', () => {
             const onRenderSpy = jasmine.createSpy('onRender');
             const newTabledHeadingRowProps = _.extend({}, basicTableHeadingRowProps, {onRender: onRenderSpy});
 
-            expect(() => tableHeadingRowInstance.UNSAFE_componentWillMount()).not.toThrow();
+            expect(() => tableHeadingRowInstance.componentDidMount()).not.toThrow();
 
             tableHeadingRow.unmount();
             tableHeadingRow.setProps(newTabledHeadingRowProps);

--- a/packages/react-vapor/src/components/toast/Toast.tsx
+++ b/packages/react-vapor/src/components/toast/Toast.tsx
@@ -35,13 +35,10 @@ export class Toast extends React.Component<IToastProps> {
         dismissible: true,
     };
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         if (this.props.onRender) {
             this.props.onRender();
         }
-    }
-
-    componentDidMount() {
         this.setTimeout();
     }
 

--- a/packages/react-vapor/src/components/toast/ToastContainer.tsx
+++ b/packages/react-vapor/src/components/toast/ToastContainer.tsx
@@ -29,7 +29,7 @@ export interface IToastContainerProps
         IToastContainerDispatchProps {}
 
 export class ToastContainer extends React.Component<IToastContainerProps> {
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         if (this.props.onRender) {
             this.props.onRender();
         }

--- a/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
+++ b/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
@@ -31,7 +31,7 @@ describe('Toasts', () => {
             const renderSpy = jasmine.createSpy('onRender');
             const newToastAttributes = _.extend({}, toastBasicAttributes, {onRender: renderSpy});
 
-            expect(() => toastInstance.UNSAFE_componentWillMount()).not.toThrow();
+            expect(() => toastInstance.componentDidMount()).not.toThrow();
 
             toastComponent.unmount();
             toastComponent.setProps(newToastAttributes).mount();

--- a/packages/react-vapor/src/components/toast/tests/ToastContainer.spec.tsx
+++ b/packages/react-vapor/src/components/toast/tests/ToastContainer.spec.tsx
@@ -47,7 +47,7 @@ describe('Toasts', () => {
             const renderSpy = jasmine.createSpy('onRender');
             const newToastAttributes = _.extend({}, basicProps, {onRender: renderSpy});
 
-            expect(() => instance.UNSAFE_componentWillMount()).not.toThrow();
+            expect(() => instance.componentDidMount()).not.toThrow();
 
             component.unmount();
             component.setProps(newToastAttributes).mount();


### PR DESCRIPTION
### Proposed Changes

Removed all the `UNSAFE_componentWillMount` lifecycle method uses and replaced them by `componentDidMount`.

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
