### PR TITLE
fix: fix color for icon in button (default + hover)

### DIFF
--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -25,7 +25,7 @@
 
     cursor: pointer;
 
-    .icon:not([class*='fill-']) {
+    .icon {
         fill: var(--button-secondary-icon-color);
     }
 
@@ -51,7 +51,7 @@
         outline-color: var(--button-secondary-hover-border-color);
 
         .icon {
-            fill: var(--button-secondary-hover-text-color);
+            fill: var(--button-secondary-hover-icon-color);
         }
     }
 

--- a/packages/vapor/scss/redesign/variables.scss
+++ b/packages/vapor/scss/redesign/variables.scss
@@ -61,11 +61,12 @@
     // Secondary
     --button-secondary-color: var(--white);
     --button-secondary-text-color: var(--navy-blue-80);
-    --button-secondary-border-color: var(--black);
-    --button-secondary-icon-color: var(--black);
+    --button-secondary-border-color: var(--navy-blue-80);
+    --button-secondary-icon-color: var(--navy-blue-80);
 
     --button-secondary-hover-border-color: var(--digital-blue-80);
     --button-secondary-hover-text-color: var(--digital-blue-80);
+    --button-secondary-hover-icon-color: var(--digital-blue-80);
     --button-secondary-hover-focus-color: var(--white);
 
     --button-secondary-focus-border-color: var(--green);


### PR DESCRIPTION
### Proposed Changes

I've changed the color of the secondary button on hover to digital-blue-80 + the default color (navy-blue-80, as seen in Figma)
![image](https://user-images.githubusercontent.com/63734941/106361460-fad48380-62eb-11eb-9e28-54a780917319.png)
![image](https://user-images.githubusercontent.com/63734941/106361481-1cce0600-62ec-11eb-9bc0-4d590e243ad1.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
