### PR TITLE
fix(option-picker): change the hover and active option picked

### DIFF
--- a/packages/vapor/scss/components/calendar.scss
+++ b/packages/vapor/scss/components/calendar.scss
@@ -251,7 +251,7 @@
 
                 &.active {
                     color: var(--white);
-                    background-color: var(--blue-purple-3);
+                    background-color: var(--digital-blue-60);
                 }
             }
         }

--- a/packages/vapor/scss/components/calendar.scss
+++ b/packages/vapor/scss/components/calendar.scss
@@ -204,7 +204,7 @@
             box-sizing: border-box;
             width: 100%;
             padding: $dropdown-choices-top-bottom-margin;
-            color: var(--medium-blue);
+            color: var(--black);
             font-size: $button-font-size;
             background: none;
             border: $default-border;

--- a/packages/vapor/scss/components/calendar.scss
+++ b/packages/vapor/scss/components/calendar.scss
@@ -245,13 +245,13 @@
 
         &:nth-child(1n) {
             button {
-                &:hover,
-                &.active {
-                    background-color: $date-picker-button-hover-bg;
+                &:hover {
+                    background-color: var(--light-grey);
                 }
 
                 &.active {
-                    border-color: var(--blue);
+                    color: var(--white);
+                    background-color: var(--blue-purple-3);
                 }
             }
         }


### PR DESCRIPTION
### Proposed Changes

The odd colors noticed in the section mentioned in the Jira's case, is due to color set to the option-picker class (used for the OptionPicker component). The .gif below shows when a cursor hovers an option and when an user select an option. The design when the option is selected is based on my understanding of the coveo library canvas (in Figma). However, I'm not really sure is what is expected (would surely need the approval of UX!).

Edit: the example can be found in the DatePicker section.
![new_color_option_picker](https://user-images.githubusercontent.com/58052881/105564637-11c61500-5cf1-11eb-8e38-f5c5328030fc.gif)


### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
