### PR TITLE
fix(button): text

### DIFF
--- a/packages/react-vapor/src/components/actionable-item/styles/ActionableItem.scss
+++ b/packages/react-vapor/src/components/actionable-item/styles/ActionableItem.scss
@@ -14,12 +14,12 @@ $actionable-item-dots-width: 12px;
 }
 
 .actionableItemContent {
-    padding: $button-padding-y $button-padding-x;
+    padding: var(--button-no-tag-button-padding-y) var(--button-padding-x);
     border-radius: $border-radius 0 0 $border-radius;
 }
 
 .actionableItemDots {
-    padding: $button-padding-y $actionable-item-dots-padding-x;
+    padding: var(--button-no-tag-button-padding-y) $actionable-item-dots-padding-x;
     border-radius: 0 $border-radius $border-radius 0;
 
     &:hover {

--- a/packages/react-vapor/src/components/button/Button.tsx
+++ b/packages/react-vapor/src/components/button/Button.tsx
@@ -47,7 +47,7 @@ export class Button extends React.Component<IButtonProps & React.ButtonHTMLAttri
             });
 
             buttonElement = (
-                <a className={`${buttonClass} btn-container`} {...buttonAttrs}>
+                <a className={`${buttonClass} btn-container mod-no-button-tag`} {...buttonAttrs}>
                     {this.props.name}
                     {this.props.children}
                 </a>

--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -153,6 +153,10 @@
         }
     }
 
+    &.mod-no-button-tag {
+        padding: var(--button-no-tag-button-padding-y) var(--button-padding-x);
+    }
+
     &.mod-link {
         background-color: transparent;
         border: none;

--- a/packages/vapor/scss/redesign/variables.scss
+++ b/packages/vapor/scss/redesign/variables.scss
@@ -101,6 +101,8 @@
     --button-line-height: 20px;
     --button-small-line-height: 17px;
     --button-text-transform: none;
+    --button-no-tag-button-padding-y: 9px;
+    --button-padding-x: 16px;
 
     // Status
     --status-blue: var(--information-60);


### PR DESCRIPTION
update padding for 9px instead of 6 when we use an other tag than button
update padding for actionable item and actionable icon

### Proposed Changes

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


<img width="435" alt="Screen Shot 2021-01-21 at 4 30 43 PM" src="https://user-images.githubusercontent.com/7167202/105415471-bddf0180-5c06-11eb-9a14-f6023455480b.png">

<img width="328" alt="Screen Shot 2021-01-21 at 4 30 37 PM" src="https://user-images.githubusercontent.com/7167202/105415503-ca635a00-5c06-11eb-8809-bf9919e9a9c8.png">

