### PR TITLE
Fix com 479 fixed input spacing

### DIFF
--- a/packages/demo/src/components/examples/SectionExamples.tsx
+++ b/packages/demo/src/components/examples/SectionExamples.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
     Form,
     Input,
+    InputConnected,
     Label,
     LabeledInput,
     Radio,
@@ -22,7 +23,7 @@ export class SectionExamples extends React.Component<any, any> {
                         title="Search panel"
                         description="Customizing the display and behavior of the interface displayed withing the search panel can be done by editing the code of your search interface directly or via the JavaScript Search Interface Editor. As for style, it can be modified by applying your own stylesheet or adding styling rules in the Advanced tab."
                     >
-                        <Section title="Main button" level={2}>
+                        <Section title="Main button">
                             <LabeledInput
                                 label="Location on screen"
                                 helpText="The widget button's position is fixed, which means it is positioned relative to the viewport and stays in the same place even if the page is scrolled."
@@ -37,7 +38,7 @@ export class SectionExamples extends React.Component<any, any> {
                                     </Radio>
                                 </RadioSelect>
                             </LabeledInput>
-                            <Section title="Content" level={2}>
+                            <Section title="Content">
                                 <LabeledInput helpText="The text that appears on the main widget button.">
                                     <Input value="Help">
                                         <Label>Text</Label>
@@ -69,13 +70,56 @@ export class SectionExamples extends React.Component<any, any> {
                 </Form>
 
                 <Form className="mt4">
-                    <Section title="Define your products structure" description="Inputs inside a Section of level 1">
+                    <Section
+                        title="This is the prefered way of using Sections, insert the section title here."
+                        description="Use this as a description for the section"
+                    >
+                        <LabeledInput
+                            label="Wrap components that do not expose a label into this <LabeledInput /> component."
+                            helpText="This `helpText` attribute helps the user understand which value to choose."
+                        >
+                            <SingleSelectConnected
+                                id="first"
+                                items={[
+                                    {
+                                        selected: true,
+                                        value: 'Product',
+                                    },
+                                    {
+                                        selected: false,
+                                        value: 'Variant',
+                                    },
+                                ]}
+                            />
+                        </LabeledInput>
+                        <InputConnected id="some-input" labelTitle="Label" />
+                        <LabeledInput
+                            label="Location on screen"
+                            helpText="The widget button's position is fixed, which means it is positioned relative to the viewport and stays in the same place even if the page is scrolled."
+                            optionalInformation="INFORMATION"
+                        >
+                            <RadioSelect>
+                                <Radio value="1">
+                                    <Label>Value 1</Label>
+                                </Radio>
+                                <Radio value="2">
+                                    <Label>Value 2</Label>
+                                </Radio>
+                            </RadioSelect>
+                        </LabeledInput>
+                    </Section>
+                </Form>
+                <Form className="mt4">
+                    <Section
+                        title="These sections help you understand the various level spacing"
+                        description="Each level has a different margin between each direct child. If you have extra spacing that you don't want, wrap the components into a single div to remove some spacing."
+                    >
                         <LabeledInput
                             label="Product Object Type"
                             helpText="Select the object type value that identifies a Product object"
                         >
                             <SingleSelectConnected
-                                id="first"
+                                id="first-level-1"
                                 items={[
                                     {
                                         selected: true,
@@ -94,7 +138,7 @@ export class SectionExamples extends React.Component<any, any> {
                             message="31 different products identified"
                         >
                             <SingleSelectConnected
-                                id="second"
+                                id="second-level-1"
                                 items={[
                                     {
                                         selected: true,
@@ -114,7 +158,7 @@ export class SectionExamples extends React.Component<any, any> {
                             helpText="Select the object type value that identifies a Product object"
                         >
                             <SingleSelectConnected
-                                id="first"
+                                id="first-level-2"
                                 items={[
                                     {
                                         selected: true,
@@ -133,7 +177,7 @@ export class SectionExamples extends React.Component<any, any> {
                             message="31 different products identified"
                         >
                             <SingleSelectConnected
-                                id="second"
+                                id="second-level-2"
                                 items={[
                                     {
                                         selected: true,
@@ -153,7 +197,7 @@ export class SectionExamples extends React.Component<any, any> {
                             helpText="Select the object type value that identifies a Product object"
                         >
                             <SingleSelectConnected
-                                id="first"
+                                id="first-level-3"
                                 items={[
                                     {
                                         selected: true,
@@ -172,7 +216,7 @@ export class SectionExamples extends React.Component<any, any> {
                             message="31 different products identified"
                         >
                             <SingleSelectConnected
-                                id="second"
+                                id="second-level-3"
                                 items={[
                                     {
                                         selected: true,

--- a/packages/vapor/scss/forms/block-form.scss
+++ b/packages/vapor/scss/forms/block-form.scss
@@ -85,7 +85,7 @@ form {
                 }
 
                 > *:not(:first-child) {
-                    margin-top: $scaledSpacing;
+                    margin-top: 0.5rem;
                 }
             }
             > .btn {


### PR DESCRIPTION
[COM-479]

### Proposed Changes

This change is an attempt to simplify the `Section` component while also integrating UX suggestions to have inputs with text closer together.

In short, most of the mock-ups always require the `Section level={3}` around every individual input. This is pretty annoying to do, so this change aims at making it very simple.

So we now enforce the `level 3` spacing between *within* a `LabeledInput` instead of *scaling with the level*. This ensures that the margin is minimal between the label, input, and help text.

The new recommended structure of a Form would be: 

```
<Form> 
  <Section title="Something">
    <LabeledInput>
       <ComponentThatDoesNotHaveItsOwnLabel />
    </LabeledInput>
    <ComponentThatProvidesItsOwnLabel />
  </Section>
  <Section title="Another thing">
     ...
  </Section>
</Form>
```

The only reason to use `level={2 | 3}` is now to have a determined *label* between the sections, not simply to provide a specific spacing.

Before: 

![image](https://user-images.githubusercontent.com/8355585/109675031-67d67580-7b45-11eb-82ef-699aa2bbd094.png)

After:

![image](https://user-images.githubusercontent.com/8355585/109676183-72453f00-7b46-11eb-8f92-bce9de679ad9.png)

### Potential Breaking Changes

Everywhere that uses `<LabeledInput />` under a section in the admin will be affected.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-479]: https://coveord.atlassian.net/browse/COM-479