### PR TITLE
feat(modal-wizard): adding onFinishAsync prop to modal wizard

### DIFF
--- a/packages/demo/src/components/examples/ModalWizardExamples.tsx
+++ b/packages/demo/src/components/examples/ModalWizardExamples.tsx
@@ -128,12 +128,17 @@ const enhanceExample2 = connect(null, (dispatch: IDispatch) => ({
 const ModalWizardWithValidationIdsDisconnected: React.FunctionComponent<ConnectedProps<typeof enhanceExample2>> = ({
     open,
 }) => (
-    <Section level={2} title="ModalWizard with built-in validation ids">
+    <Section level={2} title="ModalWizard with built-in validation ids using onFinishAsync">
         <Button name="Open wizard with validation ids" enabled primary onClick={() => open('validation-wizard')} />
         <ModalWizardWithValidations
             id="validation-wizard"
             title="Wizard 🧙‍♂️"
-            onFinish={() => alert('Congratulations! You completed the wizard')}
+            onFinishAsync={async () => {
+                alert(
+                    'Sorry, you cannot finish this modal! - onFinishAsync prop was used and an error was thrown which will keep this modal open'
+                );
+                throw new Error('Modal stays open because an error is thrown');
+            }}
             validationIdsByStep={[['name-input'], ['favorite-animal-select']]}
         >
             <Form title="Step 1" mods={['mod-form-top-bottom-padding', 'mod-header-padding']}>

--- a/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
+++ b/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import * as React from 'react';
 import {connect} from 'react-redux';
 
+import _ from 'underscore';
 import {ConnectedProps, IDispatch, TooltipPlacement} from '../../utils';
 import {Button} from '../button';
 import {ModalActions} from '../modal/ModalActions';
@@ -90,7 +91,7 @@ const ModalWizardDisconneted: React.FunctionComponent<ModalWizardProps & Connect
                                             onFinish?.();
                                             close();
                                         } else if (onFinishAsync) {
-                                            onFinishAsync()?.then(close);
+                                            onFinishAsync().then(close).catch(_.noop);
                                         }
                                     } else {
                                         setCurrentStep(currentStep + 1);

--- a/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
+++ b/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
@@ -13,6 +13,7 @@ export interface ModalWizardProps
     extends Omit<IModalCompositeOwnProps, 'modalBodyChildren' | 'validateShouldNavigate'> {
     id: string;
     onFinish?: () => unknown;
+    onFinishAsync?: () => Promise<void>;
     validateStep?: (currentStep: number, isLastStep?: boolean) => {isValid: boolean; message?: string};
     isDirty?: boolean;
     cancelButtonLabel?: string;
@@ -29,6 +30,7 @@ const ModalWizardDisconneted: React.FunctionComponent<ModalWizardProps & Connect
     id,
     close,
     onFinish,
+    onFinishAsync,
     children,
     modalFooterChildren,
     validateStep,
@@ -84,8 +86,12 @@ const ModalWizardDisconneted: React.FunctionComponent<ModalWizardProps & Connect
                                 enabled={isValid}
                                 onClick={() => {
                                     if (isLastStep) {
-                                        onFinish?.();
-                                        close();
+                                        if (onFinish) {
+                                            onFinish?.();
+                                            close();
+                                        } else if (onFinishAsync) {
+                                            onFinishAsync()?.then(close);
+                                        }
                                     } else {
                                         setCurrentStep(currentStep + 1);
                                     }

--- a/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
+++ b/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
@@ -113,7 +113,25 @@ describe('ModalWizard', () => {
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
-    it('does not call "onFinishAsync" function when onFinish is provided', async () => {
+    it('calls the "onFinishAsync" prop and the modal stays open after it is rejected', () => {
+        const finishSpy = jest.fn().mockRejectedValue('helloWorld');
+
+        renderModal(
+            <ModalWizard id="🧙‍♂️" onFinishAsync={finishSpy}>
+                <div>Step 1</div>
+                <div>Step 2</div>
+            </ModalWizard>,
+            {initialState: {modals: [{id: '🧙‍♂️', isOpened: true}]}}
+        );
+
+        userEvent.click(screen.getByRole('button', {name: 'Next'}));
+        userEvent.click(screen.getByRole('button', {name: 'Finish'}));
+
+        expect(finishSpy).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('does not call "onFinishAsync" function when onFinish is provided', () => {
         const onFinishSpy = jest.fn();
         const onFinishAsyncSpy = jest.fn();
 
@@ -129,7 +147,6 @@ describe('ModalWizard', () => {
         userEvent.click(screen.getByRole('button', {name: 'Finish'}));
 
         expect(onFinishAsyncSpy).toHaveBeenCalledTimes(0);
-        await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
     });
 
     it('disables the next button if the current step is invalid', () => {

--- a/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
+++ b/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
@@ -91,6 +91,45 @@ describe('ModalWizard', () => {
 
         expect(finishSpy).toHaveBeenCalledTimes(1);
         await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('calls the "onFinishAsync" prop and close the modal when clicking on the "finish" button', async () => {
+        const finishSpy = jest.fn().mockResolvedValue('success!');
+
+        renderModal(
+            <ModalWizard id="🧙‍♂️" onFinishAsync={finishSpy}>
+                <div>Step 1</div>
+                <div>Step 2</div>
+            </ModalWizard>,
+            {initialState: {modals: [{id: '🧙‍♂️', isOpened: true}]}}
+        );
+
+        userEvent.click(screen.getByRole('button', {name: 'Next'}));
+        userEvent.click(screen.getByRole('button', {name: 'Finish'}));
+
+        expect(finishSpy).toHaveBeenCalledTimes(1);
+        await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('does not call "onFinishAsync" function when onFinish is provided', async () => {
+        const onFinishSpy = jest.fn();
+        const onFinishAsyncSpy = jest.fn();
+
+        renderModal(
+            <ModalWizard id="🧙‍♂️" onFinish={onFinishSpy} onFinishAsync={onFinishAsyncSpy}>
+                <div>Step 1</div>
+                <div>Step 2</div>
+            </ModalWizard>,
+            {initialState: {modals: [{id: '🧙‍♂️', isOpened: true}]}}
+        );
+
+        userEvent.click(screen.getByRole('button', {name: 'Next'}));
+        userEvent.click(screen.getByRole('button', {name: 'Finish'}));
+
+        expect(onFinishAsyncSpy).toHaveBeenCalledTimes(0);
+        await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
     });
 
     it('disables the next button if the current step is invalid', () => {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/66333175/111212379-e8fe2580-85a5-11eb-84d9-02a53620ca06.png)


### Proposed Changes
Added a new prop `onFinishAsync` to ModalWizard component to prevent closing of the modal if the finish method encounters an error.


<!-- Explain what are your changes. -->

The reason for this change is because without having this option, when a function errors out, it will close the modal and reset the users progress. Having this `onFinishAsync` will allow the modal to stay open. 

E.g
When a user enters a duplicate name for the Web Source, the original `onFinish` method will throw an error and automatically run the `close()` method from the ModalWizard since the method is async. Having this prop will allow the function to complete and then close the modal upon clicking `Finish`

`onFinishAsync()?.then(close);`

### How to test:
1. Go to the ModalWizard component
2. Test the second modal with validation and onFinishAsync
3. When completing the modal, pressing the `Finish` will open an alert saying that it cannot finish since an error was thrown.

https://user-images.githubusercontent.com/66333175/111213023-b7d22500-85a6-11eb-90dd-5affc87a12fd.mp4



### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
