### PR TITLE
fix(toast): use high-elevation-on-neutral shadow

### DIFF
--- a/packages/vapor/scss/components/toast.scss
+++ b/packages/vapor/scss/components/toast.scss
@@ -3,7 +3,6 @@ $toast-container-margin: 20px;
 $toast-margin-top: $header-height;
 $toast-margin: 10px 0px;
 $toast-radius: 8px;
-$toast-box-shadow: 0px 14px 26px rgba(142, 142, 142, 0.16);
 $toast-download-padding: 20px;
 $toast-text-font-size: 14px;
 $toast-title-font-weight: 500;
@@ -57,7 +56,7 @@ $toast-info-token-padding: 12px 16px 12px 8px;
         // override
         background-color: var(--background-color);
         border-radius: $toast-radius;
-        box-shadow: $toast-box-shadow;
+        box-shadow: var(--high-elevation-on-neutral);
         pointer-events: all;
 
         // variables
@@ -146,7 +145,7 @@ $toast-info-token-padding: 12px 16px 12px 8px;
         padding: 0;
         background: var(--info-60);
         border-radius: 6px;
-        box-shadow: 0 2px 4px rgba(var(--black-rgb), $transparency-4);
+        box-shadow: var(--high-elevation-on-neutral);
 
         .toast-title,
         .toast-close {


### PR DESCRIPTION
### Proposed Changes

Looks the same as before but uses the new variable.

![image](https://user-images.githubusercontent.com/35579930/119730818-2c95cb00-be44-11eb-96c5-11613a8318a5.png)

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
