### PR TITLE
fix(multivaluesinput): validate all the inputs

### DIFF
--- a/packages/react-vapor/src/components/multiValueInputs/MultiValuesInput.tsx
+++ b/packages/react-vapor/src/components/multiValueInputs/MultiValuesInput.tsx
@@ -95,7 +95,7 @@ export const MultiValuesInput: React.FunctionComponent<MultiValuesInputProps> = 
                         innerInputClasses={innerInputClasses}
                         disabledTooltip={isTooltipRequired && disabledTooltipTitle ? disabledTooltipTitle : ''}
                         labelTitle={index === 0 ? inputProps?.labelTitle : ''}
-                        validate={index === 0 ? inputProps?.validate : (value: string) => true}
+                        validate={inputProps?.validate}
                     />
                 );
             })

--- a/packages/react-vapor/src/components/multiValueInputs/tests/MultiValuesInput.spec.tsx
+++ b/packages/react-vapor/src/components/multiValueInputs/tests/MultiValuesInput.spec.tsx
@@ -318,7 +318,7 @@ describe('MultiValuesInput', () => {
         expect(oneInputConnectedBeforelastProps.labelTitle).toBe('');
     });
 
-    it("should only validate the first input's content", () => {
+    it("should validate all the inputs' content", () => {
         const component = shallowWithState(<MultiValuesInput {...defaultProps} data={defaultValues} />, {}).dive();
 
         const body = shallowWithState(
@@ -329,7 +329,7 @@ describe('MultiValuesInput', () => {
         const lastInputConnectedValidation = body.find(InputConnected).last().props().validate('');
         const firstInputConnectedValidation = body.find(InputConnected).first().props().validate('');
 
-        expect(lastInputConnectedValidation).toBe(true);
+        expect(lastInputConnectedValidation).toBe(false);
         expect(firstInputConnectedValidation).toBe(false);
     });
 


### PR DESCRIPTION
### Proposed Changes

If `inputProps.validate` is defined, we need to validate all the inputs instead of only the first one.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
