### PR TITLE
feat(code editor): value in store

### DIFF
--- a/packages/demo/src/components/examples/CodeEditorExamples.tsx
+++ b/packages/demo/src/components/examples/CodeEditorExamples.tsx
@@ -6,8 +6,15 @@ export class CodeEditorExamples extends React.Component {
         return (
             <div className="mt2">
                 <div className="form-group">
-                    <label className="form-control-label">Code Editor using codemirror with line wrapping</label>
-                    <CodeEditor value="" mode={CodeMirrorModes.Python} options={{lineWrapping: true}} />
+                    <label className="form-control-label">
+                        Code Editor with line wrapping and a starting value in the redux store
+                    </label>
+                    <CodeEditor
+                        id="CodeEditorId"
+                        value="A starting value"
+                        mode={CodeMirrorModes.Python}
+                        options={{lineWrapping: true}}
+                    />
                 </div>
 
                 <div className="form-group">

--- a/packages/react-vapor/src/ReactVapor.ts
+++ b/packages/react-vapor/src/ReactVapor.ts
@@ -12,6 +12,7 @@ import {IDropState} from './components/drop/redux/DropReducers';
 import {IDropdownState} from './components/dropdown/DropdownReducers';
 import {IDropdownOption} from './components/dropdownSearch/DropdownSearch';
 import {IDropdownSearchState} from './components/dropdownSearch/DropdownSearchReducers';
+import {CodeEditorState} from './components/editor/CodeEditorReducers';
 import {JSONEditorState} from './components/editor/JSONEditorReducers';
 import {IFacet} from './components/facets/Facet';
 import {IFacetState} from './components/facets/FacetReducers';
@@ -74,6 +75,7 @@ export interface IReactVaporState {
     groupableCheckboxes?: IGroupableCheckboxesState[];
     inputs?: IInputState[];
     itemFilters?: IItemFilterState[];
+    codeEditors?: CodeEditorState[];
     jsonEditors?: JSONEditorState[];
     lastAction?: Redux.Action;
     lastUpdatedComposite?: ILastUpdatedState[];

--- a/packages/react-vapor/src/ReactVaporReducers.ts
+++ b/packages/react-vapor/src/ReactVaporReducers.ts
@@ -10,6 +10,7 @@ import {datePickersReducer} from './components/datePicker/DatePickerReducers';
 import {dropReducer} from './components/drop/redux/DropReducers';
 import {dropdownsReducer} from './components/dropdown/DropdownReducers';
 import {dropdownsSearchReducer} from './components/dropdownSearch/DropdownSearchReducers';
+import {codeEditorsReducer} from './components/editor/CodeEditorReducers';
 import {jsonEditorsReducer} from './components/editor/JSONEditorReducers';
 import {facetsReducer} from './components/facets/FacetReducers';
 import {filepickersReducer} from './components/filepicker/FilepickerReducers';
@@ -72,6 +73,7 @@ export const ReactVaporReducers: ReducersMapObject = {
     groupableCheckboxes: groupableCheckboxesReducer,
     inputs: inputsReducer,
     itemFilters: itemFiltersReducer,
+    codeEditors: codeEditorsReducer,
     jsonEditors: jsonEditorsReducer,
     lastAction,
     lastUpdatedComposite: lastUpdatedCompositeReducer,

--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -6,17 +6,21 @@ import 'codemirror/addon/search/matchesonscrollbar';
 import 'codemirror/addon/search/search';
 import 'codemirror/mode/python/python';
 
+import classNames from 'classnames';
 import * as CodeMirror from 'codemirror';
 import * as React from 'react';
 import * as ReactCodeMirror from 'react-codemirror2';
-
-import classNames from 'classnames';
 import {connect} from 'react-redux';
-import {CollapsibleSelectors} from '../collapsible/CollapsibleSelectors';
-import {CodeMirrorGutters} from './EditorConstants';
+import * as _ from 'underscore';
+
 import {IReactVaporState} from '../../ReactVapor';
+import {IDispatch} from '../../utils';
+import {CollapsibleSelectors} from '../collapsible/CollapsibleSelectors';
+import {CodeEditorActions} from './CodeEditorActions';
+import {CodeMirrorGutters} from './EditorConstants';
 
 export interface ICodeEditorProps {
+    id?: string;
     value: string;
     mode: any;
     readOnly?: boolean;
@@ -38,8 +42,13 @@ const mapStateToProps = (state: IReactVaporState, {collapsibleId}: ICodeEditorPr
     isCollapsibleExpanded: CollapsibleSelectors.isExpanded(state, collapsibleId),
 });
 
+const mapDispatchToProps = (dispatch: IDispatch, {id}: {id?: string}) => ({
+    updateStoreValue: (value: string) => dispatch(CodeEditorActions.updateValue(id, value)),
+    clearCodeEditorFromStore: () => dispatch(CodeEditorActions.remove(id)),
+});
+
 class CodeEditorDisconnect extends React.Component<
-    ICodeEditorProps & Partial<ReturnType<typeof mapStateToProps>>,
+    ICodeEditorProps & Partial<ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>>,
     CodeEditorState
 > {
     static defaultProps: Partial<ICodeEditorProps> = {
@@ -76,6 +85,9 @@ class CodeEditorDisconnect extends React.Component<
             this.editor.refresh();
             this.setState({numberOfRefresh: this.state.numberOfRefresh + 1});
         }
+        if (this.props.id) {
+            this.props.updateStoreValue(this.props.value);
+        }
     }
 
     componentDidUpdate(prevProps: ICodeEditorProps) {
@@ -88,6 +100,16 @@ class CodeEditorDisconnect extends React.Component<
             this.editor.getDoc().clearHistory();
         }
     }
+
+    componentWillUnmount() {
+        if (this.props.id) {
+            this.props.clearCodeEditorFromStore();
+        }
+    }
+
+    private debouncedUpdateStore = _.debounce((value: string) => {
+        this.props.updateStoreValue(value);
+    }, 500);
 
     render() {
         return (
@@ -103,6 +125,9 @@ class CodeEditorDisconnect extends React.Component<
                 value={this.state.value}
                 onChange={(editor, data, value: string) => {
                     this.props.onChange?.(value);
+                    if (this.props.id) {
+                        this.debouncedUpdateStore(value);
+                    }
                 }}
                 options={{
                     ...CodeEditorDisconnect.defaultOptions,
@@ -125,4 +150,4 @@ class CodeEditorDisconnect extends React.Component<
     }
 }
 
-export const CodeEditor = connect(mapStateToProps)(CodeEditorDisconnect);
+export const CodeEditor = connect(mapStateToProps, mapDispatchToProps)(CodeEditorDisconnect);

--- a/packages/react-vapor/src/components/editor/CodeEditorActions.ts
+++ b/packages/react-vapor/src/components/editor/CodeEditorActions.ts
@@ -1,0 +1,26 @@
+import {IReduxAction} from '../../utils';
+
+export const CodeEditorActionTypes = {
+    remove: 'REMOVE_CODE_EDITOR',
+    update: 'UPDATE_CODE_EDITOR',
+};
+
+export interface CodeEditorActionPayload {
+    id: string;
+    value?: string;
+}
+
+const updateValue = (id: string, value = ''): IReduxAction<CodeEditorActionPayload> => ({
+    type: CodeEditorActionTypes.update,
+    payload: {id, value},
+});
+
+const remove = (id: string): IReduxAction<CodeEditorActionPayload> => ({
+    type: CodeEditorActionTypes.remove,
+    payload: {id},
+});
+
+export const CodeEditorActions = {
+    updateValue,
+    remove,
+};

--- a/packages/react-vapor/src/components/editor/CodeEditorReducers.ts
+++ b/packages/react-vapor/src/components/editor/CodeEditorReducers.ts
@@ -1,0 +1,38 @@
+import {IReduxAction} from '../../utils';
+import {CodeEditorActionPayload, CodeEditorActionTypes} from './CodeEditorActions';
+
+export interface CodeEditorsState {
+    [key: string]: CodeEditorState;
+}
+
+export interface CodeEditorState {
+    id: string;
+    value: string;
+}
+
+export const CodeEditorsInitialState: CodeEditorsState = null;
+
+export const codeEditorsReducer = (
+    state: CodeEditorsState = CodeEditorsInitialState,
+    action: IReduxAction<CodeEditorActionPayload>
+): CodeEditorsState => {
+    switch (action.type) {
+        case CodeEditorActionTypes.update:
+            return {
+                ...state,
+                [action.payload.id]: {
+                    id: action.payload.id,
+                    value: action.payload.value,
+                },
+            };
+        case CodeEditorActionTypes.remove:
+            if (Object.keys(state).length > 1) {
+                delete state[action.payload.id];
+            } else {
+                state = null;
+            }
+            return state;
+        default:
+            return state;
+    }
+};

--- a/packages/react-vapor/src/components/editor/CodeEditorSelectors.ts
+++ b/packages/react-vapor/src/components/editor/CodeEditorSelectors.ts
@@ -1,0 +1,13 @@
+import * as _ from 'underscore';
+
+import {IReactVaporState} from '../../ReactVapor';
+import {CodeEditorState} from './CodeEditorReducers';
+
+const getValue = (state: IReactVaporState, id: string): string => {
+    const codeEditor: CodeEditorState = _.findWhere(state.codeEditors, {id});
+    return codeEditor?.value ?? '';
+};
+
+export const CodeEditorSelectors = {
+    getValue,
+};

--- a/packages/react-vapor/src/components/editor/tests/codeEditorReducer.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/codeEditorReducer.spec.tsx
@@ -1,0 +1,53 @@
+import {IReduxAction} from '../../../utils';
+import {CodeEditorActionPayload, CodeEditorActions} from '../CodeEditorActions';
+import {CodeEditorsInitialState, codeEditorsReducer, CodeEditorsState} from '../CodeEditorReducers';
+
+describe('codeEditorReducers', () => {
+    const unrelatedAction: IReduxAction<CodeEditorActionPayload> = {
+        type: 'DO_SOMETHING',
+        payload: {id: ''},
+    };
+
+    it('should return the default state if the action is not related and the state is undefined', () => {
+        expect(codeEditorsReducer(undefined, unrelatedAction)).toEqual(CodeEditorsInitialState);
+    });
+
+    it('should return the old state when the action is unrelated to codeEditor containers', () => {
+        const state: any = null;
+        const newState: CodeEditorsState = codeEditorsReducer(state, unrelatedAction);
+
+        expect(state).toEqual(newState);
+    });
+
+    describe('updateValue', () => {
+        it('should return codeEditor with the value in the payload if passed', () => {
+            const state = {
+                anId: {id: 'anId', value: 'a value'},
+                anotherId: {id: 'anotherId', value: 'another value'},
+            };
+
+            const action = CodeEditorActions.updateValue(state.anotherId.id, 'a changed value');
+            const newState: any = codeEditorsReducer(state, action);
+
+            expect(newState.anId.value).toBe('a value');
+            expect(newState.anotherId.value).toBe(action.payload.value);
+        });
+    });
+    describe('remove', () => {
+        it('should remove from the store the codeEditor payload id', () => {
+            const state = {
+                anId: {id: 'anId', value: 'a value'},
+                anotherId: {id: 'anotherId', value: 'another value'},
+            };
+
+            let action = CodeEditorActions.remove(state.anotherId.id);
+            let newState: any = codeEditorsReducer(state, action);
+
+            expect(newState.anId.value).toBe('a value');
+            expect(newState.anotherId).toBeUndefined();
+
+            action = CodeEditorActions.remove(state.anId.id);
+            newState = codeEditorsReducer(state, action);
+        });
+    });
+});

--- a/packages/react-vapor/src/components/editor/tests/codeEditorSelectors.spec.ts
+++ b/packages/react-vapor/src/components/editor/tests/codeEditorSelectors.spec.ts
@@ -1,0 +1,21 @@
+import {IReactVaporState} from '../../../ReactVapor';
+import {CodeEditorState} from '../CodeEditorReducers';
+import {CodeEditorSelectors} from '../CodeEditorSelectors';
+
+describe('CodeEditorSelectors', () => {
+    describe('getValue', () => {
+        it('should not throw and return an empty string when passing a falsy id', () => {
+            expect(CodeEditorSelectors.getValue({} as IReactVaporState, undefined)).toBe('');
+            expect(CodeEditorSelectors.getValue({} as IReactVaporState, null)).toBe('');
+            expect(CodeEditorSelectors.getValue({} as IReactVaporState, '')).toBe('');
+        });
+
+        it('should return the value at the specified id', () => {
+            const id = '🥔';
+            const expectedValue = '{}';
+            const expectedCodeEditor: CodeEditorState = {id, value: expectedValue};
+
+            expect(CodeEditorSelectors.getValue({codeEditors: [expectedCodeEditor]}, '🥔')).toBe(expectedValue);
+        });
+    });
+});


### PR DESCRIPTION
### Proposed Changes

I gave the possibility for the `CodeEditor` to have a value in the redux store.

Basically, if you set the `id` prop. An action will be dispatched on change to set the value of the `CodeEditor` in the store.

You can check the Demo, the first `CodeEditor` displayed there should dispatch the update action on change.

![Peek 2021-04-07 13-29](https://user-images.githubusercontent.com/45688129/113909029-3b95c080-97a5-11eb-843c-894c9fa16a2b.gif)
![2021-04-07_13-57](https://user-images.githubusercontent.com/45688129/113912413-160ab600-97a9-11eb-8eb1-269a046cb1de.png)


I debounced the redux call not to spam the store with new values on each stroke.

EDIT: upon unmount, the component will remove its ID from the store

We also have a selector to get the value from the codeEditor.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
