### PR TITLE
style(variable.scss): reduce navigation icon size 20 -> 16px

### DIFF
--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -229,7 +229,7 @@ $navigation-border-for-scroll-bar: 1px;
 $navigation-background-color: var(--purple-blue);
 $navigation-active-background-color: var(--blue-purple-2);
 $navigation-active-border-width: 3px;
-$navigation-section-icon-size: 20px;
+$navigation-section-icon-size: 16px;
 $navigation-section-icon-margin-right: 10px;
 $navigation-section-icon-margin-left: 15px;
 $navigation-section-arrow-margin: 15px;


### PR DESCRIPTION
### Proposed Changes

changed icon size in admin navigation from 20px to 16px

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
