### PR TITLE
fix(next): text colors in demo

### DIFF
--- a/packages/demo/src/components/examples/BlankSlateExample.tsx
+++ b/packages/demo/src/components/examples/BlankSlateExample.tsx
@@ -29,7 +29,10 @@ export class BlankSlateExample extends React.Component<any, any> {
                         title="Title test"
                         description={
                             <span>
-                                This is a description with a link to <a href="https//www.google.com">this website</a>
+                                This is a description with a link to{' '}
+                                <a target="_blank" href="http://www.perdu.com/">
+                                    this website
+                                </a>
                             </span>
                         }
                     />

--- a/packages/demo/src/styles/components/Member.tsx
+++ b/packages/demo/src/styles/components/Member.tsx
@@ -17,8 +17,8 @@ export const Member = () => (
                 <Svg svgName={VaporSVG.svg.domainGoogle.name} className="member-icon-provider icon mod-2x" />
             </div>
             <div className="member-info">
-                <div className="member-info-name">Member name</div>
-                <div className="member-info-email">member@domain.com</div>
+                <div className="member-info-name label">Member name</div>
+                <div className="member-info-email label">member@domain.com</div>
             </div>
         </div>
     </VaporComponent>

--- a/packages/demo/src/styles/filtering/ValuePopup.tsx
+++ b/packages/demo/src/styles/filtering/ValuePopup.tsx
@@ -112,7 +112,7 @@ export const ValuePopup = () => {
 
                                     <div className="string-filters popover-row">
                                         <div className="form-control checkbox-labels-group">
-                                            <label className="checkbox checkbox-label">
+                                            <label className="checkbox checkbox-label mb1">
                                                 <input type="checkbox" className="empty-filter" />
                                                 <button type="button" />
                                                 <span className="label">Include blank values in filter</span>

--- a/packages/demo/src/styles/typography/Utilities.tsx
+++ b/packages/demo/src/styles/typography/Utilities.tsx
@@ -12,7 +12,7 @@ export default () => (
         <h3>
             <div className="bold">Text in bold</div>
 
-            <div className="semibold">Text in semibold</div>
+            <div className="bolder">Text in bolder</div>
 
             <div className="regular">Text in regular</div>
 

--- a/packages/react-vapor/src/components/breadcrumbs/BreadcrumbLink.tsx
+++ b/packages/react-vapor/src/components/breadcrumbs/BreadcrumbLink.tsx
@@ -25,7 +25,6 @@ export class BreadcrumbLink extends React.Component<IBreadcrumbLinkProps> {
         const linkClasses = classNames(
             {
                 link: this.props.link,
-                bold: !this.props.link,
             },
             this.props.classes
         );

--- a/packages/react-vapor/src/components/diffViewer/styles/DiffViewer.scss
+++ b/packages/react-vapor/src/components/diffViewer/styles/DiffViewer.scss
@@ -19,9 +19,15 @@
     }
 
     :global(.d2h-diff-table) {
+        color: var(--title-text-color);
         font-size: $code-font-size;
         font-family: $code-font-family;
         border-bottom: $default-border;
+    }
+
+    :global(.d2h-file-list-title) {
+        color: var(--title-text-color);
+        font-weight: var(--main-font-bold);
     }
 
     :global(.d2h-code-linenumber) {

--- a/packages/vapor/scss/components/header.scss
+++ b/packages/vapor/scss/components/header.scss
@@ -2,8 +2,12 @@
     display: flex;
     width: 100%;
     height: $header-height;
-    color: var(--header-text-color);
+    color: var(--white);
     background-color: var(--header-background-color);
+
+    h3 {
+        color: inherit;
+    }
 }
 
 .header-section {

--- a/packages/vapor/scss/components/home-card.scss
+++ b/packages/vapor/scss/components/home-card.scss
@@ -27,7 +27,6 @@
 
 .home-card-header {
     padding: $home-card-y-padding $home-card-x-padding;
-    color: var(--medium-blue);
     line-height: $header-line-height;
 
     h2 {
@@ -48,7 +47,7 @@
 
 .home-card-footer-action {
     padding: 0;
-    color: var(--blue);
+    color: var(--links-color);
     font-size: $small-font-size;
     background: none;
     border: none;

--- a/packages/vapor/scss/components/limit-box.scss
+++ b/packages/vapor/scss/components/limit-box.scss
@@ -5,13 +5,6 @@
     border-radius: $border-radius;
 }
 
-.limit-box-numbers {
-    label.form-control-label,
-    .input-field input:valid + label {
-        color: var(--dark-medium-grey);
-    }
-}
-
 .limit-box-usage,
 .limit-box-limit {
     width: 50%;
@@ -23,6 +16,7 @@
     width: 100%;
     height: $input-height;
     padding: $input-padding;
+    color: var(--title-text-color);
     font-size: $input-font-size;
 }
 

--- a/packages/vapor/scss/components/multi-step-bar.scss
+++ b/packages/vapor/scss/components/multi-step-bar.scss
@@ -87,6 +87,7 @@
     bottom: 0;
     left: 0;
     z-index: 1;
+    color: var(--title-text-color);
 }
 
 .multi-step-bar-backdrop-container {

--- a/packages/vapor/scss/components/selected-option.scss
+++ b/packages/vapor/scss/components/selected-option.scss
@@ -10,7 +10,7 @@
     height: 100%;
     min-height: $dropdown-multiselect-option-height;
     margin: $dropdown-multiselect-margin;
-    color: var(--medium-blue);
+    color: var(--title-text-color);
     font-size: $button-small-font-size;
     line-height: $dropdown-multiselect-option-height;
     background-color: var(--pure-white);

--- a/packages/vapor/scss/components/sub-navigation.scss
+++ b/packages/vapor/scss/components/sub-navigation.scss
@@ -15,7 +15,7 @@
             .sub-navigation-item-link {
                 display: block;
                 padding: $sub-navigation-item-padding;
-                color: var(--medium-blue);
+                color: var(--title-text-color);
                 line-height: $sub-navigation-line-height;
 
                 &.disabled {

--- a/packages/vapor/scss/controls/filtering/filters-values.scss
+++ b/packages/vapor/scss/controls/filtering/filters-values.scss
@@ -13,7 +13,6 @@
             .selected-filter {
                 height: $selected-filter-height;
                 padding-left: $selected-filter-padding-left;
-                color: var(--medium-blue);
                 font-weight: var(--main-font-bold);
                 font-size: var(--default-font-size);
                 line-height: $selected-filter-height;

--- a/packages/vapor/scss/redesign/fonts.scss
+++ b/packages/vapor/scss/redesign/fonts.scss
@@ -14,8 +14,6 @@
     --spacing: #{$spacing};
 
     // Typography
-    --small-font-size: #{$small-font-size};
-    --default-font-size: #{$default-font-size};
     --title-font-size: #{$title-font-size};
     --medium-title-font-size: #{$medium-title-font-size};
     --big-font-size: #{$big-font-size};

--- a/packages/vapor/scss/redesign/variables.scss
+++ b/packages/vapor/scss/redesign/variables.scss
@@ -25,7 +25,6 @@
 
     // Header
     --header-background-color: var(--navy-blue-80);
-    --header-text-color: var(--white);
     --header-hamburger-color: var(--white);
 
     // Gradient

--- a/packages/vapor/scss/typography/headings.scss
+++ b/packages/vapor/scss/typography/headings.scss
@@ -3,7 +3,13 @@ h2,
 h3,
 h4,
 h5,
-h6 {
+h6,
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
     color: var(--title-text-color);
     font-family: var(--main-font);
     line-height: $standard-line-height;

--- a/packages/vapor/scss/typography/utility.scss
+++ b/packages/vapor/scss/typography/utility.scss
@@ -1,16 +1,13 @@
 // Typography utility classes
 // Source: https://github.com/basscss/utility-typography
 
-.bold {
+.bold,
+.semibold {
     font-weight: var(--main-font-bold);
 }
 
 .bolder {
     font-weight: var(--main-font-bolder);
-}
-
-.semibold {
-    font-weight: var(--main-font-bold);
 }
 
 .regular {


### PR DESCRIPTION
### Proposed Changes

This PR includes several fixes for the `next` branch, mostly related to the font. Here is the list of changes:

- Styles > Wizard: header text color 
![image](https://user-images.githubusercontent.com/52677246/108916160-decab600-75fb-11eb-814f-3c3cfb60b1e0.png)

- Styles > Member: text color
![image](https://user-images.githubusercontent.com/52677246/108916268-03bf2900-75fc-11eb-9310-8f205b139ef8.png)

- Components > BlankSlate: update the link of `this website`
![image](https://user-images.githubusercontent.com/52677246/108916374-26514200-75fc-11eb-955f-864beea0f7dc.png)

- Styles > Cards > Home: color of `Dismiss` link
![image](https://user-images.githubusercontent.com/52677246/108916452-497bf180-75fc-11eb-90b6-64fd053a1731.png)

- Styles > Value Popup: header text color, horizontal space between two checkboxes
![image](https://user-images.githubusercontent.com/52677246/108916561-73351880-75fc-11eb-97e6-c9673410d7f6.png)

- Styles > Typography > Utilities: remove `semibold`, add `bolder`
![image](https://user-images.githubusercontent.com/52677246/108916684-9bbd1280-75fc-11eb-86f8-0b16335388ff.png)

- Styles > Utility > Text Size: text color of `.h1` - `.h6`, default font-size 14px, small font-size 12px
![image](https://user-images.githubusercontent.com/52677246/108916865-dde65400-75fc-11eb-9b6c-bc9338643463.png)

- Components > DiffViewer: font-weight of the title `Files changed`
![image](https://user-images.githubusercontent.com/52677246/108916961-01a99a00-75fd-11eb-9e24-888da024e6c3.png)

- Components > Limit: text color
![image](https://user-images.githubusercontent.com/52677246/108917030-1ab24b00-75fd-11eb-9b9b-cbcf826f4296.png)

- Components > MultiSelect: selected label text color
![image](https://user-images.githubusercontent.com/52677246/108917091-387fb000-75fd-11eb-8818-2d8c245f016a.png)

- Components > MultiStepBar: text color
![image](https://user-images.githubusercontent.com/52677246/108917142-49302600-75fd-11eb-9eb6-81cea3e25612.png)

- Components > Header: text color of `not a link`
![image](https://user-images.githubusercontent.com/52677246/108917181-58af6f00-75fd-11eb-8e7a-7d1e50ac4d40.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
