### PR TITLE
fix(validation-message): replace validation-error with text mod-error

### DIFF
--- a/packages/react-vapor/src/components/userFeedback/UserFeedback.spec.tsx
+++ b/packages/react-vapor/src/components/userFeedback/UserFeedback.spec.tsx
@@ -138,7 +138,7 @@ describe('<UserFeedback>', () => {
                 it('should have the error text color class', () => {
                     const componentOnStateError = getShallowOutput('', UserFeedbackState.ERROR);
 
-                    expect(componentOnStateError.hasClass('validation-error')).toBe(true);
+                    expect(componentOnStateError.hasClass('mod-error')).toBe(true);
                 });
             });
         });

--- a/packages/react-vapor/src/components/userFeedback/UserFeedback.tsx
+++ b/packages/react-vapor/src/components/userFeedback/UserFeedback.tsx
@@ -29,7 +29,7 @@ export class UserFeedback extends React.Component<IUserFeedbackProps, any> {
         const displayClassOnShow = this.props.displayOnShow || DisplayClass.BLOCK;
 
         const renderedDisplayClass = state === UserFeedbackState.VALID ? DisplayClass.HIDDEN : displayClassOnShow;
-        const renderedTextColorClass = state === UserFeedbackState.ERROR ? 'validation-error' : null;
+        const renderedTextColorClass = state === UserFeedbackState.ERROR ? 'text mod-error' : 'text mod-emphasized';
         const renderedExtraClasses = this.props.extraClasses || [];
 
         return {

--- a/packages/react-vapor/src/components/validation/components/ValidationMessage.tsx
+++ b/packages/react-vapor/src/components/validation/components/ValidationMessage.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import {connect} from 'react-redux';
+
 import {IReactVaporState} from '../../../ReactVapor';
 import {IDispatch} from '../../../utils';
 import {ValidationActions} from '../ValidationActions';
@@ -21,11 +22,6 @@ const mapDispatchToProps = (dispatch: IDispatch, ownProps: IValidationMessagePro
     cleanMessage: () => dispatch(ValidationActions.cleanMessage(ownProps.id)),
 });
 
-export const ValidationMessageClasses = {
-    error: 'validation-error',
-    warning: 'validation-warning',
-};
-
 export const ValidationMessageDisconnect: React.FunctionComponent<
     IValidationMessageProps & ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>
 > = ({onlyShowIfDirty, isDirty, errors, warnings, cleanMessage}) => {
@@ -42,9 +38,9 @@ export const ValidationMessageDisconnect: React.FunctionComponent<
                 eitherErrorsOrWarnings.map(({validationType, value}) => (
                     <span
                         key={validationType}
-                        className={classNames({
-                            [ValidationMessageClasses.error]: hasErrors,
-                            [ValidationMessageClasses.warning]: !hasErrors,
+                        className={classNames('text', {
+                            'mod-error': hasErrors,
+                            'mod-warning': !hasErrors,
                         })}
                     >
                         {value}

--- a/packages/react-vapor/src/components/validation/components/tests/ValidationMessage.spec.tsx
+++ b/packages/react-vapor/src/components/validation/components/tests/ValidationMessage.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {getStoreMock} from '../../../../utils/tests/TestUtils';
 import {ValidationActions} from '../../ValidationActions';
 import {ValidationState} from '../../ValidationState';
-import {IValidationMessageProps, ValidationMessage, ValidationMessageClasses} from '../ValidationMessage';
+import {IValidationMessageProps, ValidationMessage} from '../ValidationMessage';
 
 describe('ValidationMessage', () => {
     const defaultProps: IValidationMessageProps = {
@@ -72,8 +72,8 @@ describe('ValidationMessage', () => {
             })
         ).dive();
 
-        expect(result.find(`.${ValidationMessageClasses.error}`).length).toBe(2);
-        expect(result.find(`.${ValidationMessageClasses.error}`).first().text()).toContain(nonEmptyMessage);
+        expect(result.find('.mod-error').length).toBe(2);
+        expect(result.find('.mod-error').first().text()).toContain(nonEmptyMessage);
     });
 
     it('should render warnings when there are warnings', () => {
@@ -93,8 +93,8 @@ describe('ValidationMessage', () => {
             })
         ).dive();
 
-        expect(result.find(`.${ValidationMessageClasses.warning}`).length).toBe(2);
-        expect(result.find(`.${ValidationMessageClasses.warning}`).first().text()).toContain(nonEmptyMessage);
+        expect(result.find('.mod-warning').length).toBe(2);
+        expect(result.find('.mod-warning').first().text()).toContain(nonEmptyMessage);
     });
 
     it('should render not render warnings if there are already errors', () => {
@@ -116,8 +116,8 @@ describe('ValidationMessage', () => {
             })
         ).dive();
 
-        expect(result.find(`.${ValidationMessageClasses.error}`).length).toBe(1);
-        expect(result.find(`.${ValidationMessageClasses.warning}`).length).toBe(0);
+        expect(result.find('.mod-error').length).toBe(1);
+        expect(result.find('.mod-warning').length).toBe(0);
     });
 
     describe('with the onlyShowIfDirty flag', () => {
@@ -144,8 +144,8 @@ describe('ValidationMessage', () => {
                 })
             ).dive();
 
-            expect(result.find(`.${ValidationMessageClasses.error}`).length).toBe(0);
-            expect(result.find(`.${ValidationMessageClasses.warning}`).length).toBe(0);
+            expect(result.find('.mod-error').length).toBe(0);
+            expect(result.find('.mod-warning').length).toBe(0);
         });
 
         it('should render errors when there are errors and the component is dirty', () => {
@@ -169,8 +169,8 @@ describe('ValidationMessage', () => {
                 })
             ).dive();
 
-            expect(result.find(`.${ValidationMessageClasses.error}`).length).toBe(2);
-            expect(result.find(`.${ValidationMessageClasses.error}`).first().text()).toContain(nonEmptyMessage);
+            expect(result.find('.mod-error').length).toBe(2);
+            expect(result.find('.mod-error').first().text()).toContain(nonEmptyMessage);
         });
     });
 });


### PR DESCRIPTION
### Proposed Changes

Before having different mods for text color, `.validation-error` was used in `ValidationMessage` to set text to red when has errors while removing all text utilities.
![image](https://user-images.githubusercontent.com/52677246/112366775-957b8e00-8caf-11eb-9f9d-8e3141cbaf41.png)

But it caused a conflict of style with the same class in admin-ui: https://github.com/coveo/admin-ui/blob/master/packages/v2/stylesheets/_inputs.scss#L215 

We can replace `validation-error` with `text mod-error` to fix this issue.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
