### PR TITLE
build(typescript): cleanup tsconfig files

### DIFF
--- a/packages/demo/src/components/examples/InputExamples.tsx
+++ b/packages/demo/src/components/examples/InputExamples.tsx
@@ -26,6 +26,7 @@ import {
 import {createStructuredSelector} from 'reselect';
 import * as _ from 'underscore';
 
+import {IReactVaporExampleState} from '../../Reducers';
 import {Store} from '../../Store';
 import {ExampleComponent} from '../ComponentsInterface';
 
@@ -185,7 +186,7 @@ const MessageWhenInputIsDirty = connect(
 const InputWithDirty = withDirtyInputHOC(InputConnected);
 
 const MultiValuesInputId = 'multivalue-id';
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state: IReactVaporExampleState) => ({
     values: MultiValuesInputSelectors.getValues(state, MultiValuesInputId),
 });
 

--- a/packages/demo/src/components/examples/RadioExamples.tsx
+++ b/packages/demo/src/components/examples/RadioExamples.tsx
@@ -61,12 +61,6 @@ const redRadioButtonProps = {
     ...radioButtonProps,
 };
 
-const greenRadioButtonProps = {
-    id: 'green',
-    value: 'green',
-    ...radioButtonProps,
-};
-
 const RadioSelectExample: React.FunctionComponent = () => (
     <Section level={2} title="Radio select with redux store">
         <LabeledInput label="The Label of the Radio Select">

--- a/packages/demo/src/components/examples/TableHOCwithBlankSlateExamples.tsx
+++ b/packages/demo/src/components/examples/TableHOCwithBlankSlateExamples.tsx
@@ -41,7 +41,7 @@ const TableWithBlankSlateExample: React.FunctionComponent = () => (
                 id="tableWithEmptyState"
                 className="table"
                 data={generateDataWithFaker(0)}
-                renderBody={(data) => generateTableRow(data, 'tableWithBlankSlate')}
+                renderBody={(data: IExampleRowData[]) => generateTableRow(data, 'tableWithBlankSlate')}
                 filterMatcher={(filter: string, data: IExampleRowData) =>
                     data.username.toLowerCase().indexOf(filter.toLowerCase()) !== -1
                 }

--- a/packages/demo/tsconfig.json
+++ b/packages/demo/tsconfig.json
@@ -2,12 +2,6 @@
     "extends": "../tsconfig-base",
     "compilerOptions": {
         "removeComments": false,
-        "sourceMap": true,
-        "experimentalDecorators": true,
-        "downlevelIteration": true,
-        "esModuleInterop": true,
-        "importHelpers": true,
-        "composite": true,
         "rootDir": "src",
         "outDir": "built",
         "baseUrl": ".",

--- a/packages/react-vapor/.eslintignore
+++ b/packages/react-vapor/.eslintignore
@@ -1,5 +1,5 @@
-node_modules/*
-dist/*
-coverage/*
-**/*.scss.d.ts
-*.js
+node_modules
+dist
+coverage
+**/*.js
+jest

--- a/packages/react-vapor/.eslintrc.js
+++ b/packages/react-vapor/.eslintrc.js
@@ -4,17 +4,17 @@ module.exports = {
     },
     extends: [require.resolve('tsjs/eslint-config')],
     parserOptions: {
-        project: 'tsconfig.eslint.json',
+        project: './tsconfig.json',
         tsconfigRootDir: __dirname,
         sourceType: 'module',
     },
     overrides: [
         {
-            files: ['**/*.spec.{ts,tsx}'],
+            files: ['**/*.spec.*'],
             env: {
                 'jest/globals': true,
             },
-            extends: ['plugin:jest/recommended', 'plugin:testing-library/recommended', 'plugin:jest-dom/recommended'],
+            extends: ['plugin:jest/recommended', 'plugin:testing-library/react', 'plugin:jest-dom/recommended'],
         },
     ],
 };

--- a/packages/react-vapor/jest.config.js
+++ b/packages/react-vapor/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
     moduleNameMapper: {
         '\\.(scss|css)$': '<rootDir>/jest/identity-obj-proxy-esm.js',
         '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': 'identity-obj-proxy',
+        '^@test-utils$': '<rootDir>/src/TestUtils.tsx',
     },
     setupFilesAfterEnv: ['<rootDir>/jest/setup.ts'],
     reporters: ['default'],
@@ -11,7 +12,6 @@ module.exports = {
     },
     testMatch: ['<rootDir>/src/**/*.spec.{ts,tsx}'],
     moduleFileExtensions: ['ts', 'tsx', 'js', 'scss'],
-    moduleDirectories: ['node_modules', 'jest/utils'],
     testPathIgnorePatterns: ['<rootDir>[/\\\\](node_modules|.next)[/\\\\]'],
     globals: {
         'ts-jest': {

--- a/packages/react-vapor/src/TestUtils.tsx
+++ b/packages/react-vapor/src/TestUtils.tsx
@@ -1,14 +1,14 @@
-import {RenderOptions, render} from '@testing-library/react';
+import {render, RenderOptions, RenderResult} from '@testing-library/react';
 import * as React from 'react';
 import {Provider} from 'react-redux';
 import {AnyAction, applyMiddleware, combineReducers, createStore, Store} from 'redux';
 import promise from 'redux-promise-middleware';
 import thunk from 'redux-thunk';
 
-import {ReactVaporReducers} from '../../src/ReactVaporReducers';
-import {IDispatch} from '../../src/utils/ReduxUtils';
-import {Defaults} from '../../src/Defaults';
-import {IReactVaporState} from '../../src/ReactVaporState';
+import {Defaults} from './Defaults';
+import {ReactVaporReducers} from './ReactVaporReducers';
+import {IReactVaporState} from './ReactVaporState';
+import {IDispatch} from './utils/ReduxUtils';
 
 const customRender = (
     ui: React.ReactElement,
@@ -26,7 +26,7 @@ const customRender = (
             dispatch: IDispatch<IReactVaporState>;
         };
     } = {}
-) => {
+): RenderResult => {
     const TestWrapper: React.FunctionComponent = ({children}) => <Provider store={store}>{children}</Provider>;
 
     return render(ui, {wrapper: TestWrapper, ...renderOptions});

--- a/packages/react-vapor/src/components/badge/tests/Badge.spec.tsx
+++ b/packages/react-vapor/src/components/badge/tests/Badge.spec.tsx
@@ -1,5 +1,5 @@
+import {render, screen, within} from '@test-utils';
 import * as React from 'react';
-import {render, screen, within} from 'react-vapor-test-utils';
 
 import {Badge} from '../Badge';
 

--- a/packages/react-vapor/src/components/collapsible/tests/CollapsibleContainerConnected.spec.tsx
+++ b/packages/react-vapor/src/components/collapsible/tests/CollapsibleContainerConnected.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {render, screen} from 'react-vapor-test-utils';
+import {render, screen} from '@test-utils';
 
 import {CollapsibleContainerConnected} from '../CollapsibleContainerConnected';
 

--- a/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
+++ b/packages/react-vapor/src/components/editor/tests/CodeEditor.spec.tsx
@@ -1,12 +1,11 @@
 import userEvent from '@testing-library/user-event';
-import {waitFor} from '@testing-library/dom';
 import * as CodeMirror from 'codemirror';
 import {ShallowWrapper} from 'enzyme';
 import {mountWithState, shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
 import * as ReactCodeMirror from 'react-codemirror2';
+import {render, waitFor, screen} from '@test-utils';
 import * as _ from 'underscore';
-import {render, screen} from 'react-vapor-test-utils';
 
 import {CollapsibleSelectors} from '../../collapsible/CollapsibleSelectors';
 import {CodeEditor, CodeEditorState, ICodeEditorProps} from '../CodeEditor';

--- a/packages/react-vapor/src/components/iconCard/tests/IconCard.spec.tsx
+++ b/packages/react-vapor/src/components/iconCard/tests/IconCard.spec.tsx
@@ -1,7 +1,7 @@
+import {fireEvent, render, screen, within} from '@test-utils';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
-import {fireEvent, render, screen, within} from 'react-vapor-test-utils';
 import {IconCard} from '../IconCard';
 
 describe('IconCard', () => {

--- a/packages/react-vapor/src/components/info-token/tests/InfoToken.spec.tsx
+++ b/packages/react-vapor/src/components/info-token/tests/InfoToken.spec.tsx
@@ -1,5 +1,6 @@
+import {render, screen} from '@test-utils';
 import * as React from 'react';
-import {render, screen} from 'react-vapor-test-utils';
+
 import {InfoToken, InfoTokenMode, InfoTokenSize, InfoTokenType} from '../InfoToken';
 
 describe('InfoToken', () => {

--- a/packages/react-vapor/src/components/modal/tests/ConfirmationModalProvider.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/ConfirmationModalProvider.spec.tsx
@@ -1,7 +1,7 @@
-import {screen} from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
-import {renderModal} from 'react-vapor-test-utils';
+import {renderModal, screen} from '@test-utils';
+
 import {ConfirmationModalProvider} from '../ConfirmationModalProvider';
 import {ModalCompositeConnected} from '../ModalComposite';
 

--- a/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
+++ b/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
@@ -1,7 +1,6 @@
-import {screen, waitForElementToBeRemoved} from '@testing-library/dom';
 import userEvent, {specialChars} from '@testing-library/user-event';
 import * as React from 'react';
-import {renderModal} from 'react-vapor-test-utils';
+import {renderModal, screen, waitForElementToBeRemoved} from '@test-utils';
 
 import {ModalWizard} from '../ModalWizard';
 

--- a/packages/react-vapor/src/components/modalWizard/tests/ModalWizardWithValidations.spec.tsx
+++ b/packages/react-vapor/src/components/modalWizard/tests/ModalWizardWithValidations.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent, {specialChars} from '@testing-library/user-event';
 import * as React from 'react';
-import {renderModal, screen, waitForElementToBeRemoved} from 'react-vapor-test-utils';
+import {renderModal, screen, waitForElementToBeRemoved} from '@test-utils';
 
 import {ModalWizardWithValidations} from '../ModalWizardWithValidations';
 

--- a/packages/react-vapor/src/components/select/hoc/tests/MultiSelectWithPredicate.spec.tsx
+++ b/packages/react-vapor/src/components/select/hoc/tests/MultiSelectWithPredicate.spec.tsx
@@ -1,14 +1,14 @@
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
-import {render, screen, within} from 'react-vapor-test-utils';
+import {render, screen, within} from '@test-utils';
 import * as _ from 'underscore';
 
+import {withServerSideProcessing} from '../../../../hoc';
 import {IFlatSelectOptionProps} from '../../../flatSelect/FlatSelectOption';
 import {IItemBoxProps} from '../../../itemBox/ItemBox';
 import {IMultiSelectOwnProps, MultiSelectConnected} from '../../MultiSelectConnected';
 import {MultiSelectWithPredicate} from '../SelectComponents';
 import {ISelectWithPredicateOwnProps, selectWithPredicate} from '../SelectWithPredicate';
-import {withServerSideProcessing} from '../../../../hoc';
 
 describe('Select', () => {
     describe('<MultiSelectWithPredicate />', () => {

--- a/packages/react-vapor/src/components/select/hoc/tests/SelectWithInfiniteScroll.spec.tsx
+++ b/packages/react-vapor/src/components/select/hoc/tests/SelectWithInfiniteScroll.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event';
-import {render, screen} from 'react-vapor-test-utils';
 import * as React from 'react';
+import {render, screen} from '@test-utils';
 
 import {SingleSelectConnected} from '../../SingleSelectConnected';
 import {selectWithInfiniteScroll} from '../SelectWithInfiniteScroll';

--- a/packages/react-vapor/src/components/select/tests/MultiSelectConnected.spec.tsx
+++ b/packages/react-vapor/src/components/select/tests/MultiSelectConnected.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
-import {render, screen, fireEvent, within} from 'react-vapor-test-utils';
+import {fireEvent, render, screen, within} from '@test-utils';
 
 import {MultiSelectConnected} from '../MultiSelectConnected';
 

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithEmptyState.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithEmptyState.spec.tsx
@@ -1,15 +1,13 @@
-import {render, screen} from 'react-vapor-test-utils';
 import {ReactWrapper} from 'enzyme';
 import {mountWithStore} from 'enzyme-redux';
 import * as React from 'react';
-import {act} from 'react-dom/test-utils';
-import * as _ from 'underscore';
+import {act, render, screen} from '@test-utils';
 
 import {getStoreMock} from '../../../utils/tests/TestUtils';
 import {TableHOCActions} from '../actions/TableHOCActions';
 import {TableHOC} from '../TableHOC';
-import {tableWithEmptyState} from '../TableWithEmptyState';
 import {TableSelectors} from '../TableSelectors';
+import {tableWithEmptyState} from '../TableWithEmptyState';
 
 describe('TableWithEmptyState', () => {
     const TableWithEmptyState = tableWithEmptyState(TableHOC);

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithPredicate.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithPredicate.spec.tsx
@@ -1,13 +1,13 @@
 import userEvent from '@testing-library/user-event';
-import {render, screen} from 'react-vapor-test-utils';
 import {shallowWithState} from 'enzyme-redux';
 import * as React from 'react';
+import {render, screen} from '@test-utils';
 import * as _ from 'underscore';
 
 import {withServerSideProcessing} from '../../../hoc/withServerSideProcessing/withServerSideProcessing';
+import {SingleSelectWithFilter} from '../../select/hoc/SelectComponents';
 import {ITableHOCProps, TableHOC} from '../TableHOC';
 import {tableWithPredicate, tableWithPredicateGeneric} from '../TableWithPredicate';
-import {SingleSelectWithFilter} from '../../select/hoc/SelectComponents';
 import {TableHOCUtils} from '../utils/TableHOCUtils';
 
 describe('Table HOC', () => {

--- a/packages/react-vapor/tsconfig.build.json
+++ b/packages/react-vapor/tsconfig.build.json
@@ -1,17 +1,5 @@
 {
     "extends": "./tsconfig",
-    "compilerOptions": {
-        "composite": true,
-        "outDir": "dist",
-        "rootDir": "src",
-        "removeComments": false,
-        "noImplicitAny": false,
-        "sourceMap": true,
-        "declaration": true,
-        "declarationMap": true,
-        "tsBuildInfoFile": "./dist/.tsbuildinfo"
-    },
-    "exclude": ["*.js", "./src/**/*.spec.*", "./src/**/*.mock.*", "**/tests/**", "./src/utils/tests"],
-    "include": ["src"],
-    "references": []
+    "references": [],
+    "exclude": ["**/*.spec.*", "./src/utils/tests", "./src/TestUtils.tsx"]
 }

--- a/packages/react-vapor/tsconfig.eslint.json
+++ b/packages/react-vapor/tsconfig.eslint.json
@@ -1,7 +1,0 @@
-{
-    "extends": "../tsconfig-base.json",
-    "compilerOptions": {
-        "noEmit": true
-    },
-    "include": ["*.ts", "src/**/*.ts", "src/**/*.tsx", "jest/**/*.ts", "jest/**/*.tsx"]
-}

--- a/packages/react-vapor/tsconfig.json
+++ b/packages/react-vapor/tsconfig.json
@@ -1,23 +1,14 @@
 {
     "extends": "../tsconfig-base",
     "compilerOptions": {
-        "emitDecoratorMetadata": true,
-        "experimentalDecorators": true,
-        "downlevelIteration": true,
-        "allowJs": true,
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "removeComments": true,
-        "noUnusedLocals": true,
-        "lib": ["es2015", "dom"],
-        "allowSyntheticDefaultImports": true,
-        "strictBindCallApply": true,
-        "importHelpers": true,
+        "outDir": "dist",
+        "rootDir": "src",
+        "tsBuildInfoFile": "./dist/.tsbuildinfo",
         "baseUrl": ".",
         "paths": {
-            "react-vapor-test-utils": ["./jest/utils/react-vapor-test-utils"],
+            "@test-utils": ["src/TestUtils.tsx"],
             "*": ["types/*", "*"]
         }
     },
-    "exclude": ["**/node_modules", "**/dist", "**/coverage", "*.js", "**/target"]
+    "include": ["src"]
 }

--- a/packages/react-vapor/tsconfig.test.json
+++ b/packages/react-vapor/tsconfig.test.json
@@ -1,9 +1,8 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "esModuleInterop": true,
+        "sourceMap": false,
         "inlineSourceMap": true,
-        "module": "CommonJS",
-        "sourceMap": false
+        "module": "CommonJS"
     }
 }

--- a/packages/tsconfig-base.json
+++ b/packages/tsconfig-base.json
@@ -4,6 +4,27 @@
         "moduleResolution": "Node",
         "target": "es5",
         "jsx": "react",
-        "skipLibCheck": true
+        "lib": ["es2015", "dom"],
+        
+        "composite": true,
+        "sourceMap": true,
+        "declaration": true,
+        "declarationMap": true,
+        
+        "allowJs": true,
+        "skipLibCheck": true,
+        
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "noUnusedLocals": true,
+        "strictBindCallApply": true,
+        
+        "experimentalDecorators": true,
+        "downlevelIteration": true,
+        "removeComments": true,
+        "emitDecoratorMetadata": true,
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "importHelpers": true
     }
 }


### PR DESCRIPTION
### Proposed Changes

My IDE experienced slownest in its intellisense in this repository, so I spent some time cleaning up the tsconfigs by leveraging config inheritence.

One other thing that seemed to have helped alot with speed issues is to setup your IDE so that it uses the same typescript version than the one specified in the package.json

### Potential Breaking Changes

None expected

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
