### PR TITLE
fix(table-with-filter): revert to previous state, ignore empty state

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableWithFilter.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithFilter.tsx
@@ -8,7 +8,6 @@ import {ConfigSupplier, HocUtils, UrlUtils} from '../../utils';
 import {BlankSlateWithTable, IBlankSlateWithTableProps} from '../blankSlate';
 import {FilterBoxConnected, FilterBoxSelectors} from '../filterBox';
 import {ITableHOCOwnProps, TableHOC} from './TableHOC';
-import {TableSelectors} from './TableSelectors';
 import {Params} from './TableWithUrlState';
 
 export interface ITableWithFilterConfig extends WithServerSideProcessingProps {
@@ -44,8 +43,6 @@ export const tableWithFilter = (
             filterText ? _.filter(ownProps.data, (datum: any) => matchFilter(filterText, datum)) : ownProps.data;
         const urlParams = UrlUtils.getSearchParams();
         return {
-            isTrulyEmpty: TableSelectors.getIsTrulyEmpty(state, ownProps),
-            isEmptyStateSet: TableSelectors.isEmptyStateSet(state, ownProps),
             filter: filterText,
             urlFilter: urlParams[Params.filter],
             data: ownProps.isServer || config.isServer ? ownProps.data : ownProps.data && filterData(),
@@ -60,18 +57,10 @@ export const tableWithFilter = (
         }
 
         render() {
-            const {
-                filterBlankslate,
-                filterMatcher,
-                filterPlaceholder,
-                filter,
-                urlFilter,
-                isEmptyStateSet,
-                isTrulyEmpty,
-                ...tableProps
-            } = this.props;
+            const {filterBlankslate, filterMatcher, filterPlaceholder, filter, urlFilter, ...tableProps} = this.props;
             const blankSlateProps = filterBlankslate || config.blankSlate;
-            const shouldShowBlankslate = !_.isEmpty(blankSlateProps) && !isEmptyStateSet && isTrulyEmpty;
+            const shouldShowBlankslate =
+                _.isEmpty(this.props.data) && !_.isEmpty(filter) && !_.isEmpty(blankSlateProps);
             const filterAction = (
                 <FilterBoxConnected
                     key="FilterBox"

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithFilter.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithFilter.spec.tsx
@@ -96,7 +96,7 @@ describe('Table HOC', () => {
                 expect(updateSpy).not.toHaveBeenCalled();
             });
 
-            it('should render a blankSlate as renderBody if the table is truly empty and the emptyState is not set', () => {
+            it('should render a blankSlate as renderBody if the data is empty and the filter is not empty', () => {
                 jest.spyOn(TableSelectors, 'getIsTrulyEmpty').mockReturnValueOnce(true);
                 const wrapper = shallowWithState(
                     <TableWithFilterServer {...defaultProps} data={null} />,


### PR DESCRIPTION
### Proposed Changes
Bug: https://coveord.atlassian.net/browse/ADUI-6845

A bug was noticed with the changes of the last release. If a tableWithFilter has a custom blankslate and the same TableHOC has a empty state set, the custom blankslate wouldn't appears. For example, the "clear filter" button wouldn't appears on the source blankslate.

To solve this issue, I revert the changes made on the tableWithFilter component.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
