### PR TITLE
fix(multiline-field): fix multiline field add action color

### DIFF
--- a/packages/react-vapor/src/components/multilineBox/hoc/MultilineBoxWithRemoveButton.tsx
+++ b/packages/react-vapor/src/components/multilineBox/hoc/MultilineBoxWithRemoveButton.tsx
@@ -78,7 +78,7 @@ export const multilineBoxWithRemoveButton = (
                 >
                     <Svg
                         svgName={VaporSVG.svg.remove.name}
-                        className="icon fill-medium-blue mod-18"
+                        className="icon mod-18"
                         style={{
                             visibility: !data.isLast ? 'visible' : 'hidden',
                         }}

--- a/packages/vapor/scss/controls/multiline-field.scss
+++ b/packages/vapor/scss/controls/multiline-field.scss
@@ -100,7 +100,7 @@
         display: block;
         width: 18px;
         height: 18px;
-        border: 2px solid var(--medium-blue);
+        border: 2px solid var(--grey-60);
         border-radius: 18px;
 
         &.add-action,
@@ -112,16 +112,16 @@
                 display: block;
                 width: 10px;
                 height: 2px;
-                background-color: var(--medium-blue);
+                background-color: var(--grey-60);
                 content: '';
             }
         }
 
         &.add-action {
-            border-color: var(--orange);
+            border-color: var(--button-primary-color);
 
             &:before {
-                background-color: var(--orange);
+                background-color: var(--button-primary-color);
             }
 
             &:after {
@@ -131,7 +131,7 @@
                 display: block;
                 width: 2px;
                 height: 10px;
-                background-color: var(--orange);
+                background-color: var(--button-primary-color);
                 content: '';
             }
         }


### PR DESCRIPTION
It was using the --orange variable, so it didn't follow the proper overrides.