### PR TITLE
fix(code-editor): add the possibility to refresh the editor

### DIFF
--- a/packages/demo/src/components/examples/CollapsibleExamples.tsx
+++ b/packages/demo/src/components/examples/CollapsibleExamples.tsx
@@ -5,6 +5,9 @@ import {
     CollapsibleConnected,
     CollapsibleContainerConnected,
     CollapsibleInfoBox,
+    fakeJSON,
+    JSONEditor,
+    JSONToString,
     Section,
     setExpandedCollapsibleContainer,
     Svg,
@@ -141,6 +144,14 @@ export const CollapsibleExamples: React.FunctionComponent = () => (
                 />
                 <CollapsibleContainerConnected id="collapsible-container-example-5" title="CollapsibleContainer">
                     You just expanded me with a button!
+                </CollapsibleContainerConnected>
+            </Section>
+            <Section>
+                <CollapsibleContainerConnected
+                    id="collapsible-container-example-6"
+                    title="CollapsibleContainer With JSON editor"
+                >
+                    <JSONEditor value={JSONToString(fakeJSON)} isRefreshRequired />
                 </CollapsibleContainerConnected>
             </Section>
         </Section>

--- a/packages/demo/src/components/examples/CollapsibleExamples.tsx
+++ b/packages/demo/src/components/examples/CollapsibleExamples.tsx
@@ -151,7 +151,7 @@ export const CollapsibleExamples: React.FunctionComponent = () => (
                     id="collapsible-container-example-6"
                     title="CollapsibleContainer With JSON editor"
                 >
-                    <JSONEditor value={JSONToString(fakeJSON)} isRefreshRequired />
+                    <JSONEditor value={JSONToString(fakeJSON)} collapsibleId="collapsible-container-example-6" />
                 </CollapsibleContainerConnected>
             </Section>
         </Section>

--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -23,6 +23,7 @@ export interface ICodeEditorProps {
     extraKeywords?: string[];
     className?: string;
     options?: CodeMirror.EditorConfiguration;
+    isRefreshRequired?: boolean;
 }
 
 export interface CodeEditorState {
@@ -59,6 +60,11 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
 
     componentDidMount() {
         this.props.onMount?.(this.codemirror.current);
+        this.props.isRefreshRequired && setInterval(this.timer, 300);
+    }
+
+    componentWillUnmount() {
+        this.props.isRefreshRequired && clearInterval();
     }
 
     componentDidUpdate(prevProps: ICodeEditorProps) {
@@ -67,6 +73,7 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
             this.editor.getDoc().clearHistory();
         }
     }
+
     render() {
         return (
             <ReactCodeMirror.Controlled
@@ -79,7 +86,10 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
                     this.setState({value});
                 }}
                 value={this.state.value}
-                onChange={(editor, data, value: string) => this.props.onChange?.(value)}
+                onChange={(editor, data, value: string) => {
+                    this.props.onChange?.(value);
+                    this.props.isRefreshRequired && clearInterval();
+                }}
                 options={{
                     ...CodeEditor.defaultOptions,
                     readOnly: this.props.readOnly,
@@ -99,4 +109,8 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
             );
         }
     }
+
+    private timer = () => {
+        this.editor.refresh();
+    };
 }

--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -11,12 +11,12 @@ import * as React from 'react';
 import * as ReactCodeMirror from 'react-codemirror2';
 
 import classNames from 'classnames';
+import {connect} from 'react-redux';
 import {CollapsibleSelectors} from '../collapsible/CollapsibleSelectors';
 import {CodeMirrorGutters} from './EditorConstants';
 import {IReactVaporState} from '../../ReactVapor';
-import {ReduxConnect} from '../../utils';
 
-export interface ICodeEditorOwnProps {
+export interface ICodeEditorProps {
     value: string;
     mode: any;
     readOnly?: boolean;
@@ -29,22 +29,18 @@ export interface ICodeEditorOwnProps {
     collapsibleId?: string;
 }
 
-export interface CodeEditorMappedState {
-    isCollapsibleExpanded?: boolean;
-}
-
 export interface CodeEditorState {
     value: string;
 }
 
-const mapStateToProps = (state: IReactVaporState, {collapsibleId}: ICodeEditorOwnProps) => ({
+const mapStateToProps = (state: IReactVaporState, {collapsibleId}: ICodeEditorProps) => ({
     isCollapsibleExpanded: CollapsibleSelectors.isExpanded(state, collapsibleId),
 });
 
-export interface ICodeEditorProps extends ICodeEditorOwnProps, Partial<ReturnType<typeof mapStateToProps>> {}
-
-@ReduxConnect(mapStateToProps)
-export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorState, CodeEditorMappedState> {
+class CodeEditorDisconnect extends React.Component<
+    ICodeEditorProps & Partial<ReturnType<typeof mapStateToProps>>,
+    CodeEditorState
+> {
     static defaultProps: Partial<ICodeEditorProps> = {
         className: 'mod-border',
         value: '{}',
@@ -100,7 +96,7 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
                     this.props.onChange?.(value);
                 }}
                 options={{
-                    ...CodeEditor.defaultOptions,
+                    ...CodeEditorDisconnect.defaultOptions,
                     readOnly: this.props.readOnly,
                     mode: this.props.mode,
                     ...this.props.options,
@@ -119,3 +115,5 @@ export class CodeEditor extends React.Component<ICodeEditorProps, CodeEditorStat
         }
     }
 }
+
+export const CodeEditor = connect(mapStateToProps)(CodeEditorDisconnect);

--- a/packages/react-vapor/src/components/editor/JSONEditor.tsx
+++ b/packages/react-vapor/src/components/editor/JSONEditor.tsx
@@ -18,7 +18,7 @@ export interface JSONEditorProps {
     className?: string;
     options?: CodeMirror.EditorConfiguration;
     ref?: React.Ref<any>;
-    isRefreshRequired?: boolean;
+    collapsibleId?: string;
 }
 
 export interface JSONEditorStateProps {
@@ -42,7 +42,7 @@ export const JSONEditor: React.FunctionComponent<JSONEditorProps & JSONEditorSta
     onMount,
     onUnmount,
     ref,
-    isRefreshRequired,
+    collapsibleId,
 }) => {
     const [isInError, setIsInError] = React.useState(false);
 
@@ -69,7 +69,7 @@ export const JSONEditor: React.FunctionComponent<JSONEditorProps & JSONEditorSta
                 className={className}
                 options={options}
                 ref={ref}
-                isRefreshRequired={isRefreshRequired}
+                collapsibleId={collapsibleId}
             />
             {isInError && <ValidationDetails errorMessage={errorMessage} />}
         </div>

--- a/packages/react-vapor/src/components/editor/JSONEditor.tsx
+++ b/packages/react-vapor/src/components/editor/JSONEditor.tsx
@@ -18,6 +18,7 @@ export interface JSONEditorProps {
     className?: string;
     options?: CodeMirror.EditorConfiguration;
     ref?: React.Ref<any>;
+    isRefreshRequired?: boolean;
 }
 
 export interface JSONEditorStateProps {
@@ -41,6 +42,7 @@ export const JSONEditor: React.FunctionComponent<JSONEditorProps & JSONEditorSta
     onMount,
     onUnmount,
     ref,
+    isRefreshRequired,
 }) => {
     const [isInError, setIsInError] = React.useState(false);
 
@@ -67,6 +69,7 @@ export const JSONEditor: React.FunctionComponent<JSONEditorProps & JSONEditorSta
                 className={className}
                 options={options}
                 ref={ref}
+                isRefreshRequired={isRefreshRequired}
             />
             {isInError && <ValidationDetails errorMessage={errorMessage} />}
         </div>

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -1,5 +1,6 @@
 import * as CodeMirror from 'codemirror';
-import {mount, ReactWrapper, shallow} from 'enzyme';
+import {ShallowWrapper} from 'enzyme';
+import {mountWithState, shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
 import * as ReactCodeMirror from 'react-codemirror2';
 import * as _ from 'underscore';
@@ -15,19 +16,17 @@ describe('CodeEditor', () => {
 
     it('should render without errors', () => {
         expect(() => {
-            shallow(<CodeEditor {...basicProps} />);
+            shallowWithState(<CodeEditor {...basicProps} />, {});
         }).not.toThrow();
     });
 
     describe('<CodeEditor />', () => {
-        let codeEditor: ReactWrapper<ICodeEditorProps, CodeEditorState>;
-        let codeEditorInstance: CodeEditor;
+        let wrapper: ShallowWrapper<any, any>;
+        let codeEditor: ShallowWrapper<ICodeEditorProps, CodeEditorState>;
 
         const mountWithProps = (props: Partial<ICodeEditorProps> = {}) => {
-            codeEditor = mount(<CodeEditor {..._.defaults(props, basicProps)} />, {
-                attachTo: document.getElementById('App'),
-            });
-            codeEditorInstance = codeEditor.instance() as any;
+            wrapper = shallowWithState(<CodeEditor {..._.defaults(props, basicProps)} />, {});
+            codeEditor = wrapper.dive();
         };
 
         beforeEach(() => {
@@ -41,13 +40,13 @@ describe('CodeEditor', () => {
         });
 
         it('should get the readonly state as a prop', () => {
-            let readOnlyProp: boolean = codeEditor.props().readOnly;
+            let readOnlyProp: boolean = wrapper.props().readOnly;
 
             expect(readOnlyProp).toBeUndefined();
 
             mountWithProps({readOnly: true});
 
-            readOnlyProp = codeEditor.props().readOnly;
+            readOnlyProp = wrapper.props().readOnly;
 
             expect(readOnlyProp).toBe(true);
         });
@@ -57,7 +56,7 @@ describe('CodeEditor', () => {
 
             expect(codeEditor.find(ReactCodeMirror.Controlled).props().className).toContain('code-editor-no-cursor');
 
-            codeEditor.setProps({readOnly: false});
+            mountWithProps();
 
             expect(codeEditor.find(ReactCodeMirror.Controlled).props().className).not.toContain(
                 'code-editor-no-cursor'
@@ -65,13 +64,13 @@ describe('CodeEditor', () => {
         });
 
         it('should get what to do on change state as a prop if set', () => {
-            let onChangeProp: (json: string) => void = codeEditor.props().onChange;
+            let onChangeProp: (json: string) => void = wrapper.props().onChange;
 
             expect(onChangeProp).toBeUndefined();
 
             mountWithProps({onChange: jest.fn()});
 
-            onChangeProp = codeEditor.props().onChange;
+            onChangeProp = wrapper.props().onChange;
 
             expect(onChangeProp).toBeDefined();
         });
@@ -85,7 +84,12 @@ describe('CodeEditor', () => {
             const expectedValue: string = 'the expected value';
 
             mountWithProps({onChange: onChangeSpy});
-            codeEditor.setProps({value: expectedValue});
+
+            codeEditor
+                .find(ReactCodeMirror.Controlled)
+                .first()
+                .props()
+                .onChange({} as CodeMirror.Editor, undefined, expectedValue);
 
             expect(onChangeSpy).toHaveBeenCalledTimes(1);
             expect(onChangeSpy).toHaveBeenCalledWith(expectedValue);
@@ -106,8 +110,15 @@ describe('CodeEditor', () => {
             const currentKeywords: string[] = [...(CodeMirror as any).helpers.hintWords[basicProps.mode]];
             const expectedNewKeywords = ['one', 'two'];
 
-            codeEditor.setProps(_.extend({}, basicProps, {extraKeywords: expectedNewKeywords}));
-            (codeEditorInstance as any).addExtraKeywords();
+            const codeEditorMounted = mountWithState(
+                <CodeEditor {..._.extend({}, basicProps, {extraKeywords: expectedNewKeywords})} />,
+                {
+                    attachTo: document.getElementById('App'),
+                }
+            );
+
+            mountWithProps(_.extend({}, basicProps, {extraKeywords: expectedNewKeywords}));
+            codeEditorMounted.find(ReactCodeMirror.Controlled).first().props().editorDidMount;
 
             const newList: string[] = (CodeMirror as any).helpers.hintWords[basicProps.mode];
 
@@ -117,13 +128,6 @@ describe('CodeEditor', () => {
 
         it('should have a border by default', () => {
             expect(codeEditor.find(ReactCodeMirror.Controlled).props().className).toContain('mod-border');
-        });
-
-        it('should set an interval to refresh the editor if the isRefreshRequired prop is true', () => {
-            const intervalSpy = spyOn(global, 'setInterval');
-            mountWithProps({isRefreshRequired: true});
-
-            expect(intervalSpy).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -118,5 +118,12 @@ describe('CodeEditor', () => {
         it('should have a border by default', () => {
             expect(codeEditor.find(ReactCodeMirror.Controlled).props().className).toContain('mod-border');
         });
+
+        it('should set an interval to refresh the editor if the isRefreshRequired prop is true', () => {
+            const intervalSpy = spyOn(global, 'setInterval');
+            mountWithProps({isRefreshRequired: true});
+
+            expect(intervalSpy).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -4,6 +4,7 @@ import {mountWithState, shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
 import * as ReactCodeMirror from 'react-codemirror2';
 import * as _ from 'underscore';
+import {CollapsibleSelectors} from '../../collapsible/CollapsibleSelectors';
 
 import {CodeEditor, CodeEditorState, ICodeEditorProps} from '../CodeEditor';
 import {CodeMirrorModes} from '../EditorConstants';
@@ -13,6 +14,7 @@ describe('CodeEditor', () => {
         value: 'any string',
         mode: CodeMirrorModes.Python,
     };
+    let codeEditorInstance: typeof CodeEditor;
 
     it('should render without errors', () => {
         expect(() => {
@@ -30,6 +32,7 @@ describe('CodeEditor', () => {
         };
 
         beforeEach(() => {
+            jest.spyOn(CollapsibleSelectors, 'isExpanded').mockReturnValue(false);
             mountWithProps();
         });
 
@@ -96,6 +99,7 @@ describe('CodeEditor', () => {
         });
 
         it(`should clear codemirror's history if we set a new value`, () => {
+            codeEditorInstance = codeEditor.dive().instance() as any;
             const clearHistorySpy: jest.SpyInstance = jest.spyOn(
                 (codeEditorInstance as any).editor.getDoc(),
                 'clearHistory'
@@ -103,7 +107,7 @@ describe('CodeEditor', () => {
 
             codeEditor.setProps({value: 'a new value'});
 
-            expect(clearHistorySpy).toHaveBeenCalledTimes(2);
+            expect(clearHistorySpy).toHaveBeenCalledTimes(1);
         });
 
         it('should add any extra keywords for the autocompletion if there are some in the props', () => {


### PR DESCRIPTION
### Proposed Changes

This fix add the possibility to refresh the editor when the `isRefreshRequired` prop is true. An example is included in the collapsible section in which the editor is display properly when the collapsible is opened. 
![collapsibleWithJsonEditor](https://user-images.githubusercontent.com/58052881/103575654-0de86500-4ea0-11eb-8de8-6de924c2d147.gif)


### Potential Breaking Changes

### Acceptance Criteria

-   [ X] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
