### PR TITLE
fix(validation): prop to show validation message only if dirty

### DIFF
--- a/packages/react-vapor/src/components/validation/components/ValidationMessage.tsx
+++ b/packages/react-vapor/src/components/validation/components/ValidationMessage.tsx
@@ -8,9 +8,11 @@ import {ValidationSelectors} from '../ValidationSelectors';
 
 export interface IValidationMessageProps {
     id: string;
+    onlyShowIfDirty?: boolean;
 }
 
 const mapStateToProps = (state: IReactVaporState, ownProps: IValidationMessageProps) => ({
+    isDirty: ValidationSelectors.getIsDirty(ownProps.id)(state),
     errors: ValidationSelectors.getErrors(ownProps.id)(state),
     warnings: ValidationSelectors.getWarnings(ownProps.id)(state),
 });
@@ -26,15 +28,17 @@ export const ValidationMessageClasses = {
 
 export const ValidationMessageDisconnect: React.FunctionComponent<
     IValidationMessageProps & ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>
-> = ({errors, warnings, cleanMessage}) => {
+> = ({onlyShowIfDirty, isDirty, errors, warnings, cleanMessage}) => {
     React.useEffect(() => () => cleanMessage(), []);
 
+    const hasDirty = !onlyShowIfDirty || isDirty.some((dirty) => dirty.value);
     const hasErrors = errors.length > 0;
     const hasWarnings = warnings.length > 0;
     const eitherErrorsOrWarnings = hasErrors ? errors : warnings;
     return (
         <>
-            {(hasErrors || hasWarnings) &&
+            {hasDirty &&
+                (hasErrors || hasWarnings) &&
                 eitherErrorsOrWarnings.map(({validationType, value}) => (
                     <span
                         key={validationType}

--- a/packages/react-vapor/src/components/validation/components/tests/ValidationMessage.spec.tsx
+++ b/packages/react-vapor/src/components/validation/components/tests/ValidationMessage.spec.tsx
@@ -119,4 +119,58 @@ describe('ValidationMessage', () => {
         expect(result.find(`.${ValidationMessageClasses.error}`).length).toBe(1);
         expect(result.find(`.${ValidationMessageClasses.warning}`).length).toBe(0);
     });
+
+    describe('with the onlyShowIfDirty flag', () => {
+        it('should render nothing when there are errors and warnings but the component is not dirty', () => {
+            const result = shallowWithState(
+                <ValidationMessage {...defaultProps} onlyShowIfDirty />,
+                getStateForExistingComponent({
+                    isDirty: [
+                        {validationType: nonEmptyValidationType, value: false},
+                        {validationType: 'somethingelse', value: false},
+                    ],
+                    error: [
+                        {
+                            validationType: nonEmptyValidationType,
+                            value: nonEmptyMessage,
+                        },
+                    ],
+                    warning: [
+                        {
+                            validationType: 'somethingelse',
+                            value: 'ohno',
+                        },
+                    ],
+                })
+            ).dive();
+
+            expect(result.find(`.${ValidationMessageClasses.error}`).length).toBe(0);
+            expect(result.find(`.${ValidationMessageClasses.warning}`).length).toBe(0);
+        });
+
+        it('should render errors when there are errors and the component is dirty', () => {
+            const result = shallowWithState(
+                <ValidationMessage {...defaultProps} onlyShowIfDirty />,
+                getStateForExistingComponent({
+                    isDirty: [
+                        {validationType: 'anotherone', value: false},
+                        {validationType: nonEmptyValidationType, value: true},
+                    ],
+                    error: [
+                        {
+                            validationType: nonEmptyValidationType,
+                            value: nonEmptyMessage,
+                        },
+                        {
+                            validationType: 'anotherone',
+                            value: 'wow',
+                        },
+                    ],
+                })
+            ).dive();
+
+            expect(result.find(`.${ValidationMessageClasses.error}`).length).toBe(2);
+            expect(result.find(`.${ValidationMessageClasses.error}`).first().text()).toContain(nonEmptyMessage);
+        });
+    });
 });

--- a/packages/react-vapor/src/components/validation/hoc/WithValidationMessageHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithValidationMessageHOC.tsx
@@ -1,13 +1,18 @@
 import * as React from 'react';
 import {ValidationMessage} from '../components/ValidationMessage';
 
-export const withValidationMessage = <T extends {id?: string}, R = any>(
+interface IWithValidationMessageHOCProps {
+    id?: string;
+    onlyShowMessageIfDirty?: boolean;
+}
+
+export const withValidationMessage = <T extends IWithValidationMessageHOCProps, R = any>(
     Component: React.ComponentClass<T, R> | React.FunctionComponent<T>
-) => (props: T) => (
+) => ({onlyShowMessageIfDirty, ...props}: T) => (
     <>
         <Component {...(props as T)} />
         <div>
-            <ValidationMessage id={props.id!} />
+            <ValidationMessage id={props.id!} onlyShowIfDirty={onlyShowMessageIfDirty} />
         </div>
     </>
 );


### PR DESCRIPTION
[COM-900]

### Proposed Changes

We needed some use cases where the message should not be shown if the component is not dirty.

So I decided to add a simple prop to make it very easy to support that.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-900]: https://coveord.atlassian.net/browse/COM-900