### PR TITLE
Ad UI 6477  utility remove mod bg color for tooltips

### DIFF
--- a/packages/vapor/scss/components/tooltip.scss
+++ b/packages/vapor/scss/components/tooltip.scss
@@ -91,31 +91,6 @@
         }
     }
 
-    @each $color in $palette {
-        $key: nth($color, 1);
-        &.mod-bg-#{$key} {
-            .tooltip-inner {
-                background-color: var(--#{$key});
-            }
-
-            &.left .tooltip-arrow {
-                border-left-color: var(--#{$key});
-            }
-
-            &.bottom .tooltip-arrow {
-                border-bottom-color: var(--#{$key});
-            }
-
-            &.top .tooltip-arrow {
-                border-top-color: var(--#{$key});
-            }
-
-            &.right .tooltip-arrow {
-                border-right-color: var(--#{$key});
-            }
-        }
-    }
-
     .tooltip-arrow {
         position: absolute;
         width: 0;


### PR DESCRIPTION
### Proposed Changes

removed the unused mod-bg-color class

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
