### PR TITLE
fix(singleselectconnected): stopPropagation on cler button

### DIFF
--- a/packages/react-vapor/src/components/select/SingleSelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SingleSelectConnected.tsx
@@ -136,7 +136,8 @@ class SingleSelect extends React.PureComponent<ISingleSelectProps> {
         );
     }
 
-    private handleDeselect = () => {
+    private handleDeselect = (e: Event) => {
+        e.stopPropagation();
         if (!this.props.disabled) {
             this.props.deselect();
         }


### PR DESCRIPTION
### Proposed Changes

stopPropagation was added to the handleDeselect, so the dropdown doesn't open when the selected
option is cleared

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
