### PR TITLE
refactor(vapor): use the deprecated color names

### DIFF
--- a/packages/demo/src/demo-styling/main.scss
+++ b/packages/demo/src/demo-styling/main.scss
@@ -1,5 +1,5 @@
 @import '~coveo-styleguide/dist/css/CoveoStyleGuide.css';
-@import '~coveo-styleguide/scss/common/palette';
+
 @import '~coveo-styleguide/scss/lib/mixins';
 @import '~coveo-styleguide/scss/variables';
 @import 'syntax-highlighting';
@@ -19,7 +19,7 @@
     }
 
     .demo-content {
-        @include slim-scroll(var(--grey-2), var(--grey-4));
+        @include slim-scroll(var(--deprecated-grey-2), var(--deprecated-grey-4));
         overflow-y: overlay;
     }
 
@@ -76,7 +76,7 @@
         margin: 2px;
 
         &:hover {
-            background-color: var(--grey-3);
+            background-color: var(--deprecated-grey-3);
         }
 
         a {

--- a/packages/vapor/scss/components/actionable-item.scss
+++ b/packages/vapor/scss/components/actionable-item.scss
@@ -22,7 +22,7 @@ $actionable-item-dots-width: 12px;
     border-radius: 0 $border-radius $border-radius 0;
 
     &:hover {
-        background-color: var(--light-grey);
+        background-color: var(--deprecated-light-grey);
     }
 }
 

--- a/packages/vapor/scss/components/banner.scss
+++ b/packages/vapor/scss/components/banner.scss
@@ -62,7 +62,7 @@
 }
 
 .banner-right {
-    color: rgba($pure-white, $transparency-2);
+    color: rgba(var(--white-rgb), $transparency-2);
     font-size: var(--default-font-size);
 }
 

--- a/packages/vapor/scss/components/blankslate.scss
+++ b/packages/vapor/scss/components/blankslate.scss
@@ -37,7 +37,7 @@
 
     // deprecated use .mod-error instead
     &.mod-danger {
-        background-color: rgba($red, $transparency-5);
+        background-color: rgba(var(--deprecated-red-rgb), $transparency-5);
         border-color: var(--red);
         h1,
         p {
@@ -46,11 +46,11 @@
     }
 
     &.mod-error {
-        background-color: rgba($orange-5, $transparency-5);
-        border-color: var(--orange-8);
+        background-color: rgba(var(--deprecated-tango-rgb), $transparency-5);
+        border-color: var(--deprecated-red);
 
         h1 {
-            color: var(--orange-8);
+            color: var(--deprecated-red);
 
             svg {
                 fill: currentColor;

--- a/packages/vapor/scss/components/browser-preview.scss
+++ b/packages/vapor/scss/components/browser-preview.scss
@@ -5,7 +5,7 @@
     box-shadow: 0px 4px 16px 0px rgba(#e5e8e8, 0.75);
 
     &__header {
-        color: var(--pure-white);
+        color: var(--white);
         font-size: 15px;
         background-color: var(--navy-blue-60);
         border-radius: $big-border-radius $big-border-radius 0px 0px;
@@ -19,7 +19,7 @@
             width: 10px;
             height: 10px;
             margin-left: 5px;
-            background-color: var(--pure-white);
+            background-color: var(--white);
             border-radius: 50%;
         }
     }

--- a/packages/vapor/scss/components/calendar.scss
+++ b/packages/vapor/scss/components/calendar.scss
@@ -19,7 +19,7 @@
 
 .date-picker-box {
     width: $date-picker-width;
-    background-color: var(--pure-white);
+    background-color: var(--white);
     border: $default-border;
     border-radius: $border-radius;
 
@@ -57,7 +57,7 @@
         }
 
         th {
-            color: var(--dark-grey);
+            color: var(--deprecated-dark-grey);
             text-transform: uppercase;
             border-bottom: $calendar-border;
         }
@@ -74,7 +74,7 @@
 
         .other-month-date,
         .un-selectable {
-            color: var(--medium-grey);
+            color: var(--deprecated-medium-grey);
         }
 
         .selected-date {
@@ -84,7 +84,7 @@
             display: block;
             width: calc(#{$calendar-cell-dimensions} + #{$calendar-border-width});
             height: $selected-date-height;
-            color: var(--pure-white);
+            color: var(--white);
             line-height: $selected-date-height;
             background-color: var(--digital-blue-60);
         }
@@ -202,8 +202,8 @@
                     }
 
                     &.other-month-date {
-                        color: var(--pure-white);
-                        background-color: var(--pure-white);
+                        color: var(--white);
+                        background-color: var(--white);
                     }
 
                     &.selected-date {
@@ -221,7 +221,7 @@
                         &.todays-date {
                             color: var(--navy-blue-80);
                             font-size: $small-font-size;
-                            background-color: var(--pure-white);
+                            background-color: var(--white);
                             border: 1px solid var(--navy-blue-80);
                         }
                     }
@@ -260,7 +260,7 @@
 .option-picker {
     li {
         width: 50%;
-        background: var(--pure-white);
+        background: var(--white);
 
         button {
             display: block;
@@ -309,7 +309,7 @@
         &:nth-child(1n) {
             button {
                 &:hover {
-                    background-color: var(--light-grey);
+                    background-color: var(--deprecated-light-grey);
                 }
 
                 &.active {
@@ -343,7 +343,7 @@
         }
 
         &.date-picked {
-            color: var(--pure-white);
+            color: var(--white);
             background-color: var(--digital-blue-60);
         }
     }

--- a/packages/vapor/scss/components/card.scss
+++ b/packages/vapor/scss/components/card.scss
@@ -1,5 +1,5 @@
-$card-container-box-shadow: 0 2px 8px 0 rgba($black, $transparency-4);
-$card-hover-box-shadow: -5px 0 5px var(--light-grey);
+$card-container-box-shadow: 0 2px 8px 0 rgba(var(--black-rgb), $transparency-4);
+$card-hover-box-shadow: -5px 0 5px var(--deprecated-light-grey);
 
 // Status Cards
 $status-card-border-width: 4px;
@@ -19,12 +19,12 @@ $status-card-small-width: 160px;
 
     border: $default-border;
     border-radius: var(--border-radius);
-    box-shadow: 0px 2px 8px rgba(229, 232, 232, 0.75);
+    box-shadow: 0px 2px 8px rgba(var(--grey-40-rgb), 0.75);
 }
 
 .status-card {
     position: relative;
-    background: var(--pure-white);
+    background: var(--white);
     border-left: $status-card-border-width solid transparent;
     border-radius: $border-radius;
     box-shadow: $table-shadow;

--- a/packages/vapor/scss/components/corner-ribbon.scss
+++ b/packages/vapor/scss/components/corner-ribbon.scss
@@ -7,12 +7,12 @@
     position: absolute;
     width: $ribbon-width;
     height: $ribbon-height;
-    color: var(--pure-white);
+    color: var(--white);
     font-size: $ribbon-font-size;
     line-height: $ribbon-height;
     letter-spacing: $ribbon-letter-spacing;
     text-align: center;
-    background-color: var(--medium-grey);
+    background-color: var(--deprecated-medium-grey);
 
     &.left {
         left: $ribbon-x-offset;

--- a/packages/vapor/scss/components/facet.scss
+++ b/packages/vapor/scss/components/facet.scss
@@ -12,8 +12,8 @@
     margin: $facet-margin-y 0;
 
     padding-bottom: $facet-spacing;
-    background: var(--pure-white);
-    border: 1px solid rgba($heather, 0.3);
+    background: var(--white);
+    border: 1px solid rgba(var(--deprecated-heather-rgb), 0.3);
     border-radius: $big-border-radius;
     box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.1);
 }
@@ -174,7 +174,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        background: var(--pure-white);
+        background: var(--white);
         border: $checkbox-default-border;
 
         &:before {
@@ -208,7 +208,7 @@
         top: 50%;
         left: 50%;
         display: block;
-        background-color: var(--medium-grey);
+        background-color: var(--deprecated-medium-grey);
         transform: translate(-50%, -50%);
         content: '';
     }
@@ -251,11 +251,11 @@
     overflow-y: auto;
     list-style: none;
 
-    background-color: var(--pure-white);
-    border: 1px solid rgba($heather, 0.3);
+    background-color: var(--white);
+    border: 1px solid rgba(var(--deprecated-heather-rgb), 0.3);
     border-radius: $big-border-radius;
 
-    @include slim-scroll(var(--light-grey), var(--medium-grey));
+    @include slim-scroll(var(--deprecated-light-grey), var(--deprecated-medium-grey));
 }
 
 .facet-opened:last-child .facet-search-results {

--- a/packages/vapor/scss/components/home-card.scss
+++ b/packages/vapor/scss/components/home-card.scss
@@ -15,8 +15,8 @@
     flex-flow: column;
     margin-bottom: $home-card-margin;
     padding: 2 * $spacing;
-    background: var(--pure-white);
-    border: 1px solid rgba($grey-5, $transparency-4);
+    background: var(--white);
+    border: 1px solid rgba(var(--deprecated-heather-rgb), 0.3);
     border-radius: $home-card-radius;
     box-shadow: $material-card-shadow;
 }

--- a/packages/vapor/scss/components/info-box.scss
+++ b/packages/vapor/scss/components/info-box.scss
@@ -9,12 +9,12 @@ $infoBoxAdditionalPadding: 3 * $spacing;
     font-size: $blankslate-small-p-font-size;
     line-height: $default-line-height;
     border-radius: $border-radius;
-    box-shadow: 0 2px 4px 0 rgba($pure-white, $transparency-5);
+    box-shadow: 0 2px 4px 0 rgba(var(--white-rgb), $transparency-5);
     border-left: $infoBoxBorderSize solid;
 
     // Variables
     --background-color: var(--information-20);
-    --border-color: var(--azure);
+    --border-color: var(--deprecated-azure);
 
     // Style Override
     background-color: var(--background-color);

--- a/packages/vapor/scss/components/lightbox-search.scss
+++ b/packages/vapor/scss/components/lightbox-search.scss
@@ -1,7 +1,7 @@
 .lightbox-search-input {
     width: 100%;
     padding: 10px 20px;
-    color: var(--dark-grey);
+    color: var(--deprecated-dark-grey);
     font-size: 2rem;
     border: none;
     outline: none;
@@ -12,20 +12,20 @@
     margin-top: 5px;
     padding: 0;
     overflow: hidden;
-    background: var(--pure-white);
+    background: var(--white);
     border: none;
     border-radius: $border-radius;
 
     ul li {
         height: auto;
         padding: 0;
-        color: var(--dark-grey);
+        color: var(--deprecated-dark-grey);
         line-height: inherit;
         cursor: pointer;
 
         &:hover,
         &.admin-active {
-            color: var(--medium-blue);
+            color: var(--deprecated-medium-blue);
             background-color: var(--white);
         }
 
@@ -33,7 +33,7 @@
             display: block;
             padding: 10px 20px;
             font-size: 1.8rem;
-            border-top: 1px solid var(--light-grey);
+            border-top: 1px solid var(--deprecated-light-grey);
         }
     }
 }

--- a/packages/vapor/scss/components/limit-box.scss
+++ b/packages/vapor/scss/components/limit-box.scss
@@ -23,7 +23,7 @@
 .limit-box-footer {
     width: 100%;
     height: $limit-progress-bar-height;
-    background-color: var(--light-grey);
+    background-color: var(--deprecated-light-grey);
 }
 
 .limit-box-bar {

--- a/packages/vapor/scss/components/list-box.scss
+++ b/packages/vapor/scss/components/list-box.scss
@@ -35,7 +35,7 @@
     }
 
     &.selected {
-        color: var(--dark-blue);
+        color: var(--deprecated-dark-blue);
         font-weight: var(--main-font-bold);
     }
 
@@ -46,12 +46,12 @@
     }
 
     &:focus {
-        border-color: var(--turquoise);
+        border-color: var(--deprecated-turquoise);
     }
 
     &.disabled {
-        color: var(--medium-grey);
-        background: var(--pure-white);
+        color: var(--deprecated-medium-grey);
+        background: var(--white);
 
         cursor: default;
     }
@@ -65,14 +65,14 @@
         height: $item-box-divider-height;
         margin: $item-box-vertical-spacing 0;
         padding: 0;
-        background-color: var(--medium-grey);
+        background-color: var(--deprecated-medium-grey);
 
         cursor: default;
     }
 
     .prepend,
     .append {
-        color: var(--medium-grey);
+        color: var(--deprecated-medium-grey);
 
         &-red {
             color: var(--red);
@@ -88,7 +88,7 @@
 .select-footer {
     padding: $item-box-vertical-spacing $item-box-horizontal-spacing;
     overflow: hidden;
-    color: var(--dark-grey);
+    color: var(--deprecated-dark-grey);
     font-size: var(--small-font-size);
     line-height: $default-line-height;
     white-space: nowrap;

--- a/packages/vapor/scss/components/logo-card.scss
+++ b/packages/vapor/scss/components/logo-card.scss
@@ -20,7 +20,7 @@
         }
 
         &.ribbon-container .corner-ribbon {
-            background-color: var(--medium-grey);
+            background-color: var(--deprecated-medium-grey);
         }
     }
 }

--- a/packages/vapor/scss/components/material-card.scss
+++ b/packages/vapor/scss/components/material-card.scss
@@ -1,7 +1,7 @@
 .material-card {
     padding: 2 * $spacing;
-    background-color: var(--pure-white);
-    border: 1px solid rgba($grey-5, $transparency-4);
+    background-color: var(--white);
+    border: 1px solid rgba(var(--deprecated-heather-rgb), 0.3);
     border-radius: $border-radius;
     box-shadow: $material-card-shadow;
     transition: box-shadow 0.1s ease-out;

--- a/packages/vapor/scss/components/member.scss
+++ b/packages/vapor/scss/components/member.scss
@@ -24,7 +24,7 @@
 
     .member-info {
         margin-left: 14px;
-        color: var(--pure-white);
+        color: var(--white);
 
         .member-info-name {
             font-weight: var(--main-font-bold);

--- a/packages/vapor/scss/components/menu.scss
+++ b/packages/vapor/scss/components/menu.scss
@@ -14,16 +14,16 @@
         cursor: pointer;
 
         .dropdown-toggle-arrow {
-            @include arrow-down-icon($pure-white);
+            @include arrow-down-icon(var(--white));
         }
 
         .dropdown-toggle-arrow-style {
-            fill: var(--pure-white);
+            fill: var(--white);
         }
     }
 
     &.open .dropdown-toggle .dropdown-toggle-arrow {
-        @include arrow-up-icon($pure-white);
+        @include arrow-up-icon(var(--white));
     }
 
     .dropdown-menu {

--- a/packages/vapor/scss/components/modal.scss
+++ b/packages/vapor/scss/components/modal.scss
@@ -45,7 +45,7 @@ $icon-size: (4em / 3);
 
 .modal-backdrop {
     z-index: $base-backdrop-z-index;
-    background: rgba($purple-blue, $transparency-1);
+    background: rgba(var(--deprecated-purple-blue-rgb), $transparency-1);
 
     opacity: 1;
     transition: all 0.3s;
@@ -176,8 +176,8 @@ $icon-size: (4em / 3);
     align-items: center;
     height: $modal-header-height;
     padding: 0 $header-padding;
-    color: var(--pure-white);
-    background-color: var(--pure-white);
+    color: var(--white);
+    background-color: var(--white);
     border-radius: $border-radius $border-radius 0 0;
 
     &:not(.mod-no-border-bottom) {
@@ -218,7 +218,7 @@ $icon-size: (4em / 3);
         & .icon {
             width: $icon-size;
             height: $icon-size;
-            fill: var(--pure-white);
+            fill: var(--white);
         }
     }
 }
@@ -228,7 +228,7 @@ $icon-size: (4em / 3);
     flex-grow: 1;
 
     overflow: auto;
-    background-color: var(--pure-white);
+    background-color: var(--white);
 
     -webkit-overflow-scrolling: touch;
 

--- a/packages/vapor/scss/components/multiselect-input.scss
+++ b/packages/vapor/scss/components/multiselect-input.scss
@@ -54,7 +54,7 @@
 
 .multiselect-empty {
     margin-bottom: $spacing;
-    color: var(--medium-grey);
+    color: var(--deprecated-medium-grey);
     line-height: $button-small-height + 2 * $button-border-width;
 }
 

--- a/packages/vapor/scss/components/navigation-loading.scss
+++ b/packages/vapor/scss/components/navigation-loading.scss
@@ -5,7 +5,7 @@
 }
 
 .loading-bg-light-grey {
-    background: var(--light-grey);
+    background: var(--deprecated-light-grey);
     background: linear-gradient(to right, #e9eef2 8%, #d1dbe3 18%, #e9eef2 33%);
     background-size: $navigation-loading-background-size;
 }

--- a/packages/vapor/scss/components/panel-header.scss
+++ b/packages/vapor/scss/components/panel-header.scss
@@ -22,8 +22,8 @@
         height: $button-height;
         padding: 0;
         vertical-align: bottom;
-        background-color: var(--pure-white);
-        border: 1px solid var(--medium-grey);
+        background-color: var(--white);
+        border: 1px solid var(--deprecated-medium-grey);
         border-radius: 2px;
 
         cursor: pointer;
@@ -31,14 +31,14 @@
         &.open,
         &:focus,
         &:active {
-            background-color: var(--light-grey);
+            background-color: var(--deprecated-light-grey);
         }
 
         span {
             vertical-align: middle;
 
             &.state-disabled {
-                color: var(--medium-grey);
+                color: var(--deprecated-medium-grey);
                 cursor: default;
             }
         }

--- a/packages/vapor/scss/components/popover.scss
+++ b/packages/vapor/scss/components/popover.scss
@@ -1,9 +1,9 @@
 .popover {
     min-width: $popover-min-width;
-    background-color: var(--pure-white);
+    background-color: var(--white);
     border: $default-border;
     border-radius: $border-radius;
-    box-shadow: 0 2px 4px rgba($stratos, 0.4);
+    box-shadow: 0 2px 4px rgba(var(--deprecated-stratos-rgb), 0.4);
 }
 
 .popover-body {
@@ -17,7 +17,7 @@
     padding: $popover-footer-y-padding $button-padding-x;
     overflow: hidden;
     background-color: var(--white);
-    border-top: solid 1px var(--medium-grey);
+    border-top: solid 1px var(--deprecated-medium-grey);
     border-radius: 0 0 $border-radius $border-radius;
 }
 

--- a/packages/vapor/scss/components/prompt.scss
+++ b/packages/vapor/scss/components/prompt.scss
@@ -19,7 +19,7 @@ $prompt-message-line-height: 20px;
                 }
 
                 h1 {
-                    color: var(--pure-white);
+                    color: var(--white);
                     white-space: inherit;
                 }
             }
@@ -51,7 +51,7 @@ $prompt-message-line-height: 20px;
             .modal-footer {
                 height: $modal-prompt-footer-height;
                 padding: $header-height-padding $modal-prompt-horizontal-padding;
-                background-color: var(--pure-white);
+                background-color: var(--white);
                 border-top: 0;
             }
         }

--- a/packages/vapor/scss/components/search-bar.scss
+++ b/packages/vapor/scss/components/search-bar.scss
@@ -37,7 +37,7 @@
 
 .search-bar-disabled svg {
     cursor: default;
-    fill: var(--light-grey);
+    fill: var(--deprecated-light-grey);
 }
 
 .search-icon-disabled {

--- a/packages/vapor/scss/components/selected-option.scss
+++ b/packages/vapor/scss/components/selected-option.scss
@@ -13,7 +13,7 @@
     color: var(--title-text-color);
     font-size: $button-small-font-size;
     line-height: $dropdown-multiselect-option-height;
-    background-color: var(--pure-white);
+    background-color: var(--white);
     border: $default-border;
     border-radius: $border-radius;
 
@@ -59,13 +59,13 @@
 }
 
 .remove-option:hover {
-    background-color: darken($light-grey, 5%);
+    background-color: var(--deprecated-medium-grey);
 
     cursor: pointer;
 }
 
 .remove-option:active {
-    background-color: darken($light-grey, 5%);
+    background-color: var(--deprecated-medium-grey);
 }
 
 // Single select

--- a/packages/vapor/scss/components/step-progress-bar.scss
+++ b/packages/vapor/scss/components/step-progress-bar.scss
@@ -11,7 +11,7 @@
     padding: 0;
 
     &:not(:last-child) {
-        border-right: $step-progress-bar-border-width solid var(--pure-white);
+        border-right: $step-progress-bar-border-width solid var(--white);
     }
 }
 

--- a/packages/vapor/scss/components/sub-navigation.scss
+++ b/packages/vapor/scss/components/sub-navigation.scss
@@ -4,7 +4,7 @@
     background-color: var(--white);
     border-right: $sub-navigation-min-width;
 
-    @include slim-scroll(var(--medium-grey), var(--dark-grey));
+    @include slim-scroll(var(--deprecated-medium-grey), var(--deprecated-dark-grey));
 
     .sub-navigation-items {
         padding-top: $sub-navigation-padding-top;
@@ -19,7 +19,7 @@
                 line-height: $sub-navigation-line-height;
 
                 &.disabled {
-                    color: var(--medium-grey);
+                    color: var(--deprecated-medium-grey);
                     cursor: default;
                 }
             }

--- a/packages/vapor/scss/components/sync-feedback.scss
+++ b/packages/vapor/scss/components/sync-feedback.scss
@@ -28,7 +28,7 @@
         border-radius: 50%;
 
         &.syncing {
-            background-color: var(--dark-grey);
+            background-color: var(--deprecated-dark-grey);
             animation: scaleout 1s infinite ease-in-out;
         }
     }

--- a/packages/vapor/scss/components/tab.scss
+++ b/packages/vapor/scss/components/tab.scss
@@ -27,7 +27,7 @@
         }
 
         &.disabled {
-            --color: var(--medium-grey);
+            --color: var(--deprecated-medium-grey);
 
             cursor: not-allowed;
         }

--- a/packages/vapor/scss/components/table-hoc.scss
+++ b/packages/vapor/scss/components/table-hoc.scss
@@ -24,7 +24,7 @@
     :global(.coveo-styleguide .table) .table-numbered-row-container {
         width: 60px;
         padding: $default-margin;
-        color: var(--medium-blue);
+        color: var(--deprecated-medium-blue);
         text-align: center;
         border-left: none;
     }

--- a/packages/vapor/scss/components/toast.scss
+++ b/packages/vapor/scss/components/toast.scss
@@ -134,9 +134,9 @@ $toast-close-size: 16px;
     .toast.toast-download {
         min-width: 300px;
         padding: 0;
-        background: $blue-purple-3;
+        background: var(--deprecated-blue-purple-3);
         border-radius: 6px;
-        box-shadow: 0 2px 4px rgba($black, $transparency-4);
+        box-shadow: 0 2px 4px rgba(var(--black-rgb), $transparency-4);
 
         .toast-title,
         .toast-close {
@@ -148,7 +148,7 @@ $toast-close-size: 16px;
             padding: $toast-padding;
             color: var(--title-text-color);
             font-size: var(--default-font-size);
-            background: var(--grey-1);
+            background: var(--deprecated-grey-1);
             border-bottom-right-radius: inherit;
             border-bottom-left-radius: inherit;
             box-shadow: inset 0px 5px 6px -5px var(--grey-100);

--- a/packages/vapor/scss/components/tooltip.scss
+++ b/packages/vapor/scss/components/tooltip.scss
@@ -102,7 +102,7 @@
     .tooltip-inner {
         max-width: 300px;
         padding: 5px 10px;
-        color: var(--pure-white);
+        color: var(--white);
         white-space: normal;
         text-decoration: none;
         word-wrap: break-word;
@@ -123,7 +123,7 @@ $chart-tooltip-content-size: 3px;
     font-size: $small-font-size;
     background-color: var(--white);
     border: $default-border;
-    box-shadow: 0 0 $chart-tooltip-content-size 0 rgba($black, $transparency-4);
+    box-shadow: 0 0 $chart-tooltip-content-size 0 rgba(var(--black-rgb), $transparency-4);
 }
 
 .chart-tooltip-color {

--- a/packages/vapor/scss/components/wizard-card.scss
+++ b/packages/vapor/scss/components/wizard-card.scss
@@ -5,7 +5,7 @@
     align-content: flex-start;
     width: $wizard-card-width;
     background-color: var(--white);
-    border: 1px solid var(--medium-grey);
+    border: 1px solid var(--deprecated-medium-grey);
     border-radius: $border-radius;
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.14);
 

--- a/packages/vapor/scss/controls/chosen.scss
+++ b/packages/vapor/scss/controls/chosen.scss
@@ -15,15 +15,15 @@
         left: -9999px;
         z-index: 1010;
         width: 100%;
-        background: var(--pure-white);
-        border: 1px solid var(--medium-grey);
+        background: var(--white);
+        border: 1px solid var(--deprecated-medium-grey);
         border-top: 0;
         border-radius: 2px;
         border-top-left-radius: 0;
         border-top-right-radius: 0;
         box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.4);
 
-        @include slim-scroll(var(--light-grey), var(--medium-grey));
+        @include slim-scroll(var(--deprecated-light-grey), var(--deprecated-medium-grey));
 
         .chosen-results {
             position: relative;
@@ -37,7 +37,7 @@
                 display: none;
                 margin: 0;
                 padding: 8px $button-padding-x;
-                color: var(--dark-grey);
+                color: var(--deprecated-dark-grey);
                 font-size: $dropdown-choice-font-size;
                 line-height: 16px;
                 word-wrap: break-word;
@@ -60,17 +60,17 @@
 
                 &.disabled-result {
                     display: list-item;
-                    color: var(--medium-grey);
+                    color: var(--deprecated-medium-grey);
                     cursor: default;
                 }
 
                 &.highlighted {
-                    background-color: var(--light-grey);
+                    background-color: var(--deprecated-light-grey);
                 }
 
                 &.no-results {
                     display: list-item;
-                    background: var(--pure-white);
+                    background: var(--white);
                 }
 
                 &.result-selected {
@@ -79,7 +79,7 @@
                 }
 
                 em {
-                    color: var(--dark-grey);
+                    color: var(--deprecated-dark-grey);
                     font-weight: var(--main-font-bold);
                     font-style: normal;
                     text-decoration: underline;
@@ -94,8 +94,8 @@
 
     &.chosen-disabled {
         .chosen-single {
-            color: var(--medium-grey);
-            border-color: var(--medium-grey);
+            color: var(--deprecated-medium-grey);
+            border-color: var(--deprecated-medium-grey);
         }
 
         b {
@@ -120,13 +120,13 @@
         line-height: 34px;
         white-space: nowrap;
         text-decoration: none;
-        background-color: var(--pure-white);
+        background-color: var(--white);
         background-clip: padding-box;
-        border: 1px solid var(--medium-grey);
+        border: 1px solid var(--deprecated-medium-grey);
         border-radius: $border-radius;
 
         &.chosen-default {
-            color: var(--medium-grey);
+            color: var(--deprecated-medium-grey);
         }
 
         span {
@@ -160,7 +160,7 @@
             width: $chosen-clear-icon-size;
             height: $chosen-clear-icon-size;
 
-            @include clear-icon($medium-grey);
+            @include clear-icon(var(--deprecated-medium-grey));
         }
 
         &.chosen-single-with-deselect span {
@@ -186,11 +186,11 @@
             background-position: right 8px center;
             background-size: $chosen-filter-icon-size $chosen-filter-icon-size;
             background-origin: border-box;
-            border: 1px solid var(--medium-grey);
+            border: 1px solid var(--deprecated-medium-grey);
             border-radius: 2px;
             outline: 0;
 
-            @include filter-icon($medium-grey);
+            @include filter-icon(var(--deprecated-medium-grey));
         }
     }
 
@@ -223,7 +223,7 @@
             ($button-padding-x + $chosen-filter-icon-size + $button-padding-x - $chosen-multi-search-choice-margin) 0
             $button-padding-x;
         overflow: hidden;
-        border: 1px solid var(--medium-grey);
+        border: 1px solid var(--deprecated-medium-grey);
         border-radius: $border-radius;
 
         cursor: text;
@@ -237,7 +237,7 @@
             height: $chosen-filter-icon-size;
             content: '';
 
-            @include filter-icon($medium-grey);
+            @include filter-icon(var(--deprecated-medium-grey));
         }
 
         li {
@@ -267,10 +267,10 @@
                 margin: $chosen-multi-search-choice-margin $chosen-multi-search-choice-margin 0 0;
                 padding: 0 (2 * $chosen-multi-search-choice-padding + $chosen-clear-icon-size) 0
                     $chosen-multi-search-choice-padding;
-                color: var(--dark-grey);
+                color: var(--deprecated-dark-grey);
                 font-size: 11px;
                 line-height: 22px;
-                border: 1px solid var(--medium-grey);
+                border: 1px solid var(--deprecated-medium-grey);
                 border-radius: $border-radius;
 
                 cursor: default;
@@ -287,14 +287,14 @@
                     width: $chosen-clear-icon-size;
                     height: $chosen-clear-icon-size;
 
-                    @include clear-icon($medium-grey);
+                    @include clear-icon(var(--deprecated-medium-grey));
                 }
             }
 
             &.search-choice-disabled {
                 padding-right: 5px;
-                color: var(--medium-grey);
-                border: 1px solid var(--medium-grey);
+                color: var(--deprecated-medium-grey);
+                border: 1px solid var(--deprecated-medium-grey);
             }
 
             &.search-choice-focus {
@@ -305,7 +305,7 @@
 
     .chosen-drop .chosen-results li.result-selected {
         display: list-item;
-        color: var(--medium-grey);
+        color: var(--deprecated-medium-grey);
         font-weight: var(--main-font-regular);
         cursor: default;
     }

--- a/packages/vapor/scss/controls/collapsable.scss
+++ b/packages/vapor/scss/controls/collapsable.scss
@@ -23,7 +23,7 @@
     }
 
     .panel {
-        border-bottom: 2px solid var(--medium-grey);
+        border-bottom: 2px solid var(--deprecated-medium-grey);
 
         + .panel {
             margin-top: 15px;
@@ -37,7 +37,7 @@
                 display: block;
                 margin-bottom: 5px;
                 padding: 3px 0 3px 26px;
-                color: var(--medium-blue);
+                color: var(--deprecated-medium-blue);
                 font-size: var(--default-font-size);
                 font-family: var(--main-font);
                 line-height: initial;

--- a/packages/vapor/scss/controls/datepicker.scss
+++ b/packages/vapor/scss/controls/datepicker.scss
@@ -1,11 +1,11 @@
 $datepicker-border-color: #f6f6f6;
-$datepicker-dayofweeks-color: var(--dark-grey);
+$datepicker-dayofweeks-color: var(--deprecated-dark-grey);
 $datepicker-day-hover-background-color: #eeeeee;
-$datepicker-day-color: var(--dark-grey);
-$datepicker-day-selected-notinmonth-color: var(--dark-grey);
+$datepicker-day-color: var(--deprecated-dark-grey);
+$datepicker-day-selected-notinmonth-color: var(--deprecated-dark-grey);
 $datepicker-day-selected-notinmonth-background-color: #d2dce6;
-$datepicker-day-selected-background-color: lighten($medium-blue, 5%);
-$datepicker-day-notinmonth-background-color: var(--dark-grey);
+$datepicker-day-selected-background-color: var(--deprecated-medium-blue);
+$datepicker-day-notinmonth-background-color: var(--deprecated-dark-grey);
 $datepicker-day-disabled-background-color: #e6e6e6;
 $datepicker-day-disabled-color: #666666;
 
@@ -24,7 +24,7 @@ $datepicker-day-disabled-color: #666666;
 }
 
 .datepicker {
-    background-color: var(--pure-white);
+    background-color: var(--white);
 
     .datepickerBlock {
         border: none !important;
@@ -43,10 +43,10 @@ $datepicker-day-disabled-color: #666666;
                 &.datepickerDoW {
                     th {
                         padding: 2px 0;
-                        border-bottom: 1px solid var(--medium-grey);
+                        border-bottom: 1px solid var(--deprecated-medium-grey);
                     }
                     span {
-                        color: var(--medium-grey);
+                        color: var(--deprecated-medium-grey);
                         font-size: 9px;
                         border-top: none;
                         border-right: none;
@@ -58,7 +58,7 @@ $datepicker-day-disabled-color: #666666;
             tr:first-child th {
                 a:hover {
                     text-decoration: none;
-                    background: var(--medium-grey);
+                    background: var(--deprecated-medium-grey);
 
                     cursor: pointer;
                 }
@@ -109,31 +109,31 @@ $datepicker-day-disabled-color: #666666;
                     }
 
                     &.datepickerSelected {
-                        background-color: var(--light-blue);
+                        background-color: var(--deprecated-light-blue);
 
                         &.datepickerNotInMonth {
-                            background-color: var(--medium-grey);
+                            background-color: var(--deprecated-medium-grey);
                             a {
-                                color: var(--dark-grey);
+                                color: var(--deprecated-dark-grey);
                             }
                         }
                     }
 
                     &.datepickerNotInMonth {
-                        background-color: var(--light-grey);
+                        background-color: var(--deprecated-light-grey);
                     }
 
                     &.datepickerFuture {
                         &.datepickerNotInMonth {
-                            background-color: var(--light-grey);
+                            background-color: var(--deprecated-light-grey);
                             a {
                                 cursor: default;
                             }
 
                             &.datepickerDisabled {
-                                background-color: var(--light-grey);
+                                background-color: var(--deprecated-light-grey);
                                 a {
-                                    color: var(--medium-grey);
+                                    color: var(--deprecated-medium-grey);
                                     cursor: default;
                                 }
                             }
@@ -141,10 +141,10 @@ $datepicker-day-disabled-color: #666666;
                     }
 
                     &.datepickerDisabled {
-                        background-color: var(--light-grey);
+                        background-color: var(--deprecated-light-grey);
 
                         a {
-                            color: var(--medium-grey);
+                            color: var(--deprecated-medium-grey);
                             cursor: default;
                         }
                     }

--- a/packages/vapor/scss/controls/dropdown.scss
+++ b/packages/vapor/scss/controls/dropdown.scss
@@ -5,11 +5,11 @@
     &.open > .dropdown-toggle,
     .dropdown-toggle.open {
         &.mod-primary .dropdown-toggle-arrow {
-            @include arrow-up-icon($pure-white);
+            @include arrow-up-icon(var(--white));
         }
 
         .dropdown-toggle-arrow {
-            @include arrow-up-icon(var(--medium-blue));
+            @include arrow-up-icon(var(--deprecated-medium-blue));
         }
     }
 
@@ -47,7 +47,7 @@
     }
 
     .disabled {
-        color: var(--medium-grey);
+        color: var(--deprecated-medium-grey);
     }
 }
 
@@ -65,7 +65,7 @@
     text-overflow: ellipsis;
 
     &:disabled .dropdown-toggle-arrow {
-        @include arrow-down-icon(var(--medium-grey));
+        @include arrow-down-icon(var(--deprecated-medium-grey));
     }
 
     &.dropdown-toggle-placeholder {
@@ -77,7 +77,7 @@
         text-transform: none;
 
         .dropdown-toggle-arrow {
-            @include arrow-down-icon($pure-white);
+            @include arrow-down-icon(var(--white));
         }
     }
 
@@ -108,7 +108,7 @@
     }
 
     .dropdown-toggle-arrow {
-        @include arrow-down-icon(var(--medium-blue));
+        @include arrow-down-icon(var(--deprecated-medium-blue));
     }
 
     &.mod-search {
@@ -181,7 +181,7 @@
             > a,
             > span,
             .dropdown-option-append {
-                color: var(--medium-grey);
+                color: var(--deprecated-medium-grey);
                 background-color: var(--grey-60);
                 cursor: default;
             }
@@ -199,7 +199,7 @@
             }
 
             &.disabled {
-                color: var(--medium-grey);
+                color: var(--deprecated-medium-grey);
                 cursor: default;
             }
 

--- a/packages/vapor/scss/controls/filtering/filter-picker.scss
+++ b/packages/vapor/scss/controls/filtering/filter-picker.scss
@@ -25,9 +25,9 @@
             display: inline-block;
             margin-left: $filter-badge-margin-left;
             overflow: visible;
-            color: var(--dark-grey);
+            color: var(--deprecated-dark-grey);
             font-size: $filter-badge-font-size;
-            background-color: var(--pure-white);
+            background-color: var(--white);
 
             cursor: pointer;
 
@@ -50,13 +50,13 @@
             }
 
             .filter-value-join {
-                color: var(--dark-grey);
+                color: var(--deprecated-dark-grey);
             }
 
             .dropdown-toggle:disabled {
                 .filter-operator,
                 .filter-value-join {
-                    color: var(--medium-grey);
+                    color: var(--deprecated-medium-grey);
                 }
             }
         }
@@ -65,7 +65,7 @@
             flex-grow: 2;
 
             padding: $filterbox-filters-container-padding;
-            background-color: var(--medium-grey);
+            background-color: var(--deprecated-medium-grey);
         }
 
         .filters {

--- a/packages/vapor/scss/controls/filtering/filters-list.scss
+++ b/packages/vapor/scss/controls/filtering/filters-list.scss
@@ -37,12 +37,12 @@
                 width: 100%;
                 margin-top: $filter-choices-section-margin-top;
                 padding-left: $filter-choices-section-padding-left;
-                color: var(--medium-blue);
+                color: var(--deprecated-medium-blue);
                 text-transform: uppercase;
             }
 
             .list {
-                @include slim-scroll(var(--light-grey), var(--medium-grey));
+                @include slim-scroll(var(--deprecated-light-grey), var(--deprecated-medium-grey));
             }
         }
     }
@@ -51,7 +51,7 @@
         max-height: 300px;
         overflow: auto;
 
-        @include slim-scroll(var(--light-grey), var(--medium-grey));
+        @include slim-scroll(var(--deprecated-light-grey), var(--deprecated-medium-grey));
     }
 
     .filter-choices,
@@ -102,19 +102,19 @@
             line-height: $filter-not-selected-line-height;
             white-space: nowrap;
             text-overflow: ellipsis;
-            background-color: var(--pure-white);
+            background-color: var(--white);
 
             cursor: pointer;
 
             .type {
-                color: var(--medium-grey);
+                color: var(--deprecated-medium-grey);
                 font-size: $filter-type-font-size;
             }
         }
 
         li.filter:hover,
         li.filter.active {
-            background-color: var(--light-grey);
+            background-color: var(--deprecated-light-grey);
         }
 
         label.filter {

--- a/packages/vapor/scss/controls/filtering/filters-values.scss
+++ b/packages/vapor/scss/controls/filtering/filters-values.scss
@@ -7,7 +7,7 @@
             width: 100%;
 
             .popup-header {
-                background-color: var(--pure-white);
+                background-color: var(--white);
             }
 
             .selected-filter {

--- a/packages/vapor/scss/controls/filtering/multi-filter-picker.scss
+++ b/packages/vapor/scss/controls/filtering/multi-filter-picker.scss
@@ -13,7 +13,7 @@
 
         .add-container {
             overflow: auto;
-            background-color: rgba($white, 0.4);
+            background-color: rgba(var(--deprecated-white-rgb), 0.4);
 
             .add {
                 padding: $multi-filterpickerbox-add-padding;
@@ -48,7 +48,7 @@
                 margin-left: $filter-where-margin-left;
                 padding: $filter-where-padding;
                 line-height: $filter-where-line-height;
-                background-color: var(--pure-white);
+                background-color: var(--white);
             }
 
             .filter-type {

--- a/packages/vapor/scss/controls/flat-select.scss
+++ b/packages/vapor/scss/controls/flat-select.scss
@@ -1,6 +1,6 @@
 .flat-select {
     display: flex;
-    background-color: var(--pure-white);
+    background-color: var(--white);
     border-radius: $border-radius;
 
     .flat-select-option {
@@ -10,7 +10,7 @@
         min-width: $flat-select-option-size;
         height: $flat-select-option-size;
         padding: 0 4px;
-        color: var(--pure-white);
+        color: var(--white);
         font-size: 13px;
         text-align: center;
         background-color: var(--navy-blue-80);
@@ -36,7 +36,7 @@
             }
 
             .icon {
-                fill: var(--pure-white);
+                fill: var(--white);
             }
         }
 
@@ -54,7 +54,7 @@
 
         &.selectable {
             color: var(--title-text-color);
-            background-color: var(--pure-white);
+            background-color: var(--white);
             border: $default-border;
 
             cursor: pointer;
@@ -77,7 +77,7 @@
             padding: 0;
             color: var(--navy-blue-80);
             font-size: var(--default-font-size);
-            background-color: var(--pure-white);
+            background-color: var(--white);
             border: none;
 
             .icon {
@@ -85,10 +85,10 @@
             }
 
             &.disabled {
-                color: var(--medium-grey);
+                color: var(--deprecated-medium-grey);
 
                 .icon {
-                    fill: var(--medium-grey);
+                    fill: var(--deprecated-medium-grey);
                 }
             }
         }
@@ -133,7 +133,7 @@
         border-radius: 0;
 
         &.selectable {
-            background-color: var(--pure-white);
+            background-color: var(--white);
             border-color: var(--default-border-color);
         }
 

--- a/packages/vapor/scss/controls/input-field.scss
+++ b/packages/vapor/scss/controls/input-field.scss
@@ -29,10 +29,10 @@
         &:focus:not([readonly]),
         &:valid,
         &:disabled {
-            color: var(--dark-grey);
-            border-bottom: 1px solid var(--lynch);
+            color: var(--deprecated-dark-grey);
+            border-bottom: 1px solid var(--deprecated-lynch);
 
-            @include placeholder(var(--lynch));
+            @include placeholder(var(--deprecated-lynch));
 
             & + label,
             & + span {
@@ -40,24 +40,24 @@
             }
 
             &:focus:not([readonly]) {
-                color: var(--lynch);
-                border-bottom-color: var(--azure);
+                color: var(--deprecated-lynch);
+                border-bottom-color: var(--deprecated-azure);
 
                 & + label,
                 & + span {
-                    color: var(--azure);
+                    color: var(--deprecated-azure);
                 }
             }
         }
 
         &:disabled,
         &[readonly='readonly'] {
-            color: var(--dark-grey);
+            color: var(--deprecated-dark-grey);
             border-bottom-color: transparent;
 
             &:not(.disabled-input) {
-                @include placeholder(var(--dark-grey));
-                -webkit-text-fill-color: var(--dark-grey);
+                @include placeholder(var(--deprecated-dark-grey));
+                -webkit-text-fill-color: var(--deprecated-dark-grey);
             }
 
             &.disabled-input {

--- a/packages/vapor/scss/controls/inputs.scss
+++ b/packages/vapor/scss/controls/inputs.scss
@@ -20,10 +20,10 @@ input[type='search'],
 input[type='tel'],
 input[type='color'] {
     padding: 3px 6px;
-    color: var(--dark-grey);
+    color: var(--deprecated-dark-grey);
     font-size: $input-font-size;
     font-family: var(--main-font);
-    border: 1px solid var(--medium-grey);
+    border: 1px solid var(--deprecated-medium-grey);
     border-radius: 2px;
 }
 
@@ -38,7 +38,7 @@ textarea {
     }
 
     &:-ms-input-placeholder {
-        color: var(--medium-grey);
+        color: var(--deprecated-medium-grey);
         font-size: inherit;
         font-family: var(--main-font);
         text-transform: none;
@@ -66,8 +66,8 @@ textarea {
         margin-left: -5px;
         padding: 0;
         vertical-align: top;
-        background-color: var(--medium-grey);
-        border: 1px solid darken($medium-grey, 10%);
+        background-color: var(--deprecated-medium-grey);
+        border: 1px solid var(--deprecated-dark-medium-grey);
         border-radius: 0 2px 2px 0;
     }
 }

--- a/packages/vapor/scss/controls/multiline-field.scss
+++ b/packages/vapor/scss/controls/multiline-field.scss
@@ -79,7 +79,7 @@
 
         &:focus {
             i {
-                box-shadow: 0 0 6px 1px var(--medium-blue);
+                box-shadow: 0 0 6px 1px var(--deprecated-medium-blue);
             }
         }
 

--- a/packages/vapor/scss/controls/numeric-input.scss
+++ b/packages/vapor/scss/controls/numeric-input.scss
@@ -18,25 +18,25 @@ $numeric-input-buttons-border-radius: 4px;
         text-overflow: ellipsis;
         border: $default-border;
         border-radius: $border-radius;
-        box-shadow: inset 0 0 3px 0 rgba($black, $transparency-5);
+        box-shadow: inset 0 0 3px 0 rgba(var(--black-rgb), $transparency-5);
     }
 
     .btn {
         display: inline-block;
         width: $numeric-input-height;
         height: $numeric-input-height;
-        color: var(--pure-white);
+        color: var(--white);
         line-height: $numeric-input-height - 2 * $default-border-size;
-        background-color: var(--blue-purple-2);
+        background-color: var(--deprecated-blue-purple-2);
         border-radius: $numeric-input-buttons-border-radius;
         outline: none;
 
         &:focus {
-            background-color: var(--blue-purple-2);
+            background-color: var(--deprecated-blue-purple-2);
         }
 
         .icon {
-            fill: var(--pure-white);
+            fill: var(--white);
         }
     }
 }

--- a/packages/vapor/scss/controls/numeric-spinner.scss
+++ b/packages/vapor/scss/controls/numeric-spinner.scss
@@ -21,7 +21,7 @@
             cursor: pointer;
 
             &:hover {
-                background-color: var(--medium-blue);
+                background-color: var(--deprecated-medium-blue);
             }
 
             i {

--- a/packages/vapor/scss/controls/radios.scss
+++ b/packages/vapor/scss/controls/radios.scss
@@ -27,7 +27,7 @@
                 z-index: 0;
                 width: $radio-button-size;
                 height: $radio-button-size;
-                background-color: var(--pure-white);
+                background-color: var(--white);
                 border-radius: 50%;
                 content: '';
             }
@@ -39,7 +39,7 @@
                 z-index: 0;
                 width: $radio-button-size;
                 height: $radio-button-size;
-                background-color: var(--pure-white);
+                background-color: var(--white);
                 border-radius: 50%;
                 transform: scale(0);
                 transform-origin: center center;
@@ -53,7 +53,7 @@
         }
 
         &:focus + label:before {
-            box-shadow: 0 0 0 4px var(--light-grey);
+            box-shadow: 0 0 0 4px var(--deprecated-light-grey);
         }
 
         &:not(:checked) + label {
@@ -158,7 +158,7 @@
         cursor: not-allowed !important;
 
         * {
-            color: var(--medium-grey);
+            color: var(--deprecated-medium-grey);
         }
     }
 }

--- a/packages/vapor/scss/controls/slide-toggle-double.scss
+++ b/packages/vapor/scss/controls/slide-toggle-double.scss
@@ -5,7 +5,7 @@
 label.coveo-slide-toggle-double {
     float: left;
     margin-bottom: 0;
-    color: var(--dark-grey);
+    color: var(--deprecated-dark-grey);
     font-size: 13px;
     line-height: 22px;
 
@@ -27,8 +27,8 @@ input.coveo-slide-toggle-double[type='checkbox'] {
         box-sizing: initial;
         width: 33px;
         height: 16px;
-        background: var(--medium-grey) url('../../resources/images/misc/two_option_toggle.png') 0 0;
-        border: 3px solid var(--medium-grey);
+        background: var(--deprecated-medium-grey) url('../../resources/images/misc/two_option_toggle.png') 0 0;
+        border: 3px solid var(--deprecated-medium-grey);
         border-radius: 3px;
 
         cursor: pointer;

--- a/packages/vapor/scss/controls/slide-toggle.scss
+++ b/packages/vapor/scss/controls/slide-toggle.scss
@@ -17,7 +17,7 @@ input[type='checkbox'].coveo-slide-toggle {
             left: 0;
             display: block;
             width: 32px;
-            background-color: var(--medium-grey);
+            background-color: var(--deprecated-medium-grey);
             border-radius: 1em;
             transition: all 0.2s linear;
             content: ' ';
@@ -66,12 +66,12 @@ input[type='checkbox'].coveo-slide-toggle {
     &.boxed {
         display: inline-block; // Required for the float button placement.
         padding: 8px 10px;
-        border: solid 1px var(--medium-grey);
+        border: solid 1px var(--deprecated-medium-grey);
 
         .toggle-description {
             display: block;
             margin-top: 8px;
-            color: var(--dark-grey);
+            color: var(--deprecated-dark-grey);
             font-size: 13px;
             line-height: 16px;
         }

--- a/packages/vapor/scss/controls/slider.scss
+++ b/packages/vapor/scss/controls/slider.scss
@@ -1,4 +1,3 @@
-@import '../common/palette';
 @import '../variables';
 
 div.slider-container {
@@ -30,12 +29,12 @@ div.slider-container {
     .rc-slider-rail {
         height: $slider-rail-height;
         margin-top: $slider-rail-margin-top;
-        background-color: var(--grey-3);
+        background-color: var(--deprecated-grey-3);
     }
 
     .rc-slider-track {
         height: $slider-track-height;
-        background: var(--science-blue);
+        background: var(--deprecated-science-blue);
         border-radius: 0;
     }
 
@@ -45,7 +44,7 @@ div.slider-container {
         height: $slider-dot-height;
         margin-top: $slider-dot-margin-top;
         margin-left: $slider-dot-margin-left;
-        background-color: var(--heather);
+        background-color: var(--deprecated-heather);
         border: none;
         border-radius: initial;
         box-shadow: $slider-dot-box-shadow;
@@ -78,7 +77,7 @@ div.slider-container {
         }
 
         .rc-slider-tooltip-inner {
-            color: var(--dark-blue);
+            color: var(--deprecated-dark-blue);
             font-size: var(--small-font-size);
             line-height: $default-line-height;
             background-color: transparent;

--- a/packages/vapor/scss/controls/splash.scss
+++ b/packages/vapor/scss/controls/splash.scss
@@ -51,7 +51,7 @@
 .splash-box {
     margin: 0 1em;
     text-align: center;
-    background: var(--pure-white);
+    background: var(--white);
     border-radius: $big-border-radius;
     box-shadow: $splash-box-shadow;
 

--- a/packages/vapor/scss/elements/btn-append-prepend.scss
+++ b/packages/vapor/scss/elements/btn-append-prepend.scss
@@ -67,7 +67,7 @@
 
         .btn-append {
             margin-left: $button-padding-x;
-            border-left: $button-border-width solid var(--medium-grey);
+            border-left: $button-border-width solid var(--deprecated-medium-grey);
         }
     }
 
@@ -76,7 +76,7 @@
 
         .btn-prepend {
             margin-right: $button-padding-x;
-            border-right: $button-border-width solid var(--medium-grey);
+            border-right: $button-border-width solid var(--deprecated-medium-grey);
         }
     }
 }

--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -1,5 +1,5 @@
 @mixin button-focus($offset) {
-    background-color: var(--light-grey);
+    background-color: var(--deprecated-light-grey);
 
     @include focus-border($offset);
 }
@@ -20,7 +20,7 @@
     text-decoration: none;
     text-overflow: ellipsis;
     vertical-align: middle;
-    background-color: var(--pure-white);
+    background-color: var(--white);
     border: $button-border-width solid var(--navy-blue-80);
     border-radius: $border-radius;
 
@@ -43,7 +43,7 @@
         @include button-focus(0px);
         color: var(--navy-blue-80);
         text-decoration: none;
-        background-color: var(--pure-white);
+        background-color: var(--white);
         outline-color: var(--green);
     }
 

--- a/packages/vapor/scss/forms/block-form.scss
+++ b/packages/vapor/scss/forms/block-form.scss
@@ -148,7 +148,7 @@ form {
 
         .inline-help-icon,
         .inline-help-icon > svg {
-            fill: var(--medium-grey);
+            fill: var(--deprecated-medium-grey);
         }
 
         .inline-link-icon,

--- a/packages/vapor/scss/forms/form-child.scss
+++ b/packages/vapor/scss/forms/form-child.scss
@@ -46,10 +46,10 @@ $child-arrow-height: 10px;
     }
 
     &.mod-pure-white {
-        background-color: var(--pure-white);
+        background-color: var(--white);
 
         &:before {
-            border-bottom-color: var(--pure-white);
+            border-bottom-color: var(--white);
         }
     }
 
@@ -65,7 +65,7 @@ $child-arrow-height: 10px;
 .child-section {
     margin-top: $child-section-spacing-top;
     padding-left: $child-section-spacing-left;
-    border-left: $child-section-border-size solid var(--light-grey);
+    border-left: $child-section-border-size solid var(--deprecated-light-grey);
 }
 
 .mod-child-section-first-input {

--- a/packages/vapor/scss/forms/form-sections.scss
+++ b/packages/vapor/scss/forms/form-sections.scss
@@ -1,13 +1,13 @@
 .section-heading {
     .heading-title {
-        color: var(--medium-blue);
+        color: var(--deprecated-medium-blue);
         font-weight: var(--main-font-bold);
         font-size: $title-font-size;
     }
 
     .heading-description {
         margin-top: $form-heading-description-margin-top;
-        color: var(--dark-grey);
+        color: var(--deprecated-dark-grey);
         font-size: 12px;
     }
 }
@@ -35,12 +35,12 @@
             margin: 5px 0;
 
             .heading-title {
-                color: var(--medium-blue);
+                color: var(--deprecated-medium-blue);
                 font-size: 13px;
                 text-transform: uppercase;
 
                 svg {
-                    fill: var(--medium-blue);
+                    fill: var(--deprecated-medium-blue);
                 }
             }
         }
@@ -55,7 +55,7 @@
 
     span {
         display: inline-block;
-        color: var(--medium-grey);
+        color: var(--deprecated-medium-grey);
         text-transform: uppercase;
 
         &:before,
@@ -69,12 +69,12 @@
 
         &:before {
             left: 0;
-            border-image: linear-gradient(to left, var(--medium-grey), white) 1;
+            border-image: linear-gradient(to left, var(--deprecated-medium-grey), white) 1;
         }
 
         &:after {
             left: 265px;
-            border-image: linear-gradient(to right, var(--medium-grey), white) 1;
+            border-image: linear-gradient(to right, var(--deprecated-medium-grey), white) 1;
         }
     }
 }

--- a/packages/vapor/scss/forms/form-validation.scss
+++ b/packages/vapor/scss/forms/form-validation.scss
@@ -9,7 +9,7 @@
             display: flex;
             align-items: center;
             padding: 0 10px;
-            color: var(--pure-white);
+            color: var(--white);
             font-size: 12px;
             line-height: 16px;
             background-color: var(--red);
@@ -37,7 +37,7 @@
     }
 
     &.multiline-input-validation-error .erroneous-input {
-        background-color: var(--pure-white);
+        background-color: var(--white);
     }
 }
 

--- a/packages/vapor/scss/forms/table-form.scss
+++ b/packages/vapor/scss/forms/table-form.scss
@@ -9,7 +9,7 @@
     .form-group {
         display: table-row;
         height: 36px;
-        color: var(--dark-grey);
+        color: var(--deprecated-dark-grey);
 
         &.hidden {
             display: none;
@@ -30,10 +30,10 @@
         & > label:first-child {
             width: 30%;
             padding: 0 10px;
-            color: var(--medium-blue);
+            color: var(--deprecated-medium-blue);
             font-size: $title-font-size;
             font-family: var(--main-font);
-            background-color: var(--pure-white);
+            background-color: var(--white);
         }
 
         .context-help {
@@ -54,13 +54,13 @@
                 font-weight: var(--main-font-bold);
                 font-size: $title-font-size;
                 font-family: var(--main-font);
-                background-color: var(--pure-white);
+                background-color: var(--white);
 
                 opacity: 0.4;
             }
 
             &.disabled {
-                background-color: var(--pure-white);
+                background-color: var(--white);
             }
 
             input,
@@ -88,12 +88,12 @@
             }
 
             &.admin-editable:hover {
-                background-color: var(--light-grey);
+                background-color: var(--deprecated-light-grey);
             }
 
             &.admin-non-editable {
                 padding-left: 9px;
-                background-color: var(--pure-white);
+                background-color: var(--white);
 
                 i {
                     margin-right: 5px;

--- a/packages/vapor/scss/helpers.scss
+++ b/packages/vapor/scss/helpers.scss
@@ -18,7 +18,7 @@ $browser-context: 13; // Default
 
 @mixin focus-border($offset) {
     outline: thin dotted;
-    outline: 2px auto var(--light-blue);
+    outline: 2px auto var(--deprecated-light-blue);
     outline: 3px auto -webkit-focus-ring-color;
     outline-offset: $offset;
 }

--- a/packages/vapor/scss/icons/icons.scss
+++ b/packages/vapor/scss/icons/icons.scss
@@ -34,15 +34,15 @@
     }
 
     &.mod-white {
-        --fill: var(--pure-white);
+        --fill: var(--white);
     }
 
     &.office365-red {
-        --fill: var(--orange-8);
+        --fill: var(--deprecated-red);
     }
 
     &.salesforce-blue {
-        --fill: var(--coveo-salesforce-blue);
+        --fill: var(--salesforce-blue);
     }
 
     &.mod-small {

--- a/packages/vapor/scss/icons/svgs.scss
+++ b/packages/vapor/scss/icons/svgs.scss
@@ -2,6 +2,8 @@
  * @deprecated Remove once Chosen (deprecated component) is removed
  */
 
+$stratos: #08080e;
+
 // Created using http://codepen.io/jakob-e/pen/doMoML
 
 @mixin clear-icon($fill: $stratos) {

--- a/packages/vapor/scss/lib/_mixins.scss
+++ b/packages/vapor/scss/lib/_mixins.scss
@@ -1,4 +1,4 @@
-@mixin slim-scroll($track-color: var(--light-grey), $thumb-color: var(--dark-grey)) {
+@mixin slim-scroll($track-color: var(--deprecated-light-grey), $thumb-color: var(--deprecated-dark-grey)) {
     &::-webkit-scrollbar,
     ::-webkit-scrollbar {
         width: $slim-scroll-bar-width;

--- a/packages/vapor/scss/redesign/colors.scss
+++ b/packages/vapor/scss/redesign/colors.scss
@@ -1,32 +1,4 @@
-@import '../common/palette';
-
 :root {
-    /* ----------- Deprecated Palette ----------- */
-    --azure: #{$azure};
-    --science-blue: #{$science-blue};
-    --lynch: #{$lynch};
-    --bali-hai: #{$bali-hai};
-    --heather: #{$heather};
-    --grey-1: #{$grey-1};
-    --grey-2: #{$grey-2};
-    --grey-3: #{$grey-3};
-    --grey-4: #{$grey-4};
-    --blue-purple-2: #{$blue-purple-2};
-    --orange-2: #{$orange-2};
-    --orange-8: #{$orange-8};
-    --dark-blue: #{$dark-blue};
-    --medium-blue: #{$medium-blue};
-    --light-blue: #{$light-blue};
-    --dark-grey: #{$dark-grey};
-    --dark-medium-grey: #{$dark-medium-grey};
-    --medium-grey: #{$medium-grey};
-    --light-grey: #{$light-grey};
-    --pure-white: #{$pure-white};
-    --soft-red: #{$soft-red};
-    --soft-green: #{$soft-green};
-    --turquoise: #{$turquoise};
-    --coveo-salesforce-blue: #{$coveo-salesforce-blue};
-
     /* ----------- New Palette for Rebranding ----------- */
 
     // Primary

--- a/packages/vapor/scss/tables/fixed-header-table.scss
+++ b/packages/vapor/scss/tables/fixed-header-table.scss
@@ -9,7 +9,7 @@
         border-top: $table-border;
         border-bottom: $table-border;
 
-        @include slim-scroll(var(--light-grey), var(--medium-grey));
+        @include slim-scroll(var(--deprecated-light-grey), var(--deprecated-medium-grey));
 
         table {
             thead tr {

--- a/packages/vapor/scss/tables/pagination.scss
+++ b/packages/vapor/scss/tables/pagination.scss
@@ -34,23 +34,23 @@
 
     .change-page-link {
         padding: 0;
-        color: var(--medium-blue);
+        color: var(--deprecated-medium-blue);
         font-size: var(--default-font-size);
-        background-color: var(--pure-white);
+        background-color: var(--white);
         border: none;
         cursor: pointer;
 
         .icon {
-            fill: var(--medium-blue);
+            fill: var(--deprecated-medium-blue);
         }
 
         &.disabled {
-            color: var(--medium-grey);
+            color: var(--deprecated-medium-grey);
             cursor: default;
             pointer-events: none;
 
             .icon {
-                fill: var(--medium-grey);
+                fill: var(--deprecated-medium-grey);
             }
         }
     }
@@ -60,13 +60,13 @@
         border: 1px solid var(--digital-blue-60);
 
         &.selectable {
-            background-color: var(--pure-white);
+            background-color: var(--white);
             border: $default-border;
         }
 
         &.mod-link {
             color: var(--digital-blue-80);
-            background-color: var(--pure-white);
+            background-color: var(--white);
             border: none;
 
             .icon {

--- a/packages/vapor/scss/tables/table-actions.scss
+++ b/packages/vapor/scss/tables/table-actions.scss
@@ -68,7 +68,7 @@
             }
 
             &.open {
-                background-color: var(--light-grey);
+                background-color: var(--deprecated-light-grey);
                 border-color: var(--grey-40);
             }
 

--- a/packages/vapor/scss/tables/table-alternating-rows.scss
+++ b/packages/vapor/scss/tables/table-alternating-rows.scss
@@ -7,7 +7,7 @@ table.mod-alternate {
         tr.collapsible-row:hover {
             td,
             td:hover {
-                background-color: var(--pure-white);
+                background-color: var(--white);
             }
 
             &.selected {

--- a/packages/vapor/scss/tables/table-collapsible-rows.scss
+++ b/packages/vapor/scss/tables/table-collapsible-rows.scss
@@ -48,9 +48,9 @@ table {
                         margin-right: -$table-first-column-padding-left;
                         margin-left: -$table-first-column-padding-left;
                         padding: 15px $table-first-column-padding-left;
-                        background: var(--pure-white);
+                        background: var(--white);
                         border-bottom: 1px solid;
-                        border-bottom-color: var(--medium-grey);
+                        border-bottom-color: var(--deprecated-medium-grey);
 
                         .details-container {
                             padding-right: $details-container-padding;
@@ -111,7 +111,7 @@ table {
                 }
 
                 td {
-                    background-color: var(--pure-white);
+                    background-color: var(--white);
                 }
             }
         }

--- a/packages/vapor/scss/tables/table-drag-and-drop.scss
+++ b/packages/vapor/scss/tables/table-drag-and-drop.scss
@@ -36,7 +36,7 @@ table.drag-and-drop-table-view {
         .icon {
             pointer-events: none;
 
-            fill: var(--medium-grey);
+            fill: var(--deprecated-medium-grey);
         }
     }
 }

--- a/packages/vapor/scss/tables/table-loading.scss
+++ b/packages/vapor/scss/tables/table-loading.scss
@@ -31,7 +31,7 @@ td.table-card-loading {
         }
 
         & p:not(:first-child) .card-cell-content-loading {
-            background-color: var(--grey-1);
+            background-color: var(--deprecated-grey-1);
         }
     }
 }

--- a/packages/vapor/scss/tables/table.scss
+++ b/packages/vapor/scss/tables/table.scss
@@ -45,7 +45,7 @@
         padding: $table-header-top-padding $table-cell-left-right-padding $table-header-bottom-padding
             $table-cell-left-right-padding;
         white-space: nowrap;
-        background-color: var(--pure-white);
+        background-color: var(--white);
         border-top: $table-border;
         border-bottom: $table-border;
 
@@ -132,9 +132,9 @@
         }
 
         &.blankslate-rows:hover {
-            background-color: var(--pure-white);
+            background-color: var(--white);
             td {
-                background-color: var(--pure-white);
+                background-color: var(--white);
             }
         }
     }
@@ -189,14 +189,14 @@
     &.confirm-delete {
         .row-selected td,
         &.row-selected:hover td {
-            background-color: rgba($red, $transparency-5);
+            background-color: rgba(var(--deprecated-red-rgb), $transparency-5);
             border-color: var(--red);
             transition: background-color 300ms;
         }
     }
 
     &.mod-deleting tbody tr.selected td {
-        background-color: rgba($red, $transparency-5);
+        background-color: rgba(var(--deprecated-red-rgb), $transparency-5);
     }
 
     .mod-card-list {
@@ -223,7 +223,7 @@
 
     .mod-card-row .mod-card {
         min-height: $mod-card-row-min-height;
-        border-left: $status-card-border-width solid $transparent;
+        border-left: $status-card-border-width solid transparent;
 
         .mod-card-header {
             color: var(--title-text-color);
@@ -235,16 +235,16 @@
 
     .mod-card {
         border-radius: $big-border-radius;
-        box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.2);
+        box-shadow: 0px 2px 10px rgba(var(--deprecated-black-rgb), 0.2);
         cursor: pointer;
 
         &:hover {
-            background-color: var(--grey-2);
+            background-color: var(--deprecated-grey-2);
         }
     }
 
     tr.selected .mod-card {
-        background-color: var(--grey-1);
+        background-color: var(--deprecated-grey-1);
         border-left: $status-card-border-width solid var(--orange);
     }
 }
@@ -302,11 +302,11 @@ $row-style: (
     }
 }
 .row-disabled {
-    color: var(--dark-medium-grey);
+    color: var(--deprecated-dark-medium-grey);
     > td:first-child {
-        border-left-color: var(--dark-medium-grey);
+        border-left-color: var(--deprecated-dark-medium-grey);
     }
     svg {
-        fill: var(--dark-medium-grey);
+        fill: var(--deprecated-dark-medium-grey);
     }
 }

--- a/packages/vapor/scss/typography/headings.scss
+++ b/packages/vapor/scss/typography/headings.scss
@@ -82,7 +82,7 @@ h6 {
     }
     h1,
     .h1 {
-        color: var(--pure-white);
+        color: var(--white);
     }
 }
 

--- a/packages/vapor/scss/utility/border.scss
+++ b/packages/vapor/scss/utility/border.scss
@@ -7,14 +7,14 @@ $borders: border-top border-bottom border-left border-right;
 
     @for $i from 1 through length($transparencies) {
         .mod-#{$border}-transparency-#{$i} {
-            #{$border}: $default-border-size solid rgba($medium-grey, nth($transparencies, $i));
+            #{$border}: $default-border-size solid rgba(var(--deprecated-medium-grey-rgb), nth($transparencies, $i));
         }
     }
 }
 
 @for $i from 1 through length($transparencies) {
     .mod-border-transparency-#{$i} {
-        border: $default-border-size solid rgba($medium-grey, nth($transparencies, $i));
+        border: $default-border-size solid rgba(var(--deprecated-medium-grey-rgb), nth($transparencies, $i));
     }
 }
 

--- a/packages/vapor/scss/utility/layout.scss
+++ b/packages/vapor/scss/utility/layout.scss
@@ -168,7 +168,7 @@
 }
 
 .background {
-    --background-color: var(--pure-white);
+    --background-color: var(--white);
     background-color: var(--background-color);
 
     &.mod-light {

--- a/packages/vapor/scss/utility/spaced-boxes.scss
+++ b/packages/vapor/scss/utility/spaced-boxes.scss
@@ -6,7 +6,7 @@
 .spaced-box {
     margin-top: $box-spacing;
     margin-left: $box-spacing;
-    color: var(--pure-white);
+    color: var(--white);
 
     &.mod-secondary {
         color: var(--navy-blue-80);

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -74,7 +74,7 @@ $radio-button-size: 22px;
 $radio-button-text-padding-top: 5px;
 
 // Input and textarea
-$input-border: 1px solid var(--lynch);
+$input-border: 1px solid var(--deprecated-lynch);
 $input-height: 34px;
 $input-font-size: 14px;
 $input-margin: 0 0 15px 0 !default;
@@ -115,7 +115,7 @@ $filterpickerbox-margin-bottom: 1px;
 $filterpickerbox-small-padding: 13px 20px;
 $multi-filterpickerbox-add-padding: 10px 20px;
 $multi-filter-picker-margin-bottom: 20px;
-$multi-filter-picker-border-bottom: 2px solid var(--pure-white);
+$multi-filter-picker-border-bottom: 2px solid var(--white);
 $multi-filter-picker-add-icon-width: 20px;
 $filters-margin-right: 5px;
 $filterbox-filters-container-padding: 4px 4px 3px;
@@ -228,7 +228,7 @@ $navigation-menu-item-font-weight: var(--main-font-regular);
 $navigation-width: 245px;
 $navigation-border-for-scroll-bar: 1px;
 $navigation-background-color: var(--white);
-$navigation-active-background-color: var(--blue-purple-2);
+$navigation-active-background-color: var(--deprecated-blue-purple-2);
 $navigation-active-border-width: 3px;
 $navigation-section-icon-size: 16px;
 $navigation-section-icon-margin-right: 10px;
@@ -291,7 +291,7 @@ $table-border-button: $table-border-width solid transparent;
 $table-selected-border-width: 5px;
 $table-column-draggable-width: 25px;
 $table-column-draggable-padding: 7px 10px;
-$table-row-drag-over-color: rgba($medium-grey, $transparency-3);
+$table-row-drag-over-color: rgba(var(--deprecated-medium-grey-rgb), $transparency-3);
 $big-table-blankslate-section-padding: 20px 40px 20px 35px;
 $big-table-row-height: 36px;
 $big-table-icon-margin: 20px;
@@ -303,7 +303,7 @@ $big-table-second-row-line-height: 17px;
 $table-slim-font-size: 13px;
 $table-small-svg-width: 20px;
 $table-action-margin-left: 10px;
-$table-shadow: 0 2px 8px 1px var(--medium-grey);
+$table-shadow: 0 2px 8px 1px var(--deprecated-medium-grey);
 $table-state-icon-size: 25px;
 $table-blankslate-row-width: 20px;
 $table-cell-border-bottom-color-loading: 3px;
@@ -420,7 +420,7 @@ $facet-value-spacing: 5px;
 $facet-checkbox-mark-size: 10px;
 $facet-checkbox-line-width: 2px;
 $facet-more-height: 200px;
-$facet-more-button-border: 2px dashed var(--medium-grey);
+$facet-more-button-border: 2px dashed var(--deprecated-medium-grey);
 $facet-more-button-icon-size: 10px;
 $facet-exclude-padding-right: 24px;
 $facet-exclude-checkbox-icon-size: 10px;
@@ -465,13 +465,13 @@ $date-picker-dimension: 36px;
 $calendar-width: 280px;
 $calendar-cell-dimensions: 40px;
 $calendar-border-width: 1px;
-$calendar-border: $calendar-border-width solid var(--light-grey);
+$calendar-border: $calendar-border-width solid var(--deprecated-light-grey);
 $selected-date-offset: 2px;
 $selected-date-height: 28px;
 $calendar-limit-border-width: 2px;
 $calendar-limit-border-length: 5px;
 $calendar-max-height: 336px;
-$date-picker-button-hover-bg: rgba($dark-grey, $transparency-3);
+$date-picker-button-hover-bg: rgba(var(--deprecated-dark-grey-rgb), $transparency-3);
 $countdown-cell-height: 28px;
 
 // Tooltip
@@ -492,7 +492,7 @@ $item-box-spacing: 5px;
 $item-box-vertical-spacing: 8px;
 $list-box-max-height: 240px;
 $list-box-vertical-spacing: 8px;
-$list-box-box-shadow: 0 2px 4px rgba($black, $transparency-4);
+$list-box-box-shadow: 0 2px 4px rgba(var(--black-rgb), $transparency-4);
 $list-box-border-radius: 0 0 2px 2px;
 
 // Limit Box
@@ -505,7 +505,7 @@ $slider-rail-margin-top: 2px;
 $slider-track-height: 8px;
 $slider-dot-margin-left: -2px;
 $slider-dot-margin-top: -5px;
-$slider-dot-box-shadow: 0 0 1px 0 var(--pure-white);
+$slider-dot-box-shadow: 0 0 1px 0 var(--white);
 $slider-dot-height: 18px;
 $slider-dot-width: 2px;
 $slider-dot-active-height: 8px;
@@ -514,7 +514,7 @@ $slider-handle-height: 18px;
 $slider-handle-margin-top: -6px;
 $slider-handle-margin-left: -18px;
 $slider-handle-background-size: 34px 18px;
-$slider-handle-box-shadow: 0 0 1px 0 var(--dark-blue);
+$slider-handle-box-shadow: 0 0 1px 0 var(--deprecated-dark-blue);
 $slider-handle-border-radius: 4px;
 
 // SlideY anim
@@ -544,9 +544,9 @@ $flippable-transition-duration: 0.8s;
 $flippable-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.3);
 
 // Material Card
-$material-card-shadow: 0 2px 20px 0 rgba($black, 0.1);
-$material-card-shadow-hover: 0 2px 30px 0 rgba($black, 0.3);
-$material-card-shadow-active: 0 2px 20px 0 rgba($black, 0.3);
+$material-card-shadow: 0 2px 20px 0 rgba(var(--black-rgb), 0.1);
+$material-card-shadow-hover: 0 2px 30px 0 rgba(var(--black-rgb), 0.3);
+$material-card-shadow-active: 0 2px 20px 0 rgba(var(--black-rgb), 0.3);
 $material-card-colored-border-height: 5px;
 
 // Content placeholder
@@ -578,8 +578,8 @@ $multi-step-bar-mod-small-text-padding: 3px 2px;
 $multi-step-bar-separation: 5px;
 $multi-step-sliding-animation-background-width: 28px;
 $multi-step-sliding-animation-background-height: 50px;
-$multi-step-animation-color: var(--light-grey);
-$multi-step-to-do-color: var(--light-grey);
+$multi-step-animation-color: var(--deprecated-light-grey);
+$multi-step-to-do-color: var(--deprecated-light-grey);
 $multi-step-doing-color: #3bb862;
 $multi-step-done-color: #3bb862;
 $multi-step-error-color: var(--red);
@@ -612,7 +612,8 @@ $banner-content-height: 165px;
 $banner-content-padding: 50px;
 $banner-right-width: 300px;
 $banner-warning-icon-fix: 2px;
-$banner-box-shadow: inset 0 5px 10px 0 rgba($black, $transparency-5), inset 0 -10px 50px 0 rgba($black, 0.2);
+$banner-box-shadow: inset 0 5px 10px 0 rgba(var(--black-rgb), $transparency-5),
+    inset 0 -10px 50px 0 rgba(var(--black-rgb), 0.2);
 
 // Status Cards
 $status-card-border-width: 4px;
@@ -628,7 +629,7 @@ $toast-close-padding-left: 5px;
 // Vertical Line
 $vertical-line-width: 1px;
 $vertical-line-height: 1rem;
-$vertical-line-border-left: 1px solid var(--dark-medium-grey);
+$vertical-line-border-left: 1px solid var(--deprecated-dark-medium-grey);
 
 // Drop
 $drop-z-index: 10000;


### PR DESCRIPTION
### Proposed Changes

Remove all usage of the old and deprecated sass color variables in favor of the new css variables with `--deprecated` color names.

### Potential Breaking Changes

None, the old palette is not yet removed.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
