### PR TITLE
Ad UI 6642 fix icons color in demo in vapor

### DIFF
--- a/packages/demo/src/components/examples/modalWindowExamples.tsx
+++ b/packages/demo/src/components/examples/modalWindowExamples.tsx
@@ -152,7 +152,7 @@ const ModalExampleDisconnected: React.FunctionComponent<ModalConnectedExamplePro
                     title="Modal composite"
                     modalHeaderChildren={
                         <Tooltip title="A tooltip for the title">
-                            <Svg svgName="help" className="icon mod-2x ml1" />
+                            <Svg svgName="help" className="icon tooltip-icon mod-2x ml1" />
                         </Tooltip>
                     }
                     modalBodyChildren={<div className="mt2">{loremIpsum({count: 10})}</div>}

--- a/packages/react-vapor/src/components/input/InputLabelWithTooltip.tsx
+++ b/packages/react-vapor/src/components/input/InputLabelWithTooltip.tsx
@@ -19,7 +19,7 @@ export const InputLabelWithTooltip: React.FunctionComponent<InputLabelWithToolti
     <Label invalidMessage={invalidMessage}>
         {label}
         <Tooltip title={tooltip} placement={TooltipPlacement.Right}>
-            <Svg svgName="info" svgClass="icon mod-16 ml1" />
+            <Svg svgName="info" svgClass="icon tooltip-icon mod-16 ml1" />
         </Tooltip>
     </Label>
 );

--- a/packages/react-vapor/src/components/svg/LinkSvg.tsx
+++ b/packages/react-vapor/src/components/svg/LinkSvg.tsx
@@ -16,7 +16,7 @@ export class LinkSvg extends React.Component<ILinkSvgProps> {
     static defaultProps: Partial<ILinkSvgProps> = {
         target: '_blank',
         linkClasses: [],
-        svg: {svgName: 'help', svgClass: 'icon'},
+        svg: {svgName: 'help', svgClass: 'icon documentation-link'},
     };
 
     render() {

--- a/packages/vapor/scss/components/labeled-value.scss
+++ b/packages/vapor/scss/components/labeled-value.scss
@@ -1,6 +1,9 @@
 .box {
     &.padded {
         padding: 5px $collapsible-box-padding;
+        > div.flex.flex-center  {
+            align-items: baseline;
+        }
     }
 
     .label,

--- a/packages/vapor/scss/components/modal.scss
+++ b/packages/vapor/scss/components/modal.scss
@@ -218,6 +218,7 @@ $icon-size: (4em / 3);
         & .icon {
             width: $icon-size;
             height: $icon-size;
+            fill: var(--pure-white);
         }
     }
 }

--- a/packages/vapor/scss/controls/input-field.scss
+++ b/packages/vapor/scss/controls/input-field.scss
@@ -85,7 +85,6 @@
         top: 10px;
         left: 0;
         z-index: 0;
-        display: flex; // Used for inline-help-tooltip placement
         box-sizing: content-box;
         height: 100%;
         color: var(--lynch);

--- a/packages/vapor/scss/elements/btn-append-prepend.scss
+++ b/packages/vapor/scss/elements/btn-append-prepend.scss
@@ -12,11 +12,11 @@
 
             &.mod-icon {
                 padding: 8px;
-                fill: var(--button-append-icon-color);
+                fill: var(--button-secondary-icon-color);
             }
 
             svg {
-                fill: var(--button-append-icon-color);
+                fill: var(--button-secondary-icon-color);
             }
         }
 
@@ -43,6 +43,17 @@
             .btn-append,
             .btn-prepend {
                 display: none;
+            }
+        }
+
+        &:hover {
+            &.mod-icon {
+                padding: 8px;
+                fill: var(--button-secondary-hover-icon-color);
+            }
+
+            svg {
+                fill: var(--button-secondary-hover-icon-color);
             }
         }
     }

--- a/packages/vapor/scss/elements/btn-append-prepend.scss
+++ b/packages/vapor/scss/elements/btn-append-prepend.scss
@@ -12,11 +12,11 @@
 
             &.mod-icon {
                 padding: 8px;
-                fill: var(--button-secondary-icon-color);
+                fill: var(--black);
             }
 
             svg {
-                fill: var(--button-secondary-icon-color);
+                fill: var(--black);
             }
         }
 
@@ -49,11 +49,11 @@
         &:hover {
             &.mod-icon {
                 padding: 8px;
-                fill: var(--button-secondary-hover-icon-color);
+                fill: var(--digital-blue-80);
             }
 
             svg {
-                fill: var(--button-secondary-hover-icon-color);
+                fill: var(--digital-blue-80);
             }
         }
     }

--- a/packages/vapor/scss/forms/block-form.scss
+++ b/packages/vapor/scss/forms/block-form.scss
@@ -53,7 +53,7 @@ form {
         .labeled-tooltip {
             width: 15px;
             height: 15px;
-            fill: var(--tooltip-icon-color);
+            fill: var(--digital-blue-60);
         }
 
         &.checkbox-label,

--- a/packages/vapor/scss/forms/block-form.scss
+++ b/packages/vapor/scss/forms/block-form.scss
@@ -53,6 +53,7 @@ form {
         .labeled-tooltip {
             width: 15px;
             height: 15px;
+            fill: var(--tooltip-icon-color);
         }
 
         &.checkbox-label,

--- a/packages/vapor/scss/icons/icons.scss
+++ b/packages/vapor/scss/icons/icons.scss
@@ -8,6 +8,10 @@
         fill: var(--documentation-link-icon-color);
     }
 
+    &.tooltip-icon {
+        fill: var(--tooltip-icon-color);
+    }
+
     &.mod-small {
         width: 0.7em;
         height: 0.7em;

--- a/packages/vapor/scss/icons/icons.scss
+++ b/packages/vapor/scss/icons/icons.scss
@@ -9,7 +9,7 @@
     }
 
     &.tooltip-icon {
-        fill: var(--tooltip-icon-color);
+        fill: var(--digital-blue-60);
     }
 
     &.mod-small {
@@ -24,7 +24,7 @@
 
     &.mod-align-with-text {
         line-height: 16px;
-        vertical-align: -2px;
+        vertical-align: -4px;
     }
 
     @for $i from 5 through 15 {

--- a/packages/vapor/scss/redesign/variables.scss
+++ b/packages/vapor/scss/redesign/variables.scss
@@ -111,7 +111,6 @@
 
     // Icon
     --documentation-link-icon-color: var(--digital-blue-60);
-    --tooltip-icon-color: var(--digital-blue-60);
 
     // Tab
     --tab-font-size: #{$button-font-size};

--- a/packages/vapor/scss/redesign/variables.scss
+++ b/packages/vapor/scss/redesign/variables.scss
@@ -111,6 +111,7 @@
 
     // Icon
     --documentation-link-icon-color: var(--digital-blue-60);
+    --tooltip-icon-color: var(--digital-blue-60);
 
     // Tab
     --tab-font-size: #{$button-font-size};


### PR DESCRIPTION
### Proposed Changes

Changed the info/tooltip/link icons that had the wrong color for 

- FilePicker
- LabeledValue (with alignement for the icon itself)
- LinkSvg
- ModalWindow
- TextInput


I've also changed the `X` to close a modal since it was not white anymore. I've tried to create classname that were relevant to the situation, but i'm open to any suggestion

Before: 

![image](https://user-images.githubusercontent.com/52010042/109203048-afd65080-7771-11eb-8b67-1871fa1b7f6b.png)

![image](https://user-images.githubusercontent.com/52010042/109203075-b795f500-7771-11eb-9c44-8b5641c027b7.png)

![image](https://user-images.githubusercontent.com/52010042/109203103-bf559980-7771-11eb-8aa0-5bbbd2293870.png)

![image](https://user-images.githubusercontent.com/52010042/109203117-c4b2e400-7771-11eb-82e8-78d3a0d50c17.png)

![image](https://user-images.githubusercontent.com/52010042/109203177-d5fbf080-7771-11eb-89f6-e08d651d58b1.png)

After:
![image](https://user-images.githubusercontent.com/52010042/109202260-c7f9a000-7770-11eb-9b3e-3e8ec3696ef5.png)
![image](https://user-images.githubusercontent.com/52010042/109202283-cfb94480-7770-11eb-82c7-4cd40476cd89.png)

![image](https://user-images.githubusercontent.com/52010042/109202346-dfd12400-7770-11eb-868f-7b95f7eadc96.png)

![image](https://user-images.githubusercontent.com/52010042/109202479-08f1b480-7771-11eb-82f8-f23e9a758c89.png)

![image](https://user-images.githubusercontent.com/52010042/109202545-1a3ac100-7771-11eb-9b27-058f299fad65.png)

![image](https://user-images.githubusercontent.com/52010042/109202596-2757b000-7771-11eb-8094-b9a0a41efc81.png)
![image](https://user-images.githubusercontent.com/52010042/109202672-3c344380-7771-11eb-8a29-9bf262fe047f.png)


### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
