### PR TITLE
build(next): avoid bumping a premajor on every commit

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -98,7 +98,7 @@ pipeline {
             if (env.BRANCH_NAME ==~ /release-.*/) {
               sh "npx lerna version patch --no-commit-hooks --no-git-tag-version --no-push --force-publish --yes"
             } else if (env.BRANCH_NAME == "next") {
-              sh "npx lerna version premajor --preid next --no-commit-hooks --no-git-tag-version --no-push --force-publish --yes"
+              sh "npx lerna version --conventional-prerelease --preid next --no-commit-hooks --no-git-tag-version --no-push --force-publish --yes"
             } else {
               sh "npx lerna version --no-commit-hooks --no-git-tag-version --no-push --force-publish=\"react-vapor\" --yes"
             }
@@ -201,7 +201,7 @@ pipeline {
             if (env.BRANCH_NAME ==~ /release-.*/) {
               sh "npx lerna publish patch --create-release github --yes --force-publish"
             } else if (env.BRANCH_NAME == "next") {
-              sh "npx lerna publish premajor --preid next --create-release github --yes --force-publish=\"react-vapor\""
+              sh "npx lerna publish --conventional-prerelease --preid next --create-release github --yes --force-publish=\"react-vapor\""
             } else {
               sh "npx lerna publish --create-release github --yes --force-publish=\"react-vapor\""
             }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-    "version": "12.0.0-next.0",
+    "version": "10.0.0-next.0",
     "packages": [
         "packages/*"
     ],

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-vapor-demo",
-    "version": "12.0.0-next.0",
+    "version": "10.0.0-next.0",
     "private": true,
     "description": "Vapor Design System",
     "main": "src/Index.ts",
@@ -22,7 +22,7 @@
     "dependencies": {
         "classnames": "2.2.6",
         "codemirror": "5.58.2",
-        "coveo-styleguide": "^11.0.0-next.0",
+        "coveo-styleguide": "^10.0.0-next.0",
         "d3": "3.5.17",
         "diff2html": "3.1.8",
         "faker": "4.1.0",
@@ -35,7 +35,7 @@
         "react-redux": "5.1.2",
         "react-router-dom": "5.2.0",
         "react-syntax-highlighter": "13.5.1",
-        "react-vapor": "^12.0.0-next.0",
+        "react-vapor": "^10.0.0-next.0",
         "redux": "4.0.5",
         "redux-devtools-extension": "2.13.8",
         "redux-promise-middleware": "6.1.2",

--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-vapor",
-    "version": "12.0.0-next.0",
+    "version": "10.0.0-next.0",
     "description": "Vapor CSS components implemented with React!",
     "keywords": [
         "coveo",
@@ -104,7 +104,7 @@
         "codecov": "3.2.0",
         "codemirror": "5.54.0",
         "concurrently": "5.1.0",
-        "coveo-styleguide": "^11.0.0-next.0",
+        "coveo-styleguide": "^10.0.0-next.0",
         "css-loader": "3.4.2",
         "d3": "3.5.17",
         "del": "5.1.0",

--- a/packages/vapor/package.json
+++ b/packages/vapor/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo-styleguide",
-    "version": "11.0.0-next.0",
+    "version": "10.0.0-next.0",
     "description": "Yet another CSS framework - but it's awesome & built by Coveo.",
     "keywords": [
         "coveo",


### PR DESCRIPTION
The premajor was "bumping" a major on every merge, which is not what we want. I saw that we can use `--conventional-prerelease` instead and do a breaking change in one of the commits to bump the major (only need to do it once).

I also reverted to version 10.0.0-next.0