### PR TITLE
fix(next): clearable date picker dropdown connected

### DIFF
--- a/packages/react-vapor/src/components/datePicker/DatePicker.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePicker.tsx
@@ -1,9 +1,10 @@
 import classNames from 'classnames';
 import * as React from 'react';
+
 import {DateUtils} from '../../utils/DateUtils';
 import {DateLimits} from './DatePickerActions';
-import {SetToNowButton} from './SetToNowButton';
 import {DEFAULT_DATE_PICKER_COLOR} from './DatePickerConstants';
+import {SetToNowButton} from './SetToNowButton';
 
 export interface IDatePickerProps extends React.ClassAttributes<DatePicker> {
     onBlur: (date: Date, isUpperLimit: boolean) => void;
@@ -77,7 +78,7 @@ export class DatePicker extends React.PureComponent<IDatePickerProps, {isSelecte
 
         const inputClasses = classNames({
             'picking-date': this.state.isSelected,
-            'date-picked': !this.state.isSelected && this.dateInput?.value,
+            'date-picked': !this.state.isSelected && !!this.props.date,
         });
 
         return (

--- a/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
@@ -168,7 +168,7 @@ export class DatePickerBox extends React.Component<IDatePickerBoxProps, any> {
 
     private getClearOptions(): JSX.Element {
         return this.props.isClearable ? (
-            <button type="button" onClick={() => this.props.onClear()} className="clear-selection-button mt2">
+            <button type="button" onClick={this.props.onClear} className="clear-selection-button btn mt2">
                 {this.props.clearLabel}
             </button>
         ) : null;

--- a/packages/vapor/scss/components/calendar.scss
+++ b/packages/vapor/scss/components/calendar.scss
@@ -324,19 +324,17 @@
 
 .clear-selection-button {
     display: block;
-    box-sizing: border-box;
     width: 100%;
     padding: $dropdown-choices-top-bottom-margin;
-    color: var(--navy-blue-80);
     font-size: $button-font-size;
-    background: none;
-    border: $default-border;
-    border-radius: $border-radius;
-
-    cursor: pointer;
+    border: $button-border-width solid var(--navy-blue-80);
 
     &:hover {
-        background-color: $date-picker-button-hover-bg;
+        border-color: var(--digital-blue-80);
+    }
+
+    &:active {
+        border-color: var(--digital-blue-100);
     }
 }
 

--- a/packages/vapor/scss/controls/multiline-field.scss
+++ b/packages/vapor/scss/controls/multiline-field.scss
@@ -88,7 +88,7 @@
             display: block;
             width: 18px;
             height: 18px;
-            border: 2px solid var(--button-secondary-disabled-icon-color);
+            border: 2px solid var(--grey-60);
             border-radius: 18px;
 
             &.add-action {
@@ -103,7 +103,7 @@
                     display: block;
                     width: 10px;
                     height: 2px;
-                    background-color: var(--button-secondary-disabled-icon-color);
+                    background-color: var(--grey-60);
                     content: '';
                 }
             }

--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -9,7 +9,7 @@
     box-sizing: border-box;
     height: $button-height;
     padding: $button-padding-y $button-padding-x;
-    color: var(--button-secondary-text-color);
+    color: var(--navy-blue-80);
     font-weight: var(--main-font-bold);
     font-size: var(--button-font-size);
     font-family: var(--main-font);
@@ -19,52 +19,53 @@
     text-decoration: none;
     text-overflow: ellipsis;
     vertical-align: middle;
-    background-color: var(--button-secondary-color);
-    border: $button-border-width solid var(--button-secondary-border-color);
+    background-color: var(--pure-white);
+    border: $button-border-width solid var(--navy-blue-80);
     border-radius: $border-radius;
 
     cursor: pointer;
 
     .icon {
-        fill: var(--button-secondary-icon-color);
+        fill: var(--navy-blue-80);
     }
 
     &:active {
-        color: var(--button-secondary-active-text-color);
-        border-color: var(--button-secondary-active-border-color);
+        color: var(--digital-blue-100);
+        border-color: var(--digital-blue-100);
 
         .icon {
-            fill: var(--button-secondary-active-text-color);
+            fill: var(--digital-blue-100);
         }
     }
+
     &:focus {
         @include button-focus(0px);
-        color: var(--button-secondary-text-color);
+        color: var(--navy-blue-80);
         text-decoration: none;
-        background-color: var(--button-secondary-focus-color);
-        outline-color: var(--button-secondary-focus-border-color);
+        background-color: var(--pure-white);
+        outline-color: var(--green);
     }
 
     &:hover {
-        color: var(--button-secondary-hover-text-color);
-        border-color: var(--button-secondary-hover-border-color);
-        outline-color: var(--button-secondary-hover-border-color);
+        color: var(--digital-blue-80);
+        border-color: var(--digital-blue-80);
+        outline-color: var(--digital-blue-80);
 
         .icon {
-            fill: var(--button-secondary-hover-icon-color);
+            fill: var(--digital-blue-80);
         }
     }
 
     &:disabled,
     &.state-disabled {
-        color: var(--button-secondary-disabled-text-color);
-        background-color: var(--button-secondary-disabled-color);
-        border-color: var(--button-secondary-disabled-border-color);
+        color: var(--grey-60);
+        background-color: var(--grey-20);
+        border-color: var(--grey-40);
         cursor: default;
         pointer-events: none;
 
         .icon {
-            fill: var(--button-secondary-disabled-icon-color);
+            fill: var(--grey-60);
         }
     }
 
@@ -72,7 +73,7 @@
         height: $button-small-height;
         padding: $button-small-padding-y $button-small-padding-x;
         font-size: $button-small-font-size;
-        line-height: var(--button-small-line-height);
+        line-height: $button-small-line-height;
     }
 
     &.mod-large {

--- a/packages/vapor/scss/redesign/fonts.scss
+++ b/packages/vapor/scss/redesign/fonts.scss
@@ -37,7 +37,6 @@
     --button-font-size: #{$button-font-size};
     --button-line-height: #{$button-line-height};
     --button-small-font-size: #{$button-small-font-size};
-    --button-small-line-height: #{$button-small-line-height};
 
     // Dropdown
     --dropdown-button-font-size: #{$dropdown-button-font-size};

--- a/packages/vapor/scss/redesign/variables.scss
+++ b/packages/vapor/scss/redesign/variables.scss
@@ -43,28 +43,6 @@
     --button-primary-disabled-text-color: var(--grey-60);
     --button-primary-disabled-icon-color: var(--grey-60);
 
-    // Secondary
-    --button-secondary-color: var(--white);
-    --button-secondary-text-color: var(--navy-blue-80);
-    --button-secondary-border-color: var(--navy-blue-80);
-    --button-secondary-icon-color: var(--navy-blue-80);
-
-    --button-secondary-hover-border-color: var(--digital-blue-80);
-    --button-secondary-hover-text-color: var(--digital-blue-80);
-    --button-secondary-hover-icon-color: var(--digital-blue-80);
-    --button-secondary-hover-focus-color: var(--white);
-
-    --button-secondary-focus-border-color: var(--green);
-    --button-secondary-focus-color: var(--white);
-
-    --button-secondary-active-border-color: var(--digital-blue-100);
-    --button-secondary-active-text-color: var(--digital-blue-100);
-
-    --button-secondary-disabled-color: var(--grey-20);
-    --button-secondary-disabled-text-color: var(--grey-60);
-    --button-secondary-disabled-icon-color: var(--grey-60);
-    --button-secondary-disabled-border-color: var(--grey-40);
-
     // Danger
     --button-danger-default-text-color: var(--white);
     --button-danger-default-icon-color: var(--white);
@@ -86,7 +64,6 @@
     --button-link-hover-color: var(--success-40);
     --button-font-size: var(--default-font-size);
     --button-line-height: 20px;
-    --button-small-line-height: 17px;
     --button-text-transform: none;
     --button-no-tag-button-padding-y: 9px;
     --button-padding-x: 16px;

--- a/packages/vapor/scss/utility/spaced-boxes.scss
+++ b/packages/vapor/scss/utility/spaced-boxes.scss
@@ -9,6 +9,6 @@
     color: var(--pure-white);
 
     &.mod-secondary {
-        color: var(--button-secondary-text-color);
+        color: var(--navy-blue-80);
     }
 }

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -55,7 +55,7 @@ $button-border-width: 1px;
 $button-height: 34px;
 $button-margin-width: 10px;
 $button-small-font-size: 11px;
-$button-small-line-height: 14px;
+$button-small-line-height: 17px;
 $button-small-padding-x: 10px;
 $button-small-padding-y: 4px;
 $button-small-height: 24px;


### PR DESCRIPTION
### Proposed Changes

- If we select the start date and the end date, then click on the **Clear** button, the end date background is stuck on blue.

The lifecycle `componentDidUpdate` is executed after the `render` method, and we can no longer use `componentWillReceiveProps` which happened before the `render` since it’s deprecated. Instead, we can directly use the `props.date` to identify if the date input has value and needs the `.date-picked` class.

- Fixed the **Clear** button style and did a cleanup on `--button-secondary` CSS variables.

Before:
![image](https://user-images.githubusercontent.com/52677246/109359281-357dfd00-7853-11eb-9d6b-76b0fce8a712.png)

After:
![Peek 2021-02-26 16-05](https://user-images.githubusercontent.com/52677246/109359208-0cf60300-7853-11eb-8555-3c032c920564.gif)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
