### PR TITLE
feat(modal): generalize the confirmation modal

### DIFF
--- a/packages/react-vapor/src/components/modal/ConfirmationModalProvider.tsx
+++ b/packages/react-vapor/src/components/modal/ConfirmationModalProvider.tsx
@@ -3,34 +3,35 @@ import * as React from 'react';
 import {Button} from '../button/Button';
 import {ModalComposite} from './ModalComposite';
 
-const defaultModalTitle = 'Unsaved Changes';
 const defaultModalClasses = ['mod-prompt', 'mod-fade-in-scale'];
-const defaultModalDescription =
-    'Are you sure you want to leave this page without saving? All unsaved changes will be lost.';
-const defaultConfirmButtonText = 'Exit without applying changes';
+const defaultConfirmButtonText = 'Confirm';
 
-export interface IUnsavedChangesModalProviderProps {
-    isDirty: boolean;
-    modalTitle?: string;
+export interface IConfirmationModalChildrenProps {
+    promptBefore: (callbackOnDiscard: () => any) => boolean;
+}
+
+export interface IConfirmationModalProviderProps {
+    shouldConfirm: boolean;
+    modalTitle: string;
+    modalBodyChildren: React.ReactNode;
     className?: string[];
-    children: (props: {promptBefore: (callbackOnDiscard: () => any) => boolean}) => React.ReactNode;
-    unsavedChangesDescription?: string;
+    children: (props: IConfirmationModalChildrenProps) => React.ReactNode;
     confirmButtonText?: string;
 }
 
-export const UnsavedChangesModalProvider: React.FunctionComponent<IUnsavedChangesModalProviderProps> = ({
-    isDirty,
+export const ConfirmationModalProvider: React.FunctionComponent<IConfirmationModalProviderProps> = ({
+    shouldConfirm,
     children,
-    modalTitle = defaultModalTitle,
+    modalTitle,
     className = defaultModalClasses,
-    unsavedChangesDescription = defaultModalDescription,
+    modalBodyChildren,
     confirmButtonText = defaultConfirmButtonText,
 }) => {
     const [isOpen, setIsOpen] = React.useState(false);
     const [confirm, setConfirm] = React.useState(null);
 
     const promptBefore = (callbackOnDiscard: () => any): boolean => {
-        if (isDirty) {
+        if (shouldConfirm) {
             setIsOpen(true);
             setConfirm(() => () => {
                 callbackOnDiscard();
@@ -53,7 +54,7 @@ export const UnsavedChangesModalProvider: React.FunctionComponent<IUnsavedChange
                 classes={className}
                 modalHeaderClasses={['mod-warning']}
                 modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
-                modalBodyChildren={<div>{unsavedChangesDescription}</div>}
+                modalBodyChildren={modalBodyChildren}
                 modalFooterChildren={
                     <>
                         <Button small name={confirmButtonText} onClick={confirm} primary />

--- a/packages/react-vapor/src/components/modal/UnsavedChangesModalProvider.tsx
+++ b/packages/react-vapor/src/components/modal/UnsavedChangesModalProvider.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+import {ConfirmationModalProvider, IConfirmationModalChildrenProps} from './ConfirmationModalProvider';
+
+const defaultModalTitle = 'Unsaved Changes';
+const defaultModalClasses = ['mod-prompt', 'mod-fade-in-scale'];
+const defaultModalDescription =
+    'Are you sure you want to leave this page without saving? All unsaved changes will be lost.';
+const defaultConfirmButtonText = 'Exit without applying changes';
+
+export interface IUnsavedChangesModalProviderProps {
+    isDirty: boolean;
+    modalTitle?: string;
+    className?: string[];
+    children: (props: IConfirmationModalChildrenProps) => React.ReactNode;
+    unsavedChangesDescription?: string;
+    confirmButtonText?: string;
+}
+
+export const UnsavedChangesModalProvider: React.FunctionComponent<IUnsavedChangesModalProviderProps> = ({
+    isDirty,
+    children,
+    modalTitle = defaultModalTitle,
+    className = defaultModalClasses,
+    unsavedChangesDescription = defaultModalDescription,
+    confirmButtonText = defaultConfirmButtonText,
+}) => (
+    <ConfirmationModalProvider
+        className={className}
+        shouldConfirm={isDirty}
+        modalTitle={modalTitle}
+        modalBodyChildren={<div>{unsavedChangesDescription}</div>}
+        confirmButtonText={confirmButtonText}
+    >
+        {(options) => children(options)}
+    </ConfirmationModalProvider>
+);

--- a/packages/react-vapor/src/components/modal/index.ts
+++ b/packages/react-vapor/src/components/modal/index.ts
@@ -1,3 +1,4 @@
+export * from './ConfirmationModalProvider';
 export * from './Modal';
 export * from './ModalActions';
 export * from './ModalBackdrop';
@@ -10,4 +11,4 @@ export * from './ModalHeader';
 export * from './ModalHeaderConnected';
 export * from './ModalReducers';
 export * from './loading/ModalLoading';
-export * from './UnsavedChangeModalProvider';
+export * from './UnsavedChangesModalProvider';

--- a/packages/react-vapor/src/components/modal/tests/ConfirmationModalProvider.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/ConfirmationModalProvider.spec.tsx
@@ -4,11 +4,11 @@ import {Provider} from 'react-redux';
 
 import {getStoreMock} from '../../../utils/tests/TestUtils';
 import {ModalCompositeConnected} from '../ModalComposite';
-import {UnsavedChangesModalProvider} from '../UnsavedChangeModalProvider';
+import {ConfirmationModalProvider} from '../ConfirmationModalProvider';
 
-describe('<UnsavedChangeModalProvider/>', () => {
-    let unsavedChangesModalProvider: ShallowWrapper;
-    let heavyUnsavedChangesModalProvider;
+describe('<ConfirmationModalProvider/>', () => {
+    let confirmationModalProvider: ShallowWrapper;
+    let heavyConfirmationModalProvider;
     let regularClickActionSpy: jasmine.Spy;
     let promptBeforeClickActionSpy: jasmine.Spy;
     const store = getStoreMock();
@@ -20,14 +20,18 @@ describe('<UnsavedChangeModalProvider/>', () => {
     afterEach(() => {
         regularClickActionSpy.calls.reset();
         promptBeforeClickActionSpy.calls.reset();
-        if (unsavedChangesModalProvider?.exists()) {
-            unsavedChangesModalProvider.unmount();
+        if (confirmationModalProvider?.exists()) {
+            confirmationModalProvider.unmount();
         }
     });
 
-    const shallowMountUnsavedModalProvider = (isDirty: boolean = false) =>
+    const shallowMountUnsavedModalProvider = (shouldConfirm: boolean = false) =>
         shallow(
-            <UnsavedChangesModalProvider isDirty={isDirty}>
+            <ConfirmationModalProvider
+                shouldConfirm={shouldConfirm}
+                modalTitle="Are you sure?"
+                modalBodyChildren={<div>some content</div>}
+            >
                 {({promptBefore}) => (
                     <ModalCompositeConnected
                         id="👾"
@@ -44,12 +48,16 @@ describe('<UnsavedChangeModalProvider/>', () => {
                         docLink={{url: 'https://www.coveo.com', tooltip: {title: 'Go to coveo.com'}}}
                     />
                 )}
-            </UnsavedChangesModalProvider>
+            </ConfirmationModalProvider>
         );
 
-    const heavilyMountUnsavedModalProvider = (isDirty: boolean = false) =>
+    const heavilyMountUnsavedModalProvider = (shouldConfirm: boolean = false) =>
         mount(
-            <UnsavedChangesModalProvider isDirty={isDirty}>
+            <ConfirmationModalProvider
+                shouldConfirm={shouldConfirm}
+                modalTitle="Are you sure?"
+                modalBodyChildren={<div>some content</div>}
+            >
                 {({promptBefore}) => (
                     <Provider store={store}>
                         <ModalCompositeConnected
@@ -68,7 +76,7 @@ describe('<UnsavedChangeModalProvider/>', () => {
                         />
                     </Provider>
                 )}
-            </UnsavedChangesModalProvider>
+            </ConfirmationModalProvider>
         );
 
     it('should mount and unmount without trowing', () => {
@@ -77,69 +85,69 @@ describe('<UnsavedChangeModalProvider/>', () => {
         }).not.toThrow();
     });
 
-    describe('when dirty changes', () => {
-        it('should open the UnsavedChangesModal to interrupt the leaving action', () => {
-            heavyUnsavedChangesModalProvider = heavilyMountUnsavedModalProvider(true);
+    describe('when should confirm changes', () => {
+        it('should open the ConfirmationModal to interrupt the leaving action', () => {
+            heavyConfirmationModalProvider = heavilyMountUnsavedModalProvider(true);
 
-            expect(heavyUnsavedChangesModalProvider.childAt(1).prop('isOpen')).toBeFalsy();
+            expect(heavyConfirmationModalProvider.childAt(1).prop('isOpen')).toBeFalsy();
 
-            const heavyModal: any = heavyUnsavedChangesModalProvider.find(ModalCompositeConnected);
+            const heavyModal: any = heavyConfirmationModalProvider.find(ModalCompositeConnected);
             heavyModal.props().modalFooterChildren.props.onClick();
-            heavyUnsavedChangesModalProvider.update();
+            heavyConfirmationModalProvider.update();
 
-            expect(heavyUnsavedChangesModalProvider.childAt(1).prop('isOpen')).toBeTruthy();
+            expect(heavyConfirmationModalProvider.childAt(1).prop('isOpen')).toBeTruthy();
         });
 
         describe('PromptBefore function', () => {
             it('should return false', () => {
-                unsavedChangesModalProvider = shallowMountUnsavedModalProvider(true);
-                unsavedChangesModalProvider.childAt(0).props().modalFooterChildren.props.onClick();
+                confirmationModalProvider = shallowMountUnsavedModalProvider(true);
+                confirmationModalProvider.childAt(0).props().modalFooterChildren.props.onClick();
 
                 expect(regularClickActionSpy).not.toHaveBeenCalled();
             });
         });
 
         it('should use the callback function in the promptBefore function when confirming the exit', () => {
-            heavyUnsavedChangesModalProvider = heavilyMountUnsavedModalProvider(true);
+            heavyConfirmationModalProvider = heavilyMountUnsavedModalProvider(true);
 
-            const modal: any = heavyUnsavedChangesModalProvider.find(ModalCompositeConnected);
+            const modal: any = heavyConfirmationModalProvider.find(ModalCompositeConnected);
             modal.props().modalFooterChildren.props.onClick();
-            heavyUnsavedChangesModalProvider.update();
-            const exitWithoutSavingButton: any = heavyUnsavedChangesModalProvider.childAt(1).find('Button').first();
+            heavyConfirmationModalProvider.update();
+            const exitWithoutSavingButton: any = heavyConfirmationModalProvider.childAt(1).find('Button').first();
             exitWithoutSavingButton.prop('onClick')();
 
             expect(promptBeforeClickActionSpy).toHaveBeenCalled();
         });
 
         it('should not use the callback function in the promptBefore function when cancelling the exit', () => {
-            heavyUnsavedChangesModalProvider = heavilyMountUnsavedModalProvider(true);
+            heavyConfirmationModalProvider = heavilyMountUnsavedModalProvider(true);
 
-            const modal: any = heavyUnsavedChangesModalProvider.find(ModalCompositeConnected);
+            const modal: any = heavyConfirmationModalProvider.find(ModalCompositeConnected);
             modal.props().modalFooterChildren.props.onClick();
-            heavyUnsavedChangesModalProvider.update();
-            const exitWithoutSavingButton: any = heavyUnsavedChangesModalProvider.childAt(1).find('Button').last();
+            heavyConfirmationModalProvider.update();
+            const exitWithoutSavingButton: any = heavyConfirmationModalProvider.childAt(1).find('Button').last();
             exitWithoutSavingButton.prop('onClick')();
 
             expect(promptBeforeClickActionSpy).not.toHaveBeenCalled();
         });
     });
 
-    describe('when the modal is not dirty', () => {
-        it('should not open the UnsavedChangesModal to interrupt the leaving action', () => {
-            heavyUnsavedChangesModalProvider = heavilyMountUnsavedModalProvider(false);
+    describe('when the modal is configured not to confirm changes', () => {
+        it('should not open the ConfirmationModal to interrupt the leaving action', () => {
+            heavyConfirmationModalProvider = heavilyMountUnsavedModalProvider(false);
 
-            expect(heavyUnsavedChangesModalProvider.childAt(1).prop('isOpen')).toBeFalsy();
+            expect(heavyConfirmationModalProvider.childAt(1).prop('isOpen')).toBeFalsy();
 
-            const heavyModal: any = heavyUnsavedChangesModalProvider.find(ModalCompositeConnected);
+            const heavyModal: any = heavyConfirmationModalProvider.find(ModalCompositeConnected);
             heavyModal.props().modalFooterChildren.props.onClick();
-            heavyUnsavedChangesModalProvider.update();
+            heavyConfirmationModalProvider.update();
 
-            expect(heavyUnsavedChangesModalProvider.childAt(1).prop('isOpen')).toBeFalsy();
+            expect(heavyConfirmationModalProvider.childAt(1).prop('isOpen')).toBeFalsy();
         });
 
         it('promptBefore function should return true', () => {
-            unsavedChangesModalProvider = shallowMountUnsavedModalProvider();
-            unsavedChangesModalProvider.childAt(0).props().modalFooterChildren.props.onClick();
+            confirmationModalProvider = shallowMountUnsavedModalProvider();
+            confirmationModalProvider.childAt(0).props().modalFooterChildren.props.onClick();
 
             expect(regularClickActionSpy).toHaveBeenCalled();
         });


### PR DESCRIPTION
[COM-789]

### Proposed Changes

We will be needing a more generic "Confirmation" provider that exposes the changes that were done, so I was thinking of re-using the `UnsavedChangesProvider` and adapting it to allow a `ReactNode` for its body. It would make it very generic and reusable for many things.

So `UnsavedChangesProvider` now uses the Confirmation provider under the hood!

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-789]: https://coveord.atlassian.net/browse/COM-789