### PR TITLE
feat(toast): added a download section to the vapor toast

### DIFF
--- a/packages/demo/src/components/examples/ToastConnectedExamples.tsx
+++ b/packages/demo/src/components/examples/ToastConnectedExamples.tsx
@@ -104,7 +104,7 @@ export class ToastConnectedExamples extends React.Component<IToastConnectedExamp
                                 });
                             }}
                         >
-                            <Svg svgName="download" svgClass="icon icon mod-lg mr1" />
+                            <Svg svgName="download" svgClass="icon mod-lg mr1" />
                             Prepare Download
                         </button>
 

--- a/packages/demo/src/components/examples/ToastConnectedExamples.tsx
+++ b/packages/demo/src/components/examples/ToastConnectedExamples.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {addToast, ReduxConnect, ToastContainerConnected, ToastType} from 'react-vapor';
+import {addToast, ReduxConnect, Svg, ToastContainerConnected, ToastType} from 'react-vapor';
 
 import {ToastContentExample} from './ToastContentExample';
 
@@ -8,6 +8,7 @@ export interface IToastConnectedExamplesProps {
 }
 
 const containerId = 'some-id';
+const downloadContainerId = 'download-toast-id';
 
 @ReduxConnect(null, {addToast})
 export class ToastConnectedExamples extends React.Component<IToastConnectedExamplesProps> {
@@ -94,7 +95,21 @@ export class ToastConnectedExamples extends React.Component<IToastConnectedExamp
                             React Component Content with children
                         </button>
 
+                        <button
+                            className="btn m0 mr1 mb1"
+                            onClick={() => {
+                                this.props.addToast(downloadContainerId, 'Preparing file for download...', {
+                                    children: <div>Some file.csv</div>,
+                                    isDownload: true,
+                                });
+                            }}
+                        >
+                            <Svg svgName="download" svgClass="icon icon mod-lg mr1" />
+                            Prepare Download
+                        </button>
+
                         <ToastContainerConnected id={containerId} />
+                        <ToastContainerConnected id={downloadContainerId} bottom left />
                     </div>
                 </div>
             </div>

--- a/packages/react-vapor/src/components/toast/Toast.tsx
+++ b/packages/react-vapor/src/components/toast/Toast.tsx
@@ -12,6 +12,7 @@ export interface IToastProps {
     dismiss?: number;
     dismissible?: boolean;
     animate?: boolean;
+    isDownload?: boolean;
     className?: string;
     /**
      * @deprecated use children instead
@@ -77,7 +78,10 @@ export class Toast extends React.Component<IToastProps> {
                 'mod-error': this.props.type === ToastType.Error,
                 'mod-animated': _.isUndefined(this.props.animate) || this.props.animate === true,
             },
-            this.props.className
+            this.props.className,
+            {
+                'toast-download': this.props.isDownload,
+            }
         );
 
         const closeButton = this.props.dismissible && (
@@ -88,7 +92,16 @@ export class Toast extends React.Component<IToastProps> {
 
         const toastContent = (!!this.props.content || !!this.props.children) && (
             <div className="toast-description">
-                {this.props.children}
+                {this.props.isDownload ? (
+                    <div className="flex space-between">
+                        {this.props.children}
+                        <div className="spinner-container relative">
+                            <div className="search-bar-spinner" />
+                        </div>
+                    </div>
+                ) : (
+                    this.props.children
+                )}
                 {_.isString(this.props.content) || !this.props.content
                     ? this.props.content
                     : React.createElement(this.props.content as React.ComponentClass)}

--- a/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
+++ b/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
@@ -275,37 +275,34 @@ describe('Toasts', () => {
     });
 
     describe('<Toast /> with download section', () => {
-        beforeEach(() => {
-            toastBasicAttributes = {
-                title: 'Preparing file for download...',
-                isDownload: true,
-            };
-
-            toastComponent = mount(<Toast {...toastBasicAttributes} />, {attachTo: document.getElementById('App')});
-            toastInstance = toastComponent.instance() as Toast;
-        });
-
         it('should have class "toast-download" if the download prop is true', () => {
             const expectedClass = '.toast-download';
-            let newToastAttributes = _.extend({}, toastBasicAttributes);
-
+            toastComponent = mount(<Toast title="a" isDownload />);
             expect(toastComponent.find(expectedClass).length).toBe(1);
+        });
 
-            newToastAttributes = _.extend({}, toastBasicAttributes, {isDownload: false});
-            toastComponent.setProps(newToastAttributes).mount();
-
+        it('should not have the class "toast-download" if the download prop is false', () => {
+            const expectedClass = '.toast-download';
+            toastComponent = mount(<Toast title="a" isDownload={false} />);
             expect(toastComponent.find(expectedClass).length).toBe(0);
         });
 
         it('should load "Preparing file for download..." as a title', () => {
+            toastComponent = mount(
+                <Toast title="Preparing file for download..." isDownload>
+                    <div>Some file.csv</div>
+                </Toast>
+            );
+
             expect(toastComponent.find('.toast-title').text()).toBe('Preparing file for download...');
         });
 
         it('should have a loading icon in the description', () => {
-            const newToastAttributes = _.extend({}, toastBasicAttributes, {children: <div>Some file.csv</div>});
-
-            toastComponent.setProps(newToastAttributes).mount();
-
+            toastComponent = mount(
+                <Toast title="a" isDownload>
+                    <div>Some file.csv</div>
+                </Toast>
+            );
             expect(toastComponent.find('.search-bar-spinner').length).toBe(1);
         });
     });

--- a/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
+++ b/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
@@ -273,4 +273,40 @@ describe('Toasts', () => {
             expect(onCloseToast).not.toHaveBeenCalled();
         });
     });
+
+    describe('<Toast /> with download section', () => {
+        beforeEach(() => {
+            toastBasicAttributes = {
+                title: 'Preparing file for download...',
+                isDownload: true,
+            };
+
+            toastComponent = mount(<Toast {...toastBasicAttributes} />, {attachTo: document.getElementById('App')});
+            toastInstance = toastComponent.instance() as Toast;
+        });
+
+        it('should have class "toast-download" if the download prop is true', () => {
+            const expectedClass = '.toast-download';
+            let newToastAttributes = _.extend({}, toastBasicAttributes);
+
+            expect(toastComponent.find(expectedClass).length).toBe(1);
+
+            newToastAttributes = _.extend({}, toastBasicAttributes, {isDownload: false});
+            toastComponent.setProps(newToastAttributes).mount();
+
+            expect(toastComponent.find(expectedClass).length).toBe(0);
+        });
+
+        it('should load "Preparing file for download..." as a title', () => {
+            expect(toastComponent.find('.toast-title').text()).toBe('Preparing file for download...');
+        });
+
+        it('should have a loading icon in the description', () => {
+            const newToastAttributes = _.extend({}, toastBasicAttributes, {children: <div>Some file.csv</div>});
+
+            toastComponent.setProps(newToastAttributes).mount();
+
+            expect(toastComponent.find('.search-bar-spinner').length).toBe(1);
+        });
+    });
 });

--- a/packages/vapor/scss/components/toast.scss
+++ b/packages/vapor/scss/components/toast.scss
@@ -129,4 +129,35 @@ $toast-close-size: 16px;
         color: $toast-text-color;
         font-size: $toast-description-font-size;
     }
+
+    .toast.toast-download {
+        min-width: 300px;
+        padding: 0;
+        background: var(--blue-purple-3);
+        border-radius: 6px;
+        box-shadow: 0 2px 4px var(--box-shadow);
+
+        .toast-title,
+        .toast-close {
+            padding: $toast-padding;
+        }
+        .toast-description {
+            margin-top: 0;
+            padding: $toast-padding;
+            color: var(--black);
+            font-size: var(--default-font-size);
+            background: var(--grey-1);
+            border-bottom-right-radius: inherit;
+            border-bottom-left-radius: inherit;
+            box-shadow: inset 0px 5px 6px -5px var(--black);
+
+            .spinner-container {
+                width: 16px;
+
+                .search-bar-spinner {
+                    left: 7px; // for pixel perfect alignment
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
A new feature in the rebrand will be a "Preparing download" section in the Toast. I went with
modifying the original instead of creating a new one. 

See UI mockup (start by clicking to the left of the red arrow, then *diagnostic log*):

 https://9pd08d.axshare.com/#id=2b9uvt&p=activityui_-_option1&g=1

### Proposed Changes

Added a section to the toast that only appears if the download prop is included. User should pass the file that's to be downloaded, ideally through Redux though I'm unsure of the best practice here

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ x ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)

![image](https://user-images.githubusercontent.com/22773767/109195039-0fc7f980-7768-11eb-89b8-c11242279e6e.png)
