### PR TITLE
fix(next): background color of whitespace examples

### DIFF
--- a/packages/demo/src/styles/utility/Whitespace.tsx
+++ b/packages/demo/src/styles/utility/Whitespace.tsx
@@ -7,38 +7,40 @@ export default () => (
     <VaporComponent id="whitespace" title="Whitespace" withSource>
         <Section level={2} title="Paddings" description="Give custom padding to your element">
             <div className="p2" style={{backgroundColor: '#e5e8e8'}}>
-                Use p0[..n] to add a uniform padding around the box.
+                Use <span className="bolder">p0[..n]</span> to add a uniform padding around the box.
             </div>
             <br />
 
             <div className="px1" style={{backgroundColor: '#e5e8e8'}}>
-                Use px1[..n] to add padding right and left (x axis).
+                Use <span className="bolder">px1[..n]</span> to add padding right and left (x axis).
             </div>
             <br />
 
             <div className="py1" style={{backgroundColor: '#e5e8e8'}}>
-                Use py1[..n] to add padding top and bottom (y axis).
+                Use <span className="bolder">py1[..n]</span> to add padding top and bottom (y axis).
             </div>
             <br />
         </Section>
         <Section level={2} title="Margins" description="Give custom margin to your element">
             <div className="m2" style={{backgroundColor: '#e5e8e8'}}>
-                Use m0[..n] to add a uniform margin around the box.
+                Use <span className="bolder">m0[..n]</span> to add a uniform margin around the box.
             </div>
 
             <div className="mt2" style={{backgroundColor: '#e5e8e8'}}>
-                Use m[t|r|b|l][1..n] to add a top, right, bottom or left margin on the element.
+                Use <span className="bolder">m[t|r|b|l][1..n]</span> to add a top, right, bottom or left margin on the
+                element.
             </div>
             <br />
 
             <div className="p3" style={{backgroundColor: '#f6f7f9'}}>
                 <div className="mt-2" style={{backgroundColor: '#e5e8e8'}}>
-                    Use m[t|r|b|l][-5..-1] to add a negative top, right, bottom or left margin on the element.
+                    Use <span className="bolder">m[t|r|b|l][-5..-1]</span> to add a negative top, right, bottom or left
+                    margin on the element.
                 </div>
             </div>
 
             <div className="mx-auto" style={{width: 200, backgroundColor: '#e5e8e8'}}>
-                Use mx-auto to have a auto margin-left and margin-right.
+                Use <span className="bolder">mx-auto</span> to have a auto margin-left and margin-right.
             </div>
         </Section>
     </VaporComponent>

--- a/packages/demo/src/styles/utility/Whitespace.tsx
+++ b/packages/demo/src/styles/utility/Whitespace.tsx
@@ -6,38 +6,38 @@ import VaporComponent from '../../demo-building-blocs/VaporComponent';
 export default () => (
     <VaporComponent id="whitespace" title="Whitespace" withSource>
         <Section level={2} title="Paddings" description="Give custom padding to your element">
-            <div className="p2" style={{backgroundColor: '#f05245'}}>
+            <div className="p2" style={{backgroundColor: '#e5e8e8'}}>
                 Use p0[..n] to add a uniform padding around the box.
             </div>
             <br />
 
-            <div className="px1" style={{backgroundColor: '#ffe300'}}>
+            <div className="px1" style={{backgroundColor: '#e5e8e8'}}>
                 Use px1[..n] to add padding right and left (x axis).
             </div>
             <br />
 
-            <div className="py1" style={{backgroundColor: '#00adff'}}>
+            <div className="py1" style={{backgroundColor: '#e5e8e8'}}>
                 Use py1[..n] to add padding top and bottom (y axis).
             </div>
             <br />
         </Section>
         <Section level={2} title="Margins" description="Give custom margin to your element">
-            <div className="m2" style={{backgroundColor: '#fa821e'}}>
+            <div className="m2" style={{backgroundColor: '#e5e8e8'}}>
                 Use m0[..n] to add a uniform margin around the box.
             </div>
 
-            <div className="mt2" style={{backgroundColor: '#9961a7'}}>
+            <div className="mt2" style={{backgroundColor: '#e5e8e8'}}>
                 Use m[t|r|b|l][1..n] to add a top, right, bottom or left margin on the element.
             </div>
             <br />
 
-            <div className="p3" style={{backgroundColor: '#e5e8e8'}}>
-                <div className="mt-2" style={{backgroundColor: '#8e959d'}}>
+            <div className="p3" style={{backgroundColor: '#f6f7f9'}}>
+                <div className="mt-2" style={{backgroundColor: '#e5e8e8'}}>
                     Use m[t|r|b|l][-5..-1] to add a negative top, right, bottom or left margin on the element.
                 </div>
             </div>
 
-            <div className="mx-auto" style={{width: 200, backgroundColor: '#15ab65'}}>
+            <div className="mx-auto" style={{width: 200, backgroundColor: '#e5e8e8'}}>
                 Use mx-auto to have a auto margin-left and margin-right.
             </div>
         </Section>


### PR DESCRIPTION
### Proposed Changes

Use single, light background color for the examples in the **Styles > Whitespace** demo, and keep the default text color.

Before:
![image](https://user-images.githubusercontent.com/52677246/108919063-6286a180-7600-11eb-894b-7e63d83e1ab6.png)

After:
![image](https://user-images.githubusercontent.com/52677246/108919102-7205ea80-7600-11eb-88b6-7007df8138dc.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
