### PR TITLE
now open for review.  defining the NEW_VERSION as environment variable to access from the build

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -100,10 +100,11 @@ pipeline {
             } else {
               sh "npx lerna version --no-commit-hooks --no-git-tag-version --no-push --force-publish=\"react-vapor\" --yes"
             }
-            NEW_VERSION = sh(
+            env.NEW_VERSION = sh(
               script: "node -p -e 'require(`./packages/react-vapor/package.json`).version;'",
               returnStdout: true
             ).trim()
+
             sh "git reset --hard"
           }
         }


### PR DESCRIPTION
### Proposed Changes

The NEW_VERSION variable will be defined as an env variable and accessible in rollup https://github.com/coveo/react-vapor/blob/master/packages/react-vapor/rollup.config.js#L156

This will fix the mismatch between the real package version and the one fronted in the ReactVapor object.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
