### PR TITLE
fix(infinite-scroll): use the infinite scroll only when the select is open

### DIFF
--- a/packages/react-vapor/src/components/listBox/ListBox.tsx
+++ b/packages/react-vapor/src/components/listBox/ListBox.tsx
@@ -127,7 +127,7 @@ export class ListBox extends React.Component<IListBoxProps> {
         const items = this.props.isLoading ? this.getLoadingItems() : this.getItems();
         return (
             <>
-                <ul className={this.getClasses()} id={this.props.id}>
+                <ul className={this.getClasses()} id={`${this.props.id}-container`}>
                     {this.props.wrapItems(items)}
                 </ul>
                 {this.props.footer}

--- a/packages/react-vapor/src/components/loading/Loading.tsx
+++ b/packages/react-vapor/src/components/loading/Loading.tsx
@@ -32,6 +32,8 @@ export class Loading extends React.Component<ILoadingProps & React.HTMLProps<HTM
     render() {
         return (
             <div
+                role="alert"
+                aria-busy="true"
                 className={classNames('spinner', this.props.className, {
                     'flex center-align flex-auto full-content-y': this.props.fullContent,
                 })}


### PR DESCRIPTION
### Proposed Changes

Use the infinite scroll only when the select is open
Removed all the tests that only get the props. Tested the actual behaviour instead

### Potential Breaking Changes

None that I can think of

### Acceptance Criteria

-   [X] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
