### PR TITLE
fix(singleselect): change the selected value if the items change

### DIFF
--- a/packages/demo/src/components/examples/SingleSelectExamples.tsx
+++ b/packages/demo/src/components/examples/SingleSelectExamples.tsx
@@ -24,6 +24,7 @@ import {
     withDirtySingleSelectHOC,
     withNonEmptySingleSelectHOC,
     ValidationMessage,
+    Label,
 } from 'react-vapor';
 
 import * as _ from 'underscore';
@@ -194,8 +195,58 @@ const SingleSelectConnectedExamples: React.ComponentType = () => (
                 name="An example button bound to the select"
             />
         </Section>
+        <Section
+            level={3}
+            title="A single select with a changing initial value"
+            description="This proves that you can change the selected item at runtime and it will properly update the input."
+        >
+            <SingleSelectWithChangingSelectedValue />
+            <SingleSelectWithChangingItems />
+        </Section>
     </Section>
 );
+
+const SingleSelectWithChangingSelectedValue = () => {
+    const [selectedIndex, setSelectedIndex] = React.useState(0);
+    return (
+        <>
+            <div>
+                <SingleSelectConnected
+                    id="changing-value"
+                    items={defaultItems.map((item, index) => ({
+                        ...item,
+                        selected: selectedIndex === index,
+                    }))}
+                    canClear
+                />
+            </div>
+            <div>
+                <Button onClick={() => setSelectedIndex((selectedIndex + 1) % defaultItems.length)}>
+                    Click me to select the next value
+                </Button>
+                <Label>Locally selected value: {defaultItems[selectedIndex].displayValue}</Label>
+            </div>
+        </>
+    );
+};
+
+const SingleSelectWithChangingItems = () => {
+    const [selectedIndex, setSelectedIndex] = React.useState(0);
+    const possibleItemsChoices = [defaultItems, itemsWithASelectedItem];
+    return (
+        <>
+            <div>
+                <SingleSelectConnected id="changing-items" items={possibleItemsChoices[selectedIndex]} canClear />
+            </div>
+            <div>
+                <Button onClick={() => setSelectedIndex((selectedIndex + 1) % possibleItemsChoices.length)}>
+                    Click me to change the items
+                </Button>
+                <Label>Locally selected items set: {selectedIndex}</Label>
+            </div>
+        </>
+    );
+};
 
 const MyCustomButton: React.FunctionComponent<ISelectButtonProps> = ({onClick, selectedOptions}) => {
     const option = selectedOptions[0];

--- a/packages/react-vapor/src/components/select/SelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SelectConnected.tsx
@@ -13,7 +13,7 @@ import {Drop} from '../drop/Drop';
 import {IDropPodProps} from '../drop/DropPod';
 import {IItemBoxProps} from '../itemBox/ItemBox';
 import {IItemBoxPropsWithIndex, IListBoxOwnProps} from '../listBox/ListBox';
-import {selectListBoxOption, setActiveListBoxOption} from '../listBox/ListBoxActions';
+import {selectListBoxOption, setActiveListBoxOption, unselectListBoxOption} from '../listBox/ListBoxActions';
 import {ListBoxConnected} from '../listBox/ListBoxConnected';
 import {addSelect, removeSelect, toggleSelect} from './SelectActions';
 import {SelectSelector} from './SelectSelector';
@@ -58,6 +58,7 @@ const mapDispatchToProps = (dispatch: IDispatch, ownProps: ISelectOwnProps) => (
     selectValue: (value: string, isMulti: boolean, index?: number) => {
         dispatch(selectListBoxOption(ownProps.id, isMulti, value, index));
     },
+    deselectValue: (value: string) => dispatch(unselectListBoxOption(ownProps.id, value)),
     setActive: (diff: number) => dispatch(setActiveListBoxOption(ownProps.id, diff)),
 });
 
@@ -86,6 +87,24 @@ export class SelectConnected extends React.PureComponent<ISelectProps> {
         if ((this.props.isOpened && !this.props.hasFocusableChild) || (wentFromOpenedToClosed && selectionChanged)) {
             this.focusOnButton();
         }
+
+        const previouslySelectedItems = prevProps.items?.filter((item) => item.selected).map((item) => item.value);
+        const currentlySelectedItems = this.props.items?.filter((item) => item.selected).map((item) => item.value);
+
+        const removedItems = _.difference(previouslySelectedItems, currentlySelectedItems);
+        const addedItems = _.difference(currentlySelectedItems, previouslySelectedItems);
+
+        removedItems.forEach((removed) => {
+            prevProps.deselectValue(removed);
+        });
+
+        addedItems.forEach((added) => {
+            this.props.selectValue(
+                added,
+                this.props.multi,
+                this.props.items.findIndex((item) => item.value === added)
+            );
+        });
     }
 
     render() {

--- a/packages/react-vapor/src/components/select/SingleSelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SingleSelectConnected.tsx
@@ -53,6 +53,11 @@ class SingleSelect extends React.PureComponent<ISingleSelectProps> {
     };
 
     componentDidUpdate(prevProps: ISingleSelectProps) {
+        const newSelectedItemValue = this.props.items?.find((item) => item.selected)?.value;
+        if (prevProps.items?.find((item) => item.selected)?.value !== newSelectedItemValue) {
+            this.props.onSelectOptionCallback?.(newSelectedItemValue);
+        }
+
         if (prevProps.selectedOption !== this.props.selectedOption) {
             this.props.onSelectOptionCallback?.(this.props.selectedOption);
         }

--- a/packages/react-vapor/src/components/validation/hoc/WithDirtySingleSelectHOC.tsx
+++ b/packages/react-vapor/src/components/validation/hoc/WithDirtySingleSelectHOC.tsx
@@ -41,7 +41,10 @@ export const withDirtySingleSelectHOC = <T extends ISingleSelectOwnProps>(Compon
             setIsDirty(props.id, initialValue !== selectedValue);
         }, [selectedValue]);
 
-        const itemsWithSelectedInitialValue = items.map((item) => ({...item, selected: item.value === initialValue}));
+        const itemsWithSelectedInitialValue = React.useMemo(
+            () => items.map((item) => ({...item, selected: item.value === initialValue})),
+            [items, initialValue]
+        );
 
         return <Component {...(props as T)} items={itemsWithSelectedInitialValue} />;
     };


### PR DESCRIPTION
[COM-891]

### Proposed Changes

I am really not sure about this fix, so I'm opening this PR as a discussion point :sweat: 

But first, let me explain the exact issue we got:

We use the `withDirtySingleSelectHOC` which exposes the `initialValue` prop. The `items` prop is iterated over to set the `selected` value according to the `initialValue`. So far, so good.

The issue happens when there is some asynchronicity in the thing. The `initialValue` is fetched asynchronously and the `items` are also fetched asynchronously.

So if we update either `initialValue` or `items`, the SingleSelect *stays unselected* because it only uses its *initial items* when rendering to update the state. Regardless of which comes back first, there will never be a selected value. (Note that the issue also occurs if you *update* wither `initialValue` or `items` for some reason)

So this here is an attempt to synchronize any `items` change.

When we explore the `React` component with the debugger, we see the `items` prop with the proper `selected: true` when there was nothing in the Select. I'm finding the new behavior less confusing overall, but I'm still not sure this is the right way :man_shrugging:  

----

Another solution could be to dispatch a single `setValue` to update the state when the `initialValue` changes, but it does not cover the case where you get the initialValue *first* and update the items afterward.

### Potential Breaking Changes

If anything used to rely on `items` update not doing anything, it could "clear" the currently selected value.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-891]: https://coveord.atlassian.net/browse/COM-891