### PR TITLE
fix(rebranding): radio shadow and facet button line-height

### DIFF
--- a/packages/react-vapor/src/components/select/SelectConnected.tsx
+++ b/packages/react-vapor/src/components/select/SelectConnected.tsx
@@ -151,7 +151,11 @@ export class SelectConnected extends React.PureComponent<ISelectProps> {
                     });
                 }
             });
-            return <div className="flex p2 flex-center flex-column mod-border-bottom">{newChildren}</div>;
+            return (
+                <div className="flex p2 flex-center flex-column mod-border-bottom select-dropdown-filter">
+                    {newChildren}
+                </div>
+            );
         }
         return null;
     }

--- a/packages/vapor/scss/components/calendar.scss
+++ b/packages/vapor/scss/components/calendar.scss
@@ -190,7 +190,7 @@
 .options-cycle-button {
     display: inline-block;
     padding: 0;
-    background: none;
+    background-color: var(--white);
     border: none;
 
     cursor: pointer;

--- a/packages/vapor/scss/components/facet.scss
+++ b/packages/vapor/scss/components/facet.scss
@@ -90,6 +90,10 @@
     line-height: $facet-value-line-height;
     cursor: pointer;
 
+    button {
+        line-height: inherit;
+    }
+
     .label {
         display: block;
         flex-grow: 1;

--- a/packages/vapor/scss/controls/checkboxes.scss
+++ b/packages/vapor/scss/controls/checkboxes.scss
@@ -109,7 +109,7 @@
         display: inline-flex;
         align-items: center;
         color: var(--title-text-color);
-        line-height: 16px;
+        line-height: 17px;
         vertical-align: middle; // Required to properly position checkboxes into tables
 
         .label {
@@ -124,6 +124,10 @@
             margin-right: calc(4 * 0.5rem);
             margin-left: 18px;
             cursor: pointer;
+        }
+
+        button {
+            line-height: inherit;
         }
 
         button:disabled + label {

--- a/packages/vapor/scss/controls/dropdown.scss
+++ b/packages/vapor/scss/controls/dropdown.scss
@@ -260,6 +260,10 @@
 
     box-shadow: $list-box-box-shadow;
 
+    .select-dropdown-filter {
+        background-color: var(--grey-20);
+    }
+
     .list-box {
         border: none;
         box-shadow: initial;

--- a/packages/vapor/scss/controls/input-field.scss
+++ b/packages/vapor/scss/controls/input-field.scss
@@ -87,14 +87,14 @@
         z-index: 0;
         box-sizing: content-box;
         height: 100%;
-        color: var(--lynch);
+        color: var(--title-text-color);
         font-size: $input-font-size;
         transition: $input-transition;
 
         &.active {
             top: -1 * $input-margin-top;
             padding-bottom: $input-margin-top;
-            color: var(--lynch);
+            color: var(--title-text-color);
             font-size: $form-control-label-font-size;
         }
     }

--- a/packages/vapor/scss/controls/radios.scss
+++ b/packages/vapor/scss/controls/radios.scss
@@ -72,9 +72,8 @@
             font-weight: var(--main-font-bolder);
 
             &:before {
-                top: 5px;
-                left: 5px;
                 z-index: 1;
+                padding: 5px;
                 background-color: transparent;
                 transform: scale(1);
                 content: url('../../resources/icons/svg/content/radiocheck.svg');

--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -257,6 +257,10 @@
     }
 }
 
+button {
+    font-family: var(--main-font);
+}
+
 .btn-container {
     display: inline-block;
     margin: 0;

--- a/packages/vapor/scss/icons/icons.scss
+++ b/packages/vapor/scss/icons/icons.scss
@@ -5,7 +5,7 @@
     height: 0.9em;
     overflow: visible;
 
-    --fill: currentColor;
+    --fill: inherit;
 
     fill: var(--fill);
 


### PR DESCRIPTION
### Proposed Changes

Fixed facet checkbox button line-height and radio shadow on focus, more adjustments will be done in the admin.

### Potential Breaking Changes

Before:
![image](https://user-images.githubusercontent.com/52677246/110655849-6af8e380-818d-11eb-8b7e-c7730dfef89c.png)
![image](https://user-images.githubusercontent.com/52677246/110655869-70562e00-818d-11eb-814f-fb5de78e3ffb.png)

After:
![image](https://user-images.githubusercontent.com/52677246/110655893-764c0f00-818d-11eb-8eea-d45bcc3de28d.png)
![image](https://user-images.githubusercontent.com/52677246/110655912-7b10c300-818d-11eb-9b99-2b2f2d17533c.png)

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
