### PR TITLE
fix(code editor): prevent reducer from crashing on empty state

### DIFF
--- a/packages/react-vapor/src/components/editor/CodeEditorReducers.ts
+++ b/packages/react-vapor/src/components/editor/CodeEditorReducers.ts
@@ -26,7 +26,7 @@ export const codeEditorsReducer = (
                 },
             };
         case CodeEditorActionTypes.remove:
-            if (Object.keys(state).length > 1) {
+            if (state && Object.keys(state).length > 1) {
                 delete state[action.payload.id];
             } else {
                 state = null;


### PR DESCRIPTION
### Proposed Changes

code editor reducer is crashing on empty state. modified the condition to avoid that.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
