### PR TITLE
fix(browser-preview): remove center-align from container

### DIFF
--- a/packages/react-vapor/src/components/browserPreview/BrowserPreview.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreview.tsx
@@ -11,7 +11,7 @@ export interface BrowserPreviewProps {
 export const BrowserPreview: React.FunctionComponent<BrowserPreviewProps> = ({children, headerDescription}) => (
     <div className="browser-preview flex flex-column">
         <BrowserPreviewHeader tooltipTitle={headerDescription ?? DefaultHeaderDescription} />
-        <div className="flex flex-column flex-auto center-align p3">{children}</div>
+        <div className="flex flex-column flex-auto px4 py3">{children}</div>
     </div>
 );
 

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreviewEmpty.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreviewEmpty.tsx
@@ -8,7 +8,12 @@ export interface BrowserPreviewEmptyProps {
 }
 
 export const BrowserPreviewEmpty: React.FunctionComponent<BrowserPreviewEmptyProps> = ({onClick, children}) => (
-    <div onClick={onClick} className={classNames('browser-preview__state', {'cursor-pointer': onClick})}>
+    <div
+        onClick={onClick}
+        className={classNames('browser-preview__state flex flex-column flex-auto center-align', {
+            'cursor-pointer': onClick,
+        })}
+    >
         {/* TODO: new svg WIP */}
         <Svg svgName="arrow-left-return" className="block" />
         <p className="medium-title-text flex flex-column center-align center">{children}</p>

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreviewError.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreviewError.tsx
@@ -16,7 +16,9 @@ export const BrowserPreviewError: React.FunctionComponent<BrowserPreviewErrorPro
 }) => (
     <div
         onClick={onClick}
-        className={classNames('browser-preview__state flex flex-column center-align', {'cursor-pointer': onClick})}
+        className={classNames('browser-preview__state flex flex-column flex-auto center-align', {
+            'cursor-pointer': onClick,
+        })}
     >
         {/* TODO: new svg WIP */}
         <Svg svgName="view" className="block" />


### PR DESCRIPTION
### Proposed Changes

By following the feedback from @nathanlb, `center-align` should be removed from the container, and be defined in the children if needed. 

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
