### PR TITLE
fix(demo): show example source code instead of compiles .js

### DIFF
--- a/packages/demo/src/components/ComponentPage.tsx
+++ b/packages/demo/src/components/ComponentPage.tsx
@@ -103,7 +103,11 @@ const DevelopmentTabContent: React.FunctionComponent<ComponentPageProps> = ({com
     const [code, setCode] = React.useState('');
     React.useEffect(() => {
         const doImport = async () => {
-            const res: {default: string} = await import('!!raw-loader!./examples/' + path.replace('./', ''));
+            const res: {default: string} = await import(
+                // path has format './ComponentName.js'
+                // source file is at '@examples/ComponentName.tsx'
+                '!!raw-loader!@examples/' + path.replace('./', '').replace('.js', '.tsx')
+            );
             return chopDownSourceFile(res.default);
         };
         doImport().then(setCode);

--- a/packages/demo/src/components/index.tsx
+++ b/packages/demo/src/components/index.tsx
@@ -7,24 +7,25 @@ import ComponentPage from './ComponentPage';
 import {IComponent} from './ComponentsInterface';
 import SideMenu from './Menu';
 
+const componentFiles = require.context('./examples', true, /Examples?\.js?$/i, 'lazy');
+
+const load = async (path: string, ctx: any) => {
+    const component = await ctx(path);
+    const name = _.keys(component)[0].replace(/Examples?/i, '');
+    const componentPrototype = _.values(component)[0];
+    const c: IComponent = {
+        name,
+        path,
+        component: componentPrototype,
+    };
+    return c;
+};
+
+const loadAll = () => Promise.all(componentFiles.keys().map((path) => load(path, componentFiles)));
+
 const Components: React.FunctionComponent<RouteComponentProps> = ({match}) => {
     const [components, setComponents] = React.useState([]);
     React.useEffect(() => {
-        const load = async (path: string, ctx: any) => {
-            const component = await ctx(path);
-            const name = _.keys(component)[0].replace(/Examples?/i, '');
-            const componentPrototype = _.values(component)[0];
-            const c: IComponent = {
-                name,
-                path,
-                component: componentPrototype,
-            };
-            return c;
-        };
-        const loadAll = () => {
-            const componentFiles = require.context('./examples', true, /Examples?\.js?$/i, 'lazy');
-            return Promise.all(componentFiles.keys().map((path) => load(path, componentFiles)));
-        };
         loadAll().then((all) => setComponents(all.filter(Boolean)));
     }, []);
 

--- a/packages/demo/webpack.config.js
+++ b/packages/demo/webpack.config.js
@@ -24,6 +24,7 @@ module.exports = {
         alias: {
             'react-vapor': path.resolve(__dirname, '../react-vapor/dist/Entry.js'),
             '@demo-styling': path.resolve(__dirname, 'src/demo-styling'),
+            '@examples': path.resolve(__dirname, 'src/components/examples'),
         },
     },
     plugins: [


### PR DESCRIPTION
### Proposed Changes

Bundling the demo from the `.js` output introduced a regression, compiled `.js` was shown in the examples code sample instead of the actual source code.

#### Before

![image](https://user-images.githubusercontent.com/35579930/115622223-8f37fc00-a2c5-11eb-8e68-5b1b5188177d.png)

#### After

![image](https://user-images.githubusercontent.com/35579930/115622319-ae368e00-a2c5-11eb-8c78-7a91afa840f4.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
