### PR TITLE
fix(single-select): buggy infinite scroll when zoom is 110% in chrome

### DIFF
--- a/packages/demo/src/components/examples/ServerSideSelectExampleUtils.tsx
+++ b/packages/demo/src/components/examples/ServerSideSelectExampleUtils.tsx
@@ -42,7 +42,7 @@ export const usePhotosAPIMock = (): [any[], number, (params?: any, overwrite?: b
 
 export const PhotoItem: React.FunctionComponent<PhotoProps> = ({id, url, title, thumbnailUrl}) => (
     <div className="flex flex-center">
-        <a href={url} target="__blank" className="mr2">
+        <a href={url} target="__blank" className="mr2 flex">
             <img src={thumbnailUrl} alt={title} width={IMG_SIZE} height={IMG_SIZE} />
         </a>
         <span>{title}</span>

--- a/packages/react-vapor/src/components/select/hoc/SelectWithInfiniteScroll.tsx
+++ b/packages/react-vapor/src/components/select/hoc/SelectWithInfiniteScroll.tsx
@@ -8,7 +8,6 @@ import {ISelectOwnProps} from '../SelectConnected';
 export interface SelectWithInfiniteScrollProps {
     totalEntries: number;
     next: () => void;
-    scrollThreshold?: React.ReactText;
 }
 
 export const selectWithInfiniteScroll = <P extends Omit<ISelectOwnProps, 'button'>>(
@@ -25,7 +24,7 @@ export const selectWithInfiniteScroll = <P extends Omit<ISelectOwnProps, 'button
                 loader={<Loading className="p2 full-content-x" />}
                 next={props.next}
                 scrollableTarget={props.id}
-                scrollThreshold={props.scrollThreshold ?? 1}
+                scrollThreshold={0.9}
                 style={{overflow: 'initial'}}
                 hasChildren={items.length > 0 || props.isLoading}
             >

--- a/packages/react-vapor/src/components/select/hoc/SelectWithInfiniteScroll.tsx
+++ b/packages/react-vapor/src/components/select/hoc/SelectWithInfiniteScroll.tsx
@@ -8,6 +8,7 @@ import {ISelectOwnProps} from '../SelectConnected';
 export interface SelectWithInfiniteScrollProps {
     totalEntries: number;
     next: () => void;
+    scrollThreshold?: React.ReactText;
 }
 
 export const selectWithInfiniteScroll = <P extends Omit<ISelectOwnProps, 'button'>>(
@@ -24,7 +25,7 @@ export const selectWithInfiniteScroll = <P extends Omit<ISelectOwnProps, 'button
                 loader={<Loading className="p2 full-content-x" />}
                 next={props.next}
                 scrollableTarget={props.id}
-                scrollThreshold={1}
+                scrollThreshold={props.scrollThreshold ?? 1}
                 style={{overflow: 'initial'}}
                 hasChildren={items.length > 0 || props.isLoading}
             >


### PR DESCRIPTION
### Proposed Changes

[ADUI-6482](https://coveord.atlassian.net/browse/ADUI-6482)

By default, the `scrollThreshold` is `1` (100%), so the `next` function (`fetchNextPage`) will be triggered only when scrolling down to the bottom. However, after investigating, the height of the list box item changes randomly when zooming. For instance, the height is 54px when 100%, but 53.631px when 110%, 53.2px when 120%, 53.333px when 150%.
![image](https://user-images.githubusercontent.com/52677246/105890331-37973680-5fdd-11eb-85ab-20b4e937aac8.png)

Therefore, this issue was mainly caused by the unfixed height of list box items. So far, I thought about 2 options, give a fixed height, or slightly reduce `scrollThreshold` value to, for example, `10px` to compensate the height lost. Then we will fetch the next page earlier once there is `10px` to the bottom of the scroll bar.

In this PR, I fixed the height for the example, but still, I think it would be worth having an optional prop scrollThreshold just in case we can’t have a fixed height for some reason.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
