### PR TITLE
Improve icon alignment

### DIFF
--- a/packages/demo/src/components/examples/SectionExamples.tsx
+++ b/packages/demo/src/components/examples/SectionExamples.tsx
@@ -60,7 +60,7 @@ export class SectionExamples extends React.Component<any, any> {
                             <div className="flex">
                                 Custom title with a Svg and Tooltip
                                 <Tooltip title="info title">
-                                    <Svg svgName="info" className="ml1 icon mod-align-with-text documentation-link" />
+                                    <Svg svgName="info" className="ml1 icon mod-20 documentation-link" />
                                 </Tooltip>
                             </div>
                         }

--- a/packages/demo/src/components/examples/SvgExamples.tsx
+++ b/packages/demo/src/components/examples/SvgExamples.tsx
@@ -6,13 +6,26 @@ export class SvgExamples extends React.Component<any, any> {
         return (
             <Form>
                 <Section level={1} title="Size modifiers" description="Change the size of the icons">
-                    <Svg svgName="clear" className="icon" />
-                    <Svg svgName="clear" className="icon mod-16" />
-                    <Svg svgName="clear" className="icon mod-lg" />
-                    <Svg svgName="clear" className="icon mod-2x" />
-                    <Svg svgName="clear" className="icon mod-3x" />
-                    <Svg svgName="clear" className="icon mod-4x" />
-                    <Svg svgName="clear" className="icon mod-5x" />
+                    <Section level={2} title="Based on the ambient font size">
+                        <Svg svgName="clear" className="icon mod-lg" />
+                        <Svg svgName="clear" className="icon mod-2x" />
+                        <Svg svgName="clear" className="icon mod-3x" />
+                        <Svg svgName="clear" className="icon mod-4x" />
+                        <Svg svgName="clear" className="icon mod-5x" />
+                    </Section>
+                    <Section level={2} title="Based on a fixed size">
+                        <Svg svgName="clear" className="icon mod-10" />
+                        <Svg svgName="clear" className="icon mod-12" />
+                        <Svg svgName="clear" className="icon mod-14" />
+                        <Svg svgName="clear" className="icon mod-16" />
+                        <Svg svgName="clear" className="icon mod-18" />
+                        <Svg svgName="clear" className="icon mod-20" />
+                        <Svg svgName="clear" className="icon mod-22" />
+                        <Svg svgName="clear" className="icon mod-24" />
+                        <Svg svgName="clear" className="icon mod-26" />
+                        <Svg svgName="clear" className="icon mod-28" />
+                        <Svg svgName="clear" className="icon mod-30" />
+                    </Section>
                 </Section>
             </Form>
         );

--- a/packages/react-vapor/src/components/button/Button.tsx
+++ b/packages/react-vapor/src/components/button/Button.tsx
@@ -35,13 +35,7 @@ export class Button extends React.Component<IButtonProps & React.ButtonHTMLAttri
         target: '',
     };
 
-    private onClick() {
-        if (this.props.onClick && this.props.enabled) {
-            this.props.onClick();
-        }
-    }
-
-    getTemplate(buttonClass: string): JSX.Element {
+    render() {
         let buttonElement: JSX.Element;
 
         let buttonAttrs = {
@@ -58,14 +52,14 @@ export class Button extends React.Component<IButtonProps & React.ButtonHTMLAttri
             });
 
             buttonElement = (
-                <a className={`${buttonClass} btn-container`} {...buttonAttrs}>
+                <a className={`${this.className} btn-container`} {...buttonAttrs}>
                     {this.props.name}
                     {this.props.children}
                 </a>
             );
         } else {
             buttonElement = (
-                <button className={buttonClass} {...buttonAttrs}>
+                <button className={this.className} {...buttonAttrs}>
                     {this.props.name}
                     {this.props.children}
                 </button>
@@ -81,7 +75,13 @@ export class Button extends React.Component<IButtonProps & React.ButtonHTMLAttri
         );
     }
 
-    private getClasses() {
+    private onClick() {
+        if (this.props.enabled) {
+            this.props.onClick?.();
+        }
+    }
+
+    private get className(): string {
         return classNames(
             'btn',
             {
@@ -91,9 +91,5 @@ export class Button extends React.Component<IButtonProps & React.ButtonHTMLAttri
             },
             this.props.classes
         );
-    }
-
-    render() {
-        return this.getTemplate(this.getClasses());
     }
 }

--- a/packages/react-vapor/src/components/input/LabeledInput.tsx
+++ b/packages/react-vapor/src/components/input/LabeledInput.tsx
@@ -30,7 +30,7 @@ export const LabeledInput: React.FunctionComponent<ILabeledInputProps> = ({
                 </header>
                 {!!information ? (
                     <Tooltip title={information} placement={TooltipPlacement.Right} className="ml1 labeled-tooltip">
-                        <Svg svgName="info-14" svgClass="icon" />
+                        <Svg svgName="info" svgClass="icon mod-14" />
                     </Tooltip>
                 ) : null}
             </div>

--- a/packages/react-vapor/src/components/labeledValue/LabeledValue.spec.tsx
+++ b/packages/react-vapor/src/components/labeledValue/LabeledValue.spec.tsx
@@ -75,8 +75,8 @@ describe('LabeledValue', () => {
             expect(labeledValue.find(Tooltip).prop('placement')).toBe(TooltipPlacement.Bottom);
         });
 
-        it('should render an svg inside the tooltip having the "info-14" name', () => {
-            expect(labeledValue.find(Tooltip).find(Svg).prop('svgName')).toBe('info-14');
+        it('should render an svg inside the tooltip having the "info" name', () => {
+            expect(labeledValue.find(Tooltip).find(Svg).prop('svgName')).toBe('info');
         });
 
         it('should have the padding prop set to true and the class "padded" by default', () => {

--- a/packages/react-vapor/src/components/labeledValue/LabeledValue.tsx
+++ b/packages/react-vapor/src/components/labeledValue/LabeledValue.tsx
@@ -28,7 +28,7 @@ export class LabeledValue extends React.PureComponent<ILabeledValueProps> {
                 placement={this.props.informationPlacement || TooltipPlacement.Top}
                 className="labeled-tooltip"
             >
-                <Svg svgName="info-14" svgClass="icon no-link" />
+                <Svg svgName="info" svgClass="icon mod-14 no-link" />
             </Tooltip>
         ) : null;
 

--- a/packages/vapor/scss/icons/icons.scss
+++ b/packages/vapor/scss/icons/icons.scss
@@ -65,8 +65,8 @@
         &.mod-#{$size} {
             width: $size + px;
             height: $size + px;
-
-            @extend .mod-align-with-text;
+            line-height: $size + px;
+            vertical-align: -0.5 * ceil($size / 4) + px;
         }
     }
 


### PR DESCRIPTION
### Proposed Changes

All the icon modifiers with a fixed size (`mod-10` to `mod-30`) had the same vertical aligment and lign-height correction of `-0.2 em` which doesn't make sense since they have difference sizes. Now the size of the corrections follows the size of each modifier.

### Potential Breaking Changes

Tested it in the admin-ui and it improves alignment in a bunch of places.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
