### PR TITLE
ci(commit): switch back git-cz for commitizen/cz-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
         "axios": "^0.21.1",
         "cz-conventional-changelog": "^3.0.2",
         "eslint": "7.5.0",
-        "git-cz": "^4.7.6",
         "husky": "4.2.5",
         "lerna": "3.18.4",
         "mime-types": "2.1.26",
@@ -47,13 +46,13 @@
         "e2e:run": "pnpm -r e2e:run --stream",
         "build": "pnpm -r build --stream",
         "lintfix": "pnpm -r lintfix --parallel",
-        "commit-cli": "git-cz",
+        "commit-cli": "cz",
         "open-cypress": "npx cypress open --project ./packages/e2eTesting",
         "reconstruct": "npx rimraf node_modules packages/*/node_modules && npm run setup && echo done"
     },
     "config": {
         "commitizen": {
-            "path": "./node_modules/cz-conventional-changelog"
+            "path": "cz-conventional-changelog"
         }
     },
     "commitlint": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,6 @@ importers:
       axios: ^0.21.1
       cz-conventional-changelog: ^3.0.2
       eslint: 7.5.0
-      git-cz: ^4.7.6
       husky: 4.2.5
       lerna: 3.18.4
       mime-types: 2.1.26
@@ -28,7 +27,6 @@ importers:
       axios: 0.21.1
       cz-conventional-changelog: 3.2.0
       eslint: 7.5.0
-      git-cz: 4.7.6
       husky: 4.2.5
       lerna: 3.18.4
       mime-types: 2.1.26
@@ -8530,11 +8528,6 @@ packages:
     resolution: {integrity: sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=}
     dependencies:
       assert-plus: 1.0.0
-    dev: true
-
-  /git-cz/4.7.6:
-    resolution: {integrity: sha512-WtQEXqetJSi9LKPI77bMdSQWvLGjE93egVbR0zjXd1KFKrFvo/YE/UuGNcMeBDiwzxfQBhjyV7Hn0YUZ8Q0BcQ==}
-    hasBin: true
     dev: true
 
   /git-raw-commits/2.0.0:


### PR DESCRIPTION
### Proposed Changes

There is some confusion around git-cz and commitizen/cz-cli. They are 2 different packages with the same name. We should be using cz-cli, not the other one because emojis break the version bumps.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
