### PR TITLE
Revert "feat(jenkins pipeline): remove skip stage"

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -43,6 +43,23 @@ pipeline {
 
   stages {
 
+    stage('Skip') {
+      // TODO: remove this once DT-3364 is fixed, set parameter `excludeJenkinsCommit=true` in the webhook instead
+      steps {
+        script {
+          setLastStageName();
+          commitMessage = sh(returnStdout: true, script: "git log -1 --pretty=%B").trim()
+          if(commitMessage.contains("[version bump]")) {
+            skipRemainingStages = true
+            println "Skipping this build because it was triggered by a version bump."
+          } else {
+            skipRemainingStages = false
+            println "Not a version bump, the build will proceed."
+          }
+        }
+      }
+    }
+
     stage('Prepare') {
       when {
         expression { !skipRemainingStages }


### PR DESCRIPTION
This reverts commit 8846283237798aa745471336348c339c4fef8ba0.

### Proposed Changes

The url param passed to the jenkings webhook that is supposed to exclude jenkins commits to rebuild is not working as expected, resulting in jenkins commiting and re-triggering a build over and over again. So I am reverting the removal of the skip stage.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
