### PR TITLE
fix(table): line-height to help align badges in table

### DIFF
--- a/packages/demo/src/components/examples/TableHOCExamples.tsx
+++ b/packages/demo/src/components/examples/TableHOCExamples.tsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import * as React from 'react';
 import {connect} from 'react-redux';
 import {
+    Badge,
     DateUtils,
     filterThrough,
     IDispatch,
@@ -100,6 +101,7 @@ const renderHeader = (tableId: string) => (
                 Username
             </TableHeaderWithSort>
             <th>Date of birth</th>
+            <th>Badge</th>
         </tr>
     </thead>
 );
@@ -111,6 +113,9 @@ export const generateTableRow = (allData: IExampleRowData[], tableId: string) =>
             <td key="email">{data.email.toLowerCase()}</td>
             <td key="username">{data.username.toLowerCase()}</td>
             <td key="date-of-birth">{data.dateOfBirth.toLocaleDateString()}</td>
+            <td>
+                <Badge label={'🥔 King'} extraClasses={['mod-small mod-success']} />
+            </td>
         </TableRowConnected>
     ));
 

--- a/packages/vapor/scss/tables/table.scss
+++ b/packages/vapor/scss/tables/table.scss
@@ -7,6 +7,7 @@
     th,
     td {
         position: relative;
+        line-height: 25px;
         vertical-align: top;
         background-clip: padding-box;
 


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/ADUI-6813

I've added a line-height of 25px to help with the badge alignment with the text in <td>. I've also added a badge colum in the demo to help visualise.
![Peek 2021-04-13 13-45](https://user-images.githubusercontent.com/63734941/114598181-988aee00-9c5f-11eb-92b6-97c561894f44.gif)


### Potential Breaking Changes

Maybe some row in some table in the admin wont be better off with the 25px line-weight :thinking: 

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
