### PR TITLE
fix(modal): add modal openOnMount to openModals state

### DIFF
--- a/packages/react-vapor/src/components/modal/Modal.tsx
+++ b/packages/react-vapor/src/components/modal/Modal.tsx
@@ -11,7 +11,6 @@ export interface IModalOwnProps {
     closeTimeout?: number;
     /**
      * Renders the Modal already opened.
-     * To be used with ModalConnected only.
      */
     openOnMount?: boolean;
     contentRef?: (el: HTMLDivElement) => void;

--- a/packages/react-vapor/src/components/modal/ModalReducers.ts
+++ b/packages/react-vapor/src/components/modal/ModalReducers.ts
@@ -64,6 +64,11 @@ export const openModalsReducer = (state: string[] = [], action: IReduxAction<IMo
                 return [...state, action.payload.id];
             }
             return state;
+        case ModalAction.addModal:
+            if (action.payload.isOpened) {
+                return [...state, action.payload.id];
+            }
+            return state;
         case ModalAction.closeModals:
             return _.without(state, ...action.payload.ids);
         case ModalAction.removeModal:

--- a/packages/react-vapor/src/components/modal/tests/ModalReducers.spec.ts
+++ b/packages/react-vapor/src/components/modal/tests/ModalReducers.spec.ts
@@ -190,6 +190,30 @@ describe('Modal', () => {
                 expect(openModalsState[1]).toBe(action.payload.id);
             });
 
+            it('adds the modal id to the array when adding a new modal opened on mount', () => {
+                const action: IReduxAction<IModalActionPayload> = {
+                    type: ModalAction.addModal,
+                    payload: {
+                        id: 'my-modal',
+                        isOpened: true,
+                    },
+                };
+
+                expect(openModalsReducer([], action)).toEqual(['my-modal']);
+            });
+
+            it('does not add the modal id to the array when adding a new modal closed on mount', () => {
+                const action: IReduxAction<IModalActionPayload> = {
+                    type: ModalAction.addModal,
+                    payload: {
+                        id: 'my-modal',
+                        isOpened: false,
+                    },
+                };
+
+                expect(openModalsReducer([], action)).toEqual([]);
+            });
+
             it('should not add the id to the openModals string array if the id of the opened modal is already there', () => {
                 let oldState: string[] = [];
                 const action: IReduxAction<IModalActionPayload> = {


### PR DESCRIPTION
### Proposed Changes

Modals with openOnMount prop set to true were not added to the openModals array in the state which was causing issues with modals not stacking properly.

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
