### PR TITLE
fix(modalwizard): make steps navigation work with function components

### DIFF
--- a/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
+++ b/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
@@ -54,14 +54,14 @@ const ModalWizardDisconneted: React.FunctionComponent<ModalWizardProps & Connect
                     modalBodyChildren={
                         <>
                             <StepProgressBar numberOfSteps={numberOfSteps} currentStep={currentStep} />
-                            {steps.map((step: React.ReactElement, index: number) =>
-                                React.cloneElement(step, {
-                                    className: classNames(step.props?.['className'], {
-                                        hidden: index !== currentStep,
-                                    }),
-                                    hidden: index !== currentStep,
-                                })
-                            )}
+                            {steps.map((step: React.ReactElement, index: number) => {
+                                const hidden = index !== currentStep;
+                                return (
+                                    <div className={classNames({hidden})} hidden={hidden} key={index}>
+                                        {step}
+                                    </div>
+                                );
+                            })}
                         </>
                     }
                     modalFooterChildren={

--- a/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
+++ b/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
@@ -36,36 +36,43 @@ describe('ModalWizard', () => {
     });
 
     it('navigates properly through the steps when clicking on "next" and "previous" buttons', () => {
+        const FunctionComponentStep = () => <div>Step 2: FunctionComponent</div>;
+        class ClassComponentStep extends React.PureComponent {
+            render() {
+                return <div>Step 3: ClassComponent</div>;
+            }
+        }
+
         renderModal(
             <ModalWizard id="🧙‍♂️">
-                <div>Step 1</div>
-                <div>Step 2</div>
-                <div>Step 3</div>
+                <div>Step 1: ReactElement</div>
+                <FunctionComponentStep />
+                <ClassComponentStep />
             </ModalWizard>,
             {initialState: {modals: [{id: '🧙‍♂️', isOpened: true}]}}
         );
 
-        expect(screen.getByText('Step 1')).toBeVisible();
-        expect(screen.getByText('Step 2')).not.toBeVisible();
-        expect(screen.getByText('Step 3')).not.toBeVisible();
+        expect(screen.getByText(/Step 1/)).toBeVisible();
+        expect(screen.getByText(/Step 2/)).not.toBeVisible();
+        expect(screen.getByText(/Step 3/)).not.toBeVisible();
 
         userEvent.click(screen.getByRole('button', {name: 'Next'}));
 
-        expect(screen.getByText('Step 1')).not.toBeVisible();
-        expect(screen.getByText('Step 2')).toBeVisible();
-        expect(screen.getByText('Step 3')).not.toBeVisible();
+        expect(screen.getByText(/Step 1/)).not.toBeVisible();
+        expect(screen.getByText(/Step 2/)).toBeVisible();
+        expect(screen.getByText(/Step 3/)).not.toBeVisible();
 
         userEvent.click(screen.getByRole('button', {name: 'Next'}));
 
-        expect(screen.getByText('Step 1')).not.toBeVisible();
-        expect(screen.getByText('Step 2')).not.toBeVisible();
-        expect(screen.getByText('Step 3')).toBeVisible();
+        expect(screen.getByText(/Step 1/)).not.toBeVisible();
+        expect(screen.getByText(/Step 2/)).not.toBeVisible();
+        expect(screen.getByText(/Step 3/)).toBeVisible();
 
         userEvent.click(screen.getByRole('button', {name: 'Previous'}));
 
-        expect(screen.getByText('Step 1')).not.toBeVisible();
-        expect(screen.getByText('Step 2')).toBeVisible();
-        expect(screen.getByText('Step 3')).not.toBeVisible();
+        expect(screen.getByText(/Step 1/)).not.toBeVisible();
+        expect(screen.getByText(/Step 2/)).toBeVisible();
+        expect(screen.getByText(/Step 3/)).not.toBeVisible();
     });
 
     it('calls the "onFinish" prop and close the modal when clicking on the "finish" button', async () => {


### PR DESCRIPTION
### Proposed Changes

If a ModalWizard component had a FunctionComponent as a child step, it didn't hide this step properly.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
