### PR TITLE
build(slack): update slack notification to be more relevant

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -172,10 +172,10 @@ pipeline {
           ]]) {
 
             
-            sh "bash ./build/deploy-demo.sh ${env.BRANCH_NAME}"
-            postCommentOnGithub("https://vaporqa.cloud.coveo.com/feature/${env.BRANCH_NAME}/index.html");
+            sh "bash ./build/deploy-demo.sh ${env.CHANGE_BRANCH}"
+            postCommentOnGithub("https://vaporqa.cloud.coveo.com/feature/${env.CHANGE_BRANCH}/index.html");
 
-            def message = "Build succeeded: https://vaporqa.cloud.coveo.com/feature/${env.BRANCH_NAME}/index.html"
+            def message = "Build succeeded for <https://github.com/coveo/react-vapor/pull/${env.CHANGE_ID}|${env.BRANCH_NAME}>: https://vaporqa.cloud.coveo.com/feature/${env.CHANGE_BRANCH}/index.html"
             notify.sendSlackWithThread(
                 color: "#00FF00", message: message,
                 ["admin-ui-builds"]


### PR DESCRIPTION
Currently the message look like this:  `Build succeeded: https://vaporqa.cloud.coveo.com/feature/PR-1868/index.html` it is hard to know what it is about.

I suggest we change it for  `Build succeeded for PR-1868 (with a link): https://vaporqa.cloud.coveo.com/feature/name-of-the-branch/index.html`