### PR TITLE
Ad UI 6527 flatselect cannot be selected

### DIFF
--- a/packages/demo/src/components/examples/FlatSelectExamples.tsx
+++ b/packages/demo/src/components/examples/FlatSelectExamples.tsx
@@ -8,22 +8,21 @@ import {
     Loading,
     Section,
     Svg,
-    UUID,
 } from 'react-vapor';
 
 export class FlatSelectExamples extends React.Component {
     render() {
         const defaultFlatSelectOption: IFlatSelectOptionProps[] = [
             {
-                id: UUID.generate(),
+                id: 'uniqueId-1',
                 option: {content: 'Option 1'},
             },
             {
-                id: UUID.generate(),
+                id: 'uniqueId-2',
                 option: {content: 'Option 2'},
             },
             {
-                id: UUID.generate(),
+                id: 'uniqueId-3',
                 option: {content: 'Option 3'},
             },
         ];
@@ -41,7 +40,7 @@ export class FlatSelectExamples extends React.Component {
                     <Section level={2} title="Default Flat Select">
                         <FlatSelectConnected
                             {...{
-                                id: UUID.generate(),
+                                id: 'flatSelectId-1',
                                 options: defaultFlatSelectOption,
                             }}
                         />
@@ -49,7 +48,7 @@ export class FlatSelectExamples extends React.Component {
                     <Section level={2} title="Flat Select mod group">
                         <FlatSelectConnected
                             {...{
-                                id: UUID.generate(),
+                                id: 'flatSelectId-2',
                                 options: defaultFlatSelectOption,
                                 group: true,
                             }}
@@ -58,7 +57,7 @@ export class FlatSelectExamples extends React.Component {
                     <Section level={2} title="Flat Select mod option picker">
                         <FlatSelectConnected
                             {...{
-                                id: UUID.generate(),
+                                id: 'flatSelectId-3',
                                 options: defaultFlatSelectOption,
                                 optionPicker: true,
                             }}
@@ -67,15 +66,15 @@ export class FlatSelectExamples extends React.Component {
                     <Section level={2} title="Flat Select with option tooltip">
                         <FlatSelectConnected
                             {...{
-                                id: UUID.generate(),
+                                id: 'flatSelectId-4',
                                 options: [
                                     {
-                                        id: UUID.generate(),
+                                        id: 'itemTooltipId-1',
                                         option: {content: 'Option 1'},
                                         tooltip: {title: 'Option 1 tooltip', container: 'body', placement: 'bottom'},
                                     },
                                     {
-                                        id: UUID.generate(),
+                                        id: 'itemTooltipId-2',
                                         option: {content: 'Option 2'},
                                         tooltip: {title: 'Option 2 tooltip', container: 'body', placement: 'bottom'},
                                     },
@@ -86,15 +85,15 @@ export class FlatSelectExamples extends React.Component {
                     <Section level={2} title="Flat Select with option append and prepend">
                         <FlatSelectConnected
                             {...{
-                                id: UUID.generate(),
+                                id: 'flatSelectId-5',
                                 options: [
                                     {
-                                        id: UUID.generate(),
+                                        id: 'prependItemId',
                                         option: {content: 'Option 1'},
                                         prepend: prepend,
                                     },
                                     {
-                                        id: UUID.generate(),
+                                        id: 'appendItemId',
                                         option: {content: 'Option 2'},
                                         append: append,
                                     },
@@ -105,14 +104,14 @@ export class FlatSelectExamples extends React.Component {
                     <Section level={2} title="Flat Select with option component">
                         <FlatSelectConnected
                             {...{
-                                id: UUID.generate(),
+                                id: 'flatSelectId-6',
                                 options: [
                                     {
-                                        id: UUID.generate(),
+                                        id: 'loadingId-1',
                                         option: {content: Loading},
                                     },
                                     {
-                                        id: UUID.generate(),
+                                        id: 'loadingId-2',
                                         option: {content: Loading},
                                     },
                                 ],
@@ -122,15 +121,15 @@ export class FlatSelectExamples extends React.Component {
                     <Section level={2} title="Flat Select with a disabled option">
                         <FlatSelectConnected
                             {...{
-                                id: UUID.generate(),
+                                id: 'flatSelectId-7',
                                 options: [
                                     {
-                                        id: UUID.generate(),
+                                        id: 'disabledId-1',
                                         option: {content: 'disabled'},
                                         disabled: true,
                                     },
                                     {
-                                        id: UUID.generate(),
+                                        id: 'disabledId-1',
                                         option: {content: 'enabled'},
                                     },
                                 ],
@@ -140,15 +139,15 @@ export class FlatSelectExamples extends React.Component {
                     <Section level={2} title="Flat Select with all options disabled">
                         <FlatSelectConnected
                             {...{
-                                id: UUID.generate(),
+                                id: 'flatSelectId-8',
                                 options: [
                                     {
-                                        id: UUID.generate(),
+                                        id: 'disabledId-3',
                                         option: {content: "I'm a disabled FlatSelectOption"},
                                         disabled: true,
                                     },
                                     {
-                                        id: UUID.generate(),
+                                        id: 'disabledId-4',
                                         option: {content: "I'm a disabled FlatSelectOption too!"},
                                     },
                                 ],

--- a/packages/vapor/scss/controls/flat-select.scss
+++ b/packages/vapor/scss/controls/flat-select.scss
@@ -1,6 +1,4 @@
 .flat-select {
-    --color: var(--title-text-color);
-
     display: flex;
     background-color: var(--pure-white);
     border-radius: $border-radius;
@@ -53,7 +51,7 @@
         }
 
         &.selectable {
-            color: var(--color);
+            color: var(--flat-select-text-color);
             background-color: var(--pure-white);
             border: 1px solid var(--default-border-color);
 
@@ -64,7 +62,7 @@
             }
 
             .icon {
-                fill: currentColor;
+                fill: var(--flat-select-text-color);
             }
         }
 
@@ -100,7 +98,6 @@
         font-weight: var(--main-font-bold);
 
         font-size: var(--button-font-size);
-        line-height: var(--button-line-height);
         text-transform: uppercase;
         border-radius: 0;
 
@@ -123,9 +120,9 @@
 
     &.mod-option-picker .flat-select-option {
         flex: auto;
-        color: var(--color);
+        color: var(--flat-select-text-color);
         background-color: var(--light-grey);
-        border: 1px solid var(--blue);
+        border: 1px solid var(--flat-select-background-color);
         border-right-width: 0;
         border-radius: 0;
 
@@ -144,7 +141,7 @@
         }
 
         &:not(.selectable) + .flat-select-option {
-            border-left-color: var(--blue);
+            border-left-color: var(--flat-select-background-color);
         }
 
         & + .flat-select-option {

--- a/packages/vapor/scss/redesign/variables.scss
+++ b/packages/vapor/scss/redesign/variables.scss
@@ -159,7 +159,7 @@
     --big-table-first-row-font-weight: var(--main-font-bolder);
 
     // Flat select
-    --flat-select-background-color: var(--digital-blue-60);
+    --flat-select-background-color: var(--navy-blue-80);
     --flat-select-prepend-color: var(--grey-100);
     --flat-select-prepend-font-size: var(--default-font-size);
     --flat-select-prepend-font-weight: var(--main-font-bolder);


### PR DESCRIPTION
### Proposed Changes

removed the UUID generated that cause de store not to catch the changes in selection. Since it's examples, I put hardcoded Ids and I took the time to change the background color with the one recom
mended by Gustavo inside the Figma file

![image](https://user-images.githubusercontent.com/52010042/106195153-c2af3280-617d-11eb-917c-a846ffc8ae61.png)


### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
