### PR TITLE
feat(drop-pod): remove the created portal when component is unmount

### DIFF
--- a/packages/react-vapor/src/components/drop/DropPod.tsx
+++ b/packages/react-vapor/src/components/drop/DropPod.tsx
@@ -47,6 +47,8 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
     readonly dropRef: React.RefObject<HTMLElement>;
 
     private lastPosition: IDropUIPosition;
+    private dropElement: HTMLDivElement;
+    private portalRoot: Element;
 
     static defaultProps: Partial<IDropPodProps> = {
         isOpen: false,
@@ -64,6 +66,9 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
         this.state = {
             offset: undefined,
         };
+
+        this.dropElement = document.createElement('div');
+        this.portalRoot = document.querySelector(this.props.selector ?? Defaults.DROP_ROOT);
 
         this.updateOffset = this.updateOffset.bind(this);
         if (
@@ -87,10 +92,12 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
         if (this.props.isOpen) {
             this.setEventsOnDocument();
         }
+        this.portalRoot.appendChild(this.dropElement);
     }
 
     componentWillUnmount() {
         this.removeEventsOnDocument();
+        this.portalRoot.removeChild(this.dropElement);
     }
 
     componentDidUpdate(prevProps: Readonly<IRDropPodProps>) {
@@ -240,7 +247,7 @@ class RDropPod extends React.PureComponent<IRDropPodProps, IDropPodState> {
 
         const drop: React.ReactNode = this.props.renderDrop(style, this.dropRef, this.lastPosition);
 
-        return ReactDOM.createPortal(drop, document.querySelector(this.props.selector ?? Defaults.DROP_ROOT));
+        return ReactDOM.createPortal(drop, this.dropElement);
     }
 }
 

--- a/packages/react-vapor/src/components/drop/tests/DropPod.spec.tsx
+++ b/packages/react-vapor/src/components/drop/tests/DropPod.spec.tsx
@@ -145,26 +145,55 @@ describe('DropPod', () => {
                         Defaults.DROP_ROOT = 'body';
                     });
 
-                    it('should create a portal with the Defaults.DROP_ROOT if no selector is passed in props', () => {
+                    it('should create a div element and create a portal with it', () => {
+                        const divElement = document.createElement('div');
+                        spyOn(document, 'querySelector').and.callThrough();
+                        const portalSpy: jasmine.Spy = spyOn(ReactDOM, 'createPortal');
+
+                        shallow(<DropPod renderDrop={() => '🍟'} ref={buttonRef} />, {}).dive();
+
+                        expect(portalSpy).toHaveBeenCalledWith('🍟', divElement);
+                    });
+
+                    it('should append the div element to the Defaults.DROP_ROOT as the portal root if no selector is passed in props', () => {
+                        const divElement = document.createElement('div');
                         const expectedElement = document.querySelector('head');
                         Defaults.DROP_ROOT = 'head';
 
                         spyOn(document, 'querySelector').and.callThrough();
-                        const portalSpy: jasmine.Spy = spyOn(ReactDOM, 'createPortal');
+                        const appendChildSpy: jasmine.Spy = spyOn(expectedElement, 'appendChild');
                         shallow(<DropPod renderDrop={() => '🍟'} ref={buttonRef} />, {}).dive();
 
-                        expect(portalSpy).toHaveBeenCalledWith('🍟', expectedElement);
+                        expect(appendChildSpy).toHaveBeenCalledWith(divElement);
                     });
 
-                    it('should create a portal with the selector prop if passed to the dropPod', () => {
+                    it('should append the div element to with the selector prop as the portal root if passed to the dropPod', () => {
+                        const divElement = document.createElement('div');
                         const expectedElement = document.querySelector('head');
                         Defaults.DROP_ROOT = '#🥔';
 
                         spyOn(document, 'querySelector').and.callThrough();
-                        const portalSpy: jasmine.Spy = spyOn(ReactDOM, 'createPortal');
+                        const appendChildSpy: jasmine.Spy = spyOn(expectedElement, 'appendChild');
                         shallow(<DropPod renderDrop={() => '🍟'} selector="head" ref={buttonRef} />, {}).dive();
 
-                        expect(portalSpy).toHaveBeenCalledWith('🍟', expectedElement);
+                        expect(appendChildSpy).toHaveBeenCalledWith(divElement);
+                    });
+
+                    it('should remove the div element with the portal root', () => {
+                        const divElement = document.createElement('div');
+                        const expectedElement = document.querySelector('head');
+                        Defaults.DROP_ROOT = 'head';
+
+                        spyOn(document, 'querySelector').and.callThrough();
+                        const removeChildSpy: jasmine.Spy = spyOn(expectedElement, 'removeChild');
+                        const componentToUnmount = shallow(
+                            <DropPod renderDrop={() => '🍟'} ref={buttonRef} />,
+                            {}
+                        ).dive();
+
+                        componentToUnmount.unmount();
+
+                        expect(removeChildSpy).toHaveBeenCalledWith(divElement);
                     });
                 });
 


### PR DESCRIPTION
### Proposed Changes
I think there's a way we can remove the created portal after we unmount the `Drop` component (thanks Germain for your support on that one). Here's a screenshot that demonstrate that the element I appended (that includes the created portal) is removed after a component is unmount:
![proof_that_portal_was_removed](https://user-images.githubusercontent.com/58052881/104246293-bc0d8500-5433-11eb-9f64-2cc356553c65.png)

However, if you want to test it out yourself,  the `ActionableItem` component actually includes a ` Drop` component in it. So, before you navigate to another page, you can select with a breakpoint in the devtool the `componentWillUnmount` event in the `DropPod` component, and see that the .removeChild(this.dropElement) function will remove the expected div element. 

### Potential Breaking Changes

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
