### PR TITLE
fix(badge): allow badges with only icons

### DIFF
--- a/packages/demo/src/components/examples/BadgeExamples.tsx
+++ b/packages/demo/src/components/examples/BadgeExamples.tsx
@@ -1,39 +1,27 @@
 import * as React from 'react';
-import {Badge} from 'react-vapor';
+import {Badge, Section} from 'react-vapor';
 
-export class BadgeExamples extends React.Component<any, any> {
-    render() {
-        return (
-            <div className="mt2">
-                <div className="form-group">
-                    <label className="form-control-label">Default Badge</label>
-                    <div className="form-control">
-                        <Badge label="Generic/Grey" />
-                        <Badge label="Generic/Navy" extraClasses={['mod-information ml1']} />
-                        <Badge label="Semantic/Success" extraClasses={['mod-success ml1']} />
-                        <Badge label="Semantic/Critical" extraClasses={['mod-critical ml1']} />
-                        <Badge label="New" extraClasses={['mod-warning ml1']} />
-                        <Badge label="Beta" extraClasses={['mod-beta ml1']} />
-                    </div>
-                </div>
-                <div className="form-group">
-                    <label className="form-control-label">Badge with Icon</label>
-                    <div className="form-control">
-                        <Badge label="Label" icon="lock" />
-                    </div>
-                </div>
-                <div className="form-group">
-                    <label className="form-control-label">Small Badge</label>
-                    <div className="form-control">
-                        <Badge label="Generic/Grey" extraClasses={['mod-small']} />
-                        <Badge label="Generic/Navy" extraClasses={['mod-small mod-information ml1']} />
-                        <Badge label="Semantic/Success" extraClasses={[' mod-small mod-success ml1']} />
-                        <Badge label="Semantic/Critical" extraClasses={['mod-small mod-critical ml1']} />
-                        <Badge label="New" extraClasses={['mod-small mod-warning ml1']} />
-                        <Badge label="Beta" extraClasses={['mod-small mod-beta ml1']} />
-                    </div>
-                </div>
-            </div>
-        );
-    }
-}
+export const BadgeExamples: React.FunctionComponent = () => (
+    <Section>
+        <Section level={2} title="Default size">
+            <Badge label="Default" />
+            <Badge label="Navy" extraClasses={['mod-information ml1']} />
+            <Badge label="Success" extraClasses={['mod-success ml1']} />
+            <Badge label="Critical" extraClasses={['mod-critical ml1']} />
+            <Badge label="New" extraClasses={['mod-warning ml1']} />
+            <Badge label="Beta" extraClasses={['mod-beta ml1']} />
+            <Badge icon="lock" extraClasses={['ml1']} />
+            <Badge icon="lock" label="Label" extraClasses={['ml1']} />
+        </Section>
+        <Section level={2} title="Small">
+            <Badge label="Default" extraClasses={['mod-small']} />
+            <Badge label="Navy" extraClasses={['mod-small mod-information ml1']} />
+            <Badge label="Success" extraClasses={[' mod-small mod-success ml1']} />
+            <Badge label="Critical" extraClasses={['mod-small mod-critical ml1']} />
+            <Badge label="New" extraClasses={['mod-small mod-warning ml1']} />
+            <Badge label="Beta" extraClasses={['mod-small mod-beta ml1']} />
+            <Badge icon="lock" extraClasses={['mod-small ml1']} />
+            <Badge icon="lock" label="Label" extraClasses={['mod-small ml1']} />
+        </Section>
+    </Section>
+);

--- a/packages/react-vapor/src/components/badge/Badge.tsx
+++ b/packages/react-vapor/src/components/badge/Badge.tsx
@@ -4,23 +4,43 @@ import {Svg} from '../svg';
 
 export const DEFAULT_BADGE_CLASSNAME = 'badge';
 
-export interface IBadgeProps {
-    label: string;
-    icon?: string;
+interface BadgeBasicProps {
     extraClasses?: string[];
 }
+
+interface BadgeWithLabelProps extends BadgeBasicProps {
+    label: string;
+}
+interface BadgeWithIconProps extends BadgeBasicProps {
+    icon: string;
+}
+
+export type IBadgeProps = BadgeWithLabelProps | BadgeWithIconProps | (BadgeWithLabelProps & BadgeWithIconProps);
 
 export class Badge extends React.Component<IBadgeProps> {
     static defaultProps: Partial<IBadgeProps> = {
         extraClasses: [],
     };
 
+    private get isSmall(): boolean {
+        return this.className.includes('mod-small');
+    }
+
+    private get className(): string {
+        return classNames(DEFAULT_BADGE_CLASSNAME, this.props.extraClasses);
+    }
+
     render() {
-        const className = classNames(DEFAULT_BADGE_CLASSNAME, this.props.extraClasses);
         return (
-            <span className={className}>
-                {this.props.icon?.length && <Svg svgName={this.props.icon} svgClass="icon" className="pr1 py1" />}
-                <span>{this.props.label}</span>
+            <span className={this.className} aria-label="badge">
+                {'icon' in this.props ? (
+                    <Svg
+                        svgName={this.props.icon}
+                        svgClass={classNames('icon', {'mod-16': !this.isSmall, 'mod-12': this.isSmall})}
+                        className={classNames({mr1: 'label' in this.props && this.props.label})}
+                    />
+                ) : null}
+                {'label' in this.props ? <span>{this.props.label}</span> : null}
             </span>
         );
     }

--- a/packages/react-vapor/src/components/badge/tests/Badge.spec.tsx
+++ b/packages/react-vapor/src/components/badge/tests/Badge.spec.tsx
@@ -1,62 +1,20 @@
-import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
-import * as _ from 'underscore';
-import {Badge, DEFAULT_BADGE_CLASSNAME, IBadgeProps} from '../Badge';
-import {Svg} from '../../svg';
+import {render, screen, within} from 'react-vapor-test-utils';
+
+import {Badge} from '../Badge';
 
 describe('Badge', () => {
-    let badge: ReactWrapper<IBadgeProps, any>;
+    it('renders a badge', () => {
+        render(<Badge label="label" icon="lock" />);
 
-    it('should render without errors', () => {
-        expect(() => {
-            shallow(<Badge label="badge" />);
-        }).not.toThrow();
+        const badge = screen.getByLabelText('badge');
+        expect(badge).toBeInTheDocument();
+        expect(within(badge).getByText('label')).toBeInTheDocument();
+        expect(within(badge).getByRole('img', {name: 'lock icon'})).toBeInTheDocument();
     });
 
-    describe('<Badge />', () => {
-        const mountWithProps = (props: Partial<IBadgeProps>) => {
-            badge = mount(<Badge {..._.defaults(props, {label: 'badge'})} />, {
-                attachTo: document.getElementById('App'),
-            });
-        };
-
-        it('should render badge with the label specified as prop', () => {
-            mountWithProps({
-                label: 'somelabel',
-            });
-
-            expect(badge.text()).toEqual('somelabel');
-        });
-
-        it('should render the badge with the default badge class', () => {
-            mountWithProps({});
-
-            expect(badge.find(`.${DEFAULT_BADGE_CLASSNAME}`).length).toBe(1);
-        });
-
-        it('should render the badge with the extra classes specified as props', () => {
-            mountWithProps({
-                extraClasses: ['bold'],
-            });
-
-            expect(badge.find('.bold').length).toBe(1);
-        });
-
-        it('should render the badge with SVG icons', () => {
-            mountWithProps({
-                extraClasses: [],
-                icon: 'lock',
-            });
-
-            expect(badge.find(Svg).length).toBe(1);
-        });
-
-        it('should not render the SVG component no props are passed in icon props', () => {
-            mountWithProps({
-                label: 'TestLabel',
-            });
-
-            expect(badge.find(Svg).length).toBe(0);
-        });
+    it('makes the icon smaller in small badges', () => {
+        render(<Badge label="label" icon="lock" extraClasses={['mod-small']} />);
+        expect(screen.getByRole('img', {name: 'lock icon'})).toHaveClass('mod-12');
     });
 });

--- a/packages/react-vapor/src/components/logoCard/LogoCard.tsx
+++ b/packages/react-vapor/src/components/logoCard/LogoCard.tsx
@@ -61,7 +61,9 @@ export class LogoCard extends React.Component<ILogoCardProps & React.HTMLProps<H
         );
         const logoIconClassName = classNames(DEFAULT_LOGO_ICON_CLASSNAME, DEFAULT_LOGO_ICON_SIZE);
 
-        const badges = this.props.badges.map((badgeProps) => <Badge {...badgeProps} key={slugify(badgeProps.label)} />);
+        const badges = this.props.badges.map((badgeProps) => (
+            <Badge {...badgeProps} key={slugify(JSON.stringify(badgeProps))} />
+        ));
 
         const logoCard: JSX.Element = (
             <Tooltip title={this.props.tooltip} placement={this.props.tooltipPlacement}>


### PR DESCRIPTION
### Proposed Changes

Badges didn't allow having only an icon and no label. This is a feature that I needed for the IconCard.

### Before

![image](https://user-images.githubusercontent.com/35579930/117875889-b0f72400-b270-11eb-8238-9a3957363831.png)

### After

![image](https://user-images.githubusercontent.com/35579930/117875916-b9e7f580-b270-11eb-960a-6c5f2f035417.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
