### PR TITLE
fix(badge): whitespace nowrap

### DIFF
--- a/packages/vapor/scss/components/badge.scss
+++ b/packages/vapor/scss/components/badge.scss
@@ -8,6 +8,7 @@
     text-transform: capitalize;
     border: var(--default-border);
     border-radius: 8px;
+    white-space: nowrap;
 
     // Variables
     --height: 32px;


### PR DESCRIPTION
### Proposed Changes

adding `whitespace: nowrap` will prevent the text to wrap and the badge to look weird if the surrounding elements squeeze the badge.

### Potential Breaking Changes

nope

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
