### PR TITLE
fix(radio-button): adding checkmark inside radio

### DIFF
--- a/packages/vapor/scss/controls/radios.scss
+++ b/packages/vapor/scss/controls/radios.scss
@@ -56,8 +56,10 @@
 
             &:after {
                 z-index: 0;
+                padding: 5px;
                 background-color: #1372ec; // digital-blue-60
-                transform: scale(0.5);
+                transform: scale(1);
+                content: url("data:image/svg+xml; utf8, <svg width='12px' fill='white' viewBox='0 0 10 10' xmlns='http://www.w3.org/2000/svg'><path d='m3.144 8-2.977-3.109c-.223-.232-.223-.61 0-.843s.586-.232.809 0l2.168 2.264 5.881-6.138c.222-.232.585-.232.809 0 .222.233.222.611-.001.844z'/></svg>");
             }
         }
 

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -70,7 +70,7 @@ $checkbox-label-margin: 18px;
 $checkbox-label-margin-top: 10px;
 $checkbox-default-border: solid 2px var(--checkbox-border-color);
 $radio-button-option-height: 18px;
-$radio-button-size: 18px;
+$radio-button-size: 22px;
 
 // Input and textarea
 $input-border: 1px solid var(--lynch);


### PR DESCRIPTION
To match the mockup design in figma and add svg checkmark

**Figma:**
![image](https://user-images.githubusercontent.com/66333175/106027615-1005a400-6099-11eb-8b89-d0e5e9a7744e.png)


### Proposed Changes
**Implementation**
![image](https://user-images.githubusercontent.com/66333175/106027582-0714d280-6099-11eb-9231-b887f309e9c0.png)

<!-- Explain what are your changes. -->
Adding svg checkmark and fill out radio button as per mockup design


### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
