### PR TITLE
feat(table-hoc-predicate): add generic tableWithPredicate

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableWithPredicate.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithPredicate.tsx
@@ -15,9 +15,10 @@ import * as styles from './styles/TableWithPredicates.scss';
 import {ITableHOCOwnProps} from './TableHOC';
 import {TableHOCUtils} from './utils/TableHOCUtils';
 
-export interface IPredicateComponentProps extends Partial<ITableWithPredicateStateProps>,
-ITableHOCOwnProps,
-WithServerSideProcessingProps {
+export interface IPredicateComponentProps
+    extends Partial<ITableWithPredicateStateProps>,
+        ITableHOCOwnProps,
+        WithServerSideProcessingProps {
     id: string;
 }
 
@@ -46,9 +47,7 @@ const defaultMatchPredicate = (predicate: string, datum: any) =>
 type TableWithPredicateComponent = React.ComponentType<ITableWithPredicateProps>;
 export const tableWithPredicateGeneric = (supplier: ConfigSupplier<ITableWithPredicateGenericConfig>) => (
     PredicateComponent: PredicateComponentType
-) => (
-    TableComponent: TableWithPredicateComponent
-): TableWithPredicateComponent => {
+) => (TableComponent: TableWithPredicateComponent): TableWithPredicateComponent => {
     const config = HocUtils.supplyConfig(supplier);
 
     const mapStateToProps = (
@@ -95,7 +94,7 @@ export const tableWithPredicateGeneric = (supplier: ConfigSupplier<ITableWithPre
 
             const predicateComponentProps = {
                 ...newProps,
-                id: key
+                id: key,
             };
 
             const predicateAction = (
@@ -130,15 +129,13 @@ export const tableWithPredicate = (supplier: ConfigSupplier<ITableWithPredicateC
     const config = HocUtils.supplyConfig(supplier);
 
     return tableWithPredicateGeneric({
-        ...config
-    })(
-      (props) => (
-            <SingleSelectConnected
-                id={props.id}
-                items={config.values}
-                buttonPrepend={config.prepend}
-                isLoading={props.isLoading}
-            />
-        )
-    );
+        ...config,
+    })((props) => (
+        <SingleSelectConnected
+            id={props.id}
+            items={config.values}
+            buttonPrepend={config.prepend}
+            isLoading={props.isLoading}
+        />
+    ));
 };


### PR DESCRIPTION

https://coveord.atlassian.net/browse/SEARCHAPI-5681

### Proposed Changes

Added a new tableWithPredicateGeneric which wraps a custom parameter.

I need to have a tableWithPredicate with another type of single selected. Instead of copying the whole file, I decided to make a generic one that takes a component as a parameter.

<!-- Explain what are your changes. -->

### Potential Breaking Changes

Since I moved some interfaces to the `tableWithPredicateGenerate` file, I exported the interface in `tableWithPredicate` as well.

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
