### PR TITLE
feat(calendar): new countdown feature for calendar

### DIFF
--- a/packages/demo/src/components/examples/DatePickerExamples.tsx
+++ b/packages/demo/src/components/examples/DatePickerExamples.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+    Calendar,
     CalendarConnected,
     ChildForm,
     DatePickerBox,
@@ -11,6 +12,7 @@ import * as _ from 'underscore';
 
 import {ExampleComponent} from '../ComponentsInterface';
 import {
+    CALENDAR_COUNTDOWN_DATES,
     CALENDAR_SELECTION_RULES,
     DATE_RANGE_EXAMPLE,
     FOUR_SELECTION_BOXES,
@@ -20,6 +22,7 @@ import {
 export const DatePickerExamples: ExampleComponent = () => (
     <Section>
         <CalendarComponent />
+        <CountdownComponent />
         <DatePickerComponents />
         <DatesSelectionComponent />
     </Section>
@@ -29,6 +32,12 @@ DatePickerExamples.title = 'DatePicker';
 const CalendarComponent: React.FunctionComponent = () => (
     <Section title="Calendar component">
         <CalendarConnected id="calendar" />
+    </Section>
+);
+
+const CountdownComponent: React.FunctionComponent = () => (
+    <Section title="Countdown component" mods={['mod-form-top-bottom-padding']}>
+        <Calendar id="countdown-calendar" countdown calendarSelection={CALENDAR_COUNTDOWN_DATES} />
     </Section>
 );
 

--- a/packages/demo/src/components/examples/DatePickerExamples.tsx
+++ b/packages/demo/src/components/examples/DatePickerExamples.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import {
-    Calendar,
     CalendarConnected,
     ChildForm,
+    Countdown,
     DatePickerBox,
     DatePickerDropdownConnected,
     DatesSelectionConnected,
@@ -12,7 +12,6 @@ import * as _ from 'underscore';
 
 import {ExampleComponent} from '../ComponentsInterface';
 import {
-    CALENDAR_COUNTDOWN_DATES,
     CALENDAR_SELECTION_RULES,
     DATE_RANGE_EXAMPLE,
     FOUR_SELECTION_BOXES,
@@ -37,7 +36,7 @@ const CalendarComponent: React.FunctionComponent = () => (
 
 const CountdownComponent: React.FunctionComponent = () => (
     <Section title="Countdown component" mods={['mod-form-top-bottom-padding']}>
-        <Calendar id="countdown-calendar" countdown calendarSelection={CALENDAR_COUNTDOWN_DATES} />
+        <Countdown />
     </Section>
 );
 

--- a/packages/demo/src/components/examples/DatePickerExamplesCommon.ts
+++ b/packages/demo/src/components/examples/DatePickerExamplesCommon.ts
@@ -5,6 +5,7 @@ import {
     DatePickerDateRange,
     DATES_SEPARATOR,
     ICalendarSelectionRule,
+    IDatePickerState,
     IDatesSelectionBox,
 } from 'react-vapor';
 
@@ -189,3 +190,13 @@ export const CALENDAR_SELECTION_RULES_SINGLE_DATE: ICalendarSelectionRule[] = [
 ];
 
 export const DATE_RANGE_EXAMPLE: DatePickerDateRange = [moment().toDate(), moment().add(3, 'day').toDate()];
+
+export const CALENDAR_COUNTDOWN_DATES: IDatePickerState[] = [
+    {
+        id: 'countdown-id',
+        calendarId: 'countdown-calendar-id',
+        isRange: true,
+        lowerLimit: moment().toDate(),
+        upperLimit: moment().date(moment().daysInMonth()).toDate(),
+    } as IDatePickerState,
+];

--- a/packages/react-vapor/src/components/calendar/Calendar.tsx
+++ b/packages/react-vapor/src/components/calendar/Calendar.tsx
@@ -37,6 +37,8 @@ export interface ICalendarOwnProps extends React.ClassAttributes<Calendar> {
     isLinkedToDateRange?: boolean;
     simple?: boolean;
     wrapperClassNames?: string;
+    showHeader?: boolean;
+    countdown?: boolean;
 }
 
 export interface ICalendarStateProps extends IReduxStatePossibleProps {
@@ -68,6 +70,8 @@ export const MONTH_PICKER_ID: string = 'calendar-months';
 export const YEAR_PICKER_ID: string = 'calendar-years';
 
 export class Calendar extends React.Component<ICalendarProps, any> {
+    private countdownHeader: React.ReactNode;
+
     static defaultProps: Partial<ICalendarProps> = {
         selectionRules: [],
         years: DEFAULT_YEARS,
@@ -75,6 +79,7 @@ export class Calendar extends React.Component<ICalendarProps, any> {
         days: DEFAULT_DAYS,
         startingMonth: DateUtils.currentMonth,
         startingDay: 0,
+        showHeader: true,
     };
 
     private getSelectedDatePicker(): IDatePickerState {
@@ -163,6 +168,7 @@ export class Calendar extends React.Component<ICalendarProps, any> {
                 (calendarSelection.isRange && day.date.isSame(selectionStart, 'day')) || day.isLowerLimit;
             day.isUpperLimit = (calendarSelection.isRange && day.date.isSame(selectionEnd, 'day')) || day.isUpperLimit;
             day.color = isSelected ? calendarSelection.color : day.color;
+            day.isCountdown = !!this.props.countdown;
 
             _.each(this.props.selectionRules, (rule: ICalendarSelectionRule) => {
                 if (day.isSelectable) {
@@ -209,7 +215,9 @@ export class Calendar extends React.Component<ICalendarProps, any> {
             ...this.props.days.slice(this.props.startingDay + 1),
             ...this.props.days.slice(0, this.props.startingDay),
         ];
-        const daysHeaderColumns: ITableHeaderCellProps[] = _.map(orderedDays, (day: string) => ({title: day}));
+        const daysHeaderColumns: ITableHeaderCellProps[] = _.map(orderedDays, (day: string) => ({
+            title: this.props.countdown ? day.substr(0, 1) : day,
+        }));
 
         const monthPicker = this.props.withReduxState ? (
             <OptionsCycleConnected
@@ -246,7 +254,11 @@ export class Calendar extends React.Component<ICalendarProps, any> {
                 );
             });
 
-            return <tr key={`week-${days[0].key}`}>{days}</tr>;
+            return (
+                <tr key={`week-${days[0].key}`} className={classNames({'no-hover': this.props.countdown})}>
+                    {days}
+                </tr>
+            );
         });
 
         const tableClasses: string = classNames('table', 'calendar-grid', {
@@ -257,21 +269,42 @@ export class Calendar extends React.Component<ICalendarProps, any> {
             'calendar',
             {
                 'mod-width-50': !this.props.simple,
+                'countdown-calendar': this.props.countdown,
             },
             this.props.wrapperClassNames
         );
 
+        if (this.props.countdown) {
+            this.countdownHeader = (
+                <div id="countdown-header">
+                    <h2 className="bold mb1">
+                        {moment().date(moment().month(this.props.months[selectedMonth]).daysInMonth()).fromNow(true)}{' '}
+                        left
+                    </h2>
+                    <div className="smaller">in {this.props.months[selectedMonth]}</div>
+                </div>
+            );
+        }
+
+        const defaultHeader = (
+            <div className="calendar-header p2">
+                {monthPicker}
+                {yearPicker}
+            </div>
+        );
+
         return (
             <div className={wrapperClasses}>
-                <div className="calendar-header p2">
-                    {monthPicker}
-                    {yearPicker}
-                </div>
+                {this.props.showHeader && (this.countdownHeader || defaultHeader)}
                 <table className={tableClasses}>
-                    <TableHeader columns={daysHeaderColumns} headerClass="mod-no-border-top" />
+                    <TableHeader
+                        columns={daysHeaderColumns}
+                        headerClass={classNames('mod-no-border-top', {'mod-no-border-bottom': this.props.countdown})}
+                    />
                     <tbody>{weeks}</tbody>
                 </table>
             </div>
         );
     }
 }
+1;

--- a/packages/react-vapor/src/components/calendar/Calendar.tsx
+++ b/packages/react-vapor/src/components/calendar/Calendar.tsx
@@ -275,12 +275,13 @@ export class Calendar extends React.Component<ICalendarProps, any> {
         );
 
         if (this.props.countdown) {
+            const countdownDays = moment()
+                .date(moment().month(this.props.months[selectedMonth]).daysInMonth())
+                .fromNow(true);
+
             this.countdownHeader = (
                 <div id="countdown-header">
-                    <h2 className="bold mb1">
-                        {moment().date(moment().month(this.props.months[selectedMonth]).daysInMonth()).fromNow(true)}{' '}
-                        left
-                    </h2>
+                    <h2 className="bold mb1">{countdownDays} left</h2>
                     <div className="smaller">in {this.props.months[selectedMonth]}</div>
                 </div>
             );
@@ -295,7 +296,7 @@ export class Calendar extends React.Component<ICalendarProps, any> {
 
         return (
             <div className={wrapperClasses}>
-                {this.props.showHeader && (this.countdownHeader || defaultHeader)}
+                {this.props.showHeader && (this.countdownHeader ?? defaultHeader)}
                 <table className={tableClasses}>
                     <TableHeader
                         columns={daysHeaderColumns}

--- a/packages/react-vapor/src/components/calendar/CalendarDay.tsx
+++ b/packages/react-vapor/src/components/calendar/CalendarDay.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import {Moment} from 'moment';
 import * as React from 'react';
 
@@ -12,6 +13,7 @@ export interface IDay {
     isUpperLimit?: boolean;
     color?: string;
     isSelectable?: boolean;
+    isCountdown?: boolean;
 }
 
 export interface ICalendarDayProps extends React.ClassAttributes<CalendarDay> {
@@ -30,50 +32,37 @@ export class CalendarDay extends React.Component<ICalendarDayProps> {
     }
 
     componentDidUpdate() {
-        if (
-            !this.props.day.isSelectable &&
-            this.props.day.isSelected &&
-            (this.props.day.isLowerLimit || this.props.day.isUpperLimit)
-        ) {
+        const {day} = this.props;
+
+        if (!day.isSelectable && day.isSelected && (day.isLowerLimit || day.isUpperLimit)) {
             this.props.onSelectUnselectable();
         }
     }
 
     render() {
-        const dayClasses: string[] = [];
-        const dayCellClasses: string[] = [CalendarDay.DEFAULT_DATE_CLASS];
+        const {day} = this.props;
 
-        if (!this.props.day.isCurrentMonth) {
-            dayClasses.push('other-month-date');
-        }
+        const isSelectedAndSelectable = day.isSelected && day.isSelectable;
 
-        if (!this.props.day.isSelectable) {
-            dayCellClasses.push('un-selectable');
-        }
+        const dayClassNames: string = classNames({
+            'other-month-date': !day.isCurrentMonth,
+            'todays-date': day.isToday,
+            countdown: day.isCountdown,
+            'selected-date': isSelectedAndSelectable,
+            'lower-limit': isSelectedAndSelectable && day.isLowerLimit,
+            'upper-limit': isSelectedAndSelectable && day.isUpperLimit,
+        });
 
-        if (this.props.day.isToday) {
-            dayClasses.push('todays-date');
-        }
+        const dayCellClassNames: string = classNames(CalendarDay.DEFAULT_DATE_CLASS, {
+            'un-selectable': !day.isSelectable,
+        });
 
-        if (this.props.day.isSelected && this.props.day.isSelectable) {
-            dayClasses.push('selected-date');
-
-            if (this.props.day.isLowerLimit) {
-                dayClasses.push('lower-limit');
-            }
-
-            if (this.props.day.isUpperLimit) {
-                dayClasses.push('upper-limit');
-            }
-        }
-
-        const bothLimitsElement: JSX.Element =
-            this.props.day.isLowerLimit && this.props.day.isUpperLimit ? <span></span> : null;
+        const bothLimitsElement: JSX.Element = day.isLowerLimit && day.isUpperLimit ? <span /> : null;
 
         return (
-            <td className={dayCellClasses.join(' ')} onClick={() => this.handleClick()}>
-                <span className={dayClasses.join(' ')}>
-                    {this.props.day.number}
+            <td className={dayCellClassNames} onClick={() => this.handleClick()}>
+                <span className={dayClassNames}>
+                    {day.number}
                     {bothLimitsElement}
                 </span>
             </td>

--- a/packages/react-vapor/src/components/calendar/CalendarDay.tsx
+++ b/packages/react-vapor/src/components/calendar/CalendarDay.tsx
@@ -42,15 +42,15 @@ export class CalendarDay extends React.Component<ICalendarDayProps> {
     render() {
         const {day} = this.props;
 
-        const isSelectedAndSelectable = day.isSelected && day.isSelectable;
+        const isSelectableAndSelected = day.isSelected && day.isSelectable;
 
         const dayClassNames: string = classNames({
             'other-month-date': !day.isCurrentMonth,
             'todays-date': day.isToday,
             countdown: day.isCountdown,
-            'selected-date': isSelectedAndSelectable,
-            'lower-limit': isSelectedAndSelectable && day.isLowerLimit,
-            'upper-limit': isSelectedAndSelectable && day.isUpperLimit,
+            'selected-date': isSelectableAndSelected,
+            'lower-limit': isSelectableAndSelected && day.isLowerLimit,
+            'upper-limit': isSelectableAndSelected && day.isUpperLimit,
         });
 
         const dayCellClassNames: string = classNames(CalendarDay.DEFAULT_DATE_CLASS, {
@@ -59,10 +59,12 @@ export class CalendarDay extends React.Component<ICalendarDayProps> {
 
         const bothLimitsElement: JSX.Element = day.isLowerLimit && day.isUpperLimit ? <span /> : null;
 
+        const isCountdownAndToday = day.isCountdown && day.isToday;
+
         return (
             <td className={dayCellClassNames} onClick={() => this.handleClick()}>
                 <span className={dayClassNames}>
-                    {day.number}
+                    {(isCountdownAndToday || !day.isCountdown) && day.number}
                     {bothLimitsElement}
                 </span>
             </td>

--- a/packages/react-vapor/src/components/calendar/Countdown.tsx
+++ b/packages/react-vapor/src/components/calendar/Countdown.tsx
@@ -1,0 +1,24 @@
+import moment from 'moment';
+import React from 'react';
+import {IDatePickerState} from '../datePicker';
+import {Calendar} from './Calendar';
+
+export interface CountdownProps {
+    startDate?: moment.Moment;
+    endDate?: moment.Moment;
+}
+
+export const Countdown: React.FunctionComponent<CountdownProps> = ({
+    startDate = moment(),
+    endDate = moment().date(moment().daysInMonth()),
+}) => {
+    const defaultProps = {
+        id: 'countdown-id',
+        calendarId: 'countdown-calendar-id',
+        isRange: true,
+        lowerLimit: startDate.toDate(),
+        upperLimit: endDate.toDate(),
+    } as IDatePickerState;
+
+    return <Calendar id="countdown-calendar" countdown calendarSelection={[defaultProps]} />;
+};

--- a/packages/react-vapor/src/components/calendar/index.ts
+++ b/packages/react-vapor/src/components/calendar/index.ts
@@ -1,3 +1,4 @@
 export * from './Calendar';
 export * from './CalendarConnected';
 export * from './CalendarDay';
+export * from './Countdown';

--- a/packages/react-vapor/src/components/calendar/tests/Calendar.spec.tsx
+++ b/packages/react-vapor/src/components/calendar/tests/Calendar.spec.tsx
@@ -577,5 +577,23 @@ describe('Calendar', () => {
                 });
             });
         });
+
+        describe('Countdown', () => {
+            it('should add the countdown-calendar class to the wrapper if countdown prop is provided', () => {
+                expect(calendar.find('.countdown-calendar').length).toBe(0);
+
+                calendar.setProps({countdown: true});
+
+                expect(calendar.find('.countdown-calendar').length).toBe(1);
+            });
+
+            it('should show the countdown-header if countdown prop provided', () => {
+                expect(calendar.find('#countdown-header').length).toBe(0);
+
+                calendar.setProps({countdown: true});
+
+                expect(calendar.find('#countdown-header').length).toBe(1);
+            });
+        });
     });
 });

--- a/packages/react-vapor/src/components/calendar/tests/CalendarDay.spec.tsx
+++ b/packages/react-vapor/src/components/calendar/tests/CalendarDay.spec.tsx
@@ -187,5 +187,17 @@ describe('Calendar day', () => {
 
             expect(unSelectableDayProps.onSelectUnselectable).toHaveBeenCalledTimes(1);
         });
+
+        describe('Countdown', () => {
+            it('should have countdown class if isCountdown prop provided', () => {
+                const newDayProps: IDay = {
+                    ...DAY,
+                    isCountdown: true,
+                };
+                const component = shallow(<CalendarDay {...BASIC_CALENDAR_DAY_PROPS} day={newDayProps} />);
+
+                expect(component.find('.countdown').length).toBe(1);
+            });
+        });
     });
 });

--- a/packages/react-vapor/src/components/calendar/tests/Countdown.spec.tsx
+++ b/packages/react-vapor/src/components/calendar/tests/Countdown.spec.tsx
@@ -1,0 +1,18 @@
+import {render} from '@testing-library/react';
+import moment from 'moment';
+import * as React from 'react';
+
+import {Countdown} from '../Countdown';
+
+describe('Countdown', () => {
+    it('should render with default props', () => {
+        const {container, getByText} = render(<Countdown />);
+
+        const todaysDate = moment().date();
+
+        const today = getByText(`${todaysDate}`);
+
+        expect(container.firstChild).toHaveClass('countdown-calendar');
+        expect(today).toHaveClass('todays-date');
+    });
+});

--- a/packages/vapor/scss/components/calendar.scss
+++ b/packages/vapor/scss/components/calendar.scss
@@ -168,6 +168,67 @@
             }
         }
     }
+
+    &.countdown-calendar {
+        table.calendar-grid {
+            tr,
+            td {
+                border: 0;
+            }
+
+            th {
+                border-bottom: 0;
+            }
+
+            td {
+                .countdown {
+                    position: relative;
+                    top: 0;
+                    left: calc(#{$selected-date-offset} + #{$calendar-limit-border-width} + 2px);
+                    display: block;
+                    width: $countdown-cell-height;
+                    height: $countdown-cell-height;
+                    color: var(--grey-40);
+                    line-height: $selected-date-height;
+                    background-color: var(--grey-40);
+                    border-radius: 50%;
+
+                    &.lower-limit,
+                    &.upper-limit {
+                        &:before,
+                        &:after {
+                            display: none;
+                        }
+                    }
+
+                    &.other-month-date {
+                        color: var(--pure-white);
+                        background-color: var(--pure-white);
+                    }
+
+                    &.selected-date {
+                        color: var(--navy-blue-80);
+                        background-color: var(--navy-blue-80);
+
+                        &.lower-limit,
+                        &.upper-limit {
+                            &:before,
+                            &:after {
+                                display: none;
+                            }
+                        }
+
+                        &.todays-date {
+                            color: var(--navy-blue-80);
+                            font-size: $small-font-size;
+                            background-color: var(--pure-white);
+                            border: 1px solid var(--navy-blue-80);
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 .options-cycle {

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -472,6 +472,7 @@ $calendar-limit-border-width: 2px;
 $calendar-limit-border-length: 5px;
 $calendar-max-height: 336px;
 $date-picker-button-hover-bg: rgba($dark-grey, $transparency-3);
+$countdown-cell-height: 28px;
 
 // Tooltip
 $tooltip-z-index: 100000;


### PR DESCRIPTION
by providing the countdown prop you can switch to a new countdown version of the calendar

[ADUI-6728](https://coveord.atlassian.net/browse/ADUI-6728)

### Proposed Changes

Added a countdown version for the existing calendar component. Changes are only visible by providing the `countdown` props

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)

### To test

In the Datepicker section of the demo you should see the countdown. The mockups are in the Jira attached above

![image](https://user-images.githubusercontent.com/22773767/112177774-99d07a00-8bcf-11eb-9bae-b3db10fc525f.png)
