### PR TITLE
fix(rebranding): radio button box-shadow on focus

### DIFF
--- a/packages/vapor/scss/controls/checkboxes.scss
+++ b/packages/vapor/scss/controls/checkboxes.scss
@@ -98,6 +98,11 @@
                 position: absolute;
                 content: url('../../resources/icons/svg/content/disabled-undeterminate-checkbox.svg');
             }
+
+            & ~ .help-text,
+            & ~ .description {
+                color: var(--grey-60);
+            }
         }
     }
 

--- a/packages/vapor/scss/controls/radios.scss
+++ b/packages/vapor/scss/controls/radios.scss
@@ -53,7 +53,7 @@
         }
 
         &:focus + label:before {
-            box-shadow: 0 0 0 8px var(--light-grey);
+            box-shadow: 0 0 0 4px var(--light-grey);
         }
 
         &:not(:checked) + label {
@@ -68,12 +68,9 @@
         }
 
         &:checked + label {
-            padding-top: $radio-button-checked-text-padding-top;
-            font-weight: var(--main-font-bolder);
-
             &:before {
                 z-index: 1;
-                padding: 5px;
+                padding: 7px 5px 5px 5px;
                 background-color: transparent;
                 transform: scale(1);
                 content: url('../../resources/icons/svg/content/radiocheck.svg');
@@ -92,12 +89,18 @@
 
         &:disabled {
             & + label {
-                color: var(--medium-grey);
+                color: var(--grey-60);
                 cursor: not-allowed;
 
                 &:before {
                     border-color: var(--grey-40);
                 }
+            }
+
+            & ~ .help-text,
+            & ~ .description,
+            & ~ .mod-align-with-radio-label {
+                color: var(--grey-60);
             }
 
             &:checked + label {

--- a/packages/vapor/scss/controls/radios.scss
+++ b/packages/vapor/scss/controls/radios.scss
@@ -70,7 +70,7 @@
         &:checked + label {
             &:before {
                 z-index: 1;
-                padding: 7px 5px 5px 5px;
+                padding: 6px 5px 5px 5px;
                 background-color: transparent;
                 transform: scale(1);
                 content: url('../../resources/icons/svg/content/radiocheck.svg');

--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -26,7 +26,7 @@
 
     cursor: pointer;
 
-    .icon {
+    .icon:not(.documentation-link) {
         fill: var(--navy-blue-80);
     }
 

--- a/packages/vapor/scss/elements/links.scss
+++ b/packages/vapor/scss/elements/links.scss
@@ -13,7 +13,3 @@ a,
         @include focus-border(-2px);
     }
 }
-
-.icon-link {
-    fill: var(--links-color);
-}

--- a/packages/vapor/scss/icons/icons.scss
+++ b/packages/vapor/scss/icons/icons.scss
@@ -14,11 +14,11 @@
     }
 
     &.no-link {
-        --fill: var(--grey-80);
+        --fill: var(--grey-60);
     }
 
     &.disabled {
-        --fill: var(--grey-60);
+        --fill: var(--grey-40);
     }
 
     &.mod-error {

--- a/packages/vapor/scss/utility/layout.scss
+++ b/packages/vapor/scss/utility/layout.scss
@@ -166,3 +166,13 @@
         z-index: $i;
     }
 }
+
+.background {
+    --background-color: var(--pure-white);
+    background-color: var(--background-color);
+
+    &.mod-light {
+        --background-color: var(--grey-20);
+    }
+    // TODO: add mod-error, mod-dark etc.
+}

--- a/packages/vapor/scss/utility/layout.scss
+++ b/packages/vapor/scss/utility/layout.scss
@@ -174,5 +174,8 @@
     &.mod-light {
         --background-color: var(--grey-20);
     }
+    &.mod-medium {
+        --background-color: var(--grey-40);
+    }
     // TODO: add mod-error, mod-dark etc.
 }

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -72,7 +72,6 @@ $checkbox-default-border: solid 2px var(--navy-blue-80);
 $radio-button-option-height: 18px;
 $radio-button-size: 22px;
 $radio-button-text-padding-top: 5px;
-$radio-button-checked-text-padding-top: 4px;
 
 // Input and textarea
 $input-border: 1px solid var(--lynch);


### PR DESCRIPTION
### Proposed Changes

This PR includes several quick fixes:
- Reduce `box-shadow` of the radio button on focus, and remove `font-weight` bolder if the radio is selected (will update this component later in another user story)
- Set the disabled text color to `--grey-20`
- Remove `icon-link` class, use `icon documentation-link` instead
- Fix icon color for `no-link` and `disabled`
- Add utilities for white and light grey background color, there is no example yet since the mods are not completed

![image](https://user-images.githubusercontent.com/52677246/110826659-4e2edf80-8263-11eb-86c9-4e9801db241d.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
