### PR TITLE
fix(datepicker): move calendarId out of lifecycle method

### DIFF
--- a/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
@@ -66,15 +66,9 @@ export class DatePickerBox extends React.Component<IDatePickerBoxProps, any> {
 
     static getCalendarId = (datePickerId: string) => `calendar-${datePickerId}`;
 
-    private id: string;
-
-    componentDidMount() {
-        this.id = DatePickerBox.getCalendarId(this.props.id);
-    }
-
     render() {
         const calendarProps: ICalendarProps = {
-            id: this.id,
+            id: DatePickerBox.getCalendarId(this.props.id),
             months: this.props.months,
             startingMonth: this.props.startingMonth,
             years: this.props.years,
@@ -150,7 +144,7 @@ export class DatePickerBox extends React.Component<IDatePickerBoxProps, any> {
                 isClearable: this.props.isClearable,
                 rangeLimit: datesSelectionBox.rangeLimit,
                 color: datesSelectionBox.color,
-                calendarId: this.id,
+                calendarId: DatePickerBox.getCalendarId(this.props.id),
                 lowerLimitPlaceholder: this.props.lowerLimitPlaceholder,
                 upperLimitPlaceholder: this.props.upperLimitPlaceholder,
                 initiallyUnselected: this.props.initiallyUnselected,


### PR DESCRIPTION
### Proposed Changes

[ADUI-6397](https://coveord.atlassian.net/browse/ADUI-6397)
Formatting `calendarId` inside of `componentDidMount` can cause a small delay, it will be `undefined` when `DatesSelection` is rendered.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
