### PR TITLE
Bugfix/ad UI 6797 isdirty modal prompt not in modal store

### DIFF
--- a/packages/react-vapor/src/components/modal/ConfirmationModalProvider.tsx
+++ b/packages/react-vapor/src/components/modal/ConfirmationModalProvider.tsx
@@ -11,6 +11,7 @@ export interface IConfirmationModalChildrenProps {
 }
 
 export interface IConfirmationModalProviderProps {
+    id?: string;
     shouldConfirm: boolean;
     modalTitle: string;
     modalBodyChildren: React.ReactNode;
@@ -20,6 +21,7 @@ export interface IConfirmationModalProviderProps {
 }
 
 export const ConfirmationModalProvider: React.FunctionComponent<IConfirmationModalProviderProps> = ({
+    id,
     shouldConfirm,
     children,
     modalTitle,
@@ -50,6 +52,7 @@ export const ConfirmationModalProvider: React.FunctionComponent<IConfirmationMod
         <>
             {children({promptBefore})}
             <ModalComposite
+                id={id}
                 title={modalTitle}
                 classes={className}
                 modalHeaderClasses={['mod-warning']}

--- a/packages/react-vapor/src/components/modal/ConfirmationModalProvider.tsx
+++ b/packages/react-vapor/src/components/modal/ConfirmationModalProvider.tsx
@@ -23,7 +23,7 @@ export interface IConfirmationModalProviderProps {
     confirmButtonText?: string;
 }
 
-const enchance = connect(null, (dispatch: IDispatch, ownProps: IConfirmationModalProviderProps) => ({
+const enhance = connect(null, (dispatch: IDispatch, ownProps: IConfirmationModalProviderProps) => ({
     onOpen: () => dispatch(ModalActions.openModal(ownProps.confirmationModalId)),
     onClose: () => dispatch(ModalActions.closeModal(ownProps.confirmationModalId)),
 }));
@@ -33,7 +33,7 @@ const enchance = connect(null, (dispatch: IDispatch, ownProps: IConfirmationModa
  */
 
 export const ConfirmationModalProviderDisconnected: React.FunctionComponent<
-    IConfirmationModalProviderProps & ConnectedProps<typeof enchance>
+    IConfirmationModalProviderProps & ConnectedProps<typeof enhance>
 > = ({
     confirmationModalId,
     shouldConfirm,
@@ -80,4 +80,4 @@ export const ConfirmationModalProviderDisconnected: React.FunctionComponent<
     );
 };
 
-export const ConfirmationModalProvider = enchance(ConfirmationModalProviderDisconnected);
+export const ConfirmationModalProvider = enhance(ConfirmationModalProviderDisconnected);

--- a/packages/react-vapor/src/components/modal/ConfirmationModalProvider.tsx
+++ b/packages/react-vapor/src/components/modal/ConfirmationModalProvider.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
+import {connect} from 'react-redux';
 
+import {ConnectedProps, IDispatch} from '../../utils';
 import {Button} from '../button/Button';
-import {ModalComposite} from './ModalComposite';
+import {ModalActions} from './ModalActions';
+import {ModalCompositeConnected} from './ModalComposite';
 
 const defaultModalClasses = ['mod-prompt', 'mod-fade-in-scale'];
 const defaultConfirmButtonText = 'Confirm';
@@ -11,7 +14,7 @@ export interface IConfirmationModalChildrenProps {
 }
 
 export interface IConfirmationModalProviderProps {
-    id?: string;
+    confirmationModalId?: string;
     shouldConfirm: boolean;
     modalTitle: string;
     modalBodyChildren: React.ReactNode;
@@ -20,39 +23,47 @@ export interface IConfirmationModalProviderProps {
     confirmButtonText?: string;
 }
 
-export const ConfirmationModalProvider: React.FunctionComponent<IConfirmationModalProviderProps> = ({
-    id,
+const enchance = connect(null, (dispatch: IDispatch, ownProps: IConfirmationModalProviderProps) => ({
+    onOpen: () => dispatch(ModalActions.openModal(ownProps.confirmationModalId)),
+    onClose: () => dispatch(ModalActions.closeModal(ownProps.confirmationModalId)),
+}));
+
+/**
+ * @description wrapper for a modal, that adds a confirmation modal below it
+ */
+
+export const ConfirmationModalProviderDisconnected: React.FunctionComponent<
+    IConfirmationModalProviderProps & ConnectedProps<typeof enchance>
+> = ({
+    confirmationModalId,
     shouldConfirm,
     children,
     modalTitle,
     className = defaultModalClasses,
     modalBodyChildren,
     confirmButtonText = defaultConfirmButtonText,
+    onOpen,
+    onClose,
 }) => {
-    const [isOpen, setIsOpen] = React.useState(false);
     const [confirm, setConfirm] = React.useState(null);
 
     const promptBefore = (callbackOnDiscard: () => any): boolean => {
         if (shouldConfirm) {
-            setIsOpen(true);
+            onOpen();
             setConfirm(() => () => {
                 callbackOnDiscard();
-                close();
+                onClose();
             });
             return false;
         }
         return true;
     };
 
-    const close = () => {
-        setIsOpen(false);
-    };
-
     return (
         <>
             {children({promptBefore})}
-            <ModalComposite
-                id={id}
+            <ModalCompositeConnected
+                id={confirmationModalId}
                 title={modalTitle}
                 classes={className}
                 modalHeaderClasses={['mod-warning']}
@@ -61,12 +72,12 @@ export const ConfirmationModalProvider: React.FunctionComponent<IConfirmationMod
                 modalFooterChildren={
                     <>
                         <Button small name={confirmButtonText} onClick={confirm} primary />
-                        <Button small autoFocus name="Cancel" onClick={close} />
+                        <Button small autoFocus name="Cancel" onClick={onClose} />
                     </>
                 }
-                isOpen={isOpen}
-                onClose={close}
             />
         </>
     );
 };
+
+export const ConfirmationModalProvider = enchance(ConfirmationModalProviderDisconnected);

--- a/packages/react-vapor/src/components/modal/ConfirmationModalProvider.tsx
+++ b/packages/react-vapor/src/components/modal/ConfirmationModalProvider.tsx
@@ -24,15 +24,11 @@ export interface IConfirmationModalProviderProps {
 }
 
 const enhance = connect(null, (dispatch: IDispatch, ownProps: IConfirmationModalProviderProps) => ({
-    onOpen: () => dispatch(ModalActions.openModal(ownProps.confirmationModalId)),
-    onClose: () => dispatch(ModalActions.closeModal(ownProps.confirmationModalId)),
+    openPrompt: () => dispatch(ModalActions.openModal(ownProps.confirmationModalId)),
+    closePrompt: () => dispatch(ModalActions.closeModal(ownProps.confirmationModalId)),
 }));
 
-/**
- * @description wrapper for a modal, that adds a confirmation modal below it
- */
-
-export const ConfirmationModalProviderDisconnected: React.FunctionComponent<
+const ConfirmationModalProviderDisconnected: React.FunctionComponent<
     IConfirmationModalProviderProps & ConnectedProps<typeof enhance>
 > = ({
     confirmationModalId,
@@ -42,17 +38,17 @@ export const ConfirmationModalProviderDisconnected: React.FunctionComponent<
     className = defaultModalClasses,
     modalBodyChildren,
     confirmButtonText = defaultConfirmButtonText,
-    onOpen,
-    onClose,
+    openPrompt,
+    closePrompt,
 }) => {
     const [confirm, setConfirm] = React.useState(null);
 
     const promptBefore = (callbackOnDiscard: () => any): boolean => {
         if (shouldConfirm) {
-            onOpen();
+            openPrompt();
             setConfirm(() => () => {
                 callbackOnDiscard();
-                onClose();
+                closePrompt();
             });
             return false;
         }
@@ -72,7 +68,7 @@ export const ConfirmationModalProviderDisconnected: React.FunctionComponent<
                 modalFooterChildren={
                     <>
                         <Button small name={confirmButtonText} onClick={confirm} primary />
-                        <Button small autoFocus name="Cancel" onClick={onClose} />
+                        <Button small autoFocus name="Cancel" onClick={closePrompt} />
                     </>
                 }
             />

--- a/packages/react-vapor/src/components/modal/UnsavedChangesModalProvider.tsx
+++ b/packages/react-vapor/src/components/modal/UnsavedChangesModalProvider.tsx
@@ -11,7 +11,7 @@ const defaultConfirmButtonText = 'Exit without applying changes';
 
 export interface IUnsavedChangesModalProviderProps {
     isDirty: boolean;
-    id?: string;
+    confirmationModalId?: string;
     modalTitle?: string;
     className?: string[];
     children: (props: IConfirmationModalChildrenProps) => React.ReactNode;
@@ -22,20 +22,20 @@ export interface IUnsavedChangesModalProviderProps {
 export const UnsavedChangesModalProvider: React.FunctionComponent<IUnsavedChangesModalProviderProps> = ({
     isDirty,
     children,
-    id = defaultModalId,
+    confirmationModalId = defaultModalId,
     modalTitle = defaultModalTitle,
     className = defaultModalClasses,
     unsavedChangesDescription = defaultModalDescription,
     confirmButtonText = defaultConfirmButtonText,
 }) => (
     <ConfirmationModalProvider
-        id={id}
+        confirmationModalId={confirmationModalId}
         className={className}
         shouldConfirm={isDirty}
         modalTitle={modalTitle}
         modalBodyChildren={<div>{unsavedChangesDescription}</div>}
         confirmButtonText={confirmButtonText}
     >
-        {(options) => children(options)}
+        {(options: IConfirmationModalChildrenProps) => children(options)}
     </ConfirmationModalProvider>
 );

--- a/packages/react-vapor/src/components/modal/UnsavedChangesModalProvider.tsx
+++ b/packages/react-vapor/src/components/modal/UnsavedChangesModalProvider.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import {ConfirmationModalProvider, IConfirmationModalChildrenProps} from './ConfirmationModalProvider';
 
+const defaultModalId = 'UnsavedChangesModalId';
 const defaultModalTitle = 'Unsaved Changes';
 const defaultModalClasses = ['mod-prompt', 'mod-fade-in-scale'];
 const defaultModalDescription =
@@ -10,6 +11,7 @@ const defaultConfirmButtonText = 'Exit without applying changes';
 
 export interface IUnsavedChangesModalProviderProps {
     isDirty: boolean;
+    id?: string;
     modalTitle?: string;
     className?: string[];
     children: (props: IConfirmationModalChildrenProps) => React.ReactNode;
@@ -20,12 +22,14 @@ export interface IUnsavedChangesModalProviderProps {
 export const UnsavedChangesModalProvider: React.FunctionComponent<IUnsavedChangesModalProviderProps> = ({
     isDirty,
     children,
+    id = defaultModalId,
     modalTitle = defaultModalTitle,
     className = defaultModalClasses,
     unsavedChangesDescription = defaultModalDescription,
     confirmButtonText = defaultConfirmButtonText,
 }) => (
     <ConfirmationModalProvider
+        id={id}
         className={className}
         shouldConfirm={isDirty}
         modalTitle={modalTitle}

--- a/packages/react-vapor/src/components/modal/tests/ConfirmationModalProvider.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/ConfirmationModalProvider.spec.tsx
@@ -1,155 +1,143 @@
-import {mount, shallow, ShallowWrapper} from 'enzyme';
+import {screen, fireEvent} from '@testing-library/dom';
+import userEvent, {specialChars} from '@testing-library/user-event';
 import * as React from 'react';
-import {Provider} from 'react-redux';
+import {renderModal} from 'react-vapor-test-utils';
+import {Store} from 'redux';
 
-import {getStoreMock} from '../../../utils/tests/TestUtils';
-import {ModalCompositeConnected} from '../ModalComposite';
+import {IReactVaporState} from '../../../ReactVapor';
+// import {clearState} from '../../../utils/ReduxUtils';
+import {TestUtils} from '../../../utils/tests/TestUtils';
 import {ConfirmationModalProvider} from '../ConfirmationModalProvider';
+import {ModalCompositeConnected} from '../ModalComposite';
 
 describe('<UnsavedChangeModalProvider/>', () => {
-    let confirmationModalProvider: ShallowWrapper;
-    let heavyConfirmationModalProvider;
-    let regularClickActionSpy: jest.Mock<any, any>;
-    let promptBeforeClickActionSpy: jest.Mock<any, any>;
-    const store = getStoreMock();
+    let store: Store<IReactVaporState>;
+
+    // const mockChildren = jest.fn(); // lol
+
+    // const defaultProps: IConfirmationModalProviderProps = {
+    //     confirmationModalId: '👾-unsaved-modal',
+    //     shouldConfirm: true,
+    //     modalTitle: 'Unsaved Changes',
+    //     modalBodyChildren: <div>some content</div>,
+    //     className: ['potato'],
+    //     children: mockChildren,
+    //     confirmButtonText: 'Confirm',
+    // };
+
     beforeEach(() => {
-        regularClickActionSpy = jest.fn();
-        promptBeforeClickActionSpy = jest.fn();
+        store = TestUtils.buildStore();
     });
 
-    afterEach(() => {
-        regularClickActionSpy.mockReset();
-        promptBeforeClickActionSpy.mockReset();
-        if (confirmationModalProvider?.exists()) {
-            confirmationModalProvider.unmount();
-        }
-    });
+    // afterEach(() => {
+    // store.dispatch(clearState());
+    // mockChildren.mockReset();
+    // });
 
-    const shallowMountUnsavedModalProvider = (shouldConfirm: boolean = false) =>
-        shallow(
-            <ConfirmationModalProvider
-                shouldConfirm={shouldConfirm}
-                modalTitle="Are you sure?"
-                modalBodyChildren={<div>some content</div>}
-            >
-                {({promptBefore}) => (
-                    <ModalCompositeConnected
-                        id="👾"
-                        title="🙄"
-                        classes={['mod-slide-in-bottom', 'mod-big', 'mod-stick-bottom']}
-                        modalBodyChildren="🙈 🙉 🙊"
-                        modalFooterChildren={
-                            <button
-                                className="btn"
-                                onClick={() => promptBefore(promptBeforeClickActionSpy) && regularClickActionSpy()}
-                            />
-                        }
-                        modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
-                        docLink={{url: 'https://www.coveo.com', tooltip: {title: 'Go to coveo.com'}}}
-                    />
-                )}
-            </ConfirmationModalProvider>
-        );
+    // const shallowMountUnsavedModalProvider = (shouldConfirm: boolean = false) =>
+    //     shallow(
+    //         <Provider store={store}>
+    //             <ConfirmationModalProvider
+    //                 shouldConfirm={shouldConfirm}
+    //                 modalTitle="Are you sure?"
+    //                 modalBodyChildren={<div>some content</div>}
+    //             >
+    //                 {({promptBefore}) => (
+    //                     <ModalCompositeConnected
+    //                         id="👾"
+    //                         title="🙄"
+    //                         classes={['mod-slide-in-bottom', 'mod-big', 'mod-stick-bottom']}
+    //                         modalBodyChildren="🙈 🙉 🙊"
+    //                         modalFooterChildren={
+    //                             <button
+    //                                 className="btn"
+    //                                 onClick={() => promptBefore(promptBeforeClickActionSpy) && regularClickActionSpy()}
+    //                             />
+    //                         }
+    //                         modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
+    //                         docLink={{url: 'https://www.coveo.com', tooltip: {title: 'Go to coveo.com'}}}
+    //                     />
+    //                 )}
+    //             </ConfirmationModalProvider>
+    //         </Provider>
+    //     );
 
-    const heavilyMountUnsavedModalProvider = (shouldConfirm: boolean = false) =>
-        mount(
-            <ConfirmationModalProvider
-                shouldConfirm={shouldConfirm}
-                modalTitle="Are you sure?"
-                modalBodyChildren={<div>some content</div>}
-            >
-                {({promptBefore}) => (
-                    <Provider store={store}>
+    // const heavilyMountUnsavedModalProvider = (shouldConfirm: boolean = false) =>
+    //     mount(
+    //         <Provider store={store}>
+    //             <ConfirmationModalProvider
+    //                 shouldConfirm={shouldConfirm}
+    //                 modalTitle="Are you sure?"
+    //                 modalBodyChildren={<div>some content</div>}
+    //             >
+    //                 {({promptBefore}) => (
+    //                     <Provider store={store}>
+    //                         <ModalCompositeConnected
+    //                             id="👾"
+    //                             title="🙄"
+    //                             classes={['mod-slide-in-bottom', 'mod-big', 'mod-stick-bottom']}
+    //                             modalBodyChildren="🙈 🙉 🙊"
+    //                             modalFooterChildren={
+    //                                 <button
+    //                                     className="btn"
+    //                                     onClick={() =>
+    //                                         promptBefore(promptBeforeClickActionSpy) && regularClickActionSpy()
+    //                                     }
+    //                                 />
+    //                             }
+    //                             modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
+    //                             docLink={{url: 'https://www.coveo.com', tooltip: {title: 'Go to coveo.com'}}}
+    //                         />
+    //                     </Provider>
+    //                 )}
+    //             </ConfirmationModalProvider>
+    //         </Provider>
+    //     );
+
+    describe('SHOULDCONFIRM: when shouldConfirm prop is true:', () => {
+        it('should open the ConfirmationModal to interrupt the leaving action', () => {
+            renderModal(
+                <ConfirmationModalProvider
+                    shouldConfirm
+                    confirmationModalId="👾-unsaved-modal"
+                    modalTitle="Are you sure?"
+                    modalBodyChildren="Big bada boom"
+                >
+                    {({promptBefore}) => (
                         <ModalCompositeConnected
+                            isDirty
                             id="👾"
                             title="🙄"
                             classes={['mod-slide-in-bottom', 'mod-big', 'mod-stick-bottom']}
-                            modalBodyChildren="🙈 🙉 🙊"
-                            modalFooterChildren={
-                                <button
-                                    className="btn"
-                                    onClick={() => promptBefore(promptBeforeClickActionSpy) && regularClickActionSpy()}
-                                />
-                            }
+                            modalBodyChildren="Hakuna matata"
+                            modalFooterChildren={<button className="btn" onClick={() => promptBefore(jest.fn())} />}
                             modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
-                            docLink={{url: 'https://www.coveo.com', tooltip: {title: 'Go to coveo.com'}}}
                         />
-                    </Provider>
-                )}
-            </ConfirmationModalProvider>
-        );
+                    )}
+                </ConfirmationModalProvider>,
+                {initialState: {modals: [{id: '👾', isOpened: true}]}}
+            );
 
-    it('should mount and unmount without trowing', () => {
-        expect(() => {
-            shallowMountUnsavedModalProvider().unmount();
-        }).not.toThrow();
-    });
+            expect(screen.queryByText('Unsaved Changes')).not.toBeInTheDocument();
 
-    describe('when should confirm changes', () => {
-        it('should open the ConfirmationModal to interrupt the leaving action', () => {
-            heavyConfirmationModalProvider = heavilyMountUnsavedModalProvider(true);
+            // fireEvent.click(document);
 
-            expect(heavyConfirmationModalProvider.childAt(1).prop('isOpen')).toBeFalsy();
+            // userEvent.click(document.body);
+            userEvent.type(screen.getByRole('dialog'), specialChars.escape);
 
-            const heavyModal: any = heavyConfirmationModalProvider.find(ModalCompositeConnected);
-            heavyModal.props().modalFooterChildren.props.onClick();
-            heavyConfirmationModalProvider.update();
-
-            expect(heavyConfirmationModalProvider.childAt(1).prop('isOpen')).toBeTruthy();
+            expect(screen.getByText('Unsaved Changes')).toBeVisible();
         });
 
-        describe('PromptBefore function', () => {
-            it('should return false', () => {
-                confirmationModalProvider = shallowMountUnsavedModalProvider(true);
-                confirmationModalProvider.childAt(0).props().modalFooterChildren.props.onClick();
+        it('PromptBefore function should return false', () => {});
 
-                expect(regularClickActionSpy).not.toHaveBeenCalled();
-            });
-        });
+        it('should use the callback function in the promptBefore function when confirming the exit', () => {});
 
-        it('should use the callback function in the promptBefore function when confirming the exit', () => {
-            heavyConfirmationModalProvider = heavilyMountUnsavedModalProvider(true);
-
-            const modal: any = heavyConfirmationModalProvider.find(ModalCompositeConnected);
-            modal.props().modalFooterChildren.props.onClick();
-            heavyConfirmationModalProvider.update();
-            const exitWithoutSavingButton: any = heavyConfirmationModalProvider.childAt(1).find('Button').first();
-            exitWithoutSavingButton.prop('onClick')();
-
-            expect(promptBeforeClickActionSpy).toHaveBeenCalled();
-        });
-
-        it('should not use the callback function in the promptBefore function when cancelling the exit', () => {
-            heavyConfirmationModalProvider = heavilyMountUnsavedModalProvider(true);
-
-            const modal: any = heavyConfirmationModalProvider.find(ModalCompositeConnected);
-            modal.props().modalFooterChildren.props.onClick();
-            heavyConfirmationModalProvider.update();
-            const exitWithoutSavingButton: any = heavyConfirmationModalProvider.childAt(1).find('Button').last();
-            exitWithoutSavingButton.prop('onClick')();
-
-            expect(promptBeforeClickActionSpy).not.toHaveBeenCalled();
-        });
+        it('should not use the callback function in the promptBefore function when cancelling the exit', () => {});
     });
 
     describe('when the modal is configured not to confirm changes', () => {
-        it('should not open the ConfirmationModal to interrupt the leaving action', () => {
-            heavyConfirmationModalProvider = heavilyMountUnsavedModalProvider(false);
+        it('should not open the ConfirmationModal to interrupt the leaving action', () => {});
 
-            expect(heavyConfirmationModalProvider.childAt(1).prop('isOpen')).toBeFalsy();
-
-            const heavyModal: any = heavyConfirmationModalProvider.find(ModalCompositeConnected);
-            heavyModal.props().modalFooterChildren.props.onClick();
-            heavyConfirmationModalProvider.update();
-
-            expect(heavyConfirmationModalProvider.childAt(1).prop('isOpen')).toBeFalsy();
-        });
-
-        it('promptBefore function should return true', () => {
-            confirmationModalProvider = shallowMountUnsavedModalProvider();
-            confirmationModalProvider.childAt(0).props().modalFooterChildren.props.onClick();
-
-            expect(regularClickActionSpy).toHaveBeenCalled();
-        });
+        it('promptBefore function should return true', () => {});
     });
 });

--- a/packages/react-vapor/src/components/modal/tests/ConfirmationModalProvider.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/ConfirmationModalProvider.spec.tsx
@@ -5,13 +5,13 @@ import {renderModal} from 'react-vapor-test-utils';
 import {ConfirmationModalProvider} from '../ConfirmationModalProvider';
 import {ModalCompositeConnected} from '../ModalComposite';
 
-describe('<UnsavedChangeModalProvider/>', () => {
+describe('ConfirmationModalProvider', () => {
     describe('when shouldConfirm prop is true:', () => {
         it('should open the ConfirmationModal to interrupt the leaving action if isDirty is true', () => {
             renderModal(
                 <ConfirmationModalProvider
                     shouldConfirm
-                    confirmationModalId="👾-unsaved-modal"
+                    confirmationModalId="👾-unsaved-changes"
                     modalTitle="Are you sure?"
                     modalBodyChildren="Big bada boom"
                 >
@@ -24,7 +24,7 @@ describe('<UnsavedChangeModalProvider/>', () => {
                             modalBodyChildren="Hakuna matata"
                             modalFooterChildren={
                                 <button className="btn" onClick={() => promptBefore(jest.fn())}>
-                                    here
+                                    prompt confirmation modal
                                 </button>
                             }
                             modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
@@ -34,37 +34,7 @@ describe('<UnsavedChangeModalProvider/>', () => {
                 {initialState: {modals: [{id: '👾', isOpened: true}]}}
             );
             expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
-            userEvent.click(screen.getByRole('button', {name: 'here'}));
-            expect(screen.getByText('Are you sure?')).toBeVisible();
-        });
-
-        it('should open the ConfirmationModal to interrupt the leaving action if isDirty is false', () => {
-            renderModal(
-                <ConfirmationModalProvider
-                    shouldConfirm
-                    confirmationModalId="👾-unsaved-modal"
-                    modalTitle="Are you sure?"
-                    modalBodyChildren="Big bada boom"
-                >
-                    {({promptBefore}) => (
-                        <ModalCompositeConnected
-                            id="👾"
-                            title="🙄"
-                            classes={['mod-slide-in-bottom', 'mod-big', 'mod-stick-bottom']}
-                            modalBodyChildren="Hakuna matata"
-                            modalFooterChildren={
-                                <button className="btn" onClick={() => promptBefore(jest.fn())}>
-                                    here
-                                </button>
-                            }
-                            modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
-                        />
-                    )}
-                </ConfirmationModalProvider>,
-                {initialState: {modals: [{id: '👾', isOpened: true}]}}
-            );
-            expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
-            userEvent.click(screen.getByRole('button', {name: 'here'}));
+            userEvent.click(screen.getByRole('button', {name: 'prompt confirmation modal'}));
             expect(screen.getByText('Are you sure?')).toBeVisible();
         });
     });
@@ -74,7 +44,7 @@ describe('<UnsavedChangeModalProvider/>', () => {
             renderModal(
                 <ConfirmationModalProvider
                     shouldConfirm={false}
-                    confirmationModalId="👾-unsaved-modal"
+                    confirmationModalId="👾-unsaved-changes"
                     modalTitle="Are you sure?"
                     modalBodyChildren="Big bada boom"
                 >
@@ -87,7 +57,7 @@ describe('<UnsavedChangeModalProvider/>', () => {
                             modalBodyChildren="Hakuna matata"
                             modalFooterChildren={
                                 <button className="btn" onClick={() => promptBefore(jest.fn())}>
-                                    here
+                                    prompt confirmation modal
                                 </button>
                             }
                             modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
@@ -97,37 +67,7 @@ describe('<UnsavedChangeModalProvider/>', () => {
                 {initialState: {modals: [{id: '👾', isOpened: true}]}}
             );
             expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
-            userEvent.click(screen.getByRole('button', {name: 'here'}));
-            expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
-        });
-
-        it('should not open the ConfirmationModal to interrupt the leaving action if isDirty is false', () => {
-            renderModal(
-                <ConfirmationModalProvider
-                    shouldConfirm={false}
-                    confirmationModalId="👾-unsaved-modal"
-                    modalTitle="Are you sure?"
-                    modalBodyChildren="Big bada boom"
-                >
-                    {({promptBefore}) => (
-                        <ModalCompositeConnected
-                            id="👾"
-                            title="🙄"
-                            classes={['mod-slide-in-bottom', 'mod-big', 'mod-stick-bottom']}
-                            modalBodyChildren="Hakuna matata"
-                            modalFooterChildren={
-                                <button className="btn" onClick={() => promptBefore(jest.fn())}>
-                                    here
-                                </button>
-                            }
-                            modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
-                        />
-                    )}
-                </ConfirmationModalProvider>,
-                {initialState: {modals: [{id: '👾', isOpened: true}]}}
-            );
-            expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
-            userEvent.click(screen.getByRole('button', {name: 'here'}));
+            userEvent.click(screen.getByRole('button', {name: 'prompt confirmation modal'}));
             expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
         });
     });

--- a/packages/react-vapor/src/components/modal/tests/ConfirmationModalProvider.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/ConfirmationModalProvider.spec.tsx
@@ -1,101 +1,13 @@
-import {screen, fireEvent} from '@testing-library/dom';
-import userEvent, {specialChars} from '@testing-library/user-event';
+import {screen} from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import {renderModal} from 'react-vapor-test-utils';
-import {Store} from 'redux';
-
-import {IReactVaporState} from '../../../ReactVapor';
-// import {clearState} from '../../../utils/ReduxUtils';
-import {TestUtils} from '../../../utils/tests/TestUtils';
 import {ConfirmationModalProvider} from '../ConfirmationModalProvider';
 import {ModalCompositeConnected} from '../ModalComposite';
 
 describe('<UnsavedChangeModalProvider/>', () => {
-    let store: Store<IReactVaporState>;
-
-    // const mockChildren = jest.fn(); // lol
-
-    // const defaultProps: IConfirmationModalProviderProps = {
-    //     confirmationModalId: '👾-unsaved-modal',
-    //     shouldConfirm: true,
-    //     modalTitle: 'Unsaved Changes',
-    //     modalBodyChildren: <div>some content</div>,
-    //     className: ['potato'],
-    //     children: mockChildren,
-    //     confirmButtonText: 'Confirm',
-    // };
-
-    beforeEach(() => {
-        store = TestUtils.buildStore();
-    });
-
-    // afterEach(() => {
-    // store.dispatch(clearState());
-    // mockChildren.mockReset();
-    // });
-
-    // const shallowMountUnsavedModalProvider = (shouldConfirm: boolean = false) =>
-    //     shallow(
-    //         <Provider store={store}>
-    //             <ConfirmationModalProvider
-    //                 shouldConfirm={shouldConfirm}
-    //                 modalTitle="Are you sure?"
-    //                 modalBodyChildren={<div>some content</div>}
-    //             >
-    //                 {({promptBefore}) => (
-    //                     <ModalCompositeConnected
-    //                         id="👾"
-    //                         title="🙄"
-    //                         classes={['mod-slide-in-bottom', 'mod-big', 'mod-stick-bottom']}
-    //                         modalBodyChildren="🙈 🙉 🙊"
-    //                         modalFooterChildren={
-    //                             <button
-    //                                 className="btn"
-    //                                 onClick={() => promptBefore(promptBeforeClickActionSpy) && regularClickActionSpy()}
-    //                             />
-    //                         }
-    //                         modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
-    //                         docLink={{url: 'https://www.coveo.com', tooltip: {title: 'Go to coveo.com'}}}
-    //                     />
-    //                 )}
-    //             </ConfirmationModalProvider>
-    //         </Provider>
-    //     );
-
-    // const heavilyMountUnsavedModalProvider = (shouldConfirm: boolean = false) =>
-    //     mount(
-    //         <Provider store={store}>
-    //             <ConfirmationModalProvider
-    //                 shouldConfirm={shouldConfirm}
-    //                 modalTitle="Are you sure?"
-    //                 modalBodyChildren={<div>some content</div>}
-    //             >
-    //                 {({promptBefore}) => (
-    //                     <Provider store={store}>
-    //                         <ModalCompositeConnected
-    //                             id="👾"
-    //                             title="🙄"
-    //                             classes={['mod-slide-in-bottom', 'mod-big', 'mod-stick-bottom']}
-    //                             modalBodyChildren="🙈 🙉 🙊"
-    //                             modalFooterChildren={
-    //                                 <button
-    //                                     className="btn"
-    //                                     onClick={() =>
-    //                                         promptBefore(promptBeforeClickActionSpy) && regularClickActionSpy()
-    //                                     }
-    //                                 />
-    //                             }
-    //                             modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
-    //                             docLink={{url: 'https://www.coveo.com', tooltip: {title: 'Go to coveo.com'}}}
-    //                         />
-    //                     </Provider>
-    //                 )}
-    //             </ConfirmationModalProvider>
-    //         </Provider>
-    //     );
-
-    describe('SHOULDCONFIRM: when shouldConfirm prop is true:', () => {
-        it('should open the ConfirmationModal to interrupt the leaving action', () => {
+    describe('when shouldConfirm prop is true:', () => {
+        it('should open the ConfirmationModal to interrupt the leaving action if isDirty is true', () => {
             renderModal(
                 <ConfirmationModalProvider
                     shouldConfirm
@@ -110,34 +22,113 @@ describe('<UnsavedChangeModalProvider/>', () => {
                             title="🙄"
                             classes={['mod-slide-in-bottom', 'mod-big', 'mod-stick-bottom']}
                             modalBodyChildren="Hakuna matata"
-                            modalFooterChildren={<button className="btn" onClick={() => promptBefore(jest.fn())} />}
+                            modalFooterChildren={
+                                <button className="btn" onClick={() => promptBefore(jest.fn())}>
+                                    here
+                                </button>
+                            }
                             modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
                         />
                     )}
                 </ConfirmationModalProvider>,
                 {initialState: {modals: [{id: '👾', isOpened: true}]}}
             );
-
-            expect(screen.queryByText('Unsaved Changes')).not.toBeInTheDocument();
-
-            // fireEvent.click(document);
-
-            // userEvent.click(document.body);
-            userEvent.type(screen.getByRole('dialog'), specialChars.escape);
-
-            expect(screen.getByText('Unsaved Changes')).toBeVisible();
+            expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
+            userEvent.click(screen.getByRole('button', {name: 'here'}));
+            expect(screen.getByText('Are you sure?')).toBeVisible();
         });
 
-        it('PromptBefore function should return false', () => {});
-
-        it('should use the callback function in the promptBefore function when confirming the exit', () => {});
-
-        it('should not use the callback function in the promptBefore function when cancelling the exit', () => {});
+        it('should open the ConfirmationModal to interrupt the leaving action if isDirty is false', () => {
+            renderModal(
+                <ConfirmationModalProvider
+                    shouldConfirm
+                    confirmationModalId="👾-unsaved-modal"
+                    modalTitle="Are you sure?"
+                    modalBodyChildren="Big bada boom"
+                >
+                    {({promptBefore}) => (
+                        <ModalCompositeConnected
+                            id="👾"
+                            title="🙄"
+                            classes={['mod-slide-in-bottom', 'mod-big', 'mod-stick-bottom']}
+                            modalBodyChildren="Hakuna matata"
+                            modalFooterChildren={
+                                <button className="btn" onClick={() => promptBefore(jest.fn())}>
+                                    here
+                                </button>
+                            }
+                            modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
+                        />
+                    )}
+                </ConfirmationModalProvider>,
+                {initialState: {modals: [{id: '👾', isOpened: true}]}}
+            );
+            expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
+            userEvent.click(screen.getByRole('button', {name: 'here'}));
+            expect(screen.getByText('Are you sure?')).toBeVisible();
+        });
     });
 
-    describe('when the modal is configured not to confirm changes', () => {
-        it('should not open the ConfirmationModal to interrupt the leaving action', () => {});
+    describe('when shouldConfirm prop is false:', () => {
+        it('should not open the ConfirmationModal to interrupt the leaving action if isDirty is true', () => {
+            renderModal(
+                <ConfirmationModalProvider
+                    shouldConfirm={false}
+                    confirmationModalId="👾-unsaved-modal"
+                    modalTitle="Are you sure?"
+                    modalBodyChildren="Big bada boom"
+                >
+                    {({promptBefore}) => (
+                        <ModalCompositeConnected
+                            isDirty
+                            id="👾"
+                            title="🙄"
+                            classes={['mod-slide-in-bottom', 'mod-big', 'mod-stick-bottom']}
+                            modalBodyChildren="Hakuna matata"
+                            modalFooterChildren={
+                                <button className="btn" onClick={() => promptBefore(jest.fn())}>
+                                    here
+                                </button>
+                            }
+                            modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
+                        />
+                    )}
+                </ConfirmationModalProvider>,
+                {initialState: {modals: [{id: '👾', isOpened: true}]}}
+            );
+            expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
+            userEvent.click(screen.getByRole('button', {name: 'here'}));
+            expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
+        });
 
-        it('promptBefore function should return true', () => {});
+        it('should not open the ConfirmationModal to interrupt the leaving action if isDirty is false', () => {
+            renderModal(
+                <ConfirmationModalProvider
+                    shouldConfirm={false}
+                    confirmationModalId="👾-unsaved-modal"
+                    modalTitle="Are you sure?"
+                    modalBodyChildren="Big bada boom"
+                >
+                    {({promptBefore}) => (
+                        <ModalCompositeConnected
+                            id="👾"
+                            title="🙄"
+                            classes={['mod-slide-in-bottom', 'mod-big', 'mod-stick-bottom']}
+                            modalBodyChildren="Hakuna matata"
+                            modalFooterChildren={
+                                <button className="btn" onClick={() => promptBefore(jest.fn())}>
+                                    here
+                                </button>
+                            }
+                            modalBodyClasses={['mod-header-padding', 'mod-form-top-bottom-padding']}
+                        />
+                    )}
+                </ConfirmationModalProvider>,
+                {initialState: {modals: [{id: '👾', isOpened: true}]}}
+            );
+            expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
+            userEvent.click(screen.getByRole('button', {name: 'here'}));
+            expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
+        });
     });
 });

--- a/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
+++ b/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
@@ -55,7 +55,7 @@ const ModalWizardDisconneted: React.FunctionComponent<ModalWizardProps & Connect
     const {isValid, message} = validateStep?.(currentStep, numberOfSteps) ?? {isValid: true};
 
     return (
-        <UnsavedChangesModalProvider isDirty={isDirty}>
+        <UnsavedChangesModalProvider isDirty={isDirty} confirmationModalId={`${id}-unsaved-modal`}>
             {({promptBefore}) => (
                 <ModalCompositeConnected
                     id={id}


### PR DESCRIPTION
### Proposed Changes

Added the ConfirmationModalProvider to the store instead of using internal mechanisms which should fix the bug of the confirmation modal not being overlayed over an isDirty modal. I also updated / removed some tests to use RTL and remove enzyme

### Potential Breaking Changes

Might be some issues when the version is updated in the admin, but in theory it should work the same

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
