### PR TITLE
improvement(logo-card): logo card title will align vertically

### DIFF
--- a/packages/demo/src/components/examples/LogoCardExamples.tsx
+++ b/packages/demo/src/components/examples/LogoCardExamples.tsx
@@ -9,7 +9,13 @@ export class LogoCardExamples extends React.Component<any, any> {
         return (
             <div className="mt2">
                 <div className="form-group">
-                    <label className="form-control-label">Default LogoCard</label>
+                    <label className="form-control-label">LogoCard with title</label>
+                    <div className="form-control">
+                        <LogoCard title="Card title only" />
+                    </div>
+                </div>
+                <div className="form-group">
+                    <label className="form-control-label">LogoCard with description</label>
                     <div className="form-control">
                         <LogoCard title="Card title" description="Card description" />
                     </div>

--- a/packages/react-vapor/src/components/logoCard/LogoCard.tsx
+++ b/packages/react-vapor/src/components/logoCard/LogoCard.tsx
@@ -63,6 +63,9 @@ export class LogoCard extends React.Component<ILogoCardProps & React.HTMLProps<H
         );
         const logoIconClassName = classNames(DEFAULT_LOGO_ICON_CLASSNAME, DEFAULT_LOGO_ICON_SIZE);
         const descriptionClassName = classNames(this.props.badges.length ? 'ml1' : '');
+        const logoCardContentClassName = classNames(
+            !this.props.badges.length && !this.props.description ? 'logo-card-content-center' : 'logo-card-content'
+        );
 
         const badges = this.props.badges.map((badgeProps) => <Badge {...badgeProps} key={slugify(badgeProps.label)} />);
         const description = this.props.description ? (
@@ -86,12 +89,9 @@ export class LogoCard extends React.Component<ILogoCardProps & React.HTMLProps<H
                     <div className="logo-card-logo">
                         <Svg svgName={this.props.svgName} className={logoIconClassName} />
                     </div>
-                    <div className="logo-card-content">
+                    <div className={logoCardContentClassName}>
                         <h2 className="logo-card-title">{this.props.title}</h2>
-                        <div>
-                            {...badges}
-                            {description}
-                        </div>
+                        {this.props.badges || this.props.description ? <div> {...badges} {description} </div> : ''}
                     </div>
                     {ribbon}
                 </div>

--- a/packages/react-vapor/src/components/logoCard/tests/LogoCard.spec.tsx
+++ b/packages/react-vapor/src/components/logoCard/tests/LogoCard.spec.tsx
@@ -32,6 +32,60 @@ describe('LogoCard', () => {
         }).not.toThrow();
     });
 
+    describe('<LogoCard /> with title only', () => {
+        let defaultLogoCardProps: Partial<ILogoCardProps>;
+
+        it('should have a logo-card-content-center class when only a title is given', () => {
+            defaultLogoCardProps = {
+                title: 'Card title only',
+            };
+            mountWithProps(defaultLogoCardProps);
+
+            expect(logoCard.find('.logo-card-content-center').length).toBe(1);
+            expect(logoCard.find('.logo-card-content').length).toBe(0);
+        });
+
+        it('should have a logo-card-content class when there are badges in the LogoCard', () => {
+            defaultLogoCardProps = {
+                title: 'Card title with badges',
+                badges: [
+                    {
+                        label: 'badge 1',
+                    },
+                    {
+                        label: 'badge 2',
+                    },
+                ],
+            };
+            mountWithProps(defaultLogoCardProps);
+
+            expect(logoCard.find('.logo-card-content-center').length).toBe(0);
+            expect(logoCard.find('.logo-card-content').length).toBe(1);
+        });
+
+        it('should have a logo-card-content class when there is a description passed in the LogoCard', () => {
+            defaultLogoCardProps = {
+                title: 'Card title with a description',
+                description: 'some description',
+            };
+            mountWithProps(defaultLogoCardProps);
+
+            expect(logoCard.find('.logo-card-content-center').length).toBe(0);
+            expect(logoCard.find('.logo-card-content').length).toBe(1);
+        });
+
+        it('should have a logo-card-content class when there are badges and a description passed in the LogoCard', () => {
+            defaultLogoCardProps = {
+                title: 'Card title with a description',
+                description: 'some description',
+            };
+            mountWithProps(defaultLogoCardProps);
+
+            expect(logoCard.find('.logo-card-content-center').length).toBe(0);
+            expect(logoCard.find('.logo-card-content').length).toBe(1);
+        });
+    });
+
     describe('Default <LogoCard />', () => {
         let defaultLogoCardProps: Partial<ILogoCardProps>;
 

--- a/packages/vapor/scss/components/logo-card.scss
+++ b/packages/vapor/scss/components/logo-card.scss
@@ -32,6 +32,12 @@
     justify-content: space-between;
 }
 
+.logo-card-content-center {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
 .logo-card-title {
     color: $logo-card-title-color;
 }


### PR DESCRIPTION
[For trials improvement ](https://coveord.atlassian.net/browse/ADUI-6382)

When a LogoCard component doesn't have a description or badges, its title is aligned to the top.




### Proposed Changes

When a user does not pass a badge or a description to the Logo Card, align the title to the center vertically to match UI mock-up.

<!-- Explain what are your changes. -->

- Conditionally render a class called `logo-card-content-center` with `justify-content: center` to align the text in the `logo-card-content` div element.

- Renamed `DefaultLogo card` to `LogoCard with description` for consistency with other examples. 

- Added a new example to show title only. 
- Title only example will be shown as the first example since it is the most basic Logo Card.
![image](https://user-images.githubusercontent.com/66333175/103926272-aff98e80-50e6-11eb-86d5-078c76954b82.png)


### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
