### PR TITLE
fix(code editor): onblur replace debounce

### DIFF
--- a/packages/react-vapor/src/components/editor/CodeEditor.tsx
+++ b/packages/react-vapor/src/components/editor/CodeEditor.tsx
@@ -104,9 +104,9 @@ class CodeEditorDisconnect extends React.Component<
         }
     }
 
-    private debouncedUpdateStore = _.debounce((value: string) => {
-        this.props.updateStoreValue(value);
-    }, 500);
+    private updateStore = () => {
+        this.props.updateStoreValue(this.state.value);
+    };
 
     render() {
         return (
@@ -122,15 +122,20 @@ class CodeEditorDisconnect extends React.Component<
                 value={this.state.value}
                 onChange={(editor, data, value: string) => {
                     this.props.onChange?.(value);
-                    if (this.props.id) {
-                        this.debouncedUpdateStore(value);
-                    }
+                    this.setState({
+                        value,
+                    });
                 }}
                 options={{
                     ...CodeEditorDisconnect.defaultOptions,
                     readOnly: this.props.readOnly,
                     mode: this.props.mode,
                     ...this.props.options,
+                }}
+                onBlur={() => {
+                    if (this.props.id) {
+                        this.updateStore();
+                    }
                 }}
                 className={classNames(this.props.className, {'code-editor-no-cursor': this.props.readOnly})}
             />

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -122,6 +122,7 @@ describe('CodeEditor', () => {
             expect(updateSpy).toHaveBeenCalledTimes(1);
 
             userEvent.type(screen.getByRole('textbox'), 'new value');
+            screen.getByRole('textbox').blur();
 
             await waitFor(() => expect(updateSpy).toHaveBeenCalledTimes(2), {timeout: 2000});
         });


### PR DESCRIPTION
### Proposed Changes

using onblur instead of a debounced onChange to trigger the store action in the codeEditor Component.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
