### PR TITLE
refactor(modal-wizard): changing the way close ModalWizard on finish

### DIFF
--- a/packages/demo/src/components/examples/ModalWizardExamples.tsx
+++ b/packages/demo/src/components/examples/ModalWizardExamples.tsx
@@ -75,7 +75,10 @@ const StandardModalWizardDisconnected: React.FunctionComponent<ConnectedProps<ty
             <ModalWizard
                 id="standard-wizard"
                 title="Wizard 🧙‍♂️"
-                onFinish={() => alert('Congratulations! You completed the wizard')}
+                onFinish={(close) => {
+                    alert('Congratulations! You completed the wizard');
+                    close();
+                }}
                 validateStep={validateStep}
                 isDirty={!!selectedPath || !!inputTwoValue}
             >
@@ -133,7 +136,10 @@ const ModalWizardWithValidationIdsDisconnected: React.FunctionComponent<Connecte
         <ModalWizardWithValidations
             id="validation-wizard"
             title="Wizard 🧙‍♂️"
-            onFinish={() => alert('Congratulations! You completed the wizard')}
+            onFinish={(close) => {
+                alert('Congratulations! You completed the wizard');
+                close();
+            }}
             validationIdsByStep={[['name-input'], ['favorite-animal-select']]}
         >
             <Form title="Step 1" mods={['mod-form-top-bottom-padding', 'mod-header-padding']}>

--- a/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
+++ b/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
@@ -12,7 +12,7 @@ import {StepProgressBar} from '../stepProgressBar';
 export interface ModalWizardProps
     extends Omit<IModalCompositeOwnProps, 'modalBodyChildren' | 'validateShouldNavigate'> {
     id: string;
-    onFinish?: () => unknown;
+    onFinish?: (close: () => void) => unknown;
     validateStep?: (currentStep: number, isLastStep?: boolean) => {isValid: boolean; message?: string};
     isDirty?: boolean;
     cancelButtonLabel?: string;
@@ -84,8 +84,7 @@ const ModalWizardDisconneted: React.FunctionComponent<ModalWizardProps & Connect
                                 enabled={isValid}
                                 onClick={() => {
                                     if (isLastStep) {
-                                        onFinish?.();
-                                        close();
+                                        onFinish?.(close);
                                     } else {
                                         setCurrentStep(currentStep + 1);
                                     }

--- a/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
+++ b/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
@@ -75,7 +75,7 @@ describe('ModalWizard', () => {
         expect(screen.getByText(/Step 3/)).not.toBeVisible();
     });
 
-    it('calls the "onFinish" prop and close the modal when clicking on the "finish" button', async () => {
+    it('calls the "onFinish" prop and the modal stays open when clicking on the "finish" button', () => {
         const finishSpy = jest.fn();
 
         renderModal(
@@ -90,7 +90,28 @@ describe('ModalWizard', () => {
         userEvent.click(screen.getByRole('button', {name: 'Finish'}));
 
         expect(finishSpy).toHaveBeenCalledTimes(1);
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('calls the "onFinish" prop and the modal closes when clicking on the "finish" button', async () => {
+        renderModal(
+            <ModalWizard
+                id="🧙‍♂️"
+                onFinish={(close) => {
+                    close();
+                }}
+            >
+                <div>Step 1</div>
+                <div>Step 2</div>
+            </ModalWizard>,
+            {initialState: {modals: [{id: '🧙‍♂️', isOpened: true}]}}
+        );
+
+        userEvent.click(screen.getByRole('button', {name: 'Next'}));
+        userEvent.click(screen.getByRole('button', {name: 'Finish'}));
+
         await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
     it('disables the next button if the current step is invalid', () => {


### PR DESCRIPTION
Removing the closing method in the last step of the modal and passing it as a callback for the onFinish function.
The user will be responsible for calling the callback to close the modal.

BREAKING CHANGE: changing the way we close the modal - the user will need to dispatch a closeModal
action at the end of the onFinish method. An example is updated to show the close method being used
after onFinish (after the alert)

### Proposed Changes

This will allow the user to close the modal after an onFinish method is completed.

<!-- Explain what are your changes. -->
How to test:

1. Go to ModalWizard and upon finish, the modal will close. (method close() was added after alert which dispatches the closeModal action)

There are no changes to the behaviour. Modal should close as expected when finishing modal.



### Potential Breaking Changes

- ModalWizard will stay open after the onFinish function is triggered unless the callback `close()` is called.

<!-- List all changes that might be breaking to react-vapor's users if any. -->
<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
