### PR TITLE
ci(jenkins): dont push on master when releasing next

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -236,7 +236,7 @@ pipeline {
             sh "pnpm install --lockfile-only"
             sh "git add pnpm-lock.yaml"
             sh "git commit -m \"chore(release): [version bump]\""
-            sh "git push -u origin master"
+            sh "git push -u origin ${env.BRANCH_NAME}"
           } else {
             sh "echo \"skipping publish since remote changed (something was merged)\""
           }


### PR DESCRIPTION
### Proposed Changes

Attempt at making publish step pass for next branch. I don't understand why were trying to push on master when releasing `next` branch. Is it to push the tags? Opening this PR for conversation.

it is failing with that error:
```bash
17:15:52  + git push -u origin master
17:15:52  error: src refspec master does not match any.
17:15:52  error: failed to push some refs to **'https://****:****@github.com/coveo/react-vapor.git'**
```
Here is what I found on stackoverflow https://stackoverflow.com/questions/4181861/message-src-refspec-master-does-not-match-any-when-pushing-commits-in-git

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
