### PR TITLE
fix(multiline-field.scss): when disabled, hide add, change remove icons

### DIFF
--- a/packages/demo/src/components/examples/InputExamples.tsx
+++ b/packages/demo/src/components/examples/InputExamples.tsx
@@ -15,6 +15,7 @@ import {
     multilineBoxContainer,
     multilineBoxWithDnD,
     multilineBoxWithRemoveButton,
+    MultilineInput,
     MultiValuesInput,
     MultiValuesInputSelectors,
     Section,
@@ -206,6 +207,9 @@ const MultilineInputExampleDisconnected: React.FunctionComponent<ReturnType<type
             <Section level={3} title="Multi-value inputs">
                 <MultiValuesInput id={MultiValuesInputId} data={['hello', 'world']} />
                 <p className="small transparency-2">Values in the state: {JSON.stringify(values, null, 2)}</p>
+            </Section>
+            <Section level={3} title="Multiline component (deprecated component)">
+                <MultilineInput values={[{id: 'deprecated', value: "I'm soooooo out fashion"}]} />
             </Section>
             <Section level={3} title="Multi-value inputs with a data limit">
                 <MultiValuesInput

--- a/packages/demo/src/components/examples/InputExamples.tsx
+++ b/packages/demo/src/components/examples/InputExamples.tsx
@@ -15,7 +15,6 @@ import {
     multilineBoxContainer,
     multilineBoxWithDnD,
     multilineBoxWithRemoveButton,
-    MultilineInput,
     MultiValuesInput,
     MultiValuesInputSelectors,
     Section,
@@ -207,9 +206,6 @@ const MultilineInputExampleDisconnected: React.FunctionComponent<ReturnType<type
             <Section level={3} title="Multi-value inputs">
                 <MultiValuesInput id={MultiValuesInputId} data={['hello', 'world']} />
                 <p className="small transparency-2">Values in the state: {JSON.stringify(values, null, 2)}</p>
-            </Section>
-            <Section level={3} title="Multiline component (deprecated component)">
-                <MultilineInput values={[{id: 'deprecated', value: "I'm soooooo out fashion"}]} />
             </Section>
             <Section level={3} title="Multi-value inputs with a data limit">
                 <MultiValuesInput

--- a/packages/vapor/scss/controls/multiline-field.scss
+++ b/packages/vapor/scss/controls/multiline-field.scss
@@ -83,30 +83,28 @@
             }
         }
 
-        &:disabled {
-            i {
-                position: relative;
-                display: block;
-                width: 18px;
-                height: 18px;
-                border: 2px solid var(--button-secondary-disabled-icon-color);
-                border-radius: 18px;
+        &:disabled i {
+            position: relative;
+            display: block;
+            width: 18px;
+            height: 18px;
+            border: 2px solid var(--button-secondary-disabled-icon-color);
+            border-radius: 18px;
 
-                &.add-action {
-                    visibility: hidden;
-                }
+            &.add-action {
+                visibility: hidden;
+            }
 
-                &.delete-action {
-                    &:before {
-                        position: relative;
-                        top: 6px;
-                        left: 2px;
-                        display: block;
-                        width: 10px;
-                        height: 2px;
-                        background-color: var(--button-secondary-disabled-icon-color);
-                        content: '';
-                    }
+            &.delete-action {
+                &:before {
+                    position: relative;
+                    top: 6px;
+                    left: 2px;
+                    display: block;
+                    width: 10px;
+                    height: 2px;
+                    background-color: var(--button-secondary-disabled-icon-color);
+                    content: '';
                 }
             }
         }

--- a/packages/vapor/scss/controls/multiline-field.scss
+++ b/packages/vapor/scss/controls/multiline-field.scss
@@ -89,7 +89,7 @@
                 display: block;
                 width: 18px;
                 height: 18px;
-                border: 2px solid var(--button-primary-disabled-color);
+                border: 2px solid var(--button-secondary-disabled-icon-color);
                 border-radius: 18px;
 
                 &.add-action {
@@ -104,7 +104,7 @@
                         display: block;
                         width: 10px;
                         height: 2px;
-                        background-color: var(--button-primary-disabled-color);
+                        background-color: var(--button-secondary-disabled-icon-color);
                         content: '';
                     }
                 }

--- a/packages/vapor/scss/controls/multiline-field.scss
+++ b/packages/vapor/scss/controls/multiline-field.scss
@@ -82,6 +82,34 @@
                 box-shadow: 0 0 6px 1px var(--medium-blue);
             }
         }
+
+        &:disabled {
+            i {
+                position: relative;
+                display: block;
+                width: 18px;
+                height: 18px;
+                border: 2px solid var(--button-primary-disabled-color);
+                border-radius: 18px;
+
+                &.add-action {
+                    visibility: hidden;
+                }
+
+                &.delete-action {
+                    &:before {
+                        position: relative;
+                        top: 6px;
+                        left: 2px;
+                        display: block;
+                        width: 10px;
+                        height: 2px;
+                        background-color: var(--button-primary-disabled-color);
+                        content: '';
+                    }
+                }
+            }
+        }
     }
 
     button {


### PR DESCRIPTION
### Proposed Changes
These changes are for an older multiline inputs configuration/classes. However, these changes are based of what seems to be the norm : the 'minus' icon is grey out when the input is disabled, but the 'plus' icon will be hidden instead.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
