### PR TITLE
build(jenkins): create a permanent demo of the next in vapor

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -157,7 +157,7 @@ pipeline {
         allOf {
           not {
             expression {
-              env.BRANCH_NAME ==~ /(master|next|release-.*)/
+              env.BRANCH_NAME ==~ /(master|release-.*)/
             }
           }
           expression { !skipRemainingStages }

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -178,7 +178,7 @@ pipeline {
             sh "bash ./build/deploy-demo.sh ${env.CHANGE_BRANCH}"
 
             if (env.BRANCH_NAME != "next") {
-                postCommentOnGithub("https://vaporqa.cloud.coveo.com/feature/${env.CHANGE_BRANCH}/index.html");
+              postCommentOnGithub("https://vaporqa.cloud.coveo.com/feature/${env.CHANGE_BRANCH}/index.html");
             }
 
             def message = "Build succeeded for <https://github.com/coveo/react-vapor/pull/${env.CHANGE_ID}|${env.BRANCH_NAME}>: https://vaporqa.cloud.coveo.com/feature/${env.CHANGE_BRANCH}/index.html"
@@ -192,9 +192,7 @@ pipeline {
 
       post {
         failure {
-          if (env.BRANCH_NAME != "next") {
-              postCommentOnGithub();
-          }
+          postCommentOnGithub();
         }
       }
     }

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -192,9 +192,12 @@ pipeline {
 
       post {
         failure {
-          postCommentOnGithub();
+          script {
+            if (env.BRANCH_NAME != "next") {
+              postCommentOnGithub();
+            }
+          }
         }
-      }
     }
 
     stage('Publish') {

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -198,6 +198,7 @@ pipeline {
             }
           }
         }
+      }
     }
 
     stage('Publish') {

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -176,7 +176,10 @@ pipeline {
 
             
             sh "bash ./build/deploy-demo.sh ${env.CHANGE_BRANCH}"
-            postCommentOnGithub("https://vaporqa.cloud.coveo.com/feature/${env.CHANGE_BRANCH}/index.html");
+
+            if (env.BRANCH_NAME != "next") {
+              postCommentOnGithub("https://vaporqa.cloud.coveo.com/feature/${env.CHANGE_BRANCH}/index.html");
+            }
 
             def message = "Build succeeded for <https://github.com/coveo/react-vapor/pull/${env.CHANGE_ID}|${env.BRANCH_NAME}>: https://vaporqa.cloud.coveo.com/feature/${env.CHANGE_BRANCH}/index.html"
             notify.sendSlackWithThread(
@@ -189,7 +192,9 @@ pipeline {
 
       post {
         failure {
+          if (env.BRANCH_NAME != "next") {
           postCommentOnGithub();
+          }
         }
       }
     }

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -178,7 +178,7 @@ pipeline {
             sh "bash ./build/deploy-demo.sh ${env.CHANGE_BRANCH}"
 
             if (env.BRANCH_NAME != "next") {
-              postCommentOnGithub("https://vaporqa.cloud.coveo.com/feature/${env.CHANGE_BRANCH}/index.html");
+                postCommentOnGithub("https://vaporqa.cloud.coveo.com/feature/${env.CHANGE_BRANCH}/index.html");
             }
 
             def message = "Build succeeded for <https://github.com/coveo/react-vapor/pull/${env.CHANGE_ID}|${env.BRANCH_NAME}>: https://vaporqa.cloud.coveo.com/feature/${env.CHANGE_BRANCH}/index.html"
@@ -193,7 +193,7 @@ pipeline {
       post {
         failure {
           if (env.BRANCH_NAME != "next") {
-          postCommentOnGithub();
+              postCommentOnGithub();
           }
         }
       }


### PR DESCRIPTION
### Proposed Changes

[ADUI-6576](https://coveord.atlassian.net/browse/ADUI-6576)

In the Jenkinsfile we skip the deploy step if the branch is next, which prevents us from having a demo. It would be nice to update one each time something is merged in the branch 

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
