### PR TITLE
fix(rollup): diff2html name export

### DIFF
--- a/packages/react-vapor/rollup.config.js
+++ b/packages/react-vapor/rollup.config.js
@@ -18,7 +18,7 @@ export default {
         {
             file: 'dist/react-vapor.esm.js',
             format: 'es',
-            sourcemap: true
+            sourcemap: true,
         },
         {
             file: 'dist/react-vapor.js',
@@ -36,7 +36,7 @@ export default {
                 underscore: '_',
                 'coveo-styleguide': 'VaporSVG',
                 'underscore.string': 's',
-                'react-dom/server': 'ReactDOMServer'
+                'react-dom/server': 'ReactDOMServer',
             },
             plugins: [
                 externalGlobals({
@@ -50,9 +50,9 @@ export default {
                     underscore: '_',
                     'coveo-styleguide': 'VaporSVG',
                     'underscore.string': 's',
-                    'react-dom/server': 'ReactDOMServer'
-                })
-            ]
+                    'react-dom/server': 'ReactDOMServer',
+                }),
+            ],
         },
         isJenkins && {
             file: 'dist/react-vapor.min.js',
@@ -70,7 +70,7 @@ export default {
                 underscore: '_',
                 'coveo-styleguide': 'VaporSVG',
                 'underscore.string': 's',
-                'react-dom/server': 'ReactDOMServer'
+                'react-dom/server': 'ReactDOMServer',
             },
             plugins: [
                 terser(),
@@ -85,10 +85,10 @@ export default {
                     underscore: '_',
                     'coveo-styleguide': 'VaporSVG',
                     'underscore.string': 's',
-                    'react-dom/server': 'ReactDOMServer'
-                })
-            ]
-        }
+                    'react-dom/server': 'ReactDOMServer',
+                }),
+            ],
+        },
     ].filter(Boolean),
     external: [
         'codemirror',
@@ -101,59 +101,59 @@ export default {
         'redux',
         'underscore',
         'coveo-styleguide',
-        'underscore.string'
+        'underscore.string',
     ],
     onwarn,
     plugins: [
         inject({
-            jQuery: 'jquery' // chosen-js expects jQuery to be available as a global
+            jQuery: 'jquery', // chosen-js expects jQuery to be available as a global
         }),
         replacePlugin(),
         postcss({
             extract: false,
             modules: {localIdentName: '[name]-[local]-[hash:base64]'},
             namedExports: true,
-            use: ['sass']
+            use: ['sass'],
         }),
         scssVariable(),
         resolve({
-            browser: true
+            browser: true,
         }),
         commonjs({
             namedExports: {
                 'hogan.js': ['Template', 'compile'],
                 'react-modal': ['setAppElement'],
                 'react-dnd': ['DragDropContext', 'DropTarget', 'DragSource'],
-                diff2html: ['diffChars', 'diffWordsWithSpace']
-            }
+                'diff/dist/diff.js': ['diffChars', 'diffWordsWithSpace'],
+            },
         }),
-        tsPlugin()
-    ]
+        tsPlugin(),
+    ],
 };
 
 function tsPlugin() {
     return typescript({
         transformers: [
-            service => ({
+            (service) => ({
                 before: [keysTransformer(service.getProgram())],
-                after: []
-            })
+                after: [],
+            }),
         ],
         useTsconfigDeclarationDir: true,
         tsconfig: 'tsconfig.build.json',
         tsconfigOverride: {
             compilerOptions: {
                 declaration: true,
-                declarationDir: 'dist/definitions'
-            }
-        }
+                declarationDir: 'dist/definitions',
+            },
+        },
     });
 }
 
 function replacePlugin() {
     return replace({
         'process.env.NODE_ENV': JSON.stringify('production'),
-        'process.env.REACT_VAPOR_VERSION': JSON.stringify(process.env.NEW_VERSION || require('./package.json').version)
+        'process.env.REACT_VAPOR_VERSION': JSON.stringify(process.env.NEW_VERSION || require('./package.json').version),
     });
 }
 
@@ -161,8 +161,8 @@ function onwarn(warning, rollupWarn) {
     const ignoredWarnings = [
         {
             ignoredCode: 'CIRCULAR_DEPENDENCY',
-            ignoredPath: 'node_modules'
-        }
+            ignoredPath: 'node_modules',
+        },
     ];
 
     // only show warning when code and path don't match


### PR DESCRIPTION
### Proposed Changes

DiffViewer page throws an error in the demo because of a rollup issue: 
[Error: "[name] is not exported by [module]"](https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module)

For some reason, `commonjs` can't find `diff2html`, but if we replace it with `diff/dist/diff.js`, it looks good.

![image](https://user-images.githubusercontent.com/52677246/107820757-4c97f780-6d49-11eb-8f55-b78106b461be.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
