### PR TITLE
feat(toast): option to move infoToken on toast when its not needed

### DIFF
--- a/packages/react-vapor/src/components/toast/Toast.tsx
+++ b/packages/react-vapor/src/components/toast/Toast.tsx
@@ -16,6 +16,7 @@ export interface IToastProps {
     isDownload?: boolean;
     isSmall?: boolean;
     className?: string;
+    showInfoToken?: boolean;
     /**
      * @deprecated use children instead
      */
@@ -45,6 +46,7 @@ export class Toast extends React.Component<IToastProps> {
     static defaultProps: Partial<IToastProps> = {
         dismissible: true,
         type: ToastType.Success,
+        showInfoToken: true,
     };
 
     componentDidMount() {
@@ -129,7 +131,7 @@ export class Toast extends React.Component<IToastProps> {
 
         return (
             <div className={classes} onMouseEnter={() => this.clearTimeout()} onMouseLeave={() => this.setTimeout()}>
-                {infoToken}
+                {this.props.showInfoToken ? infoToken : null}
                 {closeButton}
                 <div className="toast-title">{this.props.title}</div>
                 {toastContent}

--- a/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
+++ b/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
@@ -1,7 +1,9 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
+import {screen} from '@testing-library/dom';
 
+import {render} from '@testing-library/react';
 import {IToastProps, Toast, ToastType} from '../Toast';
 
 describe('Toasts', () => {
@@ -166,7 +168,6 @@ describe('Toasts', () => {
 
             const newToastAttributes = _.extend({}, toastBasicAttributes, {isSmall: false, dismissible: true});
             toastComponent.setProps(newToastAttributes).mount();
-
             expect(toastComponent.find(closeSelector).length).toBe(1);
         });
 
@@ -327,7 +328,27 @@ describe('Toasts', () => {
                     <div>Some file.csv</div>
                 </Toast>
             );
+
             expect(toastComponent.find('.search-bar-spinner').length).toBe(1);
+        });
+        it('should render the by default infoToken Svg', () => {
+            render(<Toast title="admin-ui" />);
+
+            expect(
+                screen.getByRole('img', {
+                    name: /checkstrokedlarge icon/i,
+                })
+            ).toBeInTheDocument();
+        });
+
+        it('should not render the infoToken Svg when showInfoToken is false', () => {
+            render(<Toast title="admin-ui" showInfoToken={false} />);
+
+            expect(
+                screen.queryByRole('img', {
+                    name: /checkstrokedlarge icon/i,
+                })
+            ).not.toBeInTheDocument();
         });
     });
 });


### PR DESCRIPTION
This gives us the option to remove the infoToken when its not needed.

Currently, with the Toast implementation, it always renders the `infoToken` which is a problem for the Login Renewal Prompt in admin-ui. The`TokenRenewalPrompt` uses this `Toast` component. In admin-ui, it renders an empty Svg with a `info-token` class coming from the `infoToken` component.

![image](https://user-images.githubusercontent.com/66333175/118272981-5ee11900-b491-11eb-8ee6-906f6a199164.png)



### Proposed Changes

Adding a `showInfoToken` prop will allow us to use it in the  `Toast` component in `TokenRenewalPrompt`, thus allowing us to remove this class and fix the spacing issue


### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
