### PR TITLE
ci(jenkinsfile.groovy): +2 more channels on master/release failure

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -48,6 +48,9 @@ pipeline {
       steps {
         script {
           setLastStageName();
+          
+          MASTER_RELEASE_FAILURE_CHANNELS = ["admin-ui-builds", "cloudadmindev", "admin-ui-guild"]
+          PR_CHANNELS = ["admin-ui-builds"]
           commitMessage = sh(returnStdout: true, script: "git log -1 --pretty=%B").trim()
           if(commitMessage.contains("[version bump]")) {
             skipRemainingStages = true
@@ -286,10 +289,17 @@ pipeline {
         def color = "FF0000";
         def message = "Build FAILED at stage *${getLastStageName()}* - ${env.JOB_NAME} (<${env.BUILD_URL}|#${env.BUILD_NUMBER}>)";
 
-        notify.sendSlackWithThread(
+        if(env.JOB_NAME ==~ /(master|release-.*)/){
+          notify.sendSlackWithThread(
             color: color, message: message,
-            ["admin-ui-builds"]
-        )
+            MASTER_RELEASE_FAILURE_CHANNELS
+          )
+        } else {
+          notify.sendSlackWithThread(
+            color: color, message: message,
+            PR_CHANNELS
+          )
+        }
       }
     }
     always {


### PR DESCRIPTION
### Related Issue

https://coveord.atlassian.net/browse/ADUI-6771

### Proposed Changes

If master or release deployment fail, it will now send a notification to admin-ui-guild and
cloudadmindev. Else, it will have the same previous behavior

### How to test

master has to fail :| (I will probably add the JOB_NAME of this pr to the groovy file and see when I make it fail, if the notif gets sent on the desired channels)

### Scope

jenkins

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [x] The steps to test the changes are clearly identified
-   [x] The scope of the changes is clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
