### PR TITLE
improvement(modalwizard): allow footer and title to depend on step

### DIFF
--- a/packages/demo/src/components/examples/ModalWizardExamples.tsx
+++ b/packages/demo/src/components/examples/ModalWizardExamples.tsx
@@ -43,7 +43,7 @@ const StandardModalWizardDisconnected: React.FunctionComponent<ConnectedProps<ty
     selectedPath,
     inputTwoValue,
 }) => {
-    const validateStep = (currentStep: number, isLastStep: boolean) => {
+    const validateStep = (currentStep: number, numberOfSteps: number) => {
         if (currentStep === 0) {
             return {
                 isValid: !!selectedPath,
@@ -60,7 +60,7 @@ const StandardModalWizardDisconnected: React.FunctionComponent<ConnectedProps<ty
             } else {
                 return {isValid: true};
             }
-        } else if (isLastStep) {
+        } else if (currentStep === numberOfSteps - 1) {
             return {
                 isValid: containsCoveo(inputTwoValue),
                 message: !containsCoveo(inputTwoValue) && 'The input at step 2 must contain "coveo" to finish.',
@@ -81,6 +81,9 @@ const StandardModalWizardDisconnected: React.FunctionComponent<ConnectedProps<ty
                 }}
                 validateStep={validateStep}
                 isDirty={!!selectedPath || !!inputTwoValue}
+                modalFooterChildren={(currentStep, numberOfSteps) =>
+                    currentStep < numberOfSteps - 1 ? null : <div className="flex-auto">Last Step!</div>
+                }
             >
                 <Form title="Step 1" mods={['mod-form-top-bottom-padding', 'mod-header-padding']}>
                     <RadioSelectConnected id="radio-step-1">

--- a/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
+++ b/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
@@ -157,4 +157,45 @@ describe('ModalWizard', () => {
         await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
+
+    it('changes the title depending on the step if a function was provided as title', () => {
+        renderModal(
+            <ModalWizard id="🧙‍♂️" title={(currentStep: number) => (currentStep === 0 ? 'Title 1' : 'Title 2')}>
+                <div>Step 1</div>
+                <div>Step 2</div>
+            </ModalWizard>,
+            {initialState: {modals: [{id: '🧙‍♂️', isOpened: true}]}}
+        );
+
+        expect(screen.getByRole('heading', {name: /title 1/i})).toBeVisible();
+        expect(screen.queryByRole('heading', {name: /title 2/i})).not.toBeInTheDocument();
+
+        userEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+        expect(screen.queryByRole('heading', {name: /title 1/i})).not.toBeInTheDocument();
+        expect(screen.getByRole('heading', {name: /title 2/i})).toBeVisible();
+    });
+
+    it('changes the footer depending on the step if a function was provided as modalFooterChildren', () => {
+        renderModal(
+            <ModalWizard
+                id="🧙‍♂️"
+                modalFooterChildren={(currentStep: number) =>
+                    currentStep === 0 ? 'Footer Children 1' : 'Footer Children 2'
+                }
+            >
+                <div>Step 1</div>
+                <div>Step 2</div>
+            </ModalWizard>,
+            {initialState: {modals: [{id: '🧙‍♂️', isOpened: true}]}}
+        );
+
+        expect(screen.getByText(/footer children 1/i)).toBeVisible();
+        expect(screen.queryByText(/footer children 2/i)).not.toBeInTheDocument();
+
+        userEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+        expect(screen.queryByText(/footer children 1/i)).not.toBeInTheDocument();
+        expect(screen.getByText(/footer children 2/i)).toBeVisible();
+    });
 });


### PR DESCRIPTION
### Proposed Changes

`title` and `modalFooterChildren` props of the `ModalWizard` component can now be step dependent. Meaning that we can have different titles or additional stuff in the footer depending on what is the current step displayed by the wizard.

### Potential Breaking Changes

BREAKING CHANGE: ModalWizard `validateStep` function now takes in the total number of steps as
second parameter instead of a boolean indicating whether if it is the last step. This change allow
for more flexibility.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
