### PR TITLE
feat(tab): redirect to url prop

### DIFF
--- a/packages/demo/src/components/examples/ExamplesUtils.ts
+++ b/packages/demo/src/components/examples/ExamplesUtils.ts
@@ -64,4 +64,5 @@ export const defaultTabs: ITabProps[] = [
     {id: 'tab1', title: 'Digimon'},
     {id: 'tab2', title: 'Beyblade'},
     {id: 'tab3', title: 'Pokemon'},
+    {id: 'tab4', title: 'Perdu', url: 'http://www.perdu.com'},
 ];

--- a/packages/react-vapor/src/components/tab/Tab.tsx
+++ b/packages/react-vapor/src/components/tab/Tab.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
+import {UrlUtils} from '../../utils';
 
 import {TooltipPlacement} from '../../utils/TooltipUtils';
 import {Tooltip} from '../tooltip/Tooltip';
@@ -11,6 +12,7 @@ export interface ITabOwnProps {
     disabled?: boolean;
     tooltip?: string;
     children?: React.ReactNode;
+    url?: string;
 }
 
 export interface ITabStateProps {
@@ -54,6 +56,9 @@ export class Tab extends React.Component<ITabProps, any> {
     private handleSelect = (e: React.MouseEvent) => {
         if (!this.props.disabled) {
             this.props.onSelect?.(e);
+            if (this.props.url) {
+                UrlUtils.redirectToUrl(this.props.url);
+            }
         }
     };
 }

--- a/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
+++ b/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
@@ -1,5 +1,6 @@
 import {shallow} from 'enzyme';
 import * as React from 'react';
+import {UrlUtils} from '../../../utils';
 import {Svg} from '../../svg';
 
 import {Tooltip} from '../../tooltip/Tooltip';
@@ -91,5 +92,20 @@ describe('Tab', () => {
 
         expect(tab.find(Svg).exists()).toBe(true);
         expect(tab.find(Svg).props().svgName).toBe('help');
+    });
+
+    it('should redirect to specific URL if the url prop is set', () => {
+        const navigateSpy = spyOn(UrlUtils, 'redirectToUrl');
+
+        const tab = shallow(
+            <Tab
+                {...basicProps}
+                url="http://www.perdu.com"
+                children={<Svg svgName={'help'} svgClass={'icon fill-orange mod-16 mr1'} />}
+            />
+        );
+        tab.simulate('click');
+
+        expect(navigateSpy).toHaveBeenCalledWith('http://www.perdu.com');
     });
 });


### PR DESCRIPTION
### Proposed Changes

If the url props is set on a tab, It will then redirect upon click.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
