### PR TITLE
feat: update preview images and some styling

### DIFF
--- a/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
+++ b/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {BrowserPreview, BrowserPreviewEmpty, BrowserPreviewError, Section, SplitLayout} from 'react-vapor';
+import {BrowserPreview, BrowserPreviewEmpty, BrowserPreviewError, Section, SplitLayout, Svg} from 'react-vapor';
 
 export const BrowserPreviewExamples: React.FunctionComponent = () => (
     <Section>
@@ -49,6 +49,23 @@ export const BrowserPreviewExamples: React.FunctionComponent = () => (
                                     Select a <span className="bolder">Query Pipeline</span>
                                 </span>
                                 <span>to see the preview</span>
+                            </BrowserPreviewEmpty>
+                        </BrowserPreview>
+                    </div>
+                }
+            />
+        </Section>
+        <Section level={2} title="Browser Preview with empty state and custom image">
+            <SplitLayout
+                leftChildren={<div />}
+                rightChildren={
+                    <div className="p3">
+                        <BrowserPreview>
+                            <BrowserPreviewEmpty
+                                onClick={() => alert('Refreshed!')}
+                                image={<Svg svgName="exportagain" className="block" />}
+                            >
+                                <span>Click to refresh this preview</span>
                             </BrowserPreviewEmpty>
                         </BrowserPreview>
                     </div>

--- a/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
+++ b/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
@@ -62,10 +62,10 @@ export const BrowserPreviewExamples: React.FunctionComponent = () => (
                     <div className="p3">
                         <BrowserPreview>
                             <BrowserPreviewEmpty
-                                onClick={() => alert('Refreshed!')}
-                                image={<Svg svgName="exportagain" className="block" />}
+                                onClick={() => alert('Wow!')}
+                                image={<Svg svgName="arrow-top-slim" className="block" />}
                             >
-                                <span>Click to refresh this preview</span>
+                                <span>Look at this browser-like header!</span>
                             </BrowserPreviewEmpty>
                         </BrowserPreview>
                     </div>

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreview.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreview.tsx
@@ -11,7 +11,7 @@ export interface BrowserPreviewProps {
 export const BrowserPreview: React.FunctionComponent<BrowserPreviewProps> = ({children, headerDescription}) => (
     <div className="browser-preview flex flex-column">
         <BrowserPreviewHeader tooltipTitle={headerDescription ?? DefaultHeaderDescription} />
-        <div className="flex flex-column flex-auto px4 py3">{children}</div>
+        <div className="browser-preview__content flex flex-column flex-auto px4 py3">{children}</div>
     </div>
 );
 

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreviewEmpty.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreviewEmpty.tsx
@@ -5,17 +5,17 @@ import {Svg} from '../svg';
 
 export interface BrowserPreviewEmptyProps {
     onClick?: () => void;
+    image?: React.ReactNode;
 }
 
-export const BrowserPreviewEmpty: React.FunctionComponent<BrowserPreviewEmptyProps> = ({onClick, children}) => (
+export const BrowserPreviewEmpty: React.FunctionComponent<BrowserPreviewEmptyProps> = ({image, onClick, children}) => (
     <div
         onClick={onClick}
         className={classNames('browser-preview__state flex flex-column flex-auto center-align', {
             'cursor-pointer': onClick,
         })}
     >
-        {/* TODO: new svg WIP */}
-        <Svg svgName="arrow-left-return" className="block" />
-        <p className="medium-title-text flex flex-column center-align center">{children}</p>
+        {image ?? <Svg svgName="arrow-left-return" className="block" />}
+        <p className="medium-title-text mt2 flex flex-column center-align center">{children}</p>
     </div>
 );

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreviewError.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreviewError.tsx
@@ -20,9 +20,8 @@ export const BrowserPreviewError: React.FunctionComponent<BrowserPreviewErrorPro
             'cursor-pointer': onClick,
         })}
     >
-        {/* TODO: new svg WIP */}
-        <Svg svgName="view" className="block" />
-        <p className="medium-title-text center bolder">{description ?? 'Unable to show preview'}</p>
+        <Svg svgName="preview-error" className="block" />
+        <p className="medium-title-text mt2 center bolder">{description ?? 'Unable to show preview'}</p>
         {errorMessage ? <p className="center mt1 browser-preview__state--error">{errorMessage}</p> : null}
     </div>
 );

--- a/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewEmpty.spec.tsx
+++ b/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewEmpty.spec.tsx
@@ -39,10 +39,17 @@ describe('BrowserPreviewEmpty', () => {
         expect(defaultProps.onClick).toHaveBeenCalledTimes(1);
     });
 
-    it('renders a Svg as child', () => {
+    it('renders a Svg as child by default', () => {
         mountWithProps(defaultProps);
 
         expect(component.find('.browser-preview__state').childAt(0).find(Svg)).toBeTruthy();
+    });
+
+    it('renders the specified node instead of the default image', () => {
+        const image = <img src="fake" />;
+        mountWithProps({...defaultProps, image});
+
+        expect(component.find('.browser-preview__state').childAt(0).find('img[src*="fake"]')).toBeTruthy();
     });
 
     it('renders the specified description as child', () => {

--- a/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewEmpty.spec.tsx
+++ b/packages/react-vapor/src/components/browserPreview/tests/BrowserPreviewEmpty.spec.tsx
@@ -49,7 +49,7 @@ describe('BrowserPreviewEmpty', () => {
         const image = <img src="fake" />;
         mountWithProps({...defaultProps, image});
 
-        expect(component.find('.browser-preview__state').childAt(0).find('img[src*="fake"]')).toBeTruthy();
+        expect(component.find('img[src*="fake"]').exists()).toBe(true);
     });
 
     it('renders the specified description as child', () => {

--- a/packages/vapor/resources/icons/svg/arrow-top-slim.svg
+++ b/packages/vapor/resources/icons/svg/arrow-top-slim.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 29 43" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.5 41.2224L14.5 2.17456" stroke="#282829" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2 15.6553L14.2917 2.17444L26.5834 15.6553" stroke="#282829" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/vapor/resources/icons/svg/arrow-top-slim.svg
+++ b/packages/vapor/resources/icons/svg/arrow-top-slim.svg
@@ -1,4 +1,10 @@
-<svg viewBox="0 0 29 43" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M14.5 41.2224L14.5 2.17456" stroke="#282829" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M2 15.6553L14.2917 2.17444L26.5834 15.6553" stroke="#282829" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 29 43" style="enable-background:new 0 0 29 43;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;}
+</style>
+<path class="st0" stroke="#282829" d="M14.4,41.2v-39"/>
+<path class="st0" stroke="#282829" d="M2.1,15.7L14.4,2.2l12.3,13.5"/>
 </svg>

--- a/packages/vapor/resources/icons/svg/preview-error.svg
+++ b/packages/vapor/resources/icons/svg/preview-error.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none">
+  <path fill="#f6f7f9" d="M0 61h45v103H0zM172 0h45v164h-45zM86 22h45v142H86z" />
+  <g transform="translate(-42 -35)" filter="url(#prefix__filter0_d)">
+    <path fill="#fff"
+      d="M53.858 157.198c-1.047-1.294-1.047-3.056 0-4.351 7.232-8.941 38.195-42.382 96.737-42.382 58.687 0 88.557 33.607 95.4 42.448a3.397 3.397 0 010 4.219c-6.843 8.841-36.713 42.448-95.4 42.448-58.542 0-89.505-33.441-96.737-42.382z" />
+  </g>
+  <path fill="#fff" stroke-width="3" stroke="#333357" d="M11 118s30.02-42.535 97.595-42.535C176.171 75.465 204 117.5 204 117.5" />
+  <circle fill="#00adff" r="28" cy="120" cx="108" />
+  <circle fill="#333357" r="14" cy="120" cx="108" />
+  <path stroke-width="3" stroke="#333357"
+    d="M113.679 64.032V43.036M164 175.842L45.191 57.034M157.172 71.031l13.997-13.997" />
+  <defs id="prefix__defs870">
+    <filter color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse" y="34.045"
+      x="17.045" id="prefix__filter0_d">
+      <feFlood id="prefix__feFlood855" result="BackgroundImageFix" flood-opacity="0" />
+      <feColorMatrix id="prefix__feColorMatrix857" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" type="matrix"
+        in="SourceAlpha" />
+      <feOffset id="prefix__feOffset859" dy="12" />
+      <feGaussianBlur id="prefix__feGaussianBlur861" stdDeviation="17" />
+      <feColorMatrix id="prefix__feColorMatrix863"
+        values="0 0 0 0 0.0941177 0 0 0 0 0.113725 0 0 0 0 0.227451 0 0 0 0.07 0" type="matrix" />
+      <feBlend id="prefix__feBlend865" result="effect1_dropShadow" in2="BackgroundImageFix" mode="normal" />
+      <feBlend id="prefix__feBlend867" result="shape" in2="effect1_dropShadow" in="SourceGraphic" mode="normal" />
+    </filter>
+  </defs>
+</svg>

--- a/packages/vapor/resources/icons/svg/preview-error.svg
+++ b/packages/vapor/resources/icons/svg/preview-error.svg
@@ -1,26 +1,30 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none">
-  <path fill="#f6f7f9" d="M0 61h45v103H0zM172 0h45v164h-45zM86 22h45v142H86z" />
-  <g transform="translate(-42 -35)" filter="url(#prefix__filter0_d)">
-    <path fill="#fff"
-      d="M53.858 157.198c-1.047-1.294-1.047-3.056 0-4.351 7.232-8.941 38.195-42.382 96.737-42.382 58.687 0 88.557 33.607 95.4 42.448a3.397 3.397 0 010 4.219c-6.843 8.841-36.713 42.448-95.4 42.448-58.542 0-89.505-33.441-96.737-42.382z" />
-  </g>
-  <path fill="#fff" stroke-width="3" stroke="#333357" d="M11 118s30.02-42.535 97.595-42.535C176.171 75.465 204 117.5 204 117.5" />
-  <circle fill="#00adff" r="28" cy="120" cx="108" />
-  <circle fill="#333357" r="14" cy="120" cx="108" />
-  <path stroke-width="3" stroke="#333357"
-    d="M113.679 64.032V43.036M164 175.842L45.191 57.034M157.172 71.031l13.997-13.997" />
-  <defs id="prefix__defs870">
-    <filter color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse" y="34.045"
-      x="17.045" id="prefix__filter0_d">
-      <feFlood id="prefix__feFlood855" result="BackgroundImageFix" flood-opacity="0" />
-      <feColorMatrix id="prefix__feColorMatrix857" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" type="matrix"
-        in="SourceAlpha" />
-      <feOffset id="prefix__feOffset859" dy="12" />
-      <feGaussianBlur id="prefix__feGaussianBlur861" stdDeviation="17" />
-      <feColorMatrix id="prefix__feColorMatrix863"
-        values="0 0 0 0 0.0941177 0 0 0 0 0.113725 0 0 0 0 0.227451 0 0 0 0.07 0" type="matrix" />
-      <feBlend id="prefix__feBlend865" result="effect1_dropShadow" in2="BackgroundImageFix" mode="normal" />
-      <feBlend id="prefix__feBlend867" result="shape" in2="effect1_dropShadow" in="SourceGraphic" mode="normal" />
-    </filter>
-  </defs>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg fill="none" version="1.1" viewBox="0 0 217 176.9" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <g fill="#f6f7f9">
+  <rect y="61" width="45" height="103"/>
+  <rect x="172" width="45" height="164"/>
+  <rect x="86" y="22" width="45" height="142"/>
+ </g>
+ <g transform="translate(-42.858 -39.198)" filter="url(#filter0_d)">
+  <path d="m53.858 157.2c-1.0472-1.294-1.0472-3.056 0-4.351 7.232-8.941 38.196-42.382 96.737-42.382 58.687 0 88.557 33.607 95.4 42.448 0.979 1.265 0.979 2.954 0 4.219-6.843 8.841-36.713 42.448-95.4 42.448-58.542 0-89.505-33.441-96.737-42.382z" fill="#fff"/>
+ </g>
+ <path fill="#fff" d="m11.007 116s29.812-43.316 96.92-43.316c67.108 0 94.745 42.806 94.745 42.806" stroke="#333357" stroke-width="3.0169"/>
+ <circle cx="108" cy="120" r="28" fill="#00adff"/>
+ <circle cx="108" cy="120" r="14" fill="#333357"/>
+ <g stroke="#333357" stroke-width="3">
+  <line x1="113.68" x2="113.68" y1="64.032" y2="43.036"/>
+  <path d="m164 175.84-118.81-118.81"/>
+  <path d="m157.17 71.031 13.997-13.997"/>
+ </g>
+ <defs>
+  <filter id="filter0_d" x="17.045" y="34.045" width="265.95" height="265.95" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+   <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+   <feColorMatrix in="SourceAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+   <feOffset dy="12"/>
+   <feGaussianBlur stdDeviation="17"/>
+   <feColorMatrix values="0 0 0 0 0.0941177 0 0 0 0 0.113725 0 0 0 0 0.227451 0 0 0 0.07 0"/>
+   <feBlend in2="BackgroundImageFix" result="effect1_dropShadow"/>
+   <feBlend in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+  </filter>
+ </defs>
 </svg>

--- a/packages/vapor/scss/components/browser-preview.scss
+++ b/packages/vapor/scss/components/browser-preview.scss
@@ -24,12 +24,16 @@
         }
     }
 
+    &__content {
+        overflow: auto;
+    }
+
     &__state {
         color: #282829; // var(--title-text-color)
 
         svg {
-            width: 300px;
-            height: 300px;
+            width: 220px;
+            height: 220px;
             fill: #5f619e; // TODO: new svg WIP
         }
 

--- a/packages/vapor/scss/components/browser-preview.scss
+++ b/packages/vapor/scss/components/browser-preview.scss
@@ -34,7 +34,7 @@
         svg {
             width: 220px;
             height: 220px;
-            fill: #5f619e; // TODO: new svg WIP
+            fill: #5f619e;
         }
 
         .medium-title-text {


### PR DESCRIPTION
### Proposed Changes

- Added official preview error image to browser preview component
- Added prop to be able to insert specific image node for empty state
- Reduced image size
- Added class for preview content and overflow:auto

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
