### PR TITLE
fix(flat-select): disabled the flatSelectOption when disabled is true

### DIFF
--- a/packages/demo/src/components/examples/FlatSelectExamples.tsx
+++ b/packages/demo/src/components/examples/FlatSelectExamples.tsx
@@ -119,6 +119,43 @@ export class FlatSelectExamples extends React.Component {
                             }}
                         />
                     </Section>
+                    <Section level={2} title="Flat Select with a disabled option">
+                        <FlatSelectConnected
+                            {...{
+                                id: UUID.generate(),
+                                options: [
+                                    {
+                                        id: UUID.generate(),
+                                        option: {content: 'disabled'},
+                                        disabled: true,
+                                    },
+                                    {
+                                        id: UUID.generate(),
+                                        option: {content: 'enabled'},
+                                    },
+                                ],
+                            }}
+                        />
+                    </Section>
+                    <Section level={2} title="Flat Select with all options disabled">
+                        <FlatSelectConnected
+                            {...{
+                                id: UUID.generate(),
+                                options: [
+                                    {
+                                        id: UUID.generate(),
+                                        option: {content: "I'm a disabled FlatSelectOption"},
+                                        disabled: true,
+                                    },
+                                    {
+                                        id: UUID.generate(),
+                                        option: {content: "I'm a disabled FlatSelectOption too!"},
+                                    },
+                                ],
+                                disabled: true,
+                            }}
+                        />
+                    </Section>
                 </Section>
             </Form>
         );

--- a/packages/react-vapor/src/components/flatSelect/FlatSelect.tsx
+++ b/packages/react-vapor/src/components/flatSelect/FlatSelect.tsx
@@ -53,7 +53,7 @@ export const FlatSelect: React.FunctionComponent<IFlatSelectProps> = ({
             key={flatSelectOption.id}
             {...flatSelectOption}
             onClick={handleClick}
-            disabled={disabled}
+            disabled={disabled || flatSelectOption.disabled}
             selected={selectedOptionId === flatSelectOption.id}
         />
     ));

--- a/packages/react-vapor/src/components/flatSelect/FlatSelectOption.tsx
+++ b/packages/react-vapor/src/components/flatSelect/FlatSelectOption.tsx
@@ -18,6 +18,7 @@ export interface IFlatSelectOptionProps {
 export class FlatSelectOption extends React.Component<IFlatSelectOptionProps, any> {
     static defaultProps: Partial<IFlatSelectOptionProps> = {
         selected: false,
+        disabled: false,
     };
 
     private onClick() {

--- a/packages/react-vapor/src/components/flatSelect/tests/FlatSelect.spec.tsx
+++ b/packages/react-vapor/src/components/flatSelect/tests/FlatSelect.spec.tsx
@@ -113,4 +113,37 @@ describe('FlatSelect', () => {
 
         expect(store.getActions()).toContain(selectFlatSelect(props.id, 'new-option'));
     });
+
+    it('should disabled all options if the disabled prop is true', () => {
+        const propsWithDisabled = {...props, disabled: true};
+        const component = shallowWithState(<FlatSelectConnected {...propsWithDisabled} />, {}).dive();
+
+        for (let i = 0; i < component.find(FlatSelectOption).length; i++) {
+            expect(component.find(FlatSelectOption).at(i).props().disabled).toBe(true);
+        }
+    });
+
+    it('should disabled only one option if the disabled prop is set in a single option', () => {
+        const optionsWithOneDisabled: IFlatSelectOptionProps[] = [
+            {
+                id: UUID.generate(),
+                option: {
+                    content: 'test',
+                },
+                disabled: true,
+            },
+            {
+                id: UUID.generate(),
+                option: {
+                    content: 'test',
+                },
+            },
+        ];
+        const propsWithOneOptionDisabled = {...props, options: optionsWithOneDisabled};
+
+        const component = shallowWithState(<FlatSelectConnected {...propsWithOneOptionDisabled} />, {}).dive();
+
+        expect(component.find(FlatSelectOption).first().props().disabled).toBe(true);
+        expect(component.find(FlatSelectOption).at(1).props().disabled).toBe(false);
+    });
 });

--- a/packages/react-vapor/src/components/flatSelect/tests/FlatSelectOption.spec.tsx
+++ b/packages/react-vapor/src/components/flatSelect/tests/FlatSelectOption.spec.tsx
@@ -71,6 +71,18 @@ describe('FlatSelect', () => {
             expect(optionElement.hasClass('selectable')).toBe(true);
         });
 
+        it('should have the class disabled if the props disabled is true', () => {
+            renderFlatSelectOption(
+                _.extend({}, defaultProps, {
+                    disabled: true,
+                })
+            );
+
+            const optionElement = flatSelect.find('a');
+
+            expect(optionElement.hasClass('disabled')).toBe(true);
+        });
+
         it('should have 1 <Content/> if only default props are set', () => {
             renderFlatSelectOption(defaultProps);
 

--- a/packages/react-vapor/src/components/select/hoc/SelectWithPredicate.tsx
+++ b/packages/react-vapor/src/components/select/hoc/SelectWithPredicate.tsx
@@ -16,6 +16,7 @@ export interface ISelectWithPredicateOwnProps {
     options: IFlatSelectOptionProps[];
     matchPredicate?: (predicate: string, item: IItemBoxProps) => boolean;
     initiallySelectedPredicateId?: string;
+    disabledFlatSelectOptions?: boolean;
 }
 const SelectWithPredicatePropsToOmit = keys<ISelectWithPredicateOwnProps>();
 
@@ -57,6 +58,7 @@ export const selectWithPredicate = <P extends Omit<ISelectOwnProps, 'button'> & 
                     group
                     optionPicker
                     defaultSelectedOptionId={props.initiallySelectedPredicateId}
+                    disabled={props.disabledFlatSelectOptions}
                 />
                 {props.children}
             </Component>


### PR DESCRIPTION
### Proposed Changes

If a option is disabled in an array of `FlatSelectOptions`, it should be disabled. Also, a few unit tests was added to prove when a single option is disabled or all the options are. You can see two examples in the `FlatSelect` section.
![disabled_flat_select_option_example](https://user-images.githubusercontent.com/58052881/105115677-3e7ef000-5a97-11eb-8983-e2949e7a0955.png)

Finally, I included an option two disabled all the options in a `SingleSelectWithPredicate` or `MultiSelectWithPredicate` component.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
