### PR TITLE
Fix ad UI 6628 badge text wrap

### DIFF
--- a/packages/vapor/scss/components/badge.scss
+++ b/packages/vapor/scss/components/badge.scss
@@ -7,6 +7,7 @@
     color: var(--badge-text-color);
     font-weight: var(--badge-font-weight);
     line-height: var(--badge-line-height);
+    white-space: nowrap;
     text-align: center;
     background-color: var(--badge-background-color);
     border: var(--badge-border);


### PR DESCRIPTION
### Proposed Changes

Adding a nowrap will prevent the badge to look weird when the surrounding element are squeezing it.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
