### PR TITLE
Ad UI 6648 fix borders in demo component in vapor

### DIFF
--- a/packages/vapor/scss/controls/filter-box.scss
+++ b/packages/vapor/scss/controls/filter-box.scss
@@ -62,6 +62,10 @@
         padding-right: 40px;
         padding-left: 20px;
 
+        &:focus {
+            outline-color: var(--green);
+        }
+
         &::-ms-clear {
             display: none;
         }

--- a/packages/vapor/scss/elements/btn-append-prepend.scss
+++ b/packages/vapor/scss/elements/btn-append-prepend.scss
@@ -15,6 +15,10 @@
                 fill: var(--button-append-icon-color);
             }
 
+            .icon {
+                display: inline-flex;
+            }
+
             svg {
                 fill: var(--button-append-icon-color);
             }


### PR DESCRIPTION
### Proposed Changes

Button with append/prepend Svg had a weird contour that I fixed and FilterBox did not have :focus border

before: 

![image](https://user-images.githubusercontent.com/52010042/109226172-4fa0d800-778c-11eb-9683-5dd498af187a.png)

![image](https://user-images.githubusercontent.com/52010042/109226195-5891a980-778c-11eb-9ac5-5d8c05131580.png)

After:

![image](https://user-images.githubusercontent.com/52010042/109226226-63e4d500-778c-11eb-8219-c70f4844cfa4.png)

![image](https://user-images.githubusercontent.com/52010042/109226246-69dab600-778c-11eb-9641-9737acbf15b6.png)

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
