### PR TITLE
fix(numeric input): realign numeric input buttons

### DIFF
--- a/packages/react-vapor/src/components/numericInput/NumericInputConnected.tsx
+++ b/packages/react-vapor/src/components/numericInput/NumericInputConnected.tsx
@@ -5,7 +5,6 @@ import * as _ from 'underscore';
 import {IReactVaporState} from '../../ReactVaporState';
 import {keyCode} from '../../utils/InputUtils';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
-import {Button} from '../button/Button';
 import {Svg} from '../svg/Svg';
 import {NumericInputActions} from './NumericInputActions';
 import {initialNumericInputState} from './NumericInputReducers';
@@ -90,14 +89,9 @@ export class NumericInputConnected extends React.PureComponent<NumericInputProps
         return (
             <div className="numeric-input flex flex-column">
                 <div className="flex flex-row">
-                    <Button
-                        classes="js-decrement mr1 p0"
-                        enabled={decrementEnabled}
-                        onClick={this.onDecrement}
-                        type="button"
-                    >
-                        <Svg svgName="minus" svgClass="icon mod-12 align-middle" />
-                    </Button>
+                    <button className="js-decrement mr1" disabled={!decrementEnabled} onClick={this.onDecrement}>
+                        <Svg svgName="minus" svgClass="icon mod-12" />
+                    </button>
                     <div className="flex flex-column">
                         <input
                             {..._.omit(this.props, inputPropsToOmit)}
@@ -114,14 +108,9 @@ export class NumericInputConnected extends React.PureComponent<NumericInputProps
                             onKeyDown={this.onKeyDown}
                         />
                     </div>
-                    <Button
-                        classes="js-increment ml1 p0"
-                        enabled={incrementEnabled}
-                        onClick={this.onIncrement}
-                        type="button"
-                    >
-                        <Svg svgName="plus" svgClass="icon mod-12 align-middle" />
-                    </Button>
+                    <button className="js-increment ml1" disabled={!incrementEnabled} onClick={this.onIncrement}>
+                        <Svg svgName="plus" svgClass="icon mod-12" />
+                    </button>
                 </div>
                 <div className="flex flex-row">
                     {this.props.hasError && <span className="generic-form-error my1">{this.props.invalidMessage}</span>}

--- a/packages/react-vapor/src/components/numericInput/tests/NumericInputConnected.spec.tsx
+++ b/packages/react-vapor/src/components/numericInput/tests/NumericInputConnected.spec.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 
 import {keyCode} from '../../../utils/InputUtils';
 import {getStoreMock, ReactVaporMockStore} from '../../../utils/tests/TestUtils';
-import {Button} from '../../button/Button';
 import {NumericInputActions} from '../NumericInputActions';
 import {NumericInputConnected} from '../NumericInputConnected';
 import {initialNumericInputState} from '../NumericInputReducers';
@@ -47,7 +46,7 @@ describe('Numeric Input', () => {
                 store
             ).dive();
 
-            expect(component.find(Button).at(0).prop('enabled')).toBe(false);
+            expect(component.find('button').at(0).prop('disabled')).toBe(true);
         });
 
         it('should trigger a setValue onClick on the decrement button', () => {
@@ -56,7 +55,7 @@ describe('Numeric Input', () => {
                 store
             ).dive();
 
-            component.find(Button).at(0).prop('onClick')();
+            component.find('button').at(0).prop<any>('onClick')();
 
             expect(store.getActions()).toContainEqual(NumericInputActions.setValue(id, initialValue - 1));
         });
@@ -68,7 +67,7 @@ describe('Numeric Input', () => {
                 store
             ).dive();
 
-            component.find(Button).at(0).prop('onClick')();
+            component.find('button').at(0).prop<any>('onClick')();
 
             expect(store.getActions()).toContainEqual(NumericInputActions.setValue(id, initialValue - step));
         });
@@ -111,7 +110,7 @@ describe('Numeric Input', () => {
                 store
             ).dive();
 
-            expect(component.find(Button).at(1).prop('enabled')).toBe(false);
+            expect(component.find('button').at(1).prop('disabled')).toBe(true);
         });
 
         it('should not overflow the min onClick on the decrement button', () => {
@@ -122,7 +121,7 @@ describe('Numeric Input', () => {
                 store
             ).dive();
 
-            component.find(Button).at(0).prop('onClick')();
+            component.find('button').at(0).prop<any>('onClick')();
 
             expect(store.getActions()).toContainEqual(NumericInputActions.setValue(id, min, min));
         });
@@ -133,7 +132,7 @@ describe('Numeric Input', () => {
                 store
             ).dive();
 
-            component.find(Button).at(1).prop('onClick')();
+            component.find('button').at(1).prop<any>('onClick')();
 
             expect(store.getActions()).toContainEqual(NumericInputActions.setValue(id, initialValue + 1));
         });
@@ -145,7 +144,7 @@ describe('Numeric Input', () => {
                 store
             ).dive();
 
-            component.find(Button).at(1).prop('onClick')();
+            component.find('button').at(1).prop<any>('onClick')();
 
             expect(store.getActions()).toContainEqual(NumericInputActions.setValue(id, initialValue + step));
         });
@@ -158,7 +157,7 @@ describe('Numeric Input', () => {
                 store
             ).dive();
 
-            component.find(Button).at(1).prop('onClick')();
+            component.find('button').at(1).prop<any>('onClick')();
 
             expect(store.getActions()).toContainEqual(NumericInputActions.setValue(id, max, undefined, max));
         });
@@ -199,7 +198,7 @@ describe('Numeric Input', () => {
             it('should decrement to the default value if initialValue is not defined', () => {
                 const component = shallowWithStore(<NumericInputConnected id={id} />, store).dive();
 
-                component.find(Button).at(0).prop('onClick')();
+                component.find('button').at(0).prop<any>('onClick')();
 
                 expect(store.getActions()).toContainEqual(
                     NumericInputActions.setValue(id, initialNumericInputState.value)
@@ -209,7 +208,7 @@ describe('Numeric Input', () => {
             it('should increment to the default value if initialValue is not defined', () => {
                 const component = shallowWithStore(<NumericInputConnected id={id} />, store).dive();
 
-                component.find(Button).at(1).prop('onClick')();
+                component.find('button').at(1).prop<any>('onClick')();
 
                 expect(store.getActions()).toContainEqual(
                     NumericInputActions.setValue(id, initialNumericInputState.value)
@@ -222,7 +221,7 @@ describe('Numeric Input', () => {
                     store
                 ).dive();
 
-                component.find(Button).at(0).prop('onClick')();
+                component.find('button').at(0).prop<any>('onClick')();
 
                 expect(store.getActions()).toContainEqual(NumericInputActions.setValue(id, initialValue));
             });
@@ -233,7 +232,7 @@ describe('Numeric Input', () => {
                     store
                 ).dive();
 
-                component.find(Button).at(1).prop('onClick')();
+                component.find('button').at(1).prop<any>('onClick')();
 
                 expect(store.getActions()).toContainEqual(NumericInputActions.setValue(id, initialValue));
             });

--- a/packages/vapor/scss/controls/numeric-input.scss
+++ b/packages/vapor/scss/controls/numeric-input.scss
@@ -21,22 +21,27 @@ $numeric-input-buttons-border-radius: 4px;
         box-shadow: inset 0 0 3px 0 rgba(var(--black-rgb), $transparency-5);
     }
 
-    .btn {
-        display: inline-block;
+    button {
+        --fill: var(--white);
         width: $numeric-input-height;
         height: $numeric-input-height;
-        color: var(--white);
-        line-height: $numeric-input-height - 2 * $default-border-size;
-        background-color: var(--deprecated-blue-purple-2);
+        padding: 0 7px;
+        line-height: $numeric-input-height;
+        background-color: var(--digital-blue-80);
         border-radius: $numeric-input-buttons-border-radius;
-        outline: none;
+        cursor: pointer;
 
-        &:focus {
-            background-color: var(--deprecated-blue-purple-2);
+        &:disabled {
+            background-color: var(--grey-40);
+            pointer-events: none;
         }
 
-        .icon {
-            fill: var(--white);
+        &:hover {
+            background-color: var(--digital-blue-100);
+        }
+
+        &:focus {
+            @include focus-border(2px);
         }
     }
 }


### PR DESCRIPTION
### Proposed Changes

Realigned the `NumericInput` buttons and also improved the overall user experience by adding a proper focus effect and disabled style.

I didn't rewrite the entire test suites, because the component will probably change soon with the new designs.

#### Before
![image](https://user-images.githubusercontent.com/35579930/118691508-25811400-b7d7-11eb-8e07-cafb99bfcede.png)

#### After
![image](https://user-images.githubusercontent.com/35579930/118691390-08e4dc00-b7d7-11eb-9fbb-bc4e0484ed10.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
