### PR TITLE
fix: new color for the add-action icon

### DIFF
--- a/packages/vapor/scss/controls/multiline-field.scss
+++ b/packages/vapor/scss/controls/multiline-field.scss
@@ -118,10 +118,10 @@
         }
 
         &.add-action {
-            border-color: var(--orange);
+            border-color: var(--azure);
 
             &:before {
-                background-color: var(--orange);
+                background-color: var(--azure);
             }
 
             &:after {
@@ -131,7 +131,7 @@
                 display: block;
                 width: 2px;
                 height: 10px;
-                background-color: var(--orange);
+                background-color: var(--azure);
                 content: '';
             }
         }


### PR DESCRIPTION
### Proposed Changes

The add-action (+) icon is now blue! (s'cuzer le placement de :hankey: )
![image](https://user-images.githubusercontent.com/63734941/104817280-541dbc80-57ee-11eb-99d3-92e6332c1766.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
