### PR TITLE
fix(calendar): added condition to default to current year if bad data

### DIFF
--- a/packages/react-vapor/src/components/calendar/Calendar.tsx
+++ b/packages/react-vapor/src/components/calendar/Calendar.tsx
@@ -56,7 +56,7 @@ export interface ICalendarProps extends ICalendarOwnProps, ICalendarStateProps, 
 export const DEFAULT_MONTHS: string[] = moment.months();
 
 export const DEFAULT_YEARS: string[] = [
-    ...DateUtils.getPreviousYears(10),
+    ...DateUtils.getPreviousYears(30),
     DateUtils.currentYear.toString(),
     ...DateUtils.getNextYears(30),
 ];

--- a/packages/react-vapor/src/components/calendar/Calendar.tsx
+++ b/packages/react-vapor/src/components/calendar/Calendar.tsx
@@ -58,7 +58,7 @@ export const DEFAULT_MONTHS: string[] = moment.months();
 export const DEFAULT_YEARS: string[] = [
     ...DateUtils.getPreviousYears(10),
     DateUtils.currentYear.toString(),
-    ...DateUtils.getNextYears(10),
+    ...DateUtils.getNextYears(30),
 ];
 
 export const DEFAULT_DAYS: string[] = moment.weekdaysShort();

--- a/packages/react-vapor/src/components/calendar/Calendar.tsx
+++ b/packages/react-vapor/src/components/calendar/Calendar.tsx
@@ -203,7 +203,6 @@ export class Calendar extends React.Component<ICalendarProps, any> {
             (isStartingYearDefined && this.props.startingYear) ||
             (startingYearIndex >= 0 ? startingYearIndex : Math.floor(this.props.years.length / 2));
 
-        // debugger;
         const yearPickerProps: IOptionsCycleProps = {
             options: this.props.years,
             isInline: true,

--- a/packages/react-vapor/src/components/calendar/Calendar.tsx
+++ b/packages/react-vapor/src/components/calendar/Calendar.tsx
@@ -195,9 +195,15 @@ export class Calendar extends React.Component<ICalendarProps, any> {
         };
 
         const startingYearIndex: number = this.props.years.indexOf(DateUtils.currentYear.toString());
+
+        // this.props.startingYear is an index, so can't be more than length of this.props.years
+        const isStartingYearDefined = !!this.props.years[this.props.startingYear];
+
         const startingYear: number =
-            this.props.startingYear ||
+            (isStartingYearDefined && this.props.startingYear) ||
             (startingYearIndex >= 0 ? startingYearIndex : Math.floor(this.props.years.length / 2));
+
+        // debugger;
         const yearPickerProps: IOptionsCycleProps = {
             options: this.props.years,
             isInline: true,

--- a/packages/react-vapor/src/components/calendar/tests/Calendar.spec.tsx
+++ b/packages/react-vapor/src/components/calendar/tests/Calendar.spec.tsx
@@ -111,6 +111,17 @@ describe('Calendar', () => {
             expect(calendar.html()).toContain(DEFAULT_YEARS[startingYear]);
         });
 
+        it('should default to the current year if the startingYear prop is out of range / not included in the list of given years', () => {
+            const startingYear: number = 50;
+
+            expect(calendar.html()).toContain(DateUtils.currentYear.toString());
+
+            calendar.unmount();
+            calendar = mount(<Calendar startingYear={startingYear} />, {attachTo: document.getElementById('App')});
+
+            expect(calendar.html()).toContain(DateUtils.currentYear.toString());
+        });
+
         it('should start the week on the startingDay sent as prop or simply use the first one (assumed to be Sunday)', () => {
             const startingDay: number = 3;
             let firstDayOfSecondWeek: number = parseInt(

--- a/packages/react-vapor/src/components/calendar/tests/Calendar.spec.tsx
+++ b/packages/react-vapor/src/components/calendar/tests/Calendar.spec.tsx
@@ -112,7 +112,7 @@ describe('Calendar', () => {
         });
 
         it('should default to the current year if the startingYear prop is out of range / not included in the list of given years', () => {
-            const startingYear: number = 50;
+            const startingYear: number = 100;
 
             expect(calendar.html()).toContain(DateUtils.currentYear.toString());
 

--- a/packages/react-vapor/src/components/calendar/tests/CalendarConnected.spec.tsx
+++ b/packages/react-vapor/src/components/calendar/tests/CalendarConnected.spec.tsx
@@ -89,7 +89,7 @@ describe('Calendar', () => {
             const expectedSelectedYear: number = 3;
 
             expect(selectedYearProp).toBeDefined();
-            expect(selectedYearProp).toBe(10);
+            expect(selectedYearProp).toBe(30);
 
             store.dispatch(changeOptionsCycle(CALENDAR_ID + YEAR_PICKER_ID, expectedSelectedYear));
             wrapper.update();


### PR DESCRIPTION
### Proposed Changes

The Datepicker works by providing a list of years and a startingYear / selectedYear index, which is used to select the year from the given list. However, if the given year index falls outside the range provided then it would break. I'm guessing this problem wasn't found before because normally pickiing the year is done in the UI, but when the Datepicker gets its data from the API it can be anything.

This PR adds a check to confirm the selected year (from the api or the user) is present in the years array. If it isn't then it defaults to the current year (UX didn't give me an answer on whether this is the best approach so if its flawed let me know)

[ADUI-6789](https://coveord.atlassian.net/browse/ADUI-6789)

### Potential Breaking Changes

None

### Steps to reproduce

This can only really be tested locally as far as I know. I tried changing the values in Redux and React Dev tools in the live site but it didn't update the DOM. What I did was to include the following line in the `DatePickerExamples` in the Demo:

```tsx
<Section level={2} title="DatePickerBox">
    <DatePickerBox id="date-picker-box" withReduxState datesSelectionBoxes={SELECTION_BOXES} />
    <DatePickerBox id="date-picker-box-2" withReduxState startingYear={2038} /> // <-- I messed around with different values here to mimic API data
</Section>
```

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
