### PR TITLE
fix(logo-card title): conditionally render margin bottom with description only

### DIFF
--- a/packages/react-vapor/src/components/logoCard/LogoCard.tsx
+++ b/packages/react-vapor/src/components/logoCard/LogoCard.tsx
@@ -65,7 +65,9 @@ export class LogoCard extends React.Component<ILogoCardProps & React.HTMLProps<H
                         <Svg svgName={this.props.svgName} className={logoIconClassName} />
                     </div>
                     <div className="logo-card-content">
-                        <h2 className="logo-card-title mb1">{this.props.title}</h2>
+                        <h2 className={classNames('logo-card-title', {mb1: !!this.props.description})}>
+                            {this.props.title}
+                        </h2>
                         {this.props.description}
                     </div>
                     {this.props.badges.length > 0 ? <div className="logo-card-badge">{...badges}</div> : null}


### PR DESCRIPTION
Adding logic to this logo card title to align it perfectly to center without description.

This fix is to capture the same logic as what was shown here:
https://github.com/coveo/react-vapor/pull/1839#issuecomment-768290488

`mb1` will only be applied when there is a description. It currently has a margin bottom with no description which makes it not perfectly centered.

Capturing it in master before the next branch merge so it will appear in admin-ui

### Proposed Changes

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
