### PR TITLE
ADUI-6481/remove border color utility

### DIFF
--- a/packages/demo/src/components/examples/CornerRibbonExamples.tsx
+++ b/packages/demo/src/components/examples/CornerRibbonExamples.tsx
@@ -41,7 +41,7 @@ export class CornerRibbonExamples extends React.Component<any, any> {
                                 label="Ribbon"
                                 placementX={PlacementX.Left}
                                 placementY={PlacementY.Top}
-                                extraClasses={['bg-pure-white', 'text-red', 'bold', 'mod-border', 'border-red']}
+                                extraClasses={['bg-pure-white', 'text-red', 'bold', 'border-accent']}
                             />
                         </div>
                     </div>

--- a/packages/react-vapor/src/components/borderedLine/BorderedLine.tsx
+++ b/packages/react-vapor/src/components/borderedLine/BorderedLine.tsx
@@ -3,10 +3,7 @@ import * as React from 'react';
 import * as styles from './styles/BorderedLine.scss';
 
 export class BorderedLine extends React.PureComponent<React.HTMLAttributes<HTMLDivElement>> {
-    static defaultClassName = classNames(
-        styles.borderedLine,
-        'bg-light-grey border-medium-grey mod-border-top mod-border-bottom'
-    );
+    static defaultClassName = classNames(styles.borderedLine, 'mod-border-top mod-border-bottom');
 
     render() {
         return (

--- a/packages/react-vapor/src/components/borderedLine/styles/BorderedLine.scss
+++ b/packages/react-vapor/src/components/borderedLine/styles/BorderedLine.scss
@@ -3,4 +3,5 @@
 
 .borderedLine {
     padding: $default-margin;
+    background-color: $line-color;
 }

--- a/packages/vapor/scss/components/corner-ribbon.scss
+++ b/packages/vapor/scss/components/corner-ribbon.scss
@@ -41,4 +41,8 @@
             transform: rotate($ribbon-rotation-angle);
         }
     }
+
+    &.border-accent {
+        border: $default-border-size solid var(--red);
+    }
 }

--- a/packages/vapor/scss/utility/colors.scss
+++ b/packages/vapor/scss/utility/colors.scss
@@ -13,10 +13,6 @@
         .text-#{$key} {
             color: var(--light);
         }
-
-        .border-#{$key} {
-            border-color: var(--light);
-        }
     } @else {
         .bg-#{$key} {
             background-color: var(--#{$key});
@@ -28,10 +24,6 @@
 
         .text-#{$key} {
             color: var(--#{$key});
-        }
-
-        .border-#{$key} {
-            border-color: var(--#{$key});
         }
     }
 }

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -650,3 +650,6 @@ $vertical-line-border-left: 1px solid var(--dark-medium-grey);
 
 // Drop
 $drop-z-index: 10000;
+
+// BorderedLine
+$line-color: var(--grey-20);


### PR DESCRIPTION
### Proposed Changes

Removed the border color util and fix broken style on borderedLine


PS: --default-border-color is grey-40 and also the same color than the line background so i need to use grey-60 :see_no_evil: 

### Potential Breaking Changes



### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
