### PR TITLE
fix: new blue for add-action icon

### DIFF
--- a/packages/vapor/scss/controls/multiline-field.scss
+++ b/packages/vapor/scss/controls/multiline-field.scss
@@ -118,10 +118,10 @@
         }
 
         &.add-action {
-            border-color: var(--orange);
+            border-color: var(--azure);
 
             &:before {
-                background-color: var(--orange);
+                background-color: var(--azure);
             }
 
             &:after {
@@ -131,7 +131,7 @@
                 display: block;
                 width: 2px;
                 height: 10px;
-                background-color: var(--orange);
+                background-color: var(--azure);
                 content: '';
             }
         }

--- a/packages/vapor/scss/controls/multiline-field.scss
+++ b/packages/vapor/scss/controls/multiline-field.scss
@@ -118,10 +118,10 @@
         }
 
         &.add-action {
-            border-color: var(--azure);
+            border-color: #1372ec; // --digital-blue-60
 
             &:before {
-                background-color: var(--azure);
+                background-color: #1372ec; // --digital-blue-60
             }
 
             &:after {
@@ -131,7 +131,7 @@
                 display: block;
                 width: 2px;
                 height: 10px;
-                background-color: var(--azure);
+                background-color: #1372ec; // --digital-blue-60
                 content: '';
             }
         }


### PR DESCRIPTION
### Proposed Changes

New color for the add-action icon!

![image](https://user-images.githubusercontent.com/63734941/104817739-0bb3ce00-57f1-11eb-9425-513664e74686.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
