### PR TITLE
feat(badge): TRI-26 adding prop to allow svg icons 

### DIFF
--- a/packages/demo/src/components/examples/BadgeExamples.tsx
+++ b/packages/demo/src/components/examples/BadgeExamples.tsx
@@ -12,6 +12,12 @@ export class BadgeExamples extends React.Component<any, any> {
                     </div>
                 </div>
                 <div className="form-group">
+                    <label className="form-control-label">Badge with Icon</label>
+                    <div className="form-control">
+                        <Badge label="Badge label" icon="lock" />
+                    </div>
+                </div>
+                <div className="form-group">
                     <label className="form-control-label">Badge with extra classes</label>
                     <div className="form-control">
                         <Badge label="Badge blue background" extraClasses={['bg-blue']} />

--- a/packages/react-vapor/src/components/badge/Badge.tsx
+++ b/packages/react-vapor/src/components/badge/Badge.tsx
@@ -1,10 +1,12 @@
 import classNames from 'classnames';
 import * as React from 'react';
+import {Svg} from '../svg';
 
 export const DEFAULT_BADGE_CLASSNAME = 'badge';
 
 export interface IBadgeProps {
     label: string;
+    icon?: string;
     extraClasses?: string[];
 }
 
@@ -15,6 +17,11 @@ export class Badge extends React.Component<IBadgeProps> {
 
     render() {
         const className = classNames(DEFAULT_BADGE_CLASSNAME, this.props.extraClasses);
-        return <span className={className}>{this.props.label}</span>;
+        return (
+            <span className={className}>
+                {this.props.icon?.length && <Svg svgName={this.props.icon} svgClass="icon" className="pr1 py1" />}
+                <span>{this.props.label}</span>
+            </span>
+        );
     }
 }

--- a/packages/react-vapor/src/components/badge/tests/Badge.spec.tsx
+++ b/packages/react-vapor/src/components/badge/tests/Badge.spec.tsx
@@ -2,6 +2,7 @@ import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
 import {Badge, DEFAULT_BADGE_CLASSNAME, IBadgeProps} from '../Badge';
+import {Svg} from '../../svg';
 
 describe('Badge', () => {
     let badge: ReactWrapper<IBadgeProps, any>;
@@ -40,6 +41,23 @@ describe('Badge', () => {
 
             expect(badge.find('.bg-blue').length).toBe(1);
             expect(badge.find('.bold').length).toBe(1);
+        });
+
+        it('should render the badge with SVG icons', () => {
+            mountWithProps({
+                extraClasses: [],
+                icon: 'lock',
+            });
+
+            expect(badge.find(Svg).length).toBe(1);
+        });
+
+        it('should not render the SVG component no props are passed in icon props', () => {
+            mountWithProps({
+                label: 'TestLabel',
+            });
+
+            expect(badge.find(Svg).length).toBe(0);
         });
     });
 });


### PR DESCRIPTION
adding badge to allow svg icons for trial experience

### Proposed Changes
![image](https://user-images.githubusercontent.com/66333175/105077732-ee823800-5a5a-11eb-8571-11fa8dbc36c3.png)

Prop added to badge component to allow SVG icon

<!-- Explain what are your changes. -->

- Add a new lock SVG provided by UI
- Added an optional prop for badges to add SVG icon

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
