### PR TITLE
Fix/sfint 3825 icon align rule update

### DIFF
--- a/packages/vapor/scss/icons/icons.scss
+++ b/packages/vapor/scss/icons/icons.scss
@@ -56,8 +56,8 @@
     }
 
     &.mod-align-with-text {
-        line-height: 16px;
-        vertical-align: -4px;
+        line-height: 1em;
+        vertical-align: -0.2em;
     }
 
     @for $i from 5 through 15 {


### PR DESCRIPTION
### Proposed Changes

The rule was applying `vertical-align: -4px` to all icons using a mod-XX class which works well for larger icons but not so much the smaller ones. I think using relative units fixes that. Open to other ideas though. Not sure why 16px was the size of choice so maybe it should still be that...

ex:
#### Before
<img width="606" alt="Screen Shot 2021-03-29 at 4 50 38 PM" src="https://user-images.githubusercontent.com/16785453/112902414-140f6b80-90b4-11eb-859a-aaa9b026913d.png">

#### After
<img width="399" alt="Screen Shot 2021-03-29 at 5 28 00 PM" src="https://user-images.githubusercontent.com/16785453/112902436-1f629700-90b4-11eb-8b58-dfb55fc9c3a8.png">

> Just look at the icon vertical alignment difference :P 

### Potential Breaking Changes

icons will be affected but i think the look is pretty consistent.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
