### PR TITLE
feat(next): color dots states

### DIFF
--- a/packages/demo/src/styles/utility/ColorDot.tsx
+++ b/packages/demo/src/styles/utility/ColorDot.tsx
@@ -1,29 +1,35 @@
 import * as React from 'react';
+import {Section} from 'react-vapor';
 
 import VaporComponent from '../../demo-building-blocs/VaporComponent';
 
 export default () => (
     <VaporComponent id="color-dots" title="Color dots" usage="Display a status." withSource>
-        <p className="p1">Standard color dots</p>
-        <i className="color-dot" />
-        <i className="color-dot state-critical" />
-        <i className="color-dot state-major" />
-        <i className="color-dot state-info" />
-        <i className="color-dot state-disabled" />
-        <i className="color-dot state-waiting" />
-
-        <p className="p1">Flashing color dots</p>
-        <i className="color-dot state-executing" />
-        <i className="color-dot state-executing state-critical" />
-        <i className="color-dot state-executing state-major" />
-        <i className="color-dot state-executing state-info" />
-        <i className="color-dot state-executing state-disabled" />
-        <i className="color-dot state-executing state-waiting" />
-
-        <p className="p1">Color dot aligned with text</p>
-        <span className="inline-flex center-align">
+        <Section level={3} title="Standard color dots">
             <i className="color-dot mr1" />
-            Success
-        </span>
+            <i className="color-dot state-critical mr1" />
+            <i className="color-dot state-major mr1" />
+            <i className="color-dot state-minor mr1" />
+            <i className="color-dot state-info mr1" />
+            <i className="color-dot state-disabled mr1" />
+            <i className="color-dot state-waiting" />
+        </Section>
+
+        <Section level={3} title="Flashing color dots">
+            <i className="color-dot state-executing mr1" />
+            <i className="color-dot state-executing state-critical mr1" />
+            <i className="color-dot state-executing state-major mr1" />
+            <i className="color-dot state-executing state-minor mr1" />
+            <i className="color-dot state-executing state-info mr1" />
+            <i className="color-dot state-executing state-disabled mr1" />
+            <i className="color-dot state-executing state-waiting" />
+        </Section>
+
+        <Section level={3} title="Color dot aligned with text">
+            <span className="inline-flex label">
+                <i className="color-dot mr1" />
+                Success
+            </span>
+        </Section>
     </VaporComponent>
 );

--- a/packages/vapor/scss/elements/color-dot.scss
+++ b/packages/vapor/scss/elements/color-dot.scss
@@ -1,37 +1,40 @@
 .color-dot {
+    --background-color: var(--success-60);
+
     display: inline-block;
-    width: var(--color-dot-size);
-    min-width: var(--color-dot-size);
-    height: var(--color-dot-size);
-    min-height: var(--color-dot-size);
-    background-color: var(--status-green);
+    width: $color-dot-size;
+    min-width: $color-dot-size;
+    height: $color-dot-size;
+    min-height: $color-dot-size;
+    background-color: var(--background-color);
     border-radius: 100%;
 
     &.state-critical {
-        background-color: var(--status-red);
+        --background-color: var(--critical-70);
     }
 
     &.state-major {
-        background-color: var(--status-orange);
+        --background-color: var(--sienna-orange-60);
     }
 
     &.state-minor {
-        background-color: var(--status-yellow);
+        --background-color: var(--warning-70);
     }
 
     &.state-info {
-        background-color: var(--status-blue);
+        --background-color: var(--information-60);
     }
 
     &.state-disabled {
-        background-color: var(--status-light-grey);
+        --background-color: var(--grey-20);
+        border: 1px solid var(--grey-60);
+    }
+
+    &.state-waiting {
+        --background-color: var(--grey-60);
     }
 
     &.state-executing {
         animation: scaleoutCentered 1s infinite ease-in-out;
-    }
-
-    &.state-waiting {
-        background-color: var(--status-medium-grey);
     }
 }

--- a/packages/vapor/scss/redesign/colors.scss
+++ b/packages/vapor/scss/redesign/colors.scss
@@ -224,21 +224,25 @@
 
     --success-100: #016b52;
     --success-80: #0d866a;
-    --success-60: #2ba488;
+    --success-60: #12a344;
     --success-40: #6edbc1;
     --success-20: #ccf9ee;
 
     --warning-100: #805700;
     --warning-80: #bf7500;
+    --warning-70: #e2b104;
     --warning-60: #f0a702;
     --warning-40: #fdcd66;
     --warning-20: #ffefcc;
 
     --critical-100: #c2271c;
     --critical-80: #da3c2f;
+    --critical-70: #cd2113;
     --critical-60: #f05245;
     --critical-40: #ff8276;
     --critical-20: #ffcecc;
+
+    --sienna-orange-60: #e06036;
 
     // *************************** //
     // *    NEW CSS Variables    * //

--- a/packages/vapor/scss/redesign/fonts.scss
+++ b/packages/vapor/scss/redesign/fonts.scss
@@ -39,9 +39,6 @@
     --button-small-font-size: #{$button-small-font-size};
     --button-small-line-height: #{$button-small-line-height};
 
-    // Color dot
-    --color-dot-size: #{$color-dot-size};
-
     // Dropdown
     --dropdown-button-font-size: #{$dropdown-button-font-size};
 

--- a/packages/vapor/scss/redesign/palette-map.scss
+++ b/packages/vapor/scss/redesign/palette-map.scss
@@ -61,12 +61,15 @@ $palette: (
     success-20: $success-20,
     warning-100: $warning-100,
     warning-80: $warning-80,
+    warning-70: $warning-70,
     warning-60: $warning-60,
     warning-40: $warning-40,
     warning-20: $warning-20,
     critical-100: $critical-100,
     critical-80: $critical-80,
+    critical-70: $critical-70,
     critical-60: $critical-60,
     critical-40: $critical-40,
-    critical-20: $critical-20
+    critical-20: $critical-20,
+    sienna-orange-60: $sienna-orange-60
 );

--- a/packages/vapor/scss/redesign/palette.scss
+++ b/packages/vapor/scss/redesign/palette.scss
@@ -64,18 +64,22 @@ $information-20: #ccefff;
 
 $success-100: #016b52;
 $success-80: #0d866a;
-$success-60: #2ba488;
+$success-60: #12a344;
 $success-40: #6edbc1;
 $success-20: #ccf9ee;
 
 $warning-100: #805700;
 $warning-80: #bf7500;
+$warning-70: #e2b104;
 $warning-60: #f0a702;
 $warning-40: #fdcd66;
 $warning-20: #ffefcc;
 
 $critical-100: #c2271c;
 $critical-80: #da3c2f;
+$critical-70: #cd2113;
 $critical-60: #f05245;
 $critical-40: #ff8276;
 $critical-20: #ffcecc;
+
+$sienna-orange-60: #e06036;

--- a/packages/vapor/scss/redesign/variables.scss
+++ b/packages/vapor/scss/redesign/variables.scss
@@ -198,9 +198,6 @@
     // Filter box
     --filter-box-icon-color: var(--grey-80);
 
-    // Color dot
-    --color-dot-size: 12px;
-
     // Facet
     --facet-box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.1);
     --facet-border: 1px solid rgba($heather, 0.3);

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -601,7 +601,7 @@ $diff-separator-padding: 3px;
 $diff-separator-margin: 10px;
 
 // Color dots
-$color-dot-size: $default-line-height;
+$color-dot-size: 12px;
 
 // Banners
 $banner-padding: 40px;


### PR DESCRIPTION
### Proposed Changes

Before:
![image](https://user-images.githubusercontent.com/52677246/109063458-24988480-76b7-11eb-9aa3-2c37d65487f3.png)

After:
![image](https://user-images.githubusercontent.com/52677246/109063505-3548fa80-76b7-11eb-8c56-45b5a18610a5.png)

### Potential Breaking Changes

`--success-60` has been changed to `#12a344` since UX updated the palette with the new semantic utility colors. More colors will be updated later.
https://www.figma.com/file/JbXRfSOwdEuq3VJGpUyyiJ/Coveo-Library?node-id=0%3A1
![image](https://user-images.githubusercontent.com/52677246/109063800-9b358200-76b7-11eb-8076-081d2f36570b.png)

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
