### PR TITLE
feat(modal-wizard): added optional onclick callback props

### DIFF
--- a/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
+++ b/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
@@ -26,6 +26,8 @@ export interface ModalWizardProps
     nextButtonLabel?: string;
     previousButtonLabel?: string;
     finishButtonLabel?: string;
+    onNext?: () => unknown;
+    onPrevious?: () => unknown;
     onCancel?: () => void;
 }
 
@@ -46,6 +48,8 @@ const ModalWizardDisconneted: React.FunctionComponent<ModalWizardProps & Connect
     nextButtonLabel = 'Next',
     previousButtonLabel = 'Previous',
     finishButtonLabel = 'Finish',
+    onNext,
+    onPrevious,
     onCancel,
     ...modalProps
 }) => {
@@ -86,6 +90,7 @@ const ModalWizardDisconneted: React.FunctionComponent<ModalWizardProps & Connect
                                         onCancel?.();
                                         close();
                                     } else {
+                                        onPrevious?.();
                                         setCurrentStep(currentStep - 1);
                                     }
                                 }}
@@ -99,6 +104,7 @@ const ModalWizardDisconneted: React.FunctionComponent<ModalWizardProps & Connect
                                     if (isLastStep) {
                                         onFinish?.(close);
                                     } else {
+                                        onNext?.();
                                         setCurrentStep(currentStep + 1);
                                     }
                                 }}

--- a/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
+++ b/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
@@ -28,7 +28,7 @@ export interface ModalWizardProps
     finishButtonLabel?: string;
     onNext?: () => unknown;
     onPrevious?: () => unknown;
-    onCancel?: () => void;
+    onCancel?: () => unknown;
 }
 
 const enhance = connect(null, (dispatch: IDispatch, {id}: ModalWizardProps) => ({

--- a/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
+++ b/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
@@ -37,6 +37,9 @@ describe('ModalWizard', () => {
     });
 
     it('navigates properly through the steps when clicking on "next" and "previous" buttons', () => {
+        const nextSpy = jest.fn();
+        const previousSpy = jest.fn();
+
         const FunctionComponentStep = () => <div>Step 2: FunctionComponent</div>;
         class ClassComponentStep extends React.PureComponent {
             render() {
@@ -45,7 +48,7 @@ describe('ModalWizard', () => {
         }
 
         renderModal(
-            <ModalWizard id="🧙‍♂️">
+            <ModalWizard id="🧙‍♂️" onNext={nextSpy} onPrevious={previousSpy}>
                 <div>Step 1: ReactElement</div>
                 <FunctionComponentStep />
                 <ClassComponentStep />
@@ -74,6 +77,9 @@ describe('ModalWizard', () => {
         expect(screen.getByText(/Step 1/)).not.toBeVisible();
         expect(screen.getByText(/Step 2/)).toBeVisible();
         expect(screen.getByText(/Step 3/)).not.toBeVisible();
+
+        expect(nextSpy).toHaveBeenCalledTimes(2);
+        expect(previousSpy).toHaveBeenCalledTimes(1);
     });
 
     it('calls the "onFinish" prop and the modal stays open when clicking on the "finish" button', () => {


### PR DESCRIPTION
### Proposed Changes
- Adding optional props for onNext and onPrevious

This comes from wanting to use the ModalWizard component in the CreateMLModel component in adui. The latter sends analytics events when these buttons are clicked so I need these props to maintain feature parity. The flexibility could likely also be beneficial to other use cases.

### Potential Breaking Changes

nah

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
