### PR TITLE
build(rollup): remove weird dependency on 'indexof'

### DIFF
--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -66,6 +66,7 @@
         "underscore.string": "^3.3.5"
     },
     "devDependencies": {
+        "@rollup/plugin-alias": "^3.1.2",
         "@rollup/plugin-commonjs": "11.0.2",
         "@rollup/plugin-inject": "4.0.1",
         "@rollup/plugin-node-resolve": "7.1.1",

--- a/packages/react-vapor/rollup.config.js
+++ b/packages/react-vapor/rollup.config.js
@@ -1,6 +1,7 @@
 import commonjs from '@rollup/plugin-commonjs';
 import inject from '@rollup/plugin-inject';
 import resolve from '@rollup/plugin-node-resolve';
+import alias from '@rollup/plugin-alias';
 import replace from '@rollup/plugin-replace';
 import path from 'path';
 import externalGlobals from 'rollup-plugin-external-globals';
@@ -103,6 +104,7 @@ export default {
     ],
     onwarn,
     plugins: [
+        alias({entries: [{find: 'indexof', replacement: 'component-indexof'}]}),
         inject({
             jQuery: 'jquery', // chosen-js expects jQuery to be available as a global
         }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,7 @@ importers:
 
   packages/react-vapor:
     specifiers:
+      '@rollup/plugin-alias': ^3.1.2
       '@rollup/plugin-commonjs': 11.0.2
       '@rollup/plugin-inject': 4.0.1
       '@rollup/plugin-node-resolve': 7.1.1
@@ -298,6 +299,7 @@ importers:
       strict-uri-encode: 2.0.0
       unidiff: 0.0.4
     devDependencies:
+      '@rollup/plugin-alias': 3.1.2_rollup@2.3.3
       '@rollup/plugin-commonjs': 11.0.2_rollup@2.3.3
       '@rollup/plugin-inject': 4.0.1_rollup@2.3.3
       '@rollup/plugin-node-resolve': 7.1.1_rollup@2.3.3
@@ -2180,6 +2182,16 @@ packages:
       sprintf-js: 1.1.2
       utf8: 3.0.0
     dev: false
+
+  /@rollup/plugin-alias/3.1.2_rollup@2.3.3:
+    resolution: {integrity: sha512-wzDnQ6v7CcoRzS0qVwFPrFdYA4Qlr+ookA217Y2Z3DPZE1R8jrFNM3jvGgOf6o6DMjbnQIn5lCIJgHPe1Bt3uw==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      rollup: 2.3.3
+      slash: 3.0.0
+    dev: true
 
   /@rollup/plugin-commonjs/11.0.2_rollup@2.3.3:
     resolution: {integrity: sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==}
@@ -8221,7 +8233,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.3.1_supports-color@6.1.0
+      debug: 4.3.1
     dev: false
 
   /for-in/1.0.2:


### PR DESCRIPTION
### Proposed Changes

The esm build we produce had a weird require of the `indexof` module which doesn't exist. I created an alias that points to the real module called `component-indexof`.

Anyone using our esm build would get 
```bash
./node_modules/react-vapor/dist/bundles/react-vapor.esm.js
Cannot find module: 'indexof'. Make sure this package is installed.
```

Since the [issue](https://github.com/component/classes/issues/31) isn't resolved yet, I added an alias that points to `component-indexof` instead.

Tested it and it works, but the weird thing is that it was working on master without the alias 😕 

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
