### PR TITLE
[COM-958] feat(badge): add badge as tag, remove some padding

### DIFF
--- a/packages/demo/src/components/examples/BadgeExamples.tsx
+++ b/packages/demo/src/components/examples/BadgeExamples.tsx
@@ -12,6 +12,7 @@ export const BadgeExamples: React.FunctionComponent = () => (
             <Badge label="Beta" extraClasses={['mod-beta ml1']} />
             <Badge icon="lock" extraClasses={['ml1']} />
             <Badge icon="lock" label="Label" extraClasses={['ml1']} />
+            <Badge icon="lock" label="tag" extraClasses={['mod-tag ml1']} />
         </Section>
         <Section level={2} title="Small">
             <Badge label="Default" extraClasses={['mod-small']} />
@@ -22,6 +23,7 @@ export const BadgeExamples: React.FunctionComponent = () => (
             <Badge label="Beta" extraClasses={['mod-small mod-beta ml1']} />
             <Badge icon="lock" extraClasses={['mod-small ml1']} />
             <Badge icon="lock" label="Label" extraClasses={['mod-small ml1']} />
+            <Badge icon="lock" label="tag" extraClasses={['mod-small mod-tag ml1']} />
         </Section>
     </Section>
 );

--- a/packages/vapor/scss/components/badge.scss
+++ b/packages/vapor/scss/components/badge.scss
@@ -5,14 +5,13 @@
     box-sizing: border-box;
     font-weight: var(--main-font-bolder);
     text-align: center;
-    text-transform: capitalize;
     border: 1px solid;
     border-radius: 8px;
     white-space: nowrap;
 
     // Variables
     --height: 32px;
-    --padding: 6px 16px;
+    --padding: 6px 8px;
     --font-size: 16px;
     --line-height: 18px;
     --color: var(--grey-80);
@@ -70,6 +69,11 @@
         --fill: var(--sienna-orange-70);
         --border-color: var(--sienna-orange-40);
         --background-color: var(--sienna-orange-20);
+    }
+
+    &.mod-tag {
+        --background-color: var(--white);
+        font-weight: var(--main-font-bold);
     }
 
     &:last-child {


### PR DESCRIPTION
[COM-958]

### Proposed Changes

While working on a feature in the Catalogs, we needed a new type of badge. We were suggested to add it in react-vapor, and I also got the recommendations from Gustavo to reduce the padding at large.

Before:

![image](https://user-images.githubusercontent.com/8355585/119857104-49341080-bee1-11eb-8796-17054c6f1671.png)

After:

![image](https://user-images.githubusercontent.com/8355585/119857282-6d8fed00-bee1-11eb-8125-c4d1a29f3dd3.png)

You can see the new "tag" which has a white background and no bold text.

It looks cleaner in the context of an inline tag in a table, for instance

![image](https://user-images.githubusercontent.com/8355585/119857558-ab8d1100-bee1-11eb-88b6-c2fa2de83c77.png)

### Potential Breaking Changes

It removes capitalization, we'll have to update the places where it assumed that.

It *could* also change the look a bit in pages that use the Badge, but this is what we want with this change :thinking: 

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-958]: https://coveord.atlassian.net/browse/COM-958