### PR TITLE
feat(radio-card): added radio card variant

### DIFF
--- a/packages/demo/src/components/examples/RadioExamples.tsx
+++ b/packages/demo/src/components/examples/RadioExamples.tsx
@@ -152,7 +152,7 @@ const RadioCardSelectExample: React.FunctionComponent = () => (
         <RadioSelectConnected
             id="radio-card-select-example"
             valueOnMount={'blue'}
-            className="flex flex-wrap spaced-boxes-container"
+            className="flex flex-wrap"
             disabledTooltip="you see me because of the disabledTooltip prop"
             disabledValuesOnMount={['red']}
         >

--- a/packages/demo/src/components/examples/RadioExamples.tsx
+++ b/packages/demo/src/components/examples/RadioExamples.tsx
@@ -125,22 +125,22 @@ const RadioSelectDisabledExample: React.FunctionComponent = () => (
 );
 
 const RadioSelectWrappedExample: React.FunctionComponent = () => (
-    <Section level={3} title="A radio select with a wrapped radio button.">
+    <Section level={3} title="A radio select with a wrapped radio button">
         <RadioSelectConnected id="addRankingResult" valueOnMount={'blue'}>
             <Radio {...blueRadioButtonProps}>
                 <Label>
-                    <span className="bold">{'Blue color'}</span>
+                    <span className="bold">Blue color</span>
                 </Label>
                 <InputDescription>
-                    <div style={{...paragraphStyle}}>{'Blue is the best color.'}</div>
+                    <div style={{...paragraphStyle}}>Blue is the best color.</div>
                 </InputDescription>
             </Radio>
             <Radio {...redRadioButtonProps}>
                 <Label>
-                    <span className="bold">{'Red color'}</span>
+                    <span className="bold">Red color</span>
                 </Label>
                 <InputDescription>
-                    <div style={{...paragraphStyle}}>{'Red is the best color.'}</div>
+                    <div style={{...paragraphStyle}}>Red is the best color.</div>
                 </InputDescription>
             </Radio>
         </RadioSelectConnected>
@@ -148,10 +148,10 @@ const RadioSelectWrappedExample: React.FunctionComponent = () => (
 );
 
 const RadioCardSelectExample: React.FunctionComponent = () => (
-    <Section level={3} title="A radio card select.">
+    <Section level={3} title="A radio card select">
         <RadioSelectConnected
             id="radio-card-select-example"
-            valueOnMount={'blue'}
+            valueOnMount="blue"
             className="flex flex-wrap"
             disabledTooltip="you see me because of the disabledTooltip prop"
             disabledValuesOnMount={['red']}
@@ -159,28 +159,28 @@ const RadioCardSelectExample: React.FunctionComponent = () => (
             <RadioCard id="blue" name="card-option" value="blue">
                 <img className="mb2" src="https://via.placeholder.com/150x100" />
                 <Label>
-                    <span className="bold">{'Blue color'}</span>
+                    <span className="bold">Blue color</span>
                 </Label>
                 <InputDescription>
-                    <div style={{...paragraphStyle}}>{'Blue is the best color.'}</div>
+                    <div style={{...paragraphStyle}}>Blue is the best color.</div>
                 </InputDescription>
             </RadioCard>
             <RadioCard id="red" name="card-option" value="red">
                 <img className="mb2" src="https://via.placeholder.com/150x100" />
                 <Label>
-                    <span className="bold">{'Red color'}</span>
+                    <span className="bold">Red color</span>
                 </Label>
                 <InputDescription>
-                    <div style={{...paragraphStyle}}>{'Red is the best color.'}</div>
+                    <div style={{...paragraphStyle}}>Red is the best color.</div>
                 </InputDescription>
             </RadioCard>
             <RadioCard id="green" name="card-option" value="green">
                 <img className="mb2" src="https://via.placeholder.com/150x100" />
                 <Label>
-                    <span className="bold">{'Green color'}</span>
+                    <span className="bold">Green color</span>
                 </Label>
                 <InputDescription>
-                    <div style={{...paragraphStyle}}>{'Green is the best color.'}</div>
+                    <div style={{...paragraphStyle}}>Green is the best color.</div>
                 </InputDescription>
             </RadioCard>
         </RadioSelectConnected>

--- a/packages/demo/src/components/examples/RadioExamples.tsx
+++ b/packages/demo/src/components/examples/RadioExamples.tsx
@@ -149,7 +149,13 @@ const RadioSelectWrappedExample: React.FunctionComponent = () => (
 
 const RadioCardSelectExample: React.FunctionComponent = () => (
     <Section level={3} title="A radio card select.">
-        <RadioSelectConnected id="radio-card-select-example" valueOnMount={'blue'} className="flex">
+        <RadioSelectConnected
+            id="radio-card-select-example"
+            valueOnMount={'blue'}
+            className="flex flex-wrap spaced-boxes-container"
+            disabledTooltip="you see me because of the disabledTooltip prop"
+            disabledValuesOnMount={['red']}
+        >
             <RadioCard id="blue" name="card-option" value="blue">
                 <img className="mb2" src="https://via.placeholder.com/150x100" />
                 <Label>
@@ -159,13 +165,22 @@ const RadioCardSelectExample: React.FunctionComponent = () => (
                     <div style={{...paragraphStyle}}>{'Blue is the best color.'}</div>
                 </InputDescription>
             </RadioCard>
-            <RadioCard id="red" name="card-option" value="red" disabled>
+            <RadioCard id="red" name="card-option" value="red">
                 <img className="mb2" src="https://via.placeholder.com/150x100" />
                 <Label>
                     <span className="bold">{'Red color'}</span>
                 </Label>
                 <InputDescription>
                     <div style={{...paragraphStyle}}>{'Red is the best color.'}</div>
+                </InputDescription>
+            </RadioCard>
+            <RadioCard id="green" name="card-option" value="green">
+                <img className="mb2" src="https://via.placeholder.com/150x100" />
+                <Label>
+                    <span className="bold">{'Green color'}</span>
+                </Label>
+                <InputDescription>
+                    <div style={{...paragraphStyle}}>{'Green is the best color.'}</div>
                 </InputDescription>
             </RadioCard>
         </RadioSelectConnected>

--- a/packages/demo/src/components/examples/RadioExamples.tsx
+++ b/packages/demo/src/components/examples/RadioExamples.tsx
@@ -6,6 +6,7 @@ import {
     Label,
     LabeledInput,
     Radio,
+    RadioCard,
     RadioSelectConnected,
     Section,
     setRadioSelect,
@@ -27,6 +28,7 @@ export const RadioButtonExamples: ExampleComponent = () => (
         <RadioSelectExample />
         <RadioSelectDisabledExample />
         <RadioSelectWrappedExample />
+        <RadioCardSelectExample />
     </Section>
 );
 
@@ -56,6 +58,12 @@ const blueRadioButtonProps = {
 const redRadioButtonProps = {
     id: 'red',
     value: 'red',
+    ...radioButtonProps,
+};
+
+const greenRadioButtonProps = {
+    id: 'green',
+    value: 'green',
     ...radioButtonProps,
 };
 
@@ -135,6 +143,31 @@ const RadioSelectWrappedExample: React.FunctionComponent = () => (
                     <div style={{...paragraphStyle}}>{'Red is the best color.'}</div>
                 </InputDescription>
             </Radio>
+        </RadioSelectConnected>
+    </Section>
+);
+
+const RadioCardSelectExample: React.FunctionComponent = () => (
+    <Section level={3} title="A radio card select.">
+        <RadioSelectConnected id="radio-card-select-example" valueOnMount={'blue'} className="flex">
+            <RadioCard id="blue" name="card-option" value="blue">
+                <img className="mb2" src="https://via.placeholder.com/150x100" />
+                <Label>
+                    <span className="bold">{'Blue color'}</span>
+                </Label>
+                <InputDescription>
+                    <div style={{...paragraphStyle}}>{'Blue is the best color.'}</div>
+                </InputDescription>
+            </RadioCard>
+            <RadioCard id="red" name="card-option" value="red" disabled>
+                <img className="mb2" src="https://via.placeholder.com/150x100" />
+                <Label>
+                    <span className="bold">{'Red color'}</span>
+                </Label>
+                <InputDescription>
+                    <div style={{...paragraphStyle}}>{'Red is the best color.'}</div>
+                </InputDescription>
+            </RadioCard>
         </RadioSelectConnected>
     </Section>
 );

--- a/packages/react-vapor/src/components/radio/RadioCard.tsx
+++ b/packages/react-vapor/src/components/radio/RadioCard.tsx
@@ -26,20 +26,20 @@ export const RadioCard: React.FunctionComponent<RadioCardProps> = (props) => {
 };
 
 const RadioCardContent: React.FunctionComponent<RadioCardProps & {classes: string}> = ({
-    classes,
-    checked,
     id,
     name,
+    classes,
+    checked,
     disabled,
     onChange,
     children,
 }) => (
     <>
         <input
-            type="radio"
-            className="card-input"
             id={id}
             name={name}
+            type="radio"
+            className="card-input"
             checked={checked}
             disabled={disabled}
             onChange={(event) => onChange(event.target.value)}

--- a/packages/react-vapor/src/components/radio/RadioCard.tsx
+++ b/packages/react-vapor/src/components/radio/RadioCard.tsx
@@ -7,40 +7,46 @@ import {Tooltip} from '../tooltip';
 export interface RadioCardProps extends Omit<IInputProps, 'outerContainerClass' | 'outerElementInContainer'> {}
 
 export const RadioCard: React.FunctionComponent<RadioCardProps> = (props) => {
-    const classes = classNames('radio-card', props.classes);
+    const classes = classNames('card', 'radio-card', props.classes);
     const containerClasses = 'radio-card-container m2';
+
+    const {onClick, ...otherProps} = props;
 
     return props.disabled && props.disabledTooltip ? (
         <label onClick={props.onClick} className={containerClasses}>
             <Tooltip title={props.disabledTooltip} placement={TooltipPlacement.Bottom}>
-                <RadioCardContent props={props} classes={classes} />
+                <RadioCardContent {...otherProps} classes={classes} />
             </Tooltip>
         </label>
     ) : (
         <label onClick={props.onClick} className={containerClasses}>
-            <RadioCardContent props={props} classes={classes} />
+            <RadioCardContent {...otherProps} classes={classes} />
         </label>
     );
 };
 
-const RadioCardContent: React.FunctionComponent<{props: RadioCardProps; classes: string}> = ({props, classes}) => {
-    // const inputProps = omit(props, ['children', 'classes']);
-    const inputProps = {
-        type: 'radio',
-        checked: props.checked,
-        id: props.id,
-        name: props.name,
-        className: 'card-input',
-        disabled: props.disabled,
-        onChange: (event: React.ChangeEvent<HTMLInputElement>) => props.onChange(event.target.value),
-    };
-    return (
-        <>
-            <input {...inputProps} />
-            <div className={classes}>{props.children}</div>
-        </>
-    );
-};
+const RadioCardContent: React.FunctionComponent<RadioCardProps & {classes: string}> = ({
+    classes,
+    checked,
+    id,
+    name,
+    disabled,
+    onChange,
+    children,
+}) => (
+    <>
+        <input
+            type="radio"
+            className="card-input"
+            id={id}
+            name={name}
+            checked={checked}
+            disabled={disabled}
+            onChange={(event) => onChange(event.target.value)}
+        />
+        <div className={classes}>{children}</div>
+    </>
+);
 
 RadioCard.defaultProps = {
     ...Input.defaultProps,

--- a/packages/react-vapor/src/components/radio/RadioCard.tsx
+++ b/packages/react-vapor/src/components/radio/RadioCard.tsx
@@ -1,22 +1,46 @@
 import classNames from 'classnames';
 import * as React from 'react';
+import {TooltipPlacement} from '../../utils/TooltipUtils';
 import {IInputProps, Input} from '../input/Input';
+import {Tooltip} from '../tooltip';
 
-export interface RadioCardProps extends IInputProps {}
+export interface RadioCardProps extends Omit<IInputProps, 'outerContainerClass' | 'outerElementInContainer'> {}
 
-export const RadioCard: React.FunctionComponent<RadioCardProps> = (props) => (
-    <label onClick={props.onClick} className="radio-card-container">
-        <input
-            type="radio"
-            checked={props.checked}
-            id={props.id}
-            name={props.name}
-            className="card-input"
-            disabled={props.disabled}
-        />
-        <div className={classNames('radio-card', props.classes)}>{props.children}</div>
-    </label>
-);
+export const RadioCard: React.FunctionComponent<RadioCardProps> = (props) => {
+    const classes = classNames('radio-card', props.classes);
+    const containerClasses = 'radio-card-container space-box p3';
+
+    return props.disabled && props.disabledTooltip ? (
+        <label onClick={props.onClick} className={containerClasses}>
+            <Tooltip title={props.disabledTooltip} placement={TooltipPlacement.Bottom}>
+                <RadioCardContent props={props} classes={classes} />
+            </Tooltip>
+        </label>
+    ) : (
+        <label onClick={props.onClick} className={containerClasses}>
+            <RadioCardContent props={props} classes={classes} />
+        </label>
+    );
+};
+
+const RadioCardContent: React.FunctionComponent<{props: RadioCardProps; classes: string}> = ({props, classes}) => {
+    // const inputProps = omit(props, ['children', 'classes']);
+    const inputProps = {
+        type: 'radio',
+        checked: props.checked,
+        id: props.id,
+        name: props.name,
+        className: 'card-input',
+        disabled: props.disabled,
+        onChange: (event: React.ChangeEvent<HTMLInputElement>) => props.onChange(event.target.value),
+    };
+    return (
+        <>
+            <input {...inputProps} />
+            <div className={classes}>{props.children}</div>
+        </>
+    );
+};
 
 RadioCard.defaultProps = {
     ...Input.defaultProps,

--- a/packages/react-vapor/src/components/radio/RadioCard.tsx
+++ b/packages/react-vapor/src/components/radio/RadioCard.tsx
@@ -8,7 +8,7 @@ export interface RadioCardProps extends Omit<IInputProps, 'outerContainerClass' 
 
 export const RadioCard: React.FunctionComponent<RadioCardProps> = (props) => {
     const classes = classNames('radio-card', props.classes);
-    const containerClasses = 'radio-card-container space-box p3';
+    const containerClasses = 'radio-card-container spaced-box m2';
 
     return props.disabled && props.disabledTooltip ? (
         <label onClick={props.onClick} className={containerClasses}>

--- a/packages/react-vapor/src/components/radio/RadioCard.tsx
+++ b/packages/react-vapor/src/components/radio/RadioCard.tsx
@@ -1,0 +1,25 @@
+import classNames from 'classnames';
+import * as React from 'react';
+import {IInputProps, Input} from '../input/Input';
+
+export interface RadioCardProps extends IInputProps {}
+
+export const RadioCard: React.FunctionComponent<RadioCardProps> = (props) => (
+    <label onClick={props.onClick} className="radio-card-container">
+        <input
+            type="radio"
+            checked={props.checked}
+            id={props.id}
+            name={props.name}
+            className="card-input"
+            disabled={props.disabled}
+        />
+        <div className={classNames('radio-card', props.classes)}>{props.children}</div>
+    </label>
+);
+
+RadioCard.defaultProps = {
+    ...Input.defaultProps,
+    checked: false,
+    disabled: false,
+};

--- a/packages/react-vapor/src/components/radio/RadioCard.tsx
+++ b/packages/react-vapor/src/components/radio/RadioCard.tsx
@@ -8,7 +8,7 @@ export interface RadioCardProps extends Omit<IInputProps, 'outerContainerClass' 
 
 export const RadioCard: React.FunctionComponent<RadioCardProps> = (props) => {
     const classes = classNames('radio-card', props.classes);
-    const containerClasses = 'radio-card-container spaced-box m2';
+    const containerClasses = 'radio-card-container m2';
 
     return props.disabled && props.disabledTooltip ? (
         <label onClick={props.onClick} className={containerClasses}>

--- a/packages/react-vapor/src/components/radio/RadioSelect.tsx
+++ b/packages/react-vapor/src/components/radio/RadioSelect.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
+import {RadioCard} from '.';
 
 import {ToggleForm} from '../childForm/ToggleForm';
 import {Radio} from './Radio';
@@ -16,7 +17,7 @@ export interface IRadioSelectProps extends IRadioSelectOnChangeCallback {
     value?: string;
     disabled?: boolean;
     disabledTooltip?: string;
-    children?: Array<React.ReactElement<typeof Radio>> | Array<React.ReactElement<ToggleForm>>;
+    children?: Array<React.ReactElement<typeof Radio | typeof RadioCard>> | Array<React.ReactElement<ToggleForm>>;
     onChangeCallback?: (value: string, id?: string, e?: React.MouseEvent<HTMLElement>, disabled?: boolean) => void;
 }
 

--- a/packages/react-vapor/src/components/radio/index.ts
+++ b/packages/react-vapor/src/components/radio/index.ts
@@ -1,4 +1,5 @@
 export * from './Radio';
+export * from './RadioCard';
 export * from './RadioSelect';
 export * from './RadioSelectActions';
 export * from './RadioSelectConnected';

--- a/packages/react-vapor/src/components/radio/tests/RadioCard.spec.tsx
+++ b/packages/react-vapor/src/components/radio/tests/RadioCard.spec.tsx
@@ -16,7 +16,7 @@ describe('RadioCard', () => {
         let radio: ReactWrapper<RadioCardProps, any>;
 
         beforeEach(() => {
-            radio = mount(<RadioCard id={anId} />, {attachTo: document.getElementById('App')});
+            radio = mount(<RadioCard id={anId} />);
         });
 
         afterEach(() => {

--- a/packages/react-vapor/src/components/radio/tests/RadioCard.spec.tsx
+++ b/packages/react-vapor/src/components/radio/tests/RadioCard.spec.tsx
@@ -1,0 +1,105 @@
+import {mount, ReactWrapper, shallow} from 'enzyme';
+import * as React from 'react';
+
+import {RadioCard, RadioCardProps} from '../RadioCard';
+
+describe('RadioCard', () => {
+    const anId = 'patate';
+
+    it('should render without errors', () => {
+        expect(() => {
+            shallow(<RadioCard id={anId} />);
+        }).not.toThrow();
+    });
+
+    describe('<RadioCard />', () => {
+        let radio: ReactWrapper<RadioCardProps, any>;
+
+        beforeEach(() => {
+            radio = mount(<RadioCard id={anId} />, {attachTo: document.getElementById('App')});
+        });
+
+        afterEach(() => {
+            radio?.unmount();
+        });
+
+        it('should set id prop', () => {
+            const innerInput = radio.find('input').first();
+
+            expect(innerInput.prop('id')).toBe(anId);
+        });
+
+        it('should set name prop when specified', () => {
+            const name = 'salut';
+
+            expect(radio.find('input').prop('name')).toBe(undefined);
+
+            radio.setProps({name}).mount().update();
+
+            expect(radio.find('input').prop('name')).toBe(name);
+        });
+
+        it('should set value prop when specified', () => {
+            const value = 'blueberry';
+
+            expect(radio.prop('value')).toBe(undefined);
+
+            radio.setProps({value}).mount();
+
+            expect(radio.prop('value')).toBe(value);
+        });
+
+        it('should set not disable inner input when disabled prop is not specified', () => {
+            const innerInput = radio.find('input').first();
+
+            expect(innerInput.prop('disabled')).toBe(false);
+        });
+
+        it('should set not check inner input when checked prop is not specified', () => {
+            const innerInput = radio.find('input').first();
+
+            expect(innerInput.prop('checked')).toBe(false);
+        });
+
+        it('should set disabled prop when specified', () => {
+            radio.setProps({disabled: false}).mount().update();
+
+            expect(radio.find('input').prop('disabled')).toBe(false);
+
+            radio.setProps({disabled: true}).mount().update();
+
+            expect(radio.find('input').prop('disabled')).toBe(true);
+        });
+
+        it('should set checked prop when specified', () => {
+            radio.setProps({checked: false}).mount().update();
+
+            expect(radio.find('input').prop('checked')).toBe(false);
+
+            radio.setProps({checked: true}).mount().update();
+
+            expect(radio.find('input').prop('checked')).toBe(true);
+        });
+
+        it('should set classes when specified', () => {
+            const innerClass = 'salut';
+            const classes = [innerClass];
+
+            expect(radio.find('div').hasClass(innerClass)).toBe(false);
+
+            radio.setProps({classes}).mount().update();
+
+            expect(radio.find('div').hasClass(innerClass)).toBe(true);
+        });
+
+        it('should call prop onChange when specified on click', () => {
+            const changeSpy = jest.fn();
+            const innerInput = radio.find('input');
+
+            radio.setProps({onChange: changeSpy}).mount();
+            innerInput.simulate('change');
+
+            expect(changeSpy.mock.calls.length).toBe(1);
+        });
+    });
+});

--- a/packages/react-vapor/src/components/radio/tests/RadioSelect.spec.tsx
+++ b/packages/react-vapor/src/components/radio/tests/RadioSelect.spec.tsx
@@ -28,7 +28,7 @@ describe('<RadioSelect />', () => {
         const secondRadioValue = 'red';
         const radioName = 'Johnny the almighty magic chicken';
 
-        const shallowRadioSelect__Radio = (props: IRadioSelectAllProps = {}) => {
+        const shallowRadioSelect = (props: IRadioSelectAllProps = {}) => {
             spy = jest.fn();
             radioSelect = shallow(
                 <RadioSelect {...props}>
@@ -38,7 +38,7 @@ describe('<RadioSelect />', () => {
             );
         };
 
-        const shallowRadioSelect__Card = (props: IRadioSelectAllProps = {}) => {
+        const shallowRadioSelectWithCard = (props: IRadioSelectAllProps = {}) => {
             spy = jest.fn();
             radioSelect = shallow(
                 <RadioSelect {...props}>
@@ -50,148 +50,148 @@ describe('<RadioSelect />', () => {
 
         const shallowRadioSelectVariations = [
             {
-                creator: shallowRadioSelect__Radio,
+                name: 'RadioSelect',
+                creator: shallowRadioSelect,
                 radioFC: Radio,
             },
             {
-                creator: shallowRadioSelect__Card,
+                name: 'RadioSelectWithCard',
+                creator: shallowRadioSelectWithCard,
                 radioFC: RadioCard,
             },
         ];
 
-        shallowRadioSelectVariations.forEach((shallowRadioSelect) => {
-            it('should call onMount on mount', () => {
-                const spyOnMount = jest.fn();
-                shallowRadioSelect.creator({
-                    onMount: spyOnMount,
+        shallowRadioSelectVariations.forEach((variation) => {
+            describe(`${variation.name}`, () => {
+                it('should call onMount on mount', () => {
+                    const spyOnMount = jest.fn();
+                    variation.creator({
+                        onMount: spyOnMount,
+                    });
+
+                    expect(spyOnMount).toHaveBeenCalledTimes(1);
                 });
 
-                expect(spyOnMount).toHaveBeenCalledTimes(1);
-            });
+                it('should call onUnmount on unmount', () => {
+                    const spyOnUnmount = jest.fn();
+                    variation.creator({
+                        onUnmount: spyOnUnmount,
+                    });
+                    radioSelect.unmount();
 
-            it('should call onUnmount on unmount', () => {
-                const spyOnUnmount = jest.fn();
-                shallowRadioSelect.creator({
-                    onUnmount: spyOnUnmount,
-                });
-                radioSelect.unmount();
-
-                expect(spyOnUnmount).toHaveBeenCalledTimes(1);
-            });
-
-            it('should set disabled on child if the props disabled is set to true', () => {
-                shallowRadioSelect.creator({
-                    disabled: true,
+                    expect(spyOnUnmount).toHaveBeenCalledTimes(1);
                 });
 
-                expect(radioSelect.find(shallowRadioSelect.radioFC).first().props().disabled).toBe(true);
-            });
+                it('should set disabled on child if the props disabled is set to true', () => {
+                    variation.creator({
+                        disabled: true,
+                    });
 
-            it('should set disabled on child if the child value is present in the disabled values list', () => {
-                shallowRadioSelect.creator({
-                    disabled: false,
-                    disabledValues: [firstRadioValue, secondRadioValue],
+                    expect(radioSelect.find(variation.radioFC).first().props().disabled).toBe(true);
                 });
 
-                expect(radioSelect.find(shallowRadioSelect.radioFC).first().props().disabled).toBe(true);
-                expect(radioSelect.find(shallowRadioSelect.radioFC).last().props().disabled).toBe(true);
-            });
+                it('should set disabled on child if the child value is present in the disabled values list', () => {
+                    variation.creator({
+                        disabled: false,
+                        disabledValues: [firstRadioValue, secondRadioValue],
+                    });
 
-            it('should use the name from the child if defined', () => {
-                shallowRadioSelect.creator();
-
-                expect(radioSelect.find(shallowRadioSelect.radioFC).last().props().name).toBe(radioName);
-            });
-
-            it('should use the name prop instead of the child name if its not defined', () => {
-                shallowRadioSelect.creator({
-                    name: 'leaf',
+                    expect(radioSelect.find(variation.radioFC).first().props().disabled).toBe(true);
+                    expect(radioSelect.find(variation.radioFC).last().props().disabled).toBe(true);
                 });
 
-                expect(radioSelect.find(shallowRadioSelect.radioFC).first().props().name).toBe('leaf');
-            });
+                it('should use the name from the child if defined', () => {
+                    variation.creator();
 
-            it('should pass disabledTooltip prop to each child', () => {
-                const disabledTooltip = 'golf';
-                shallowRadioSelect.creator({
-                    disabledTooltip,
+                    expect(radioSelect.find(variation.radioFC).last().props().name).toBe(radioName);
                 });
 
-                expect(radioSelect.find(shallowRadioSelect.radioFC).first().props().disabledTooltip).toBe(
-                    disabledTooltip
-                );
-                expect(radioSelect.find(shallowRadioSelect.radioFC).last().props().disabledTooltip).toBe(
-                    disabledTooltip
-                );
-            });
+                it('should use the name prop instead of the child name if its not defined', () => {
+                    variation.creator({
+                        name: 'leaf',
+                    });
 
-            it('should set the prop checked of the children with the same value than the radio select', () => {
-                shallowRadioSelect.creator({
-                    value: firstRadioValue,
+                    expect(radioSelect.find(variation.radioFC).first().props().name).toBe('leaf');
                 });
 
-                expect(radioSelect.find(shallowRadioSelect.radioFC).first().props().checked).toBe(true);
-                expect(radioSelect.find(shallowRadioSelect.radioFC).last().props().checked).toBe(false);
-            });
+                it('should pass disabledTooltip prop to each child', () => {
+                    const disabledTooltip = 'golf';
+                    variation.creator({
+                        disabledTooltip,
+                    });
 
-            it('should call onClick on children props if defined', () => {
-                shallowRadioSelect.creator();
-
-                expect(radioSelect.find(shallowRadioSelect.radioFC).first().props().onClick).toBeDefined();
-
-                radioSelect
-                    .find(shallowRadioSelect.radioFC)
-                    .first()
-                    .props()
-                    .onClick({} as any);
-
-                expect(spy).toHaveBeenCalledTimes(1);
-            });
-
-            it('should call onChange prop when the child call onClick', () => {
-                const spyOnChange = jest.fn();
-                shallowRadioSelect.creator({
-                    onChange: spyOnChange,
+                    expect(radioSelect.find(variation.radioFC).first().props().disabledTooltip).toBe(disabledTooltip);
+                    expect(radioSelect.find(variation.radioFC).last().props().disabledTooltip).toBe(disabledTooltip);
                 });
 
-                radioSelect
-                    .find(shallowRadioSelect.radioFC)
-                    .first()
-                    .props()
-                    .onClick({} as any);
+                it('should set the prop checked of the children with the same value than the radio select', () => {
+                    variation.creator({
+                        value: firstRadioValue,
+                    });
 
-                expect(spyOnChange).toHaveBeenCalledTimes(1);
-            });
-
-            it('should not call onChange prop when the child call onClick if the component is disabled', () => {
-                const spyOnChange = jest.fn();
-                shallowRadioSelect.creator({
-                    onChange: spyOnChange,
-                    disabled: true,
+                    expect(radioSelect.find(variation.radioFC).first().props().checked).toBe(true);
+                    expect(radioSelect.find(variation.radioFC).last().props().checked).toBe(false);
                 });
 
-                radioSelect
-                    .find(shallowRadioSelect.radioFC)
-                    .first()
-                    .props()
-                    .onClick({} as any);
+                it('should call onClick on children props if defined', () => {
+                    variation.creator();
 
-                expect(spyOnChange).toHaveBeenCalledTimes(0);
-            });
+                    expect(radioSelect.find(variation.radioFC).first().props().onClick).toBeDefined();
 
-            it('should call onChangeCallback prop when the child call onClick', () => {
-                const spyOnChangeCallback = jest.fn();
-                shallowRadioSelect.creator({
-                    onChangeCallback: spyOnChangeCallback,
+                    radioSelect
+                        .find(variation.radioFC)
+                        .first()
+                        .props()
+                        .onClick({} as any);
+
+                    expect(spy).toHaveBeenCalledTimes(1);
                 });
 
-                radioSelect
-                    .find(shallowRadioSelect.radioFC)
-                    .first()
-                    .props()
-                    .onClick({} as any);
+                it('should call onChange prop when the child call onClick', () => {
+                    const spyOnChange = jest.fn();
+                    variation.creator({
+                        onChange: spyOnChange,
+                    });
 
-                expect(spyOnChangeCallback).toHaveBeenCalledTimes(1);
+                    radioSelect
+                        .find(variation.radioFC)
+                        .first()
+                        .props()
+                        .onClick({} as any);
+
+                    expect(spyOnChange).toHaveBeenCalledTimes(1);
+                });
+
+                it('should not call onChange prop when the child call onClick if the component is disabled', () => {
+                    const spyOnChange = jest.fn();
+                    variation.creator({
+                        onChange: spyOnChange,
+                        disabled: true,
+                    });
+
+                    radioSelect
+                        .find(variation.radioFC)
+                        .first()
+                        .props()
+                        .onClick({} as any);
+
+                    expect(spyOnChange).toHaveBeenCalledTimes(0);
+                });
+
+                it('should call onChangeCallback prop when the child call onClick', () => {
+                    const spyOnChangeCallback = jest.fn();
+                    variation.creator({
+                        onChangeCallback: spyOnChangeCallback,
+                    });
+
+                    radioSelect
+                        .find(variation.radioFC)
+                        .first()
+                        .props()
+                        .onClick({} as any);
+
+                    expect(spyOnChangeCallback).toHaveBeenCalledTimes(1);
+                });
             });
         });
     });

--- a/packages/react-vapor/src/components/radio/tests/RadioSelect.spec.tsx
+++ b/packages/react-vapor/src/components/radio/tests/RadioSelect.spec.tsx
@@ -2,6 +2,7 @@ import {shallow, ShallowWrapper} from 'enzyme';
 import * as React from 'react';
 
 import {Radio} from '../Radio';
+import {RadioCard} from '../RadioCard';
 import {IRadioSelectAllProps, RadioSelect} from '../RadioSelect';
 
 describe('<RadioSelect />', () => {
@@ -27,7 +28,7 @@ describe('<RadioSelect />', () => {
         const secondRadioValue = 'red';
         const radioName = 'Johnny the almighty magic chicken';
 
-        const shallowRadioSelect = (props: IRadioSelectAllProps = {}) => {
+        const shallowRadioSelect__Radio = (props: IRadioSelectAllProps = {}) => {
             spy = jest.fn();
             radioSelect = shallow(
                 <RadioSelect {...props}>
@@ -37,134 +38,161 @@ describe('<RadioSelect />', () => {
             );
         };
 
-        it('should call onMount on mount', () => {
-            const spyOnMount = jest.fn();
-            shallowRadioSelect({
-                onMount: spyOnMount,
+        const shallowRadioSelect__Card = (props: IRadioSelectAllProps = {}) => {
+            spy = jest.fn();
+            radioSelect = shallow(
+                <RadioSelect {...props}>
+                    <RadioCard id="radio1" value={firstRadioValue} onClick={spy} />
+                    <RadioCard id="radio2" value={secondRadioValue} name={radioName} />
+                </RadioSelect>
+            );
+        };
+
+        const shallowRadioSelectVariations = [
+            {
+                creator: shallowRadioSelect__Radio,
+                radioFC: Radio,
+            },
+            {
+                creator: shallowRadioSelect__Card,
+                radioFC: RadioCard,
+            },
+        ];
+
+        shallowRadioSelectVariations.forEach((shallowRadioSelect) => {
+            it('should call onMount on mount', () => {
+                const spyOnMount = jest.fn();
+                shallowRadioSelect.creator({
+                    onMount: spyOnMount,
+                });
+
+                expect(spyOnMount).toHaveBeenCalledTimes(1);
             });
 
-            expect(spyOnMount).toHaveBeenCalledTimes(1);
-        });
+            it('should call onUnmount on unmount', () => {
+                const spyOnUnmount = jest.fn();
+                shallowRadioSelect.creator({
+                    onUnmount: spyOnUnmount,
+                });
+                radioSelect.unmount();
 
-        it('should call onUnmount on unmount', () => {
-            const spyOnUnmount = jest.fn();
-            shallowRadioSelect({
-                onUnmount: spyOnUnmount,
-            });
-            radioSelect.unmount();
-
-            expect(spyOnUnmount).toHaveBeenCalledTimes(1);
-        });
-
-        it('should set disabled on child if the props disabled is set to true', () => {
-            shallowRadioSelect({
-                disabled: true,
+                expect(spyOnUnmount).toHaveBeenCalledTimes(1);
             });
 
-            expect(radioSelect.find(Radio).first().props().disabled).toBe(true);
-        });
+            it('should set disabled on child if the props disabled is set to true', () => {
+                shallowRadioSelect.creator({
+                    disabled: true,
+                });
 
-        it('should set disabled on child if the child value is present in the disabled values list', () => {
-            shallowRadioSelect({
-                disabled: false,
-                disabledValues: [firstRadioValue, secondRadioValue],
+                expect(radioSelect.find(shallowRadioSelect.radioFC).first().props().disabled).toBe(true);
             });
 
-            expect(radioSelect.find(Radio).first().props().disabled).toBe(true);
-            expect(radioSelect.find(Radio).last().props().disabled).toBe(true);
-        });
+            it('should set disabled on child if the child value is present in the disabled values list', () => {
+                shallowRadioSelect.creator({
+                    disabled: false,
+                    disabledValues: [firstRadioValue, secondRadioValue],
+                });
 
-        it('should use the name from the child if defined', () => {
-            shallowRadioSelect();
-
-            expect(radioSelect.find(Radio).last().props().name).toBe(radioName);
-        });
-
-        it('should use the name prop instead of the child name if its not defined', () => {
-            shallowRadioSelect({
-                name: 'leaf',
+                expect(radioSelect.find(shallowRadioSelect.radioFC).first().props().disabled).toBe(true);
+                expect(radioSelect.find(shallowRadioSelect.radioFC).last().props().disabled).toBe(true);
             });
 
-            expect(radioSelect.find(Radio).first().props().name).toBe('leaf');
-        });
+            it('should use the name from the child if defined', () => {
+                shallowRadioSelect.creator();
 
-        it('should pass disabledTooltip prop to each child', () => {
-            const disabledTooltip = 'golf';
-            shallowRadioSelect({
-                disabledTooltip,
+                expect(radioSelect.find(shallowRadioSelect.radioFC).last().props().name).toBe(radioName);
             });
 
-            expect(radioSelect.find(Radio).first().props().disabledTooltip).toBe(disabledTooltip);
-            expect(radioSelect.find(Radio).last().props().disabledTooltip).toBe(disabledTooltip);
-        });
+            it('should use the name prop instead of the child name if its not defined', () => {
+                shallowRadioSelect.creator({
+                    name: 'leaf',
+                });
 
-        it('should set the prop checked of the children with the same value than the radio select', () => {
-            shallowRadioSelect({
-                value: firstRadioValue,
+                expect(radioSelect.find(shallowRadioSelect.radioFC).first().props().name).toBe('leaf');
             });
 
-            expect(radioSelect.find(Radio).first().props().checked).toBe(true);
-            expect(radioSelect.find(Radio).last().props().checked).toBe(false);
-        });
+            it('should pass disabledTooltip prop to each child', () => {
+                const disabledTooltip = 'golf';
+                shallowRadioSelect.creator({
+                    disabledTooltip,
+                });
 
-        it('should call onClick on children props if defined', () => {
-            shallowRadioSelect();
-
-            expect(radioSelect.find(Radio).first().props().onClick).toBeDefined();
-
-            radioSelect
-                .find(Radio)
-                .first()
-                .props()
-                .onClick({} as any);
-
-            expect(spy).toHaveBeenCalledTimes(1);
-        });
-
-        it('should call onChange prop when the child call onClick', () => {
-            const spyOnChange = jest.fn();
-            shallowRadioSelect({
-                onChange: spyOnChange,
+                expect(radioSelect.find(shallowRadioSelect.radioFC).first().props().disabledTooltip).toBe(
+                    disabledTooltip
+                );
+                expect(radioSelect.find(shallowRadioSelect.radioFC).last().props().disabledTooltip).toBe(
+                    disabledTooltip
+                );
             });
 
-            radioSelect
-                .find(Radio)
-                .first()
-                .props()
-                .onClick({} as any);
+            it('should set the prop checked of the children with the same value than the radio select', () => {
+                shallowRadioSelect.creator({
+                    value: firstRadioValue,
+                });
 
-            expect(spyOnChange).toHaveBeenCalledTimes(1);
-        });
-
-        it('should not call onChange prop when the child call onClick if the component is disabled', () => {
-            const spyOnChange = jest.fn();
-            shallowRadioSelect({
-                onChange: spyOnChange,
-                disabled: true,
+                expect(radioSelect.find(shallowRadioSelect.radioFC).first().props().checked).toBe(true);
+                expect(radioSelect.find(shallowRadioSelect.radioFC).last().props().checked).toBe(false);
             });
 
-            radioSelect
-                .find(Radio)
-                .first()
-                .props()
-                .onClick({} as any);
+            it('should call onClick on children props if defined', () => {
+                shallowRadioSelect.creator();
 
-            expect(spyOnChange).toHaveBeenCalledTimes(0);
-        });
+                expect(radioSelect.find(shallowRadioSelect.radioFC).first().props().onClick).toBeDefined();
 
-        it('should call onChangeCallback prop when the child call onClick', () => {
-            const spyOnChangeCallback = jest.fn();
-            shallowRadioSelect({
-                onChangeCallback: spyOnChangeCallback,
+                radioSelect
+                    .find(shallowRadioSelect.radioFC)
+                    .first()
+                    .props()
+                    .onClick({} as any);
+
+                expect(spy).toHaveBeenCalledTimes(1);
             });
 
-            radioSelect
-                .find(Radio)
-                .first()
-                .props()
-                .onClick({} as any);
+            it('should call onChange prop when the child call onClick', () => {
+                const spyOnChange = jest.fn();
+                shallowRadioSelect.creator({
+                    onChange: spyOnChange,
+                });
 
-            expect(spyOnChangeCallback).toHaveBeenCalledTimes(1);
+                radioSelect
+                    .find(shallowRadioSelect.radioFC)
+                    .first()
+                    .props()
+                    .onClick({} as any);
+
+                expect(spyOnChange).toHaveBeenCalledTimes(1);
+            });
+
+            it('should not call onChange prop when the child call onClick if the component is disabled', () => {
+                const spyOnChange = jest.fn();
+                shallowRadioSelect.creator({
+                    onChange: spyOnChange,
+                    disabled: true,
+                });
+
+                radioSelect
+                    .find(shallowRadioSelect.radioFC)
+                    .first()
+                    .props()
+                    .onClick({} as any);
+
+                expect(spyOnChange).toHaveBeenCalledTimes(0);
+            });
+
+            it('should call onChangeCallback prop when the child call onClick', () => {
+                const spyOnChangeCallback = jest.fn();
+                shallowRadioSelect.creator({
+                    onChangeCallback: spyOnChangeCallback,
+                });
+
+                radioSelect
+                    .find(shallowRadioSelect.radioFC)
+                    .first()
+                    .props()
+                    .onClick({} as any);
+
+                expect(spyOnChangeCallback).toHaveBeenCalledTimes(1);
+            });
         });
     });
 });

--- a/packages/vapor/scss/controls/radios.scss
+++ b/packages/vapor/scss/controls/radios.scss
@@ -123,11 +123,13 @@
 }
 
 .radio-card-container {
+    flex: 0;
+
     .radio-card {
         @extend .card;
-
         display: flex;
         flex-direction: column;
+
         height: 100%;
         padding: 27px 25px;
 
@@ -144,20 +146,17 @@
     }
 
     .card-input:checked + .radio-card {
-        border: 2px solid var(--digital-blue-60);
+        box-shadow: 0 0 0 2px var(--digital-blue-60);
     }
 
     .card-input:disabled + .radio-card {
         background-color: var(--grey-20);
+        cursor: not-allowed;
     }
 }
 
 .radio-select {
     .radio-option + .radio-option {
         margin-top: $checkbox-label-margin-top;
-    }
-
-    .radio-card-container + .radio-card-container {
-        margin-left: $radio-card-margin-left;
     }
 }

--- a/packages/vapor/scss/controls/radios.scss
+++ b/packages/vapor/scss/controls/radios.scss
@@ -122,8 +122,42 @@
     }
 }
 
+.radio-card-container {
+    .radio-card {
+        @extend .card;
+
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        padding: 27px 25px;
+
+        &:hover {
+            cursor: pointer !important;
+        }
+        *:hover {
+            cursor: pointer !important;
+        }
+    }
+
+    .card-input {
+        display: none;
+    }
+
+    .card-input:checked + .radio-card {
+        border: 2px solid var(--digital-blue-60);
+    }
+
+    .card-input:disabled + .radio-card {
+        background-color: var(--grey-20);
+    }
+}
+
 .radio-select {
     .radio-option + .radio-option {
         margin-top: $checkbox-label-margin-top;
+    }
+
+    .radio-card-container + .radio-card-container {
+        margin-left: $radio-card-margin-left;
     }
 }

--- a/packages/vapor/scss/controls/radios.scss
+++ b/packages/vapor/scss/controls/radios.scss
@@ -123,21 +123,26 @@
 }
 
 .radio-card-container {
+    --shadow-color: rgba(229, 232, 232, 0.75);
     flex: 0;
 
     .radio-card {
-        @extend .card;
         display: flex;
         flex-direction: column;
-
         height: 100%;
-        padding: 27px 25px;
+        padding: 20px;
+        border: $default-border;
+        border-radius: 8px;
+        box-shadow: 0px 2px 8px var(--shadow-color);
+        transition: all 0.3s ease-in-out;
 
         &:hover {
+            box-shadow: 0px 8px 8px var(--shadow-color);
+            transform: translate3d(0px, -8px, 0px);
             cursor: pointer !important;
         }
-        *:hover {
-            cursor: pointer !important;
+        *:hover:not(a) {
+            cursor: inherit;
         }
     }
 
@@ -146,12 +151,18 @@
     }
 
     .card-input:checked + .radio-card {
-        box-shadow: 0 0 0 2px var(--digital-blue-60);
+        box-shadow: 0px 4px 8px var(--shadow-color), inset 0 0 0 2px var(--digital-blue-60);
+        transform: translate3d(0px, -4px, 0px);
     }
 
     .card-input:disabled + .radio-card {
-        background-color: var(--grey-20);
-        cursor: not-allowed;
+        box-shadow: none;
+        transform: none;
+        cursor: not-allowed !important;
+
+        * {
+            color: var(--medium-grey);
+        }
     }
 }
 

--- a/packages/vapor/scss/controls/radios.scss
+++ b/packages/vapor/scss/controls/radios.scss
@@ -151,8 +151,8 @@
     }
 
     .card-input:checked + .radio-card {
-        box-shadow: 0px 4px 8px var(--shadow-color), inset 0 0 0 2px var(--digital-blue-60);
-        transform: translate3d(0px, -4px, 0px);
+        box-shadow: 0px 2px 8px var(--shadow-color), inset 0 0 0 2px var(--digital-blue-60);
+        transform: none;
     }
 
     .card-input:disabled + .radio-card {

--- a/packages/vapor/scss/controls/radios.scss
+++ b/packages/vapor/scss/controls/radios.scss
@@ -131,9 +131,6 @@
         flex-direction: column;
         height: 100%;
         padding: 20px;
-        border: $default-border;
-        border-radius: 8px;
-        box-shadow: 0px 2px 8px var(--shadow-color);
         transition: all 0.3s ease-in-out;
 
         &:hover {

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -72,7 +72,6 @@ $checkbox-default-border: solid 2px var(--navy-blue-80);
 $radio-button-option-height: 18px;
 $radio-button-size: 22px;
 $radio-button-text-padding-top: 5px;
-$radio-card-margin-left: 37px;
 
 // Input and textarea
 $input-border: 1px solid var(--lynch);

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -72,6 +72,7 @@ $checkbox-default-border: solid 2px var(--navy-blue-80);
 $radio-button-option-height: 18px;
 $radio-button-size: 22px;
 $radio-button-text-padding-top: 5px;
+$radio-card-margin-left: 37px;
 
 // Input and textarea
 $input-border: 1px solid var(--lynch);


### PR DESCRIPTION
### Proposed Changes
- Added a RadioCard component to enable usage of the RadioSelect component with cards instead of checkboxes

FYI: This has been developed with members of the UX team. 

#### Sample
https://user-images.githubusercontent.com/16785453/114727369-27554480-9d0c-11eb-8597-13a5a78fd448.mov


This is born from the task to create a ModalSelect component to be used when offering a choice between detailed options.
To avoid confining this type of radio button to this modal component I built it separately. 
I thought, for example, that it might be used in a ModalWizard scenario.

<img width="564" alt="Screen Shot 2021-04-13 at 2 40 57 PM" src="https://user-images.githubusercontent.com/16785453/114603892-46010000-9c66-11eb-9777-72c3ee250adc.png">

### Potential Breaking Changes
Don't think there are any

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
