### PR TITLE
feat(browser-preview): add new components

### DIFF
--- a/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
+++ b/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
@@ -32,10 +32,7 @@ export const BrowserPreviewExamples: React.FunctionComponent = () => (
                 rightChildren={
                     <div className="p3">
                         <BrowserPreview>
-                            <BrowserPreviewError
-                                onClick={() => alert('Clicked!')}
-                                errorMessage="The Query expression within the Reference Cases field is not valid."
-                            />
+                            <BrowserPreviewError errorMessage="The Query expression within the Reference Cases field is not valid." />
                         </BrowserPreview>
                     </div>
                 }

--- a/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
+++ b/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
@@ -30,7 +30,7 @@ export const BrowserPreviewExamples: React.FunctionComponent = () => (
                     <div className="p3">
                         <BrowserPreviewError
                             onClick={() => alert('Clicked!')}
-                            errorMessage="Invalid Query Expression for «Reference cases»"
+                            errorMessage="The Query expression within the Reference Cases field is not valid."
                         />
                     </div>
                 }

--- a/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
+++ b/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
@@ -13,25 +13,47 @@ export const BrowserPreviewExamples: React.FunctionComponent = () => (
                 }
             />
         </Section>
-        <Section level={2} title="Browser Preview in the empty state">
+        <Section level={2} title="Browser Preview with custom content">
             <SplitLayout
                 leftChildren={<div />}
                 rightChildren={
                     <div className="p3">
-                        <BrowserPreviewEmpty onClick={() => alert('Clicked!')} />
+                        <BrowserPreview>
+                            <h1>Hello World</h1>
+                            <p>Here's the description</p>
+                        </BrowserPreview>
                     </div>
                 }
             />
         </Section>
-        <Section level={2} title="Browser Preview in the error state">
+        <Section level={2} title="Browser Preview with error message">
             <SplitLayout
                 leftChildren={<div />}
                 rightChildren={
                     <div className="p3">
-                        <BrowserPreviewError
-                            onClick={() => alert('Clicked!')}
-                            errorMessage="The Query expression within the Reference Cases field is not valid."
-                        />
+                        <BrowserPreview>
+                            <BrowserPreviewError
+                                onClick={() => alert('Clicked!')}
+                                errorMessage="The Query expression within the Reference Cases field is not valid."
+                            />
+                        </BrowserPreview>
+                    </div>
+                }
+            />
+        </Section>
+        <Section level={2} title="Browser Preview with empty state">
+            <SplitLayout
+                leftChildren={<div />}
+                rightChildren={
+                    <div className="p3">
+                        <BrowserPreview>
+                            <BrowserPreviewEmpty onClick={() => alert('Clicked!')}>
+                                <span>
+                                    Select a <span className="bolder">Query Pipeline</span>
+                                </span>
+                                <span>to see the preview</span>
+                            </BrowserPreviewEmpty>
+                        </BrowserPreview>
                     </div>
                 }
             />

--- a/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
+++ b/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import {BrowserPreview, BrowserPreviewEmpty, BrowserPreviewError, Section, SplitLayout} from 'react-vapor';
+
+export const BrowserPreviewExamples: React.FunctionComponent = () => (
+    <Section>
+        <Section level={2} title="Browser Preview container">
+            <SplitLayout
+                leftChildren={<div />}
+                rightChildren={
+                    <div className="p3">
+                        <BrowserPreview />
+                    </div>
+                }
+            />
+        </Section>
+        <Section level={2} title="Browser Preview in the empty state">
+            <SplitLayout
+                leftChildren={<div />}
+                rightChildren={
+                    <div className="p3">
+                        <BrowserPreviewEmpty onClick={() => alert('Clicked!')} />
+                    </div>
+                }
+            />
+        </Section>
+        <Section level={2} title="Browser Preview in the error state">
+            <SplitLayout
+                leftChildren={<div />}
+                rightChildren={
+                    <div className="p3">
+                        <BrowserPreviewError
+                            onClick={() => alert('Clicked!')}
+                            errorMessage="Invalid Query Expression for «Reference cases»"
+                        />
+                    </div>
+                }
+            />
+        </Section>
+    </Section>
+);

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreview.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreview.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+
+import {TooltipPlacement} from '../../utils';
+import {Svg} from '../svg';
+import {Tooltip} from '../tooltip';
+
+export interface BrowserPreviewProps {
+    headerDescription?: string;
+}
+
+export const BrowserPreview: React.FunctionComponent<BrowserPreviewProps> = ({children, headerDescription}) => (
+    <div className="browser-preview flex flex-column">
+        <BrowserPreviewHeader tooltipTitle={headerDescription ?? DefaultHeaderDescription} />
+        <div className="flex flex-column flex-auto center-align p3">{children}</div>
+    </div>
+);
+
+const BrowserPreviewHeader: React.FunctionComponent<{tooltipTitle: string}> = ({tooltipTitle}) => (
+    <div className="browser-preview__header flex space-between px2 py1">
+        <div>
+            <span className="bolder">Preview</span>
+            <Tooltip title={tooltipTitle} placement={TooltipPlacement.Right}>
+                <Svg svgName="info" svgClass="icon mod-14 ml1" />
+            </Tooltip>
+        </div>
+        <div>
+            <span className="white-dot" />
+            <span className="white-dot" />
+            <span className="white-dot" />
+        </div>
+    </div>
+);
+
+const DefaultHeaderDescription =
+    'The final look in your search page may differ due to the customization you made in your page.';

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreviewEmpty.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreviewEmpty.tsx
@@ -1,29 +1,16 @@
 import classNames from 'classnames';
 import * as React from 'react';
 
-import {BrowserPreview} from './BrowserPreview';
 import {Svg} from '../svg';
 
 export interface BrowserPreviewEmptyProps {
     onClick?: () => void;
-    description?: React.ReactNode;
 }
 
-export const BrowserPreviewEmpty: React.FunctionComponent<BrowserPreviewEmptyProps> = ({onClick, description}) => (
-    <BrowserPreview>
-        <div onClick={onClick} className={classNames('browser-preview__state', {'cursor-pointer': onClick})}>
-            {/* TODO: new svg WIP */}
-            <Svg svgName="arrow-left-return" className="block" />
-            <p className="medium-title-text flex flex-column center-align center">
-                {description ?? (
-                    <>
-                        <span>
-                            Select a <span className="bolder">Query Pipeline</span>
-                        </span>
-                        <span>to see the preview</span>
-                    </>
-                )}
-            </p>
-        </div>
-    </BrowserPreview>
+export const BrowserPreviewEmpty: React.FunctionComponent<BrowserPreviewEmptyProps> = ({onClick, children}) => (
+    <div onClick={onClick} className={classNames('browser-preview__state', {'cursor-pointer': onClick})}>
+        {/* TODO: new svg WIP */}
+        <Svg svgName="arrow-left-return" className="block" />
+        <p className="medium-title-text flex flex-column center-align center">{children}</p>
+    </div>
 );

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreviewEmpty.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreviewEmpty.tsx
@@ -1,0 +1,29 @@
+import classNames from 'classnames';
+import * as React from 'react';
+
+import {BrowserPreview} from './BrowserPreview';
+import {Svg} from '../svg';
+
+export interface BrowserPreviewEmptyProps {
+    onClick?: () => void;
+    description?: React.ReactNode;
+}
+
+export const BrowserPreviewEmpty: React.FunctionComponent<BrowserPreviewEmptyProps> = ({onClick, description}) => (
+    <BrowserPreview>
+        <div onClick={onClick} className={classNames('browser-preview__state', {'cursor-pointer': onClick})}>
+            {/* TODO: new svg WIP */}
+            <Svg svgName="arrow-left-return" className="block" />
+            <p className="medium-title-text flex flex-column center-align">
+                {description ?? (
+                    <>
+                        <span>
+                            Select a <span className="bolder">Query Pipeline</span>
+                        </span>
+                        <span>to see the preview</span>
+                    </>
+                )}
+            </p>
+        </div>
+    </BrowserPreview>
+);

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreviewEmpty.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreviewEmpty.tsx
@@ -14,7 +14,7 @@ export const BrowserPreviewEmpty: React.FunctionComponent<BrowserPreviewEmptyPro
         <div onClick={onClick} className={classNames('browser-preview__state', {'cursor-pointer': onClick})}>
             {/* TODO: new svg WIP */}
             <Svg svgName="arrow-left-return" className="block" />
-            <p className="medium-title-text flex flex-column center-align">
+            <p className="medium-title-text flex flex-column center-align center">
                 {description ?? (
                     <>
                         <span>

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreviewError.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreviewError.tsx
@@ -1,0 +1,31 @@
+import classNames from 'classnames';
+import * as React from 'react';
+
+import {BrowserPreview} from './BrowserPreview';
+import {Svg} from '../svg';
+
+export interface BrowserPreviewErrorProps {
+    onClick?: () => void;
+    description?: string;
+    errorMessage?: string;
+}
+
+export const BrowserPreviewError: React.FunctionComponent<BrowserPreviewErrorProps> = ({
+    onClick,
+    description,
+    errorMessage,
+}) => (
+    <BrowserPreview>
+        <div
+            onClick={onClick}
+            className={classNames('browser-preview__state flex flex-column center-align', {'cursor-pointer': onClick})}
+        >
+            {/* TODO: new svg WIP */}
+            <Svg svgName="view" className="block" />
+            <div className="big-text bolder">{description ?? 'Unable to show preview'}</div>
+            {errorMessage ? (
+                <div className="medium-title-text center mt1 browser-preview__state--error">{errorMessage}</div>
+            ) : null}
+        </div>
+    </BrowserPreview>
+);

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreviewError.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreviewError.tsx
@@ -22,10 +22,8 @@ export const BrowserPreviewError: React.FunctionComponent<BrowserPreviewErrorPro
         >
             {/* TODO: new svg WIP */}
             <Svg svgName="view" className="block" />
-            <div className="big-text bolder">{description ?? 'Unable to show preview'}</div>
-            {errorMessage ? (
-                <div className="medium-title-text center mt1 browser-preview__state--error">{errorMessage}</div>
-            ) : null}
+            <p className="medium-title-text center bolder">{description ?? 'Unable to show preview'}</p>
+            {errorMessage ? <p className="center mt1 browser-preview__state--error">{errorMessage}</p> : null}
         </div>
     </BrowserPreview>
 );

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreviewError.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreviewError.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
 
-import {BrowserPreview} from './BrowserPreview';
 import {Svg} from '../svg';
 
 export interface BrowserPreviewErrorProps {
@@ -15,15 +14,13 @@ export const BrowserPreviewError: React.FunctionComponent<BrowserPreviewErrorPro
     description,
     errorMessage,
 }) => (
-    <BrowserPreview>
-        <div
-            onClick={onClick}
-            className={classNames('browser-preview__state flex flex-column center-align', {'cursor-pointer': onClick})}
-        >
-            {/* TODO: new svg WIP */}
-            <Svg svgName="view" className="block" />
-            <p className="medium-title-text center bolder">{description ?? 'Unable to show preview'}</p>
-            {errorMessage ? <p className="center mt1 browser-preview__state--error">{errorMessage}</p> : null}
-        </div>
-    </BrowserPreview>
+    <div
+        onClick={onClick}
+        className={classNames('browser-preview__state flex flex-column center-align', {'cursor-pointer': onClick})}
+    >
+        {/* TODO: new svg WIP */}
+        <Svg svgName="view" className="block" />
+        <p className="medium-title-text center bolder">{description ?? 'Unable to show preview'}</p>
+        {errorMessage ? <p className="center mt1 browser-preview__state--error">{errorMessage}</p> : null}
+    </div>
 );

--- a/packages/react-vapor/src/components/browserPreview/index.ts
+++ b/packages/react-vapor/src/components/browserPreview/index.ts
@@ -1,0 +1,3 @@
+export * from './BrowserPreview';
+export * from './BrowserPreviewEmpty';
+export * from './BrowserPreviewError';

--- a/packages/react-vapor/src/components/browserPreview/tests/BrowserPreview.spec.tsx
+++ b/packages/react-vapor/src/components/browserPreview/tests/BrowserPreview.spec.tsx
@@ -1,17 +1,10 @@
-import {mount, ReactWrapper, shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import * as React from 'react';
 
 import {Tooltip} from '../../tooltip';
-import {BrowserPreview, BrowserPreviewProps} from '../BrowserPreview';
+import {BrowserPreview} from '../BrowserPreview';
 
 describe('BrowserPreview', () => {
-    let component: ReactWrapper<BrowserPreviewProps>;
-    const mountWithProps = (props: BrowserPreviewProps) => {
-        component = mount(<BrowserPreview {...props} />, {
-            attachTo: document.getElementById('App'),
-        });
-    };
-
     it('renders without errors', () => {
         expect(() => {
             shallow(<BrowserPreview />);
@@ -20,7 +13,7 @@ describe('BrowserPreview', () => {
 
     it('renders the specified header description as tooltip title', () => {
         const headerDescription = '🥰';
-        mountWithProps({headerDescription});
+        const component = mount(<BrowserPreview headerDescription={headerDescription} />);
 
         expect(component.find(Tooltip).prop('title')).toEqual(headerDescription);
     });

--- a/packages/react-vapor/src/components/browserPreview/tests/BrowserPreview.spec.tsx
+++ b/packages/react-vapor/src/components/browserPreview/tests/BrowserPreview.spec.tsx
@@ -1,0 +1,27 @@
+import {mount, ReactWrapper, shallow} from 'enzyme';
+import * as React from 'react';
+
+import {Tooltip} from '../../tooltip';
+import {BrowserPreview, BrowserPreviewProps} from '../BrowserPreview';
+
+describe('BrowserPreview', () => {
+    let component: ReactWrapper<BrowserPreviewProps>;
+    const mountWithProps = (props: BrowserPreviewProps) => {
+        component = mount(<BrowserPreview {...props} />, {
+            attachTo: document.getElementById('App'),
+        });
+    };
+
+    it('renders without errors', () => {
+        expect(() => {
+            shallow(<BrowserPreview />);
+        }).not.toThrow();
+    });
+
+    it('renders the specified header description as tooltip title', () => {
+        const headerDescription = '🥰';
+        mountWithProps({headerDescription});
+
+        expect(component.find(Tooltip).prop('title')).toEqual(headerDescription);
+    });
+});

--- a/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewEmpty.spec.tsx
+++ b/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewEmpty.spec.tsx
@@ -11,9 +11,7 @@ describe('BrowserPreviewEmpty', () => {
     };
 
     const mountWithProps = (props: BrowserPreviewEmptyProps, children?: React.ReactNode) => {
-        component = mount(<BrowserPreviewEmpty {...props}>{children}</BrowserPreviewEmpty>, {
-            attachTo: document.getElementById('App'),
-        });
+        component = mount(<BrowserPreviewEmpty {...props}>{children}</BrowserPreviewEmpty>);
     };
 
     it('renders without errors', () => {

--- a/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewEmpty.spec.tsx
+++ b/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewEmpty.spec.tsx
@@ -8,11 +8,10 @@ describe('BrowserPreviewEmpty', () => {
     let component: ReactWrapper<BrowserPreviewEmptyProps>;
     const defaultProps: BrowserPreviewEmptyProps = {
         onClick: jest.fn(),
-        description: '💖',
     };
 
-    const mountWithProps = (props: BrowserPreviewEmptyProps) => {
-        component = mount(<BrowserPreviewEmpty {...props} />, {
+    const mountWithProps = (props: BrowserPreviewEmptyProps, children?: React.ReactNode) => {
+        component = mount(<BrowserPreviewEmpty {...props}>{children}</BrowserPreviewEmpty>, {
             attachTo: document.getElementById('App'),
         });
     };
@@ -49,8 +48,9 @@ describe('BrowserPreviewEmpty', () => {
     });
 
     it('renders the specified description as child', () => {
-        mountWithProps(defaultProps);
+        const description = '💖';
+        mountWithProps(defaultProps, description);
 
-        expect(component.find('.browser-preview__state').childAt(1).text()).toEqual(defaultProps.description);
+        expect(component.find('.browser-preview__state').childAt(1).text()).toEqual(description);
     });
 });

--- a/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewEmpty.spec.tsx
+++ b/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewEmpty.spec.tsx
@@ -1,0 +1,56 @@
+import {mount, ReactWrapper, shallow} from 'enzyme';
+import * as React from 'react';
+
+import {Svg} from '../../svg';
+import {BrowserPreviewEmpty, BrowserPreviewEmptyProps} from '../BrowserPreviewEmpty';
+
+describe('BrowserPreviewEmpty', () => {
+    let component: ReactWrapper<BrowserPreviewEmptyProps>;
+    const defaultProps: BrowserPreviewEmptyProps = {
+        onClick: jest.fn(),
+        description: '💖',
+    };
+
+    const mountWithProps = (props: BrowserPreviewEmptyProps) => {
+        component = mount(<BrowserPreviewEmpty {...props} />, {
+            attachTo: document.getElementById('App'),
+        });
+    };
+
+    it('renders without errors', () => {
+        expect(() => {
+            shallow(<BrowserPreviewEmpty />);
+        }).not.toThrow();
+    });
+
+    it('has cursor-pointer class if the content is clickable', () => {
+        mountWithProps(defaultProps);
+
+        expect(component.find('.browser-preview__state').hasClass('cursor-pointer')).toBeTruthy();
+    });
+
+    it('does not have cursor-pointer class if onClick prop is undefined', () => {
+        mountWithProps({onClick: undefined});
+
+        expect(component.find('.browser-preview__state').hasClass('cursor-pointer')).toBeFalsy();
+    });
+
+    it('calls the onClick prop when clicking on the content', () => {
+        mountWithProps(defaultProps);
+        component.find('.browser-preview__state').simulate('click');
+
+        expect(defaultProps.onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders a Svg as child', () => {
+        mountWithProps(defaultProps);
+
+        expect(component.find('.browser-preview__state').childAt(0).find(Svg)).toBeTruthy();
+    });
+
+    it('renders the specified description as child', () => {
+        mountWithProps(defaultProps);
+
+        expect(component.find('.browser-preview__state').childAt(1).text()).toEqual(defaultProps.description);
+    });
+});

--- a/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewError.spec.tsx
+++ b/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewError.spec.tsx
@@ -13,9 +13,7 @@ describe('BrowserPreviewError', () => {
     };
 
     const mountWithProps = (props: BrowserPreviewErrorProps) => {
-        component = mount(<BrowserPreviewError {...props} />, {
-            attachTo: document.getElementById('App'),
-        });
+        component = mount(<BrowserPreviewError {...props} />);
     };
 
     it('renders without errors', () => {

--- a/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewError.spec.tsx
+++ b/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewError.spec.tsx
@@ -1,0 +1,63 @@
+import {mount, ReactWrapper, shallow} from 'enzyme';
+import * as React from 'react';
+
+import {Svg} from '../../svg';
+import {BrowserPreviewError, BrowserPreviewErrorProps} from '../BrowserPreviewError';
+
+describe('BrowserPreviewError', () => {
+    let component: ReactWrapper<BrowserPreviewErrorProps>;
+    const defaultProps: BrowserPreviewErrorProps = {
+        onClick: jest.fn(),
+        description: '💖',
+        errorMessage: '😮',
+    };
+
+    const mountWithProps = (props: BrowserPreviewErrorProps) => {
+        component = mount(<BrowserPreviewError {...props} />, {
+            attachTo: document.getElementById('App'),
+        });
+    };
+
+    it('renders without errors', () => {
+        expect(() => {
+            shallow(<BrowserPreviewError />);
+        }).not.toThrow();
+    });
+
+    it('has cursor-pointer class if the content is clickable', () => {
+        mountWithProps(defaultProps);
+
+        expect(component.find('.browser-preview__state').hasClass('cursor-pointer')).toBeTruthy();
+    });
+
+    it('does not have cursor-pointer class if onClick prop is undefined', () => {
+        mountWithProps({onClick: undefined});
+
+        expect(component.find('.browser-preview__state').hasClass('cursor-pointer')).toBeFalsy();
+    });
+
+    it('calls the onClick prop when clicking on the content', () => {
+        mountWithProps(defaultProps);
+        component.find('.browser-preview__state').simulate('click');
+
+        expect(defaultProps.onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders a Svg as child', () => {
+        mountWithProps(defaultProps);
+
+        expect(component.find('.browser-preview__state').childAt(0).find(Svg)).toBeTruthy();
+    });
+
+    it('renders the specified description as child', () => {
+        mountWithProps(defaultProps);
+
+        expect(component.find('.browser-preview__state').childAt(1).text()).toEqual(defaultProps.description);
+    });
+
+    it('renders an error message if defined', () => {
+        mountWithProps(defaultProps);
+
+        expect(component.find('.browser-preview__state').childAt(2).text()).toEqual(defaultProps.errorMessage);
+    });
+});

--- a/packages/react-vapor/src/components/index.ts
+++ b/packages/react-vapor/src/components/index.ts
@@ -6,6 +6,7 @@ export * from './banner';
 export * from './blankSlate';
 export * from './borderedLine';
 export * from './breadcrumbs';
+export * from './browserPreview';
 export * from './button';
 export * from './calendar';
 export * from './chart';

--- a/packages/vapor/scss/components/browser-preview.scss
+++ b/packages/vapor/scss/components/browser-preview.scss
@@ -1,0 +1,48 @@
+.browser-preview {
+    height: 720px;
+    border: 1px solid #e5e8e8; // var(--grey-40)
+    border-radius: $big-border-radius;
+    box-shadow: 0px 4px 16px 0px rgba(#e5e8e8, 0.75); // var(--grey-40)
+
+    &__header {
+        color: var(--pure-white);
+        font-size: 15px;
+        background-color: #5f619e; // var(--navy-blue-60)
+        border-radius: $big-border-radius $big-border-radius 0px 0px;
+
+        svg {
+            fill: currentColor;
+        }
+
+        .white-dot {
+            display: inline-block;
+            width: 10px;
+            height: 10px;
+            margin-left: 5px;
+            background-color: var(--pure-white);
+            border-radius: 50%;
+        }
+    }
+
+    &__state {
+        color: #282829; // var(--grey-100)
+
+        svg {
+            width: 300px;
+            height: 300px;
+            fill: #5f619e; // TODO: new svg WIP
+        }
+
+        p.medium-title-text {
+            line-height: 24px;
+        }
+
+        .big-text {
+            line-height: 32px;
+        }
+
+        &--error {
+            color: #ff3e2e;
+        }
+    }
+}

--- a/packages/vapor/scss/components/browser-preview.scss
+++ b/packages/vapor/scss/components/browser-preview.scss
@@ -1,6 +1,6 @@
 .browser-preview {
     height: 720px;
-    border: 1px solid #e5e8e8; // var(--grey-40)
+    border: 1px solid #e5e8e8; // var(--default-border-color)
     border-radius: $big-border-radius;
     box-shadow: 0px 4px 16px 0px rgba(#e5e8e8, 0.75); // var(--grey-40)
 
@@ -25,7 +25,7 @@
     }
 
     &__state {
-        color: #282829; // var(--grey-100)
+        color: #282829; // var(--title-text-color)
 
         svg {
             width: 300px;
@@ -33,16 +33,14 @@
             fill: #5f619e; // TODO: new svg WIP
         }
 
-        p.medium-title-text {
+        .medium-title-text {
             line-height: 24px;
         }
 
-        .big-text {
-            line-height: 32px;
-        }
-
         &--error {
-            color: #ff3e2e;
+            color: #626971; // var(--default-text-color)
+            font-size: 14px; // var(--default-font-size)
+            line-height: 18px;
         }
     }
 }

--- a/packages/vapor/scss/guide.scss
+++ b/packages/vapor/scss/guide.scss
@@ -120,6 +120,7 @@
     @import 'components/search-bar';
     @import 'components/multi-step-bar';
     @import 'components/card';
+    @import 'components/browser-preview';
     // Forms
     @import 'forms/form-sections';
     @import 'forms/form-child';


### PR DESCRIPTION
### Proposed Changes

[ADUI-6495](https://coveord.atlassian.net/browse/ADUI-6495)
We need new components of Browser Preview to be added to the SplitLayout. It can be used as a container, or in the empty / error state.

Note: 
- The Gibson is not implemented yet into the master branch of react-vapor, but the font should be good in admin-ui
- UX is working on the new SVG, for now, we put a placeholder of 300 * 300

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
