### PR TITLE
(style): TRI-26 LogoCard and Badge style changes

### DIFF
--- a/packages/demo/src/components/examples/LogoCardExamples.tsx
+++ b/packages/demo/src/components/examples/LogoCardExamples.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {LogoCard} from 'react-vapor';
 import {TooltipPlacement} from 'react-vapor/src/utils/TooltipUtils';
 
-import {EXAMPLE_RIBBON_PROPS, MULTIPLE_BADGES} from './LogoCardExamplesCommon';
+import {MULTIPLE_BADGES} from './LogoCardExamplesCommon';
 
 export class LogoCardExamples extends React.Component<any, any> {
     render() {
@@ -11,7 +11,19 @@ export class LogoCardExamples extends React.Component<any, any> {
                 <div className="form-group">
                     <label className="form-control-label">LogoCard with title</label>
                     <div className="form-control">
-                        <LogoCard title="Card title only" />
+                        <LogoCard title="Card title" />
+                    </div>
+                </div>
+                <div className="form-group">
+                    <label className="form-control-label">Disabled logo card with a tooltip and locked badge</label>
+                    <div className="form-control">
+                        <LogoCard
+                            title="Card title"
+                            disabled
+                            badges={[{label: 'Unavailable', icon: 'lock', extraClasses: ['bg-school-bus-yellow']}]}
+                            tooltip="Hello I am a tooltip and I appear on top of this logo card, this card is disabled with a badge"
+                            tooltipPlacement={TooltipPlacement.Top}
+                        />
                     </div>
                 </div>
                 <div className="form-group">
@@ -21,27 +33,9 @@ export class LogoCardExamples extends React.Component<any, any> {
                     </div>
                 </div>
                 <div className="form-group">
-                    <label className="form-control-label">LogoCard with badges, description and ribbon</label>
+                    <label className="form-control-label">LogoCard with badges and description</label>
                     <div className="form-control">
-                        <LogoCard
-                            title="Card title"
-                            badges={MULTIPLE_BADGES}
-                            ribbon={EXAMPLE_RIBBON_PROPS}
-                            description="Card description"
-                        />
-                    </div>
-                </div>
-                <div className="form-group">
-                    <label className="form-control-label">Disabled logo card with a tooltip</label>
-                    <div className="form-control">
-                        <LogoCard
-                            title="Card title"
-                            badges={MULTIPLE_BADGES}
-                            description="Card description"
-                            disabled
-                            tooltip="Hello I am a tooltip and I appear on top of this logo card"
-                            tooltipPlacement={TooltipPlacement.Top}
-                        />
+                        <LogoCard title="Card title" badges={MULTIPLE_BADGES} description="Card description" />
                     </div>
                 </div>
             </div>

--- a/packages/demo/src/components/examples/LogoCardExamplesCommon.ts
+++ b/packages/demo/src/components/examples/LogoCardExamplesCommon.ts
@@ -1,4 +1,4 @@
-import {IBadgeProps, ICornerRibbonProps} from 'react-vapor';
+import {IBadgeProps} from 'react-vapor';
 
 export const MULTIPLE_BADGES: IBadgeProps[] = [
     {
@@ -7,15 +7,10 @@ export const MULTIPLE_BADGES: IBadgeProps[] = [
     },
     {
         label: 'Badge 2',
-        extraClasses: ['bg-medium-blue'],
+        extraClasses: ['bg-orange'],
     },
     {
         label: 'Badge 3',
-        extraClasses: ['bg-darker-blue'],
+        extraClasses: ['bg-anakiwa'],
     },
 ];
-
-export const EXAMPLE_RIBBON_PROPS: ICornerRibbonProps = {
-    label: 'Ribbon',
-    extraClasses: ['bg-orange', 'bold'],
-};

--- a/packages/react-vapor/src/components/logoCard/LogoCard.tsx
+++ b/packages/react-vapor/src/components/logoCard/LogoCard.tsx
@@ -7,11 +7,6 @@ import {slugify} from 'underscore.string';
 
 import {TooltipPlacement} from '../../utils';
 import {Badge, IBadgeProps} from '../badge/Badge';
-import {
-    CornerRibbon,
-    DEFAULT_CORNER_RIBBON_CONTAINER_CLASSNAME,
-    ICornerRibbonProps,
-} from '../cornerRibbon/CornerRibbon';
 import {Svg} from '../svg/Svg';
 import {Tooltip} from '../tooltip';
 
@@ -19,16 +14,14 @@ export const DEFAULT_LOGO_CARD_CLASSNAME: string = 'logo-card';
 export const DEFAULT_LOGO_ICON: string = VaporSVG.svg.sourceCustom.name;
 export const DEFAULT_LOGO_ICON_CLASSNAME: string = 'icon';
 export const DEFAULT_LOGO_ICON_SIZE: string = 'mod-4x';
-export const DEFAULT_DISABLED_RIBBON_LABEL: string = 'Unavailable';
+export const DEFAULT_DISABLED_BADGE: string = 'Unavailable';
 
 export interface ILogoCardProps {
     badges?: IBadgeProps[];
     description?: string;
     disabled?: boolean;
-    disabledRibbon?: ICornerRibbonProps;
     extraContainerClasses?: string[];
     onClick?: () => void;
-    ribbon?: ICornerRibbonProps;
     svgName?: string;
     title: string;
     tooltip?: string;
@@ -41,9 +34,6 @@ export class LogoCard extends React.Component<ILogoCardProps & React.HTMLProps<H
     static defaultProps: Partial<ILogoCardProps> = {
         badges: [],
         disabled: false,
-        disabledRibbon: {
-            label: DEFAULT_DISABLED_RIBBON_LABEL,
-        },
         extraContainerClasses: [],
         svgName: DEFAULT_LOGO_ICON,
     };
@@ -57,27 +47,12 @@ export class LogoCard extends React.Component<ILogoCardProps & React.HTMLProps<H
     render() {
         const containerClassName = classNames(
             DEFAULT_LOGO_CARD_CLASSNAME,
-            this.props.disabled || this.props.ribbon ? DEFAULT_CORNER_RIBBON_CONTAINER_CLASSNAME : '',
             this.props.extraContainerClasses,
             this.props.disabled ? 'disabled' : ''
         );
         const logoIconClassName = classNames(DEFAULT_LOGO_ICON_CLASSNAME, DEFAULT_LOGO_ICON_SIZE);
-        const descriptionClassName = classNames(this.props.badges.length ? 'ml1' : '');
-        const logoCardContentClassName = classNames(
-            !this.props.badges.length && !this.props.description ? 'logo-card-content-center' : 'logo-card-content'
-        );
 
         const badges = this.props.badges.map((badgeProps) => <Badge {...badgeProps} key={slugify(badgeProps.label)} />);
-        const description = this.props.description ? (
-            <span className={descriptionClassName}>{this.props.description}</span>
-        ) : null;
-
-        let ribbon = null;
-        if (this.props.disabled) {
-            ribbon = <CornerRibbon {...this.props.disabledRibbon} />;
-        } else if (this.props.ribbon) {
-            ribbon = <CornerRibbon {...this.props.ribbon} />;
-        }
 
         const logoCard: JSX.Element = (
             <Tooltip title={this.props.tooltip} placement={this.props.tooltipPlacement}>
@@ -89,11 +64,11 @@ export class LogoCard extends React.Component<ILogoCardProps & React.HTMLProps<H
                     <div className="logo-card-logo">
                         <Svg svgName={this.props.svgName} className={logoIconClassName} />
                     </div>
-                    <div className={logoCardContentClassName}>
-                        <h2 className="logo-card-title">{this.props.title}</h2>
-                        {this.props.badges || this.props.description ? <div> {...badges} {description} </div> : ''}
+                    <div className="logo-card-content">
+                        <h2 className="logo-card-title mb1">{this.props.title}</h2>
+                        {this.props.description}
                     </div>
-                    {ribbon}
+                    {this.props.badges.length > 0 ? <div className="logo-card-badge">{...badges}</div> : null}
                 </div>
             </Tooltip>
         );

--- a/packages/react-vapor/src/components/logoCard/tests/LogoCard.spec.tsx
+++ b/packages/react-vapor/src/components/logoCard/tests/LogoCard.spec.tsx
@@ -3,13 +3,6 @@ import * as React from 'react';
 import * as _ from 'underscore';
 
 import {
-    CornerRibbon,
-    DEFAULT_CORNER_RIBBON_CONTAINER_CLASSNAME,
-    PlacementX,
-    PlacementY,
-} from '../../cornerRibbon/CornerRibbon';
-import {Tooltip} from '../../tooltip';
-import {
     DEFAULT_LOGO_CARD_CLASSNAME,
     DEFAULT_LOGO_ICON,
     DEFAULT_LOGO_ICON_CLASSNAME,
@@ -17,6 +10,7 @@ import {
     ILogoCardProps,
     LogoCard,
 } from '../LogoCard';
+import {Tooltip} from '../../tooltip';
 
 describe('LogoCard', () => {
     let logoCard: ReactWrapper<ILogoCardProps>;
@@ -30,60 +24,6 @@ describe('LogoCard', () => {
         expect(() => {
             shallow(<LogoCard title="test card" />);
         }).not.toThrow();
-    });
-
-    describe('<LogoCard /> with title only', () => {
-        let defaultLogoCardProps: Partial<ILogoCardProps>;
-
-        it('should have a logo-card-content-center class when only a title is given', () => {
-            defaultLogoCardProps = {
-                title: 'Card title only',
-            };
-            mountWithProps(defaultLogoCardProps);
-
-            expect(logoCard.find('.logo-card-content-center').length).toBe(1);
-            expect(logoCard.find('.logo-card-content').length).toBe(0);
-        });
-
-        it('should have a logo-card-content class when there are badges in the LogoCard', () => {
-            defaultLogoCardProps = {
-                title: 'Card title with badges',
-                badges: [
-                    {
-                        label: 'badge 1',
-                    },
-                    {
-                        label: 'badge 2',
-                    },
-                ],
-            };
-            mountWithProps(defaultLogoCardProps);
-
-            expect(logoCard.find('.logo-card-content-center').length).toBe(0);
-            expect(logoCard.find('.logo-card-content').length).toBe(1);
-        });
-
-        it('should have a logo-card-content class when there is a description passed in the LogoCard', () => {
-            defaultLogoCardProps = {
-                title: 'Card title with a description',
-                description: 'some description',
-            };
-            mountWithProps(defaultLogoCardProps);
-
-            expect(logoCard.find('.logo-card-content-center').length).toBe(0);
-            expect(logoCard.find('.logo-card-content').length).toBe(1);
-        });
-
-        it('should have a logo-card-content class when there are badges and a description passed in the LogoCard', () => {
-            defaultLogoCardProps = {
-                title: 'Card title with a description',
-                description: 'some description',
-            };
-            mountWithProps(defaultLogoCardProps);
-
-            expect(logoCard.find('.logo-card-content-center').length).toBe(0);
-            expect(logoCard.find('.logo-card-content').length).toBe(1);
-        });
     });
 
     describe('Default <LogoCard />', () => {
@@ -104,10 +44,6 @@ describe('LogoCard', () => {
             expect(logoCard.html()).toContain(DEFAULT_LOGO_CARD_CLASSNAME);
         });
 
-        it('should not have the ribbon-container class if no ribbon is used on the LogoCard', () => {
-            expect(logoCard.html()).not.toContain(DEFAULT_CORNER_RIBBON_CONTAINER_CLASSNAME);
-        });
-
         it('should render the specied title as props', () => {
             expect(logoCard.find('.logo-card-title').text()).toEqual(defaultLogoCardProps.title);
         });
@@ -116,10 +52,6 @@ describe('LogoCard', () => {
             logoCard.props().onClick();
 
             expect(defaultLogoCardProps.onClick).toHaveBeenCalledTimes(1);
-        });
-
-        it('should not render a corner-ribbon if no ribbon is set when not disabled', () => {
-            expect(logoCard.find('CornerRibbon').length).toBe(0);
         });
 
         it('should render no badges if no badges are specified as props', () => {
@@ -144,12 +76,6 @@ describe('LogoCard', () => {
             disabledLogoCardProps = {
                 disabled: true,
                 onClick: jest.fn(),
-                ribbon: {
-                    label: 'ribbonWhenEnabled',
-                },
-                disabledRibbon: {
-                    label: 'ribbonWhenDisabled',
-                },
                 tooltip: 'Tooltip',
             };
         });
@@ -162,18 +88,10 @@ describe('LogoCard', () => {
             expect(logoCard.html()).toContain('disabled');
         });
 
-        it('should have the ribbon-container class', () => {
-            expect(logoCard.html()).toContain(DEFAULT_CORNER_RIBBON_CONTAINER_CLASSNAME);
-        });
-
         it('should not call onClick when clicking on the logoCard', () => {
             logoCard.simulate('click');
 
             expect(disabledLogoCardProps.onClick).not.toHaveBeenCalled();
-        });
-
-        it('should render the disabled ribbon when a ribbon is already applied', () => {
-            expect(logoCard.find(CornerRibbon).text()).toBe(disabledLogoCardProps.disabledRibbon.label);
         });
 
         it('should render a tooltip if the props are given', () => {
@@ -181,7 +99,7 @@ describe('LogoCard', () => {
         });
     });
 
-    describe('<LogoCard /> with badges, description and ribbon', () => {
+    describe('<LogoCard /> with badges, description', () => {
         const thisLogoCardProps: Partial<ILogoCardProps> = {
             badges: [
                 {
@@ -191,12 +109,6 @@ describe('LogoCard', () => {
                     label: 'badge 2',
                 },
             ],
-            ribbon: {
-                label: 'some-ribbon',
-                placementX: PlacementX.Right,
-                placementY: PlacementY.Bottom,
-                extraClasses: ['bold'],
-            },
             description: 'some description',
             extraContainerClasses: ['some-extra-class'],
             svgName: 'source-rss',
@@ -208,17 +120,6 @@ describe('LogoCard', () => {
 
         it('should render as many badges as specified in the props if any', () => {
             expect(logoCard.find('Badge').length).toBe(thisLogoCardProps.badges.length);
-        });
-
-        it('should render a ribbon as specified in the props if any', () => {
-            expect(logoCard.find(CornerRibbon).props()).toEqual(thisLogoCardProps.ribbon);
-        });
-
-        it('should render a description with ml1 class', () => {
-            const descriptionSpan = logoCard.find('span.ml1');
-
-            expect(descriptionSpan.length).toBeGreaterThan(0);
-            expect(descriptionSpan.text()).toBe(thisLogoCardProps.description);
         });
 
         it('should render extra container classes if specified as props', () => {

--- a/packages/vapor/scss/components/badge.scss
+++ b/packages/vapor/scss/components/badge.scss
@@ -6,10 +6,8 @@
     padding: var(--badge-padding);
     color: var(--badge-text-color);
     font-weight: var(--badge-font-weight);
-    font-size: var(--badge-font-size);
     line-height: var(--badge-line-height);
     text-align: center;
-    text-transform: var(--badge-text-transform);
     background-color: var(--badge-background-color);
     border: var(--badge-border);
 

--- a/packages/vapor/scss/components/logo-card.scss
+++ b/packages/vapor/scss/components/logo-card.scss
@@ -3,7 +3,6 @@
     margin: $logo-card-margin;
     padding: $logo-card-padding;
     border: $logo-card-border;
-
     cursor: pointer;
 
     &.disabled {
@@ -29,15 +28,17 @@
 .logo-card-content {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
-}
-
-.logo-card-content-center {
-    display: flex;
-    flex-direction: column;
+    flex-grow: 1;
     justify-content: center;
 }
 
 .logo-card-title {
     color: $logo-card-title-color;
+}
+
+.logo-card-badge {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
 }

--- a/packages/vapor/scss/redesign/variables.scss
+++ b/packages/vapor/scss/redesign/variables.scss
@@ -192,7 +192,8 @@
 
     // Badge
     --badge-background-color: var(--orange);
-    --badge-text-color: var(--pure-white);
+    --badge-font-size: 0.92em;
+    --badge-text-color: var(--black);
     --badge-height: #{$badge-height};
     --badge-margin: #{$badge-margin};
     --badge-padding: #{$badge-padding};

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -525,13 +525,12 @@ $step-progress-bar-doing-color: var(--caribbean-green);
 $step-progress-bar-to-do-color: var(--white);
 
 // Badge
-$badge-font-size: 0.77em;
+$badge-font-size: 0.92em;
 $badge-mod-small-font-size: 9px;
 $badge-height: 2em;
 $badge-line-height: 1em;
-$badge-padding: 0.5em 1em;
+$badge-padding: 0.46em 1.23em 0.46em 0.92em;
 $badge-margin: 4px;
-$badge-border-radius: 2px;
 
 // Corner ribbon
 $ribbon-width: 10rem;


### PR DESCRIPTION
### Proposed Changes

Improvements to LogoCard design for trial ux experience and mockup as per design

<!-- Explain what are your changes. -->

- Moving the badges to the right side of LogoCard
- Deprecating ribbon from LogoCard
- Stylize Badge and LogoCard component

![image](https://user-images.githubusercontent.com/66333175/105394613-cece4980-5beb-11eb-9a6b-fbb1f3d75798.png)


### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
