### PR TITLE
feat(modal-select): added ModalSelect component

### DIFF
--- a/packages/demo/src/components/examples/ModalSelectExamples.tsx
+++ b/packages/demo/src/components/examples/ModalSelectExamples.tsx
@@ -46,7 +46,7 @@ const ExampleModalSelectDisconnected: React.FunctionComponent<ConnectedProps<typ
         <ModalSelect
             id={modalSelectId}
             radioId={radioId}
-            title="The Best Color"
+            title="Select The Best Color"
             isDirty={!!selectedValue}
             onConfirm={(close) => {
                 close();

--- a/packages/demo/src/components/examples/ModalSelectExamples.tsx
+++ b/packages/demo/src/components/examples/ModalSelectExamples.tsx
@@ -52,39 +52,33 @@ const ExampleModalSelectDisconnected: React.FunctionComponent<ConnectedProps<typ
                 close();
             }}
         >
-            <RadioSelectConnected
-                id={radioSelectId}
-                valueOnMount={selectedValue}
-                className="flex flex-wrap mx-auto center-align full-content-y"
-            >
-                <RadioCard id="blue" name="card-option" value="blue">
-                    <div className="mb2" style={{backgroundColor: 'deepskyblue', width: '150px', height: '100px'}} />
-                    <Label>
-                        <span className="bold">{'Blue color'}</span>
-                    </Label>
-                    <InputDescription>
-                        <div style={{...paragraphStyle}}>{'Blue is the best color.'}</div>
-                    </InputDescription>
-                </RadioCard>
-                <RadioCard id="red" name="card-option" value="red">
-                    <div className="mb2" style={{backgroundColor: 'tomato', width: '150px', height: '100px'}} />
-                    <Label>
-                        <span className="bold">{'Red color'}</span>
-                    </Label>
-                    <InputDescription>
-                        <div style={{...paragraphStyle}}>{'Red is the best color.'}</div>
-                    </InputDescription>
-                </RadioCard>
-                <RadioCard id="yellow" name="card-option" value="yellow">
-                    <div className="mb2" style={{backgroundColor: 'gold', width: '150px', height: '100px'}} />
-                    <Label>
-                        <span className="bold">{'Yellow color'}</span>
-                    </Label>
-                    <InputDescription>
-                        <div style={{...paragraphStyle}}>{'Yellow is the best color.'}</div>
-                    </InputDescription>
-                </RadioCard>
-            </RadioSelectConnected>
+            <RadioCard id="blue" name="card-option" value="blue">
+                <div className="mb2" style={{backgroundColor: 'deepskyblue', width: '150px', height: '100px'}} />
+                <Label>
+                    <span className="bold">{'Blue color'}</span>
+                </Label>
+                <InputDescription>
+                    <div style={{...paragraphStyle}}>{'Blue is the best color.'}</div>
+                </InputDescription>
+            </RadioCard>
+            <RadioCard id="red" name="card-option" value="red">
+                <div className="mb2" style={{backgroundColor: 'tomato', width: '150px', height: '100px'}} />
+                <Label>
+                    <span className="bold">{'Red color'}</span>
+                </Label>
+                <InputDescription>
+                    <div style={{...paragraphStyle}}>{'Red is the best color.'}</div>
+                </InputDescription>
+            </RadioCard>
+            <RadioCard id="yellow" name="card-option" value="yellow">
+                <div className="mb2" style={{backgroundColor: 'gold', width: '150px', height: '100px'}} />
+                <Label>
+                    <span className="bold">{'Yellow color'}</span>
+                </Label>
+                <InputDescription>
+                    <div style={{...paragraphStyle}}>{'Yellow is the best color.'}</div>
+                </InputDescription>
+            </RadioCard>
         </ModalSelect>
     </Section>
 );

--- a/packages/demo/src/components/examples/ModalSelectExamples.tsx
+++ b/packages/demo/src/components/examples/ModalSelectExamples.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+import {
+    Button,
+    ConnectedProps,
+    IDispatch,
+    InputDescription,
+    Label,
+    ModalSelect,
+    openModal,
+    RadioCard,
+    RadioSelectConnected,
+    ModalSelectSelectors,
+    Section,
+} from 'react-vapor';
+
+import {IReactVaporExampleState} from '../../Reducers';
+
+const paragraphStyle = {
+    marginTop: 10,
+    marginRight: 36,
+};
+
+// start-print
+
+const modalSelectId = 'modal-select';
+const radioSelectId = 'radio-select';
+
+const enhanceExample1 = connect(
+    (state: IReactVaporExampleState) => ({
+        selectedValue: ModalSelectSelectors.getValue(state, {id: modalSelectId}),
+    }),
+    (dispatch: IDispatch) => ({
+        open: (id: string) => dispatch(openModal(id)),
+    })
+);
+
+const ExampleModalSelectDisconnected: React.FunctionComponent<ConnectedProps<typeof enhanceExample1>> = ({
+    open,
+    selectedValue,
+}) => (
+    <Section level={2} title="ModalSelect">
+        <Button enabled={true} classes={['mod-append']} name="The Best Color" onClick={() => open('modal-select')}>
+            <span className="btn-append">{selectedValue ?? 'none'}</span>
+        </Button>
+        <ModalSelect
+            id={modalSelectId}
+            radioSelectId={radioSelectId}
+            title="The Best Color"
+            isDirty={!!selectedValue}
+            onConfirm={(close) => {
+                // alert('Correct! This is indeed the best color.');
+                close();
+            }}
+        >
+            <RadioSelectConnected id={radioSelectId} className="flex flex-wrap mx-auto center-align full-content-y ">
+                <RadioCard id="blue" name="card-option" value="blue">
+                    <div className="mb2" style={{backgroundColor: 'deepskyblue', width: '150px', height: '100px'}} />
+                    <Label>
+                        <span className="bold">{'Blue color'}</span>
+                    </Label>
+                    <InputDescription>
+                        <div style={{...paragraphStyle}}>{'Blue is the best color.'}</div>
+                    </InputDescription>
+                </RadioCard>
+                <RadioCard id="red" name="card-option" value="red">
+                    <div className="mb2" style={{backgroundColor: 'tomato', width: '150px', height: '100px'}} />
+                    <Label>
+                        <span className="bold">{'Red color'}</span>
+                    </Label>
+                    <InputDescription>
+                        <div style={{...paragraphStyle}}>{'Red is the best color.'}</div>
+                    </InputDescription>
+                </RadioCard>
+                <RadioCard id="green" name="card-option" value="green">
+                    <div className="mb2" style={{backgroundColor: 'gold', width: '150px', height: '100px'}} />
+                    <Label>
+                        <span className="bold">{'Yellow color'}</span>
+                    </Label>
+                    <InputDescription>
+                        <div style={{...paragraphStyle}}>{'Yellow is the best color.'}</div>
+                    </InputDescription>
+                </RadioCard>
+            </RadioSelectConnected>
+        </ModalSelect>
+    </Section>
+);
+
+const ExampleModalSelect = enhanceExample1(ExampleModalSelectDisconnected);
+
+export const ModalSelectExamples = () => (
+    <Section>
+        <ExampleModalSelect />
+    </Section>
+);

--- a/packages/demo/src/components/examples/ModalSelectExamples.tsx
+++ b/packages/demo/src/components/examples/ModalSelectExamples.tsx
@@ -26,7 +26,7 @@ const paragraphStyle = {
 const modalSelectId = 'modal-select';
 const radioSelectId = 'radio-select';
 
-const enhanceExample1 = connect(
+const enhanceExample = connect(
     (state: IReactVaporExampleState) => ({
         selectedValue: ModalSelectSelectors.getValue(state, {id: modalSelectId}),
     }),
@@ -35,7 +35,7 @@ const enhanceExample1 = connect(
     })
 );
 
-const ExampleModalSelectDisconnected: React.FunctionComponent<ConnectedProps<typeof enhanceExample1>> = ({
+const ExampleModalSelectDisconnected: React.FunctionComponent<ConnectedProps<typeof enhanceExample>> = ({
     open,
     selectedValue,
 }) => (
@@ -49,11 +49,14 @@ const ExampleModalSelectDisconnected: React.FunctionComponent<ConnectedProps<typ
             title="The Best Color"
             isDirty={!!selectedValue}
             onConfirm={(close) => {
-                // alert('Correct! This is indeed the best color.');
                 close();
             }}
         >
-            <RadioSelectConnected id={radioSelectId} className="flex flex-wrap mx-auto center-align full-content-y ">
+            <RadioSelectConnected
+                id={radioSelectId}
+                valueOnMount={selectedValue}
+                className="flex flex-wrap mx-auto center-align full-content-y"
+            >
                 <RadioCard id="blue" name="card-option" value="blue">
                     <div className="mb2" style={{backgroundColor: 'deepskyblue', width: '150px', height: '100px'}} />
                     <Label>
@@ -72,7 +75,7 @@ const ExampleModalSelectDisconnected: React.FunctionComponent<ConnectedProps<typ
                         <div style={{...paragraphStyle}}>{'Red is the best color.'}</div>
                     </InputDescription>
                 </RadioCard>
-                <RadioCard id="green" name="card-option" value="green">
+                <RadioCard id="yellow" name="card-option" value="yellow">
                     <div className="mb2" style={{backgroundColor: 'gold', width: '150px', height: '100px'}} />
                     <Label>
                         <span className="bold">{'Yellow color'}</span>
@@ -86,7 +89,7 @@ const ExampleModalSelectDisconnected: React.FunctionComponent<ConnectedProps<typ
     </Section>
 );
 
-const ExampleModalSelect = enhanceExample1(ExampleModalSelectDisconnected);
+const ExampleModalSelect = enhanceExample(ExampleModalSelectDisconnected);
 
 export const ModalSelectExamples = () => (
     <Section>

--- a/packages/demo/src/components/examples/ModalSelectExamples.tsx
+++ b/packages/demo/src/components/examples/ModalSelectExamples.tsx
@@ -24,7 +24,7 @@ const paragraphStyle = {
 // start-print
 
 const modalSelectId = 'modal-select';
-const radioSelectId = 'radio-select';
+const radioId = 'radio-select';
 
 const enhanceExample = connect(
     (state: IReactVaporExampleState) => ({
@@ -45,14 +45,17 @@ const ExampleModalSelectDisconnected: React.FunctionComponent<ConnectedProps<typ
         </Button>
         <ModalSelect
             id={modalSelectId}
-            radioSelectId={radioSelectId}
+            radioId={radioId}
             title="The Best Color"
             isDirty={!!selectedValue}
             onConfirm={(close) => {
                 close();
             }}
+            radioSelectProps={{
+                valueOnMount: 'Blue',
+            }}
         >
-            <RadioCard id="blue" name="card-option" value="blue">
+            <RadioCard id="blue" name="card-option" value="Blue">
                 <div className="mb2" style={{backgroundColor: 'deepskyblue', width: '150px', height: '100px'}} />
                 <Label>
                     <span className="bold">{'Blue color'}</span>
@@ -61,7 +64,7 @@ const ExampleModalSelectDisconnected: React.FunctionComponent<ConnectedProps<typ
                     <div style={{...paragraphStyle}}>{'Blue is the best color.'}</div>
                 </InputDescription>
             </RadioCard>
-            <RadioCard id="red" name="card-option" value="red">
+            <RadioCard id="red" name="card-option" value="Red">
                 <div className="mb2" style={{backgroundColor: 'tomato', width: '150px', height: '100px'}} />
                 <Label>
                     <span className="bold">{'Red color'}</span>
@@ -70,7 +73,7 @@ const ExampleModalSelectDisconnected: React.FunctionComponent<ConnectedProps<typ
                     <div style={{...paragraphStyle}}>{'Red is the best color.'}</div>
                 </InputDescription>
             </RadioCard>
-            <RadioCard id="yellow" name="card-option" value="yellow">
+            <RadioCard id="yellow" name="card-option" value="Yellow">
                 <div className="mb2" style={{backgroundColor: 'gold', width: '150px', height: '100px'}} />
                 <Label>
                     <span className="bold">{'Yellow color'}</span>

--- a/packages/demo/src/components/examples/ModalSelectExamples.tsx
+++ b/packages/demo/src/components/examples/ModalSelectExamples.tsx
@@ -38,7 +38,11 @@ const ExampleModalSelectDisconnected: React.FunctionComponent<ConnectedProps<typ
     open,
     selectedValue,
 }) => (
-    <Section level={2} title="ModalSelect">
+    <Section
+        level={2}
+        title="ModalSelect"
+        description="The ModalSelect component offers detailed choice selection in a compact format using a modal."
+    >
         <Button enabled={true} classes={['mod-append']} name="The Best Color" onClick={() => open('modal-select')}>
             <span className="btn-append">{selectedValue ?? 'none'}</span>
         </Button>

--- a/packages/demo/src/components/examples/ModalSelectExamples.tsx
+++ b/packages/demo/src/components/examples/ModalSelectExamples.tsx
@@ -9,7 +9,6 @@ import {
     ModalSelect,
     openModal,
     RadioCard,
-    RadioSelectConnected,
     ModalSelectSelectors,
     Section,
 } from 'react-vapor';
@@ -47,7 +46,6 @@ const ExampleModalSelectDisconnected: React.FunctionComponent<ConnectedProps<typ
             id={modalSelectId}
             radioId={radioId}
             title="Select The Best Color"
-            isDirty={!!selectedValue}
             onConfirm={(close) => {
                 close();
             }}

--- a/packages/react-vapor/src/ReactVapor.ts
+++ b/packages/react-vapor/src/ReactVapor.ts
@@ -27,6 +27,7 @@ import {IListBoxState} from './components/listBox/ListBoxReducers';
 import {ILoadingState} from './components/loading/LoadingReducers';
 import {IMenusState} from './components/menu/MenuReducers';
 import {IModalState} from './components/modal/ModalReducers';
+import {IModalSelectState} from './components/modalSelect/ModalSelectReducers';
 import {IPaginationState} from './components/navigation/pagination/NavigationPaginationReducers';
 import {IPerPageState} from './components/navigation/perPage/NavigationPerPageReducers';
 import {INumericInputsState} from './components/numericInput/NumericInputReducers';
@@ -81,6 +82,7 @@ export interface IReactVaporState {
     listBoxes?: IListBoxState[];
     menus?: IMenusState;
     modals?: IModalState[];
+    modalSelects?: IModalSelectState[];
     multilineIds?: IStringListCompositeState;
     numericInputs?: INumericInputsState;
     openModals?: string[];

--- a/packages/react-vapor/src/ReactVaporReducers.ts
+++ b/packages/react-vapor/src/ReactVaporReducers.ts
@@ -1,4 +1,5 @@
 import {ReducersMapObject} from 'redux';
+import {modalSelectsReducer} from './components';
 
 import {actionBarsReducer} from './components/actions/ActionBarReducers';
 import {itemFiltersReducer} from './components/actions/filters/ItemFilterReducers';
@@ -79,6 +80,7 @@ export const ReactVaporReducers: ReducersMapObject = {
     loadings: loadingsReducer,
     menus: menuCompositeReducer,
     modals: modalsReducer,
+    modalSelects: modalSelectsReducer,
     multilineIds: stringListCompositeReducer,
     numericInputs: numericInputReducer,
     openModals: openModalsReducer,

--- a/packages/react-vapor/src/components/index.ts
+++ b/packages/react-vapor/src/components/index.ts
@@ -45,6 +45,7 @@ export * from './logoCard';
 export * from './menu';
 export * from './modal';
 export * from './modalPrompt';
+export * from './modalSelect';
 export * from './modalWizard';
 export * from './multilineBox';
 export * from './multilineInput';

--- a/packages/react-vapor/src/components/modalSelect/ModalSelect.tsx
+++ b/packages/react-vapor/src/components/modalSelect/ModalSelect.tsx
@@ -8,9 +8,6 @@ import {IModalCompositeOwnProps, ModalCompositeConnected} from '../modal/ModalCo
 import {IRadioSelectAllProps, RadioSelectConnected, RadioSelectSelectors} from '../radio';
 import {IReactVaporState} from '../../ReactVapor';
 import {ModalSelectSelectors} from './ModalSelectSelectors';
-
-type DependsOnStep<T> = (currentStep: number, numberOfSteps: number) => T;
-
 export interface IModalSelectOwnProps
     extends Omit<
         IModalCompositeOwnProps,
@@ -19,8 +16,8 @@ export interface IModalSelectOwnProps
     id: string;
     radioId: string;
     onConfirm?: (close: () => void) => unknown;
-    modalFooterChildren?: React.ReactNode | DependsOnStep<React.ReactNode>;
-    title?: string | DependsOnStep<string>;
+    modalFooterChildren?: React.ReactNode;
+    title?: string;
     cancelButtonLabel?: string;
     confirmButtonLabel?: string;
     radioSelectProps?: IRadioSelectAllProps;

--- a/packages/react-vapor/src/components/modalSelect/ModalSelect.tsx
+++ b/packages/react-vapor/src/components/modalSelect/ModalSelect.tsx
@@ -5,7 +5,6 @@ import {Button} from '../button';
 import {ModalActions} from '../modal/ModalActions';
 import {setModalSelect, removeModalSelect} from './ModalSelectActions';
 import {IModalCompositeOwnProps, ModalCompositeConnected} from '../modal/ModalComposite';
-import {UnsavedChangesModalProvider} from '../modal/UnsavedChangesModalProvider';
 import {IRadioSelectAllProps, RadioSelectConnected, RadioSelectSelectors} from '../radio';
 import {IReactVaporState} from '../../ReactVapor';
 import {ModalSelectSelectors} from './ModalSelectSelectors';
@@ -67,40 +66,35 @@ const ModalSelectDisconnected: React.FunctionComponent<IModalSelectProps> = ({
     }, []);
 
     return (
-        <UnsavedChangesModalProvider isDirty={isDirty}>
-            {({promptBefore}) => (
-                <ModalCompositeConnected
-                    id={id}
-                    modalBodyChildren={
-                        <RadioSelectConnected
-                            id={radioId}
-                            className="flex flex-wrap mx-auto center-align full-content-y"
-                            {...radioSelectProps}
-                            valueOnMount={selectedValue || radioSelectProps?.valueOnMount}
-                        >
-                            {React.Children.toArray(children) as React.ReactElement[]}
-                        </RadioSelectConnected>
-                    }
-                    modalFooterChildren={
-                        <>
-                            {modalFooterChildren}
-                            <Button name={cancelButtonLabel} onClick={close} enabled />
-                            <Button
-                                primary
-                                name={confirmButtonLabel}
-                                onClick={() => {
-                                    setValue(radioValue);
-                                    onConfirm?.(close);
-                                }}
-                            />
-                        </>
-                    }
-                    validateShouldNavigate={() => promptBefore(close)}
-                    title={title}
-                    {...modalProps}
-                />
-            )}
-        </UnsavedChangesModalProvider>
+        <ModalCompositeConnected
+            id={id}
+            modalBodyChildren={
+                <RadioSelectConnected
+                    id={radioId}
+                    className="flex flex-wrap mx-auto center-align full-content-y"
+                    {...radioSelectProps}
+                    valueOnMount={selectedValue || radioSelectProps?.valueOnMount}
+                >
+                    {React.Children.toArray(children) as React.ReactElement[]}
+                </RadioSelectConnected>
+            }
+            modalFooterChildren={
+                <>
+                    {modalFooterChildren}
+                    <Button name={cancelButtonLabel} onClick={close} enabled />
+                    <Button
+                        primary
+                        name={confirmButtonLabel}
+                        onClick={() => {
+                            setValue(radioValue);
+                            onConfirm?.(close);
+                        }}
+                    />
+                </>
+            }
+            title={title}
+            {...modalProps}
+        />
     );
 };
 

--- a/packages/react-vapor/src/components/modalSelect/ModalSelect.tsx
+++ b/packages/react-vapor/src/components/modalSelect/ModalSelect.tsx
@@ -6,8 +6,9 @@ import {ModalActions} from '../modal/ModalActions';
 import {setModalSelect, removeModalSelect} from './ModalSelectActions';
 import {IModalCompositeOwnProps, ModalCompositeConnected} from '../modal/ModalComposite';
 import {UnsavedChangesModalProvider} from '../modal/UnsavedChangesModalProvider';
-import {RadioSelectSelectors} from '../radio';
+import {IRadioSelectAllProps, RadioSelectConnected, RadioSelectSelectors} from '../radio';
 import {IReactVaporState} from '../../ReactVapor';
+import {ModalSelectSelectors} from './ModalSelectSelectors';
 
 type DependsOnStep<T> = (currentStep: number, numberOfSteps: number) => T;
 
@@ -24,10 +25,12 @@ export interface IModalSelectOwnProps
     isDirty?: boolean;
     cancelButtonLabel?: string;
     confirmButtonLabel?: string;
+    radioSelectProps?: IRadioSelectAllProps;
 }
 
-const mapStateToProps = (state: IReactVaporState, props: {radioSelectId: string}) => ({
-    selectedValue: RadioSelectSelectors.getValue(state, {id: props.radioSelectId}),
+const mapStateToProps = (state: IReactVaporState, props: {id: string; radioSelectId: string}) => ({
+    radioValue: RadioSelectSelectors.getValue(state, {id: props.radioSelectId}),
+    selectedValue: ModalSelectSelectors.getValue(state, {id: props.id}),
 });
 
 const mapDispatchToProps = (dispatch: IDispatch, ownProps: IModalSelectOwnProps) => ({
@@ -49,11 +52,13 @@ const ModalSelectDisconnected: React.FunctionComponent<IModalSelectProps> = ({
     isDirty,
     cancelButtonLabel = 'Cancel',
     confirmButtonLabel = 'Confirm',
+    radioValue,
     selectedValue,
     close,
     setValue,
     remove,
     onConfirm,
+    radioSelectProps,
     ...modalProps
 }) => {
     React.useEffect(() => () => remove(), []);
@@ -63,7 +68,16 @@ const ModalSelectDisconnected: React.FunctionComponent<IModalSelectProps> = ({
             {({promptBefore}) => (
                 <ModalCompositeConnected
                     id={id}
-                    modalBodyChildren={children}
+                    modalBodyChildren={
+                        <RadioSelectConnected
+                            id={radioSelectId}
+                            valueOnMount={selectedValue}
+                            className="flex flex-wrap mx-auto center-align full-content-y"
+                            {...radioSelectProps}
+                        >
+                            {React.Children.toArray(children) as React.ReactElement[]}
+                        </RadioSelectConnected>
+                    }
                     modalFooterChildren={
                         <>
                             {modalFooterChildren}
@@ -72,7 +86,7 @@ const ModalSelectDisconnected: React.FunctionComponent<IModalSelectProps> = ({
                                 primary
                                 name={confirmButtonLabel}
                                 onClick={() => {
-                                    setValue(selectedValue);
+                                    setValue(radioValue);
                                     onConfirm?.(close);
                                 }}
                             />

--- a/packages/react-vapor/src/components/modalSelect/ModalSelect.tsx
+++ b/packages/react-vapor/src/components/modalSelect/ModalSelect.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import {connect} from 'react-redux';
+import {IDispatch, ReduxUtils} from '../../utils';
+import {Button} from '../button';
+import {ModalActions} from '../modal/ModalActions';
+import {setModalSelect, removeModalSelect} from './ModalSelectActions';
+import {IModalCompositeOwnProps, ModalCompositeConnected} from '../modal/ModalComposite';
+import {UnsavedChangesModalProvider} from '../modal/UnsavedChangesModalProvider';
+import {RadioSelectSelectors} from '../radio';
+import {IReactVaporState} from '../../ReactVapor';
+
+type DependsOnStep<T> = (currentStep: number, numberOfSteps: number) => T;
+
+export interface IModalSelectOwnProps
+    extends Omit<
+        IModalCompositeOwnProps,
+        'modalBodyChildren' | 'validateShouldNavigate' | 'modalFooterChildren' | 'title'
+    > {
+    id: string;
+    radioSelectId: string;
+    onConfirm?: (close: () => void) => unknown;
+    modalFooterChildren?: React.ReactNode | DependsOnStep<React.ReactNode>;
+    title?: string | DependsOnStep<string>;
+    isDirty?: boolean;
+    cancelButtonLabel?: string;
+    confirmButtonLabel?: string;
+}
+
+const mapStateToProps = (state: IReactVaporState, props: {radioSelectId: string}) => ({
+    selectedValue: RadioSelectSelectors.getValue(state, {id: props.radioSelectId}),
+});
+
+const mapDispatchToProps = (dispatch: IDispatch, ownProps: IModalSelectOwnProps) => ({
+    close: () => dispatch(ModalActions.closeModal(ownProps.id)),
+    setValue: (value: string) => dispatch(setModalSelect(ownProps.id, value)),
+    remove: () => dispatch(removeModalSelect(ownProps.id)),
+});
+
+export type IModalSelectProps = IModalSelectOwnProps &
+    ReturnType<typeof mapStateToProps> &
+    ReturnType<typeof mapDispatchToProps>;
+
+const ModalSelectDisconnected: React.FunctionComponent<IModalSelectProps> = ({
+    id,
+    radioSelectId,
+    title,
+    children,
+    modalFooterChildren,
+    isDirty,
+    cancelButtonLabel = 'Cancel',
+    confirmButtonLabel = 'Confirm',
+    selectedValue,
+    close,
+    setValue,
+    remove,
+    onConfirm,
+    ...modalProps
+}) => {
+    React.useEffect(() => () => remove(), []);
+
+    return (
+        <UnsavedChangesModalProvider isDirty={isDirty}>
+            {({promptBefore}) => (
+                <ModalCompositeConnected
+                    id={id}
+                    modalBodyChildren={children}
+                    modalFooterChildren={
+                        <>
+                            {modalFooterChildren}
+                            <Button name={cancelButtonLabel} onClick={close} enabled />
+                            <Button
+                                primary
+                                name={confirmButtonLabel}
+                                onClick={() => {
+                                    setValue(selectedValue);
+                                    onConfirm?.(close);
+                                }}
+                            />
+                        </>
+                    }
+                    validateShouldNavigate={() => promptBefore(close)}
+                    title={title}
+                    {...modalProps}
+                />
+            )}
+        </UnsavedChangesModalProvider>
+    );
+};
+
+export const ModalSelect: React.ComponentClass<IModalSelectOwnProps> = connect(
+    mapStateToProps,
+    mapDispatchToProps,
+    ReduxUtils.mergeProps
+)(ModalSelectDisconnected);

--- a/packages/react-vapor/src/components/modalSelect/ModalSelect.tsx
+++ b/packages/react-vapor/src/components/modalSelect/ModalSelect.tsx
@@ -18,7 +18,7 @@ export interface IModalSelectOwnProps
         'modalBodyChildren' | 'validateShouldNavigate' | 'modalFooterChildren' | 'title'
     > {
     id: string;
-    radioSelectId: string;
+    radioId: string;
     onConfirm?: (close: () => void) => unknown;
     modalFooterChildren?: React.ReactNode | DependsOnStep<React.ReactNode>;
     title?: string | DependsOnStep<string>;
@@ -28,8 +28,8 @@ export interface IModalSelectOwnProps
     radioSelectProps?: IRadioSelectAllProps;
 }
 
-const mapStateToProps = (state: IReactVaporState, props: {id: string; radioSelectId: string}) => ({
-    radioValue: RadioSelectSelectors.getValue(state, {id: props.radioSelectId}),
+const mapStateToProps = (state: IReactVaporState, props: {id: string; radioId: string}) => ({
+    radioValue: RadioSelectSelectors.getValue(state, {id: props.radioId}),
     selectedValue: ModalSelectSelectors.getValue(state, {id: props.id}),
 });
 
@@ -45,7 +45,7 @@ export type IModalSelectProps = IModalSelectOwnProps &
 
 const ModalSelectDisconnected: React.FunctionComponent<IModalSelectProps> = ({
     id,
-    radioSelectId,
+    radioId,
     title,
     children,
     modalFooterChildren,
@@ -61,7 +61,10 @@ const ModalSelectDisconnected: React.FunctionComponent<IModalSelectProps> = ({
     radioSelectProps,
     ...modalProps
 }) => {
-    React.useEffect(() => () => remove(), []);
+    React.useEffect(() => {
+        setValue(radioSelectProps?.valueOnMount);
+        return () => remove();
+    }, []);
 
     return (
         <UnsavedChangesModalProvider isDirty={isDirty}>
@@ -70,10 +73,10 @@ const ModalSelectDisconnected: React.FunctionComponent<IModalSelectProps> = ({
                     id={id}
                     modalBodyChildren={
                         <RadioSelectConnected
-                            id={radioSelectId}
-                            valueOnMount={selectedValue}
+                            id={radioId}
                             className="flex flex-wrap mx-auto center-align full-content-y"
                             {...radioSelectProps}
+                            valueOnMount={selectedValue || radioSelectProps?.valueOnMount}
                         >
                             {React.Children.toArray(children) as React.ReactElement[]}
                         </RadioSelectConnected>

--- a/packages/react-vapor/src/components/modalSelect/ModalSelect.tsx
+++ b/packages/react-vapor/src/components/modalSelect/ModalSelect.tsx
@@ -21,7 +21,6 @@ export interface IModalSelectOwnProps
     onConfirm?: (close: () => void) => unknown;
     modalFooterChildren?: React.ReactNode | DependsOnStep<React.ReactNode>;
     title?: string | DependsOnStep<string>;
-    isDirty?: boolean;
     cancelButtonLabel?: string;
     confirmButtonLabel?: string;
     radioSelectProps?: IRadioSelectAllProps;
@@ -48,7 +47,6 @@ const ModalSelectDisconnected: React.FunctionComponent<IModalSelectProps> = ({
     title,
     children,
     modalFooterChildren,
-    isDirty,
     cancelButtonLabel = 'Cancel',
     confirmButtonLabel = 'Confirm',
     radioValue,

--- a/packages/react-vapor/src/components/modalSelect/ModalSelectActions.ts
+++ b/packages/react-vapor/src/components/modalSelect/ModalSelectActions.ts
@@ -1,0 +1,26 @@
+import {IReduxAction} from '../../utils/ReduxUtils';
+
+export interface IModalSelectActionPayload {
+    id: string;
+    value?: string;
+}
+
+export const ModalSelectActions = {
+    set: 'SET_MODALSELECT',
+    remove: 'REMOVE_MODALSELECT',
+};
+
+export const setModalSelect = (id: string, value?: string): IReduxAction<IModalSelectActionPayload> => ({
+    type: ModalSelectActions.set,
+    payload: {
+        id,
+        value,
+    },
+});
+
+export const removeModalSelect = (id: string): IReduxAction<IModalSelectActionPayload> => ({
+    type: ModalSelectActions.remove,
+    payload: {
+        id,
+    },
+});

--- a/packages/react-vapor/src/components/modalSelect/ModalSelectActions.ts
+++ b/packages/react-vapor/src/components/modalSelect/ModalSelectActions.ts
@@ -20,7 +20,5 @@ export const setModalSelect = (id: string, value?: string): IReduxAction<IModalS
 
 export const removeModalSelect = (id: string): IReduxAction<IModalSelectActionPayload> => ({
     type: ModalSelectActions.remove,
-    payload: {
-        id,
-    },
+    payload: {id},
 });

--- a/packages/react-vapor/src/components/modalSelect/ModalSelectReducers.ts
+++ b/packages/react-vapor/src/components/modalSelect/ModalSelectReducers.ts
@@ -1,0 +1,34 @@
+import * as _ from 'underscore';
+import {IReduxAction} from '../../utils/ReduxUtils';
+import {IModalSelectActionPayload, ModalSelectActions} from './ModalSelectActions';
+
+export interface IModalSelectState {
+    id: string;
+    value: string;
+}
+
+export const modalSelectInitialState: IModalSelectState = {id: undefined, value: undefined};
+export const modalSelectsInitialState: IModalSelectState[] = [];
+
+export const modalSelectsReducer = (
+    state: IModalSelectState[] = modalSelectsInitialState,
+    action: IReduxAction<IModalSelectActionPayload>
+): IModalSelectState[] => {
+    switch (action.type) {
+        case ModalSelectActions.set:
+            const modalSelect = _.findWhere(state, {id: action.payload.id});
+            const shouldReplaceValue = modalSelect && !_.isUndefined(action.payload.value);
+
+            return modalSelect
+                ? _.reject(state, (modalRadio) => modalRadio.id === action.payload.id).concat({
+                      ...modalSelect,
+                      ...action.payload,
+                      value: shouldReplaceValue ? action.payload.value : modalSelect.value,
+                  })
+                : [...state, {...modalSelectInitialState, ...action.payload}];
+        case ModalSelectActions.remove:
+            return _.reject(state, (modalRadio) => action.payload.id === modalRadio.id);
+        default:
+            return state;
+    }
+};

--- a/packages/react-vapor/src/components/modalSelect/ModalSelectSelectors.ts
+++ b/packages/react-vapor/src/components/modalSelect/ModalSelectSelectors.ts
@@ -1,0 +1,15 @@
+import {createSelector} from 'reselect';
+import * as _ from 'underscore';
+
+import {IReactVaporState} from '../../ReactVapor';
+import {IModalSelectState, modalSelectInitialState} from './ModalSelectReducers';
+
+const get = (state: IReactVaporState, {id}: {id: string}): IModalSelectState =>
+    _.findWhere(state.modalSelects, {id}) || modalSelectInitialState;
+
+const getValue = createSelector(get, (modalSelect: IModalSelectState) => modalSelect && modalSelect.value);
+
+export const ModalSelectSelectors = {
+    get,
+    getValue,
+};

--- a/packages/react-vapor/src/components/modalSelect/index.ts
+++ b/packages/react-vapor/src/components/modalSelect/index.ts
@@ -1,0 +1,4 @@
+export * from './ModalSelect';
+export * from './ModalSelectActions';
+export * from './ModalSelectReducers';
+export * from './ModalSelectSelectors';

--- a/packages/react-vapor/src/components/modalSelect/tests/ModalSelect.spec.tsx
+++ b/packages/react-vapor/src/components/modalSelect/tests/ModalSelect.spec.tsx
@@ -1,0 +1,84 @@
+import {screen, waitForElementToBeRemoved} from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import {renderModal} from 'react-vapor-test-utils';
+import {RadioCard} from '../../radio/RadioCard';
+import {ModalSelect} from '../ModalSelect';
+
+describe('ModalSelect', () => {
+    const modalId = 'modal-id';
+    const radioId = '📻';
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+    });
+
+    it('closes the modal when clicking on "cancel"', async () => {
+        renderModal(
+            <div>
+                <ModalSelect id={modalId} radioId={radioId}>
+                    <RadioCard id="option1" value="1">
+                        <div>Option 1</div>
+                    </RadioCard>
+                    <RadioCard id="option2" value="2">
+                        <div>Option 2</div>
+                    </RadioCard>
+                </ModalSelect>
+            </div>,
+            {initialState: {modals: [{id: modalId, isOpened: true}]}}
+        );
+
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+        userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+        await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('calls the "onConfirm" prop and the modal stays open when clicking on the "confirm" button', () => {
+        const confirmSpy = jest.fn();
+
+        renderModal(
+            <ModalSelect id={modalId} radioId={radioId} onConfirm={confirmSpy}>
+                <RadioCard id="option1" value="1">
+                    <div>Option 1</div>
+                </RadioCard>
+                <RadioCard id="option2" value="2">
+                    <div>Option 2</div>
+                </RadioCard>
+            </ModalSelect>,
+            {initialState: {modals: [{id: modalId, isOpened: true}]}}
+        );
+
+        userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
+
+        expect(confirmSpy).toHaveBeenCalledTimes(1);
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('calls the "onFinish" prop and the modal closes when clicking on the "finish" button', async () => {
+        const onConfirm = (close: () => any) => close();
+        renderModal(
+            <ModalSelect id={modalId} radioId={radioId} onConfirm={onConfirm}>
+                <RadioCard id="option1" value="1">
+                    <div>Option 1</div>
+                </RadioCard>
+                <RadioCard id="option2" value="2">
+                    <div>Option 2</div>
+                </RadioCard>
+            </ModalSelect>,
+            {initialState: {modals: [{id: modalId, isOpened: true}]}}
+        );
+
+        userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
+
+        await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+});

--- a/packages/react-vapor/src/components/modalSelect/tests/ModalSelectActions.spec.ts
+++ b/packages/react-vapor/src/components/modalSelect/tests/ModalSelectActions.spec.ts
@@ -1,0 +1,32 @@
+import {IReduxAction} from '../../../utils/ReduxUtils';
+import {setModalSelect, IModalSelectActionPayload, removeModalSelect, ModalSelectActions} from '../ModalSelectActions';
+
+const MODAL_SELECT_ID: string = 'the-item-filter';
+
+describe('Modal Select', () => {
+    describe('ModalSelectActions', () => {
+        it('should create an action to change the modal select value', () => {
+            const value: string = 'the value';
+            const expectedAction: IReduxAction<IModalSelectActionPayload> = {
+                type: ModalSelectActions.set,
+                payload: {
+                    id: MODAL_SELECT_ID,
+                    value,
+                },
+            };
+
+            expect(setModalSelect(MODAL_SELECT_ID, value)).toEqual(expectedAction);
+        });
+
+        it('should create an action to remove the modal select', () => {
+            const expectedAction: IReduxAction<IModalSelectActionPayload> = {
+                type: ModalSelectActions.remove,
+                payload: {
+                    id: MODAL_SELECT_ID,
+                },
+            };
+
+            expect(removeModalSelect(MODAL_SELECT_ID)).toEqual(expectedAction);
+        });
+    });
+});

--- a/packages/react-vapor/src/components/modalSelect/tests/ModalSelectReducers.spec.ts
+++ b/packages/react-vapor/src/components/modalSelect/tests/ModalSelectReducers.spec.ts
@@ -1,0 +1,92 @@
+import * as _ from 'underscore';
+import {IReduxAction} from '../../../utils/ReduxUtils';
+import {IModalSelectActionPayload, removeModalSelect, setModalSelect} from '../ModalSelectActions';
+import {
+    IModalSelectState,
+    modalSelectInitialState,
+    modalSelectsInitialState,
+    modalSelectsReducer,
+} from '../ModalSelectReducers';
+
+describe('ModalSelect', () => {
+    describe('ModalSelectReducers', () => {
+        const genericAction: IReduxAction<IModalSelectActionPayload> = {
+            type: 'DO_SOMETHING',
+            payload: {
+                id: 'some-modalselect',
+            },
+        };
+
+        it('should return the default state if the action is not defined and the state is undefined', () => {
+            const oldState: IModalSelectState[] = undefined;
+            const modalSelectsState: IModalSelectState[] = modalSelectsReducer(oldState, genericAction);
+
+            expect(modalSelectsState).toBe(modalSelectsInitialState);
+        });
+
+        it('should return the old state when the action is not defined', () => {
+            const oldState: IModalSelectState[] = [modalSelectInitialState];
+            const modalSelectsState: IModalSelectState[] = modalSelectsReducer(oldState, genericAction);
+
+            expect(modalSelectsState).toBe(oldState);
+        });
+
+        it('should return the old state with one more IModalSelectState when the action is "ModalSelectAction.set" and the id is not yet in the state', () => {
+            let oldState: IModalSelectState[] = modalSelectsInitialState;
+            const action = setModalSelect('idontexistinthestateyet', 'anywoulddo');
+            let modalSelectsState: IModalSelectState[] = modalSelectsReducer(oldState, action);
+
+            expect(modalSelectsState.length).toBe(oldState.length + 1);
+            expect(modalSelectsState.filter((modalSelect) => modalSelect.id === action.payload.id).length).toBe(1);
+
+            oldState = modalSelectsState;
+            action.payload.id = 'ialsodontexistinthestateyet';
+            modalSelectsState = modalSelectsReducer(oldState, action);
+
+            expect(modalSelectsState.length).toBe(oldState.length + 1);
+            expect(modalSelectsState.filter((modalSelect) => modalSelect.id === action.payload.id).length).toBe(1);
+        });
+
+        describe('"ModalSelectAction.set" when id is arleady in the state', () => {
+            it('should return the old state with the same number of IModalSelectState and update the proper IModalSelectState', () => {
+                let oldState: IModalSelectState[] = [
+                    {...modalSelectInitialState, id: 'somealreadyexistingmodalselect'},
+                ];
+                const modalSelectId = 'testModalSelect';
+                const action = setModalSelect(modalSelectId, 'anywoulddo');
+                let modalSelectsState: IModalSelectState[] = modalSelectsReducer(oldState, action);
+
+                expect(modalSelectsState.length).toBe(oldState.length + 1);
+                expect(modalSelectsState.filter((modalSelect) => modalSelect.id === action.payload.id).length).toBe(1);
+
+                oldState = modalSelectsState;
+                action.payload.value = 'check if the value changed';
+                modalSelectsState = modalSelectsReducer(oldState, action);
+
+                expect(modalSelectsState.length).toBe(oldState.length);
+                expect(_.findWhere(modalSelectsState, {id: action.payload.id}).value).toBe(action.payload.value);
+                expect(_.reject(modalSelectsState, (modal) => modal.id === action.payload.id)).toEqual(
+                    _.reject(oldState, (modal) => modal.id === action.payload.id)
+                );
+            });
+        });
+
+        it('should return the old state without the IModalSelectState when the action is "ModalSelectAction.remove"', () => {
+            const oldState: IModalSelectState[] = [
+                {
+                    id: 'some-modalSelect1',
+                    value: 'somevalue',
+                },
+                {
+                    id: 'some-modalSelect2',
+                    value: 'somevalue2',
+                },
+            ];
+            const action: IReduxAction<IModalSelectActionPayload> = removeModalSelect('some-modalSelect1');
+            const modalSelectsState: IModalSelectState[] = modalSelectsReducer(oldState, action);
+
+            expect(modalSelectsState.length).toBe(oldState.length - 1);
+            expect(modalSelectsState.filter((modalSelect) => modalSelect.id === action.payload.id).length).toBe(0);
+        });
+    });
+});

--- a/packages/react-vapor/src/components/modalSelect/tests/ModalSelectSelectors.spec.ts
+++ b/packages/react-vapor/src/components/modalSelect/tests/ModalSelectSelectors.spec.ts
@@ -1,0 +1,49 @@
+import {IModalSelectState, modalSelectInitialState} from '../ModalSelectReducers';
+import {ModalSelectSelectors} from '../ModalSelectSelectors';
+
+describe('ModalSelectSelectors', () => {
+    describe('get', () => {
+        it('should return the default modal select state when the modal select does not exist in the state', () => {
+            const modalSelect = ModalSelectSelectors.get({modalSelects: []}, {id: 'I-do-not-exist-in-the-state'});
+
+            expect(modalSelect).toEqual(modalSelectInitialState);
+        });
+
+        it('should return the right modal select state for the specified id', () => {
+            const expectedModalSelect: IModalSelectState = {
+                id: 'modal-select-123',
+                value: 'choice-2',
+            };
+            const modalSelect = ModalSelectSelectors.get(
+                {modalSelects: [expectedModalSelect]},
+                {id: expectedModalSelect.id}
+            );
+
+            expect(modalSelect).toEqual(expectedModalSelect);
+        });
+    });
+
+    describe('getValue', () => {
+        it('should return undefined when the modal select does not exist in the state', () => {
+            const selectedValue = ModalSelectSelectors.getValue(
+                {modalSelects: []},
+                {id: 'I-do-not-exist-in-the-state'}
+            );
+
+            expect(selectedValue).toBeUndefined();
+        });
+
+        it('should return the modal select value from the state', () => {
+            const expectedModalSelect: IModalSelectState = {
+                id: 'modal-select-123',
+                value: 'choice-2',
+            };
+            const selectedValue = ModalSelectSelectors.getValue(
+                {modalSelects: [expectedModalSelect]},
+                {id: expectedModalSelect.id}
+            );
+
+            expect(selectedValue).toBe(expectedModalSelect.value);
+        });
+    });
+});


### PR DESCRIPTION
### Proposed Changes

- Added a ModalSelect component which offers a RadioSelect choice and saves the selected value inside the vapor store after the modal is closed and the radio component is unmounted.
- The component's children must be Radio or RadioCard components but RadioCard is recommended as the whole point is to offer a detailed choice without taking up interface real-estate.

### Potential Breaking Changes

> Shouldn't be any

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
