### PR TITLE
fix(options-cycle): text alignment

### DIFF
--- a/packages/react-vapor/src/components/optionsCycle/OptionsCycle.tsx
+++ b/packages/react-vapor/src/components/optionsCycle/OptionsCycle.tsx
@@ -76,7 +76,7 @@ export class OptionsCycle extends React.Component<IOptionsCycleProps> {
                 >
                     <Svg svgName="arrow-left-rounded" svgClass="icon fill-dark-blue mod-16" />
                 </button>
-                <span className={classNames('options-cycle-option', this.props.buttonClassName)}>
+                <span className={classNames('options-cycle-option mod-no-button-tag', this.props.buttonClassName)}>
                     {this.props.options[this.props.currentOption]}
                 </span>
                 <button


### PR DESCRIPTION
add class to center align text in a tag using class btn without button tag

### Proposed Changes

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)

<img width="292" alt="Screen Shot 2021-01-21 at 5 05 56 PM" src="https://user-images.githubusercontent.com/7167202/105418402-13b5a880-5c0b-11eb-9558-c69d6900f804.png">

