### PR TITLE
refactor(font): implement gibson and update default text colors

### DIFF
--- a/packages/demo/src/components/examples/ListBoxExamples.tsx
+++ b/packages/demo/src/components/examples/ListBoxExamples.tsx
@@ -37,7 +37,7 @@ export class ListBoxExamples extends React.Component {
 
         return (
             <div className="mt2">
-                <h1 className="text-blue mb1">List Box</h1>
+                <h1 className="mb1">List Box</h1>
 
                 <div className="form-group">
                     <label className="form-control-label">Default List Box</label>

--- a/packages/demo/src/components/examples/RadioExamples.tsx
+++ b/packages/demo/src/components/examples/RadioExamples.tsx
@@ -75,9 +75,7 @@ const RadioSelectExample: React.FunctionComponent = () => (
                 </Radio>
                 <Radio id="Option2" name="enabledOptions" value="green">
                     <Label>Green</Label>
-                    <div className="mod-align-with-radio-label text-lynch mt1">
-                        The green color has an optional description.
-                    </div>
+                    <div className="mod-align-with-radio-label mt1">The green color has an optional description.</div>
                 </Radio>
                 <Radio id="Option3" name="enabledOptions" value="brown">
                     <Label>Brown</Label>

--- a/packages/demo/src/components/examples/SectionExamples.tsx
+++ b/packages/demo/src/components/examples/SectionExamples.tsx
@@ -44,7 +44,7 @@ export class SectionExamples extends React.Component<any, any> {
                                     </Input>
                                 </LabeledInput>
                                 <LabeledInput helpText="This is the font family that will be used on the button...">
-                                    <Input value="Lato, Arial, sans serif">
+                                    <Input value="Canada type gibson, sans serif">
                                         <Label>Font Family</Label>
                                     </Input>
                                 </LabeledInput>

--- a/packages/demo/src/components/examples/TabConnectedExample.tsx
+++ b/packages/demo/src/components/examples/TabConnectedExample.tsx
@@ -22,7 +22,7 @@ export class TabsExamples extends React.Component<any, any> {
                             <TabConnected id={TAB1_ID} title="A Tab" />
                             <TabConnected id={TAB2_ID} title="Another Tab" tooltip="I am an enabled tab" />
                             <TabConnected id={TAB3_ID} title="Tab with an icon">
-                                <Svg svgName={'help'} svgClass={'icon mod-16 mr1'} />
+                                <Svg svgName={'help'} svgClass={'icon documentation-link mod-16 mr1'} />
                             </TabConnected>
                             <TabConnected
                                 id={TAB4_ID}

--- a/packages/demo/src/demo-building-blocs/MarkdownOverrides.tsx
+++ b/packages/demo/src/demo-building-blocs/MarkdownOverrides.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-const heading = ({level, children}: any) =>
-    React.createElement(`h${level}`, {className: `h${level} text-medium-blue`}, children);
+const heading = ({level, children}: any) => React.createElement(`h${level}`, {className: `h${level}`}, children);
 
 const table = ({children}: any) => React.createElement('table', {className: 'table mb2'}, children);
 

--- a/packages/demo/src/index.html
+++ b/packages/demo/src/index.html
@@ -3,6 +3,7 @@
     <head>
         <title>Vapor Design System</title>
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+        <link rel="stylesheet" href="https://use.typekit.net/wqe4zqp.css" />
     </head>
     <body class="bg-grey-1">
         <div id="App" class="mod-width-70">

--- a/packages/demo/src/styles/cards/Wizard.tsx
+++ b/packages/demo/src/styles/cards/Wizard.tsx
@@ -15,8 +15,8 @@ const Wizard = () => (
                     <div className="coveo-form">
                         <div className="form-group left-align">
                             <h3>
-                                Coveo Cloud has identified the following{' '}
-                                <em className="bold text-medium-blue">Coveo organizations</em> related to your account.
+                                Coveo Cloud has identified the following <em className="bold">Coveo organizations</em>{' '}
+                                related to your account.
                             </h3>
                         </div>
                         <div className="form-group input-field">

--- a/packages/demo/src/styles/general-guidelines.tsx
+++ b/packages/demo/src/styles/general-guidelines.tsx
@@ -139,7 +139,7 @@ export default () => (
             </p>
         </Section>
         <Section title="Hit Zones">
-            <p className="h2 bold text-light-blue">
+            <p className="h2 bold">
                 <Svg svgName={VaporSVG.svg.tips.name} svgClass="icon mr1" />
                 44px x 44px + 10px clearance around hit zones (54px total)
             </p>

--- a/packages/react-vapor/src/components/actionable-item/ActionableItem.tsx
+++ b/packages/react-vapor/src/components/actionable-item/ActionableItem.tsx
@@ -28,7 +28,7 @@ export class ActionableItem extends React.Component<IActionableItemProps & React
                 <div
                     className={classNames(
                         {'cursor-pointer': !!this.props.onItemClick},
-                        'actionable-item-content inline-block text-medium-blue border-color-medium-grey mod-border bg-pure-white',
+                        'actionable-item-content align-middle inline-block border-color-medium-grey mod-border bg-pure-white',
                         styles.actionableItemContent,
                         styles.actionableItemContainer,
                         this.props.containerClassName
@@ -46,7 +46,7 @@ export class ActionableItem extends React.Component<IActionableItemProps & React
                             <div
                                 onClick={onClick}
                                 className={classNames(
-                                    'actionable-item-dots cursor-pointer inline-block mod-border-top mod-border-right border-color-medium-grey mod-border-bottom bg-pure-white',
+                                    'actionable-item-dots align-middle cursor-pointer inline-block mod-border-top mod-border-right border-color-medium-grey mod-border-bottom bg-pure-white',
                                     styles.actionableItemDots,
                                     styles.actionableItemContainer
                                 )}

--- a/packages/react-vapor/src/components/banner/styles/Banner.scss
+++ b/packages/react-vapor/src/components/banner/styles/Banner.scss
@@ -29,6 +29,7 @@
 }
 
 .bannerTitle {
+    color: var(--banner-text-color);
     font-size: $big-title-font-size;
 }
 

--- a/packages/react-vapor/src/components/collapsible/CollapsibleContainerConnected.tsx
+++ b/packages/react-vapor/src/components/collapsible/CollapsibleContainerConnected.tsx
@@ -55,10 +55,7 @@ export const CollapsibleContainerDisconnected: React.FunctionComponent<
         'mod-border-bottom'
     );
 
-    const headerClasses = classNames(
-        'inline-flex flex-center text-medium-blue caps p2 bold ml3',
-        collapsibleHeaderClassName
-    );
+    const headerClasses = classNames('inline-flex flex-center caps p2 bold ml3', collapsibleHeaderClassName);
 
     return (
         <CollapsibleConnected

--- a/packages/react-vapor/src/components/collapsible/CollapsibleInfoBox.tsx
+++ b/packages/react-vapor/src/components/collapsible/CollapsibleInfoBox.tsx
@@ -33,7 +33,7 @@ export class CollapsibleInfoBox extends React.PureComponent<CollapsibleInfoBoxPr
     private getHeader(): React.ReactNode {
         return this.props.isSection ? (
             <div className="flex pl1">
-                <h2 className="text-medium-blue">{this.props.title}</h2>
+                <h2>{this.props.title}</h2>
                 {this.props.sectionAdditionalContent && (
                     <span className={this.getAdditionalInfoClasses()}>{this.props.sectionAdditionalContent}</span>
                 )}
@@ -41,7 +41,7 @@ export class CollapsibleInfoBox extends React.PureComponent<CollapsibleInfoBoxPr
         ) : (
             <div className="inline-flex">
                 <Svg svgName="info" className="icon mod-20 mx1 js-info-svg" />
-                <h3 className="text-medium-blue">{this.props.title}</h3>
+                <h3>{this.props.title}</h3>
             </div>
         );
     }

--- a/packages/react-vapor/src/components/collapsible/tests/CollapsibleTestCommon.mock.tsx
+++ b/packages/react-vapor/src/components/collapsible/tests/CollapsibleTestCommon.mock.tsx
@@ -74,25 +74,21 @@ export const collapsiblePossibleProps: CollapsibleOwnProps[] = [
     {
         id: `collapsible-${_.uniqueId()}`,
         headerContent: <div>Some header content</div>,
-        headerClasses: 'text-medium-blue',
     },
     {
         id: `collapsible-${_.uniqueId()}`,
         headerContent: <div>Some header content</div>,
-        headerClasses: 'text-medium-blue',
         expandedOnMount: true,
     },
     {
         id: `collapsible-${_.uniqueId()}`,
         headerContent: <div>Some header content</div>,
-        headerClasses: 'text-medium-blue',
         expandedOnMount: true,
         withBorders: true,
     },
     {
         id: `collapsible-${_.uniqueId()}`,
         headerContent: <div>Some header content</div>,
-        headerClasses: 'text-medium-blue',
         expandedOnMount: true,
         withBorders: true,
         className: 'bg-white',

--- a/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
@@ -158,7 +158,7 @@ export class DatePickerBox extends React.Component<IDatePickerBoxProps, any> {
 
             return (
                 <div key={boxId}>
-                    <h3 className="bold text-medium-blue">{datesSelectionBox.title}</h3>
+                    <h3 className="bold">{datesSelectionBox.title}</h3>
                     {optionPicker}
                     {dateSelection}
                 </div>

--- a/packages/react-vapor/src/components/form/Form.tsx
+++ b/packages/react-vapor/src/components/form/Form.tsx
@@ -12,7 +12,7 @@ export interface IFormProps {
 
 export const Form: React.FunctionComponent<IFormProps> = ({children, className, title, mods, noMargin}) => (
     <fieldset className={classNames('coveo-form mod-padding-children', {my2: !noMargin}, mods, className)}>
-        {title && <h2 className="text-medium-blue mb2">{title}</h2>}
+        {title && <h2 className="mb2">{title}</h2>}
         {children}
     </fieldset>
 );

--- a/packages/react-vapor/src/components/form/FormGroup.tsx
+++ b/packages/react-vapor/src/components/form/FormGroup.tsx
@@ -12,7 +12,7 @@ export interface IFormGroupProps {
  */
 export const FormGroup: React.FunctionComponent<IFormGroupProps> = ({children, title, description, className}) => (
     <div className={classNames(className, 'form-group', 'mod-padding-children')}>
-        <h3 className="text-medium-blue bold">{title}</h3>
+        <h3 className="bold">{title}</h3>
         {description && <p className="description">{description}</p>}
         {children}
     </div>

--- a/packages/react-vapor/src/components/input/LabeledInput.tsx
+++ b/packages/react-vapor/src/components/input/LabeledInput.tsx
@@ -25,7 +25,7 @@ export const LabeledInput: React.FunctionComponent<ILabeledInputProps> = ({
     const header =
         !!label || !!information ? (
             <div className="flex">
-                <header className={classNames('label', 'text-light-blue', headerClassName)}>
+                <header className={classNames('label', headerClassName)}>
                     {!!label ? <span>{label}</span> : null}
                 </header>
                 {!!information ? (

--- a/packages/react-vapor/src/components/optionsCycle/OptionsCycle.tsx
+++ b/packages/react-vapor/src/components/optionsCycle/OptionsCycle.tsx
@@ -64,7 +64,7 @@ export class OptionsCycle extends React.Component<IOptionsCycleProps> {
     render() {
         return (
             <div
-                className={classNames('options-cycle text-medium-blue', this.props.className, {
+                className={classNames('options-cycle', this.props.className, {
                     'mod-inline': this.props.isInline,
                 })}
             >

--- a/packages/react-vapor/src/components/section/Section.tsx
+++ b/packages/react-vapor/src/components/section/Section.tsx
@@ -20,7 +20,7 @@ export const Section: React.FunctionComponent<ISectionProps> = ({
     level = 1,
 }) => {
     const titleProps: React.HTMLProps<HTMLElement> = {
-        className: 'text-medium-blue mb1',
+        className: 'mb1',
         children: title,
     };
     const H = `h${level + 1}`;

--- a/packages/react-vapor/src/components/statusCard/StatusCard.tsx
+++ b/packages/react-vapor/src/components/statusCard/StatusCard.tsx
@@ -25,7 +25,7 @@ export class StatusCard extends React.Component<StatusCardProps> {
     }
 
     private getContent(): JSX.Element {
-        const titleClasses: string = classNames('text-medium-blue', styles.statusCardTitle);
+        const titleClasses: string = classNames(styles.statusCardTitle);
 
         return this.props.loading ? (
             <Loading key="loading" className="center-align" />

--- a/packages/react-vapor/src/components/table-hoc/TableRowNumberColumn.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableRowNumberColumn.tsx
@@ -6,7 +6,7 @@ import * as styles from './styles/TableRowNumber.scss';
 // eslint-disable-next-line id-blacklist
 export const TableRowNumberColumn = (props: {number: React.ReactNode}) => (
     <td key="table-row-number" className={classNames('bg-grey-1 mod-border-right', styles.tableNumberedRow)}>
-        <div className={classNames('text-lynch flex flex-column flex-center center', styles.tableNumberedRowContainer)}>
+        <div className={classNames('flex flex-column flex-center center', styles.tableNumberedRowContainer)}>
             {props.number}
         </div>
     </td>

--- a/packages/react-vapor/src/components/tables/TableError.tsx
+++ b/packages/react-vapor/src/components/tables/TableError.tsx
@@ -34,7 +34,7 @@ export class TableError extends React.Component<ITableErrorProps, any> {
 
         const errorTroubleshoot: JSX.Element = this.props.error.errorTroubleshoot ? (
             <div>
-                <div className="label text-light-blue">{troubleshootingLabel}</div>
+                <div className="label">{troubleshootingLabel}</div>
                 <div className="value" dangerouslySetInnerHTML={{__html: this.props.error.errorTroubleshoot}}></div>
             </div>
         ) : null;
@@ -44,7 +44,7 @@ export class TableError extends React.Component<ITableErrorProps, any> {
                 <h4 className="caps bold error-title">{this.props.error.errorStatus}</h4>
                 <section className="columns">
                     <div className="details-container error-description-container">
-                        <div className="label text-light-blue">{descriptionLabel}</div>
+                        <div className="label">{descriptionLabel}</div>
                         <div className="value error-description">
                             <div dangerouslySetInnerHTML={{__html: this.props.error.errorDescription}}></div>
                             {errorPrecision}
@@ -52,7 +52,7 @@ export class TableError extends React.Component<ITableErrorProps, any> {
                     </div>
                     <div className="details-container troubleshooting-container">
                         {errorTroubleshoot}
-                        <div className="label text-light-blue">{errorCodeLabel}</div>
+                        <div className="label">{errorCodeLabel}</div>
                         <div className="value text-dark-blue">{this.props.error.errorCode}</div>
                     </div>
                 </section>

--- a/packages/vapor/scss/components/blankslate.scss
+++ b/packages/vapor/scss/components/blankslate.scss
@@ -1,6 +1,8 @@
 .blankslate {
+    --color: var(--title-text-color);
+
     padding: $blankslate-padding;
-    color: var(--blankslate-text-color);
+    color: var(--color);
     font-weight: var(--main-font-regular);
     text-align: center;
     background-color: var(--blankslate-background-color);
@@ -19,7 +21,7 @@
     p {
         max-width: $blankslate-description-width;
         margin: 0 auto $blankslate-paragraph-margin-bottom auto;
-        color: var(--blankslate-text-color);
+        color: var(--color);
     }
 
     &.mod-small {

--- a/packages/vapor/scss/components/facet.scss
+++ b/packages/vapor/scss/components/facet.scss
@@ -56,9 +56,7 @@
 }
 
 .facet-header-title {
-    --color: var(--title-text-color);
-
-    color: var(--color);
+    color: var(--title-text-color);
     font-weight: var(--facet-header-font-weight);
     font-size: var(--facet-header-font-size);
     font-family: var(--main-font);

--- a/packages/vapor/scss/components/facet.scss
+++ b/packages/vapor/scss/components/facet.scss
@@ -56,7 +56,9 @@
 }
 
 .facet-header-title {
-    color: var(--facet-header-text-color);
+    --color: var(--title-text-color);
+
+    color: var(--color);
     font-weight: var(--facet-header-font-weight);
     font-size: var(--facet-header-font-size);
     font-family: var(--main-font);

--- a/packages/vapor/scss/components/labeled-value.scss
+++ b/packages/vapor/scss/components/labeled-value.scss
@@ -1,4 +1,6 @@
 .box {
+    --color: var(--default-text-color);
+
     &.padded {
         padding: 5px $collapsible-box-padding;
     }
@@ -10,14 +12,16 @@
     }
 
     .label {
+        --color: var(--title-text-color);
+
         padding: 5px 0px 5px 5px;
-        color: var(--title-text-color);
+        color: var(--color);
         font-size: var(--small-font-size);
     }
 
     .value {
         padding: 5px;
-        color: var(--default-text-color);
+        color: var(--color);
         font-size: var(--default-font-size);
         line-height: $default-line-height;
     }

--- a/packages/vapor/scss/components/labeled-value.scss
+++ b/packages/vapor/scss/components/labeled-value.scss
@@ -11,15 +11,20 @@
 
     .label {
         padding: 5px 0px 5px 5px;
-        color: var(--label-text-color);
+        color: var(--title-text-color);
         font-size: var(--small-font-size);
     }
 
     .value {
         padding: 5px;
+        color: var(--default-text-color);
         font-size: var(--default-font-size);
         line-height: $default-line-height;
     }
+}
+
+.label {
+    color: var(--title-text-color);
 }
 
 .mod-align-header {

--- a/packages/vapor/scss/components/markdown-documentation.scss
+++ b/packages/vapor/scss/components/markdown-documentation.scss
@@ -5,7 +5,7 @@
     h4,
     h5,
     h6 {
-        color: var(--medium-blue);
+        color: var(--title-text-color);
     }
 
     h1,

--- a/packages/vapor/scss/components/tab.scss
+++ b/packages/vapor/scss/components/tab.scss
@@ -23,14 +23,12 @@
         transition: all 0.2s ease;
 
         &.active {
-            color: var(--color);
             border-bottom: $tab-bottom-border-height solid var(--tab-border-color);
         }
 
         &.disabled {
             --color: var(--medium-grey);
 
-            color: var(--color);
             cursor: not-allowed;
         }
 

--- a/packages/vapor/scss/components/tab.scss
+++ b/packages/vapor/scss/components/tab.scss
@@ -1,4 +1,6 @@
 .tab-navigation {
+    --color: var(--title-text-color);
+
     min-height: $tab-navigation-min-height;
     padding: 0 $header-padding;
     border-bottom: $default-border;
@@ -9,7 +11,7 @@
         display: inline-block;
         margin-right: $tab-margin-right;
         padding: $tab-padding;
-        color: var(--tab-text-color);
+        color: var(--color);
         font-weight: var(--tab-font-weight);
         font-size: var(--tab-font-size);
         line-height: 16px;
@@ -21,12 +23,14 @@
         transition: all 0.2s ease;
 
         &.active {
-            color: var(--tab-text-color);
+            color: var(--color);
             border-bottom: $tab-bottom-border-height solid var(--tab-border-color);
         }
 
         &.disabled {
-            color: var(--medium-grey);
+            --color: var(--medium-grey);
+
+            color: var(--color);
             cursor: not-allowed;
         }
 

--- a/packages/vapor/scss/controls/checkboxes.scss
+++ b/packages/vapor/scss/controls/checkboxes.scss
@@ -100,9 +100,11 @@ input[type='checkbox'].coveo-checkbox {
 }
 
 .coveo-checkbox-label {
+    --color: var(--title-text-color);
+
     display: inline-flex;
     align-items: center;
-    color: var(--checkbox-text-color);
+    color: var(--color);
     line-height: 16px;
     vertical-align: middle; // Required to properly position checkboxes into tables
 

--- a/packages/vapor/scss/controls/dropdown.scss
+++ b/packages/vapor/scss/controls/dropdown.scss
@@ -71,7 +71,7 @@
 
     &.mod-primary {
         font-size: $button-font-size;
-        text-transform: uppercase;
+        text-transform: var(--button-text-transform);
 
         .dropdown-toggle-arrow {
             @include arrow-down-icon(var(--pure-white));

--- a/packages/vapor/scss/controls/flat-select.scss
+++ b/packages/vapor/scss/controls/flat-select.scss
@@ -1,4 +1,6 @@
 .flat-select {
+    --color: var(--title-text-color);
+
     display: flex;
     background-color: var(--pure-white);
     border-radius: $border-radius;
@@ -51,7 +53,7 @@
         }
 
         &.selectable {
-            color: var(--flat-select-text-color);
+            color: var(--color);
             background-color: var(--pure-white);
             border: 1px solid var(--default-border-color);
 
@@ -62,7 +64,7 @@
             }
 
             .icon {
-                fill: var(--flat-select-text-color);
+                fill: var(--color);
             }
         }
 
@@ -121,7 +123,7 @@
 
     &.mod-option-picker .flat-select-option {
         flex: auto;
-        color: var(--flat-select-text-color);
+        color: var(--color);
         background-color: var(--light-grey);
         border: 1px solid var(--blue);
         border-right-width: 0;

--- a/packages/vapor/scss/controls/flat-select.scss
+++ b/packages/vapor/scss/controls/flat-select.scss
@@ -64,7 +64,7 @@
             }
 
             .icon {
-                fill: var(--color);
+                fill: currentColor;
             }
         }
 

--- a/packages/vapor/scss/forms/block-form.scss
+++ b/packages/vapor/scss/forms/block-form.scss
@@ -28,10 +28,12 @@ form {
     }
 
     .form-control-label {
+        --color: var(--title-text-color);
+
         display: inline-flex; // Used for inline-help-tooltip placement
         align-items: center;
         margin-bottom: $form-control-label-margin;
-        color: var(--medium-blue);
+        color: var(--color);
         font-size: $form-control-label-font-size;
 
         &.flex {

--- a/packages/vapor/scss/lib/_mixins.scss
+++ b/packages/vapor/scss/lib/_mixins.scss
@@ -23,7 +23,7 @@
     }
 }
 
-@mixin placeholder($text-color: var(--placeholder-text-color), $font-family: var(--main-font)) {
+@mixin placeholder($text-color: var(--default-text-color), $font-family: var(--main-font)) {
     &::placeholder {
         color: $text-color;
         font-size: inherit;

--- a/packages/vapor/scss/redesign/fonts.scss
+++ b/packages/vapor/scss/redesign/fonts.scss
@@ -4,6 +4,9 @@
     --main-font-bold: 400;
     --main-font-bolder: 500;
 
+    --default-font-size: 14px;
+    --small-font-size: 12px;
+
     // General
     --default-margin: #{$default-margin};
     --default-line-height: #{$default-line-height};
@@ -37,7 +40,6 @@
     --button-line-height: #{$button-line-height};
     --button-small-font-size: #{$button-small-font-size};
     --button-small-line-height: #{$button-small-line-height};
-    --button-text-transform: uppercase;
 
     // Color dot
     --color-dot-size: #{$color-dot-size};

--- a/packages/vapor/scss/redesign/variables.scss
+++ b/packages/vapor/scss/redesign/variables.scss
@@ -1,13 +1,9 @@
 :root {
     // General
-    // Use these variables as much as possible
-    --heading-text-color: var(--navy-blue-80);
-    --label-text-color: var(--navy-blue-80);
+    --default-text-color: var(--grey-80);
+    --title-text-color: var(--grey-100);
     --default-border-color: var(--grey-40);
     --links-color: var(--digital-blue-60);
-
-    --default-font-size: 14px;
-    --small-font-size: 12px;
 
     --default-border: 1px solid;
 
@@ -142,7 +138,6 @@
     // Tab
     --tab-font-size: #{$button-font-size};
     --tab-font-weight: var(--main-font-bolder);
-    --tab-text-color: var(--grey-100);
     --tab-border-color: var(--digital-blue-60);
 
     // Table
@@ -152,7 +147,6 @@
     --table-action-label-font-size: var(--default-font-size);
     --table-action-label-font-weight: var(--main-font-bolder);
     --table-action-label-color: var(--navy-blue-80);
-    --table-header-text-color: var(--grey-80);
     --table-header-font-size: #{$small-font-size};
     --table-header-sort-icon-color: var(--grey-60);
     --table-row-font-size: var(--default-font-size);
@@ -160,15 +154,11 @@
     --table-row-selected-color: var(--grey-20);
     --table-cell-loading-color: var(--grey-40);
     --blankslate-border-color: var(--grey-40);
-    --blankslate-text-color: var(--grey-100);
-    --big-table-first-row-text-color: var(--navy-blue-80);
     --big-table-first-row-font-size: var(--default-font-size);
     --big-table-first-row-font-weight: var(--main-font-bolder);
-    --big-table-second-row-text-color: var(--grey-80);
 
     // Flat select
     --flat-select-background-color: var(--digital-blue-60);
-    --flat-select-text-color: var(--navy-blue-80);
     --flat-select-prepend-color: var(--grey-100);
     --flat-select-prepend-font-size: var(--default-font-size);
     --flat-select-prepend-font-weight: var(--main-font-bolder);
@@ -226,10 +216,8 @@
 
     // Input
     --input-font-size: var(--default-font-size);
-    --placeholder-text-color: var(--grey-80);
     --checkbox-border-color: var(--navy-blue-80);
     --checkbox-checked-color: var(--digital-blue-60);
-    --checkbox-text-color: var(--grey-100);
 
     // Filter box
     --filter-box-icon-color: var(--grey-80);
@@ -247,7 +235,6 @@
     --facet-header-font-size: #{$title-font-size};
     --facet-header-font-weight: var(--main-font-regular);
     --facet-header-line-height: 20px;
-    --facet-header-text-color: var(--grey-100);
     --facet-value-count-text-color: var(--grey-60);
     --facet-value-hover-background-color: var(--grey-20);
 

--- a/packages/vapor/scss/tables/big-table.scss
+++ b/packages/vapor/scss/tables/big-table.scss
@@ -1,4 +1,6 @@
 table.big-table {
+    --color: var(--title-text-color);
+
     tbody {
         tr {
             height: $big-table-row-height;
@@ -29,7 +31,7 @@ table.big-table {
                         }
 
                         .label {
-                            color: var(--dark-grey);
+                            color: var(--color);
                         }
                     }
                 }
@@ -40,15 +42,17 @@ table.big-table {
                 position: relative;
 
                 .first-row {
-                    color: var(--big-table-first-row-text-color);
+                    color: var(--color);
                     font-weight: var(--big-table-first-row-font-weight);
                     font-size: var(--big-table-first-row-font-size);
                     line-height: $big-table-first-row-line-height;
                 }
 
                 div.second-row {
+                    --color: var(--default-text-color);
+
                     margin-top: 2px;
-                    color: var(--big-table-second-row-text-color);
+                    color: var(--color);
                     font-size: var(--big-table-second-row-font-size);
                     line-height: $big-table-second-row-line-height;
                 }

--- a/packages/vapor/scss/tables/table-collapsible-rows.scss
+++ b/packages/vapor/scss/tables/table-collapsible-rows.scss
@@ -38,7 +38,7 @@ table {
 
                     .section-title {
                         padding-top: $collapsible-title-padding;
-                        color: var(--medium-blue);
+                        color: var(--title-text-color);
                         font-weight: var(--main-font-bold);
                         font-size: $collapsible-content-font-size;
                         text-transform: uppercase;

--- a/packages/vapor/scss/tables/table.scss
+++ b/packages/vapor/scss/tables/table.scss
@@ -1,4 +1,6 @@
 .table {
+    --color: var(--default-text-color);
+
     width: 100%;
     text-align: left;
     border: none;
@@ -7,7 +9,6 @@
     th,
     td {
         position: relative;
-        text-align: left;
         vertical-align: top;
         background-clip: padding-box;
 
@@ -23,11 +24,15 @@
         .coveo-checkbox-label + .cell-content {
             margin-left: 10px;
         }
+
+        &:not(.center) {
+            text-align: left;
+        }
     }
 
     thead tr {
         height: $table-header-height;
-        color: var(--table-header-text-color);
+        color: var(--color);
         font-weight: var(--main-font-bold);
         font-size: var(--table-header-font-size);
         line-height: $table-header-line-height;
@@ -135,8 +140,10 @@
     }
 
     td {
+        --color: var(--title-text-color);
+
         padding: $table-row-top-bottom-padding $table-cell-left-right-padding;
-        color: var(--black);
+        color: var(--color);
         text-align: left;
 
         &:not(.mod-no-border-bottom) {
@@ -150,7 +157,7 @@
         }
 
         &.edit.enabled {
-            color: var(--medium-blue);
+            color: var(--color);
             cursor: pointer;
         }
 
@@ -222,7 +229,9 @@
         border-left: $status-card-border-width solid $transparent;
 
         .mod-card-header {
-            color: var(--medium-blue);
+            --color: var(--title-text-color);
+
+            color: var(--color);
             font-weight: var(--main-font-bold);
             font-size: $medium-title-font-size;
             border-bottom: 2px solid var(--table-row-hover-color);

--- a/packages/vapor/scss/typography/elements.scss
+++ b/packages/vapor/scss/typography/elements.scss
@@ -1,5 +1,5 @@
 .description {
-    color: var(--dark-grey);
+    color: var(--default-text-color);
     font-size: var(--default-font-size);
     line-height: $big-line-height;
 }

--- a/packages/vapor/scss/typography/headings.scss
+++ b/packages/vapor/scss/typography/headings.scss
@@ -4,7 +4,7 @@ h3,
 h4,
 h5,
 h6 {
-    color: var(--heading-text-color);
+    color: var(--title-text-color);
     font-family: var(--main-font);
     line-height: $standard-line-height;
 }

--- a/packages/vapor/scss/typography/utility.scss
+++ b/packages/vapor/scss/typography/utility.scss
@@ -29,6 +29,10 @@
     text-transform: uppercase;
 }
 
+.capitalize {
+    text-transform: capitalize;
+}
+
 .reset-text-transform {
     text-transform: none;
 }
@@ -79,7 +83,7 @@
 }
 
 .help-text {
-    color: var(--lynch);
+    color: var(--default-text-color);
     font-size: $help-text-font-size;
     line-height: $help-text-line-height;
 }


### PR DESCRIPTION
### Proposed Changes

- Implemented Gibson into react-vapor
- As discussed with UX, created `--default-text-color` #626971 and `--title-text-color` #282829. In General, `--title-text-color` will replace medium-blue that we currently use for labels and headings. And `--default-text-color` is for paragraph and description. We can still use different text colors for certain components, these two are default values for most use cases.
- Other small fixes of style

### Potential Breaking Changes

Label colors and heading colors should be replaced by `--title-text-color`. We will need more adjustments for text colors of specific components, but nothing changed to the functionalities.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
