### PR TITLE
Style/ad UI 6990 fix toast styling issues 2

### DIFF
--- a/packages/demo/src/components/examples/ToastExamples.tsx
+++ b/packages/demo/src/components/examples/ToastExamples.tsx
@@ -213,11 +213,30 @@ const ToastsWithReduxStoreDisconnected: React.FunctionComponent<ReturnType<typeo
                 />
             </Section>
 
+            <Section level={2} title="Toasts with big descriptions" className="flex">
+                <Label className="flex">Sometimes we only want toasts with a description</Label>
+
+                <Button
+                    enabled
+                    className="btn m0 mr1 mb1"
+                    name="Description"
+                    onClick={() => renderToast('containerId', '', {type: ToastType.Info, content: toastDescription})}
+                />
+
+                <Button
+                    enabled
+                    className="btn m0 mr1 mb1"
+                    name="Longer description"
+                    onClick={() =>
+                        renderToast('containerId', '', {
+                            type: ToastType.Info,
+                            content: `${toastDescription} ${toastDescription}`,
+                        })
+                    }
+                />
+            </Section>
+
             <Section level={2} title="Small toasts" className="flex">
-                <Label className="flex">
-                    The small version of the toast needs a dismiss value because they don't have an X button to close
-                    them manually.
-                </Label>
                 <Button
                     enabled
                     className="btn m0 mr1 mb1"

--- a/packages/react-vapor/src/components/toast/Toast.tsx
+++ b/packages/react-vapor/src/components/toast/Toast.tsx
@@ -27,7 +27,7 @@ export interface IToastProps {
      */
     onRender?: () => void;
     /**
-     * @deprecated - can't find any instances in RV or Admin that use this but leaving in just case
+     * @deprecated - Use onClose instead
      */
     onDestroy?: () => void;
 }

--- a/packages/react-vapor/src/components/toast/Toast.tsx
+++ b/packages/react-vapor/src/components/toast/Toast.tsx
@@ -111,30 +111,45 @@ export class Toast extends React.Component<IToastProps> {
             />
         );
 
-        const toastContent = (!!this.props.content || !!this.props.children) && !this.props.isSmall && (
-            <div className="toast-description">
-                {this.props.isDownload ? (
+        const downloadToast = (
+            <div className="toast-download-container flex flex-column">
+                <div className="toast-title">{this.props.title}</div>
+                <div className="toast-description">
                     <div className="flex space-between">
                         {this.props.children}
                         <div className="spinner-container relative">
                             <div className="search-bar-spinner" />
                         </div>
                     </div>
-                ) : (
-                    this.props.children
-                )}
-                {_.isString(this.props.content) || !this.props.content
-                    ? this.props.content
-                    : React.createElement(this.props.content as React.ComponentClass)}
+                </div>
+            </div>
+        );
+
+        const toastContent = (!!this.props.content || !!this.props.children) && !this.props.isSmall && (
+            <div className="toast-description">
+                <div>
+                    {this.props.children}
+                    {_.isString(this.props.content) || !this.props.content
+                        ? this.props.content
+                        : React.createElement(this.props.content as React.ComponentClass)}
+                </div>
             </div>
         );
 
         return (
             <div className={classes} onMouseEnter={() => this.clearTimeout()} onMouseLeave={() => this.setTimeout()}>
-                {this.props.showInfoToken ? infoToken : null}
-                {closeButton}
-                <div className="toast-title">{this.props.title}</div>
-                {toastContent}
+                {this.props.isDownload ? (
+                    downloadToast
+                ) : (
+                    <>
+                        {this.props.showInfoToken ? infoToken : null}
+                        <div className="toast-content-container">
+                            {this.props.title && <div className="toast-title">{this.props.title}</div>}
+                            {toastContent}
+                        </div>
+                        {closeButton}
+                    </>
+                )}
             </div>
         );
     }

--- a/packages/react-vapor/src/components/toast/Toast.tsx
+++ b/packages/react-vapor/src/components/toast/Toast.tsx
@@ -79,15 +79,9 @@ export const Toast: React.FC<IToastProps> = ({
         };
     }, []);
 
-    const close = () => {
-        if (onClose) {
-            onClose();
-        }
-    };
-
     const handleSetTimeout = () => {
         if (dismissible && dismiss > 0) {
-            timeout = setTimeout(() => close(), dismiss) as any;
+            timeout = setTimeout(() => onClose?.(), dismiss) as any;
         }
     };
 
@@ -112,7 +106,7 @@ export const Toast: React.FC<IToastProps> = ({
     );
 
     const closeButton = dismissible && !isSmall && (
-        <span className="toast-close" onClick={() => close()}>
+        <span className="toast-close" onClick={() => onClose?.()}>
             <Svg svgName="close" className="icon mod-lg" />
         </span>
     );

--- a/packages/react-vapor/src/components/toast/Toast.tsx
+++ b/packages/react-vapor/src/components/toast/Toast.tsx
@@ -23,7 +23,7 @@ export interface IToastProps {
      */
     content?: React.ReactNode;
     /**
-     * @deprecated - can't find any instances in RV or Admin that use this but leaving in just case
+     * @deprecated
      */
     onRender?: () => void;
     /**

--- a/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
+++ b/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
@@ -1,4 +1,5 @@
-import {render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
@@ -280,30 +281,21 @@ describe('Toasts', () => {
             expect(onCloseToast).toHaveBeenCalledTimes(1);
         });
 
-        it.skip('should not dismiss the toast if the dismiss is set to 0', async () => {
+        it('should not dismiss the toast if the dismiss is set to 0', async () => {
             const newToastAttributes = _.extend({}, toastBasicAttributes, {dismiss: 0});
 
-            // const {container} = render(<Toast {...newToastAttributes} />);
+            render(<Toast {...newToastAttributes} />);
 
-            // userEvent.hover(container);
+            userEvent.hover(screen.queryByText('some title'));
 
-            // await waitForElementToBeRemoved(container);
-
-            // screen.logTestingPlaygroundURL();
-
-            const component = mount(<Toast {...newToastAttributes} />, {attachTo: document.getElementById('App')});
-
-            expect(onCloseToast).not.toHaveBeenCalled();
-
-            component.simulate('mouseEnter');
-            jest.advanceTimersByTime(dismissDelay);
-
-            expect(onCloseToast).not.toHaveBeenCalled();
-
-            component.simulate('mouseLeave');
-            jest.advanceTimersByTime(dismissDelay);
-
-            expect(onCloseToast).not.toHaveBeenCalled();
+            await waitFor(
+                () => {
+                    expect(screen.queryByText('some title')).toBeInTheDocument();
+                },
+                {
+                    timeout: dismissDelay,
+                }
+            );
         });
     });
 

--- a/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
+++ b/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
@@ -1,10 +1,8 @@
+import {render, screen} from '@testing-library/react';
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
-import {screen, waitForElementToBeRemoved} from '@testing-library/react';
 
-import {render} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import {IToastProps, Toast, ToastType} from '../Toast';
 
 describe('Toasts', () => {

--- a/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
+++ b/packages/react-vapor/src/components/toast/tests/Toast.spec.tsx
@@ -1,15 +1,15 @@
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
-import {screen} from '@testing-library/dom';
+import {screen, waitForElementToBeRemoved} from '@testing-library/react';
 
 import {render} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {IToastProps, Toast, ToastType} from '../Toast';
 
 describe('Toasts', () => {
     let toastComponent: ReactWrapper<IToastProps>;
     let toastBasicAttributes: IToastProps;
-    let toastInstance: Toast;
 
     it('should render without errors', () => {
         expect(() => shallow(<Toast title="Hello" />)).not.toThrow();
@@ -22,7 +22,6 @@ describe('Toasts', () => {
             };
 
             toastComponent = mount(<Toast {...toastBasicAttributes} />, {attachTo: document.getElementById('App')});
-            toastInstance = toastComponent.instance() as Toast;
         });
 
         it('should call prop onRender on mounting if set', () => {
@@ -39,11 +38,9 @@ describe('Toasts', () => {
             const destroySpy = jest.fn();
             const newToastAttributes = _.extend({}, toastBasicAttributes, {onDestroy: destroySpy});
 
-            expect(() => toastInstance.componentWillUnmount()).not.toThrow();
-
-            toastComponent.setProps(newToastAttributes).mount();
-
-            toastComponent.unmount();
+            expect(() =>
+                mount(<Toast {...newToastAttributes} />, {attachTo: document.getElementById('App')}).unmount()
+            ).not.toThrow();
 
             expect(destroySpy).toHaveBeenCalledTimes(1);
         });
@@ -157,7 +154,12 @@ describe('Toasts', () => {
             });
 
             expect(toastComponent.find(descriptionContainer).length).toBe(1);
-            expect(toastComponent.find(descriptionContainer).children().equals(expectedChildren)).toBe(true);
+            expect(
+                toastComponent
+                    .find(descriptionContainer)
+                    .children()
+                    .equals(<div>{expectedChildren}</div>)
+            ).toBe(true);
         });
 
         it('should contain a toast-close when the prop is undefined or true and isSmall is false', () => {
@@ -221,7 +223,6 @@ describe('Toasts', () => {
             jest.useFakeTimers();
 
             toastComponent = mount(<Toast {...toastBasicAttributes} />, {attachTo: document.getElementById('App')});
-            toastInstance = toastComponent.instance() as Toast;
         });
 
         afterEach(() => {
@@ -281,18 +282,27 @@ describe('Toasts', () => {
             expect(onCloseToast).toHaveBeenCalledTimes(1);
         });
 
-        it('should not dismiss the toast if the dismiss is set to 0', () => {
+        it.skip('should not dismiss the toast if the dismiss is set to 0', async () => {
             const newToastAttributes = _.extend({}, toastBasicAttributes, {dismiss: 0});
-            toastComponent.setProps(newToastAttributes).mount();
+
+            // const {container} = render(<Toast {...newToastAttributes} />);
+
+            // userEvent.hover(container);
+
+            // await waitForElementToBeRemoved(container);
+
+            // screen.logTestingPlaygroundURL();
+
+            const component = mount(<Toast {...newToastAttributes} />, {attachTo: document.getElementById('App')});
 
             expect(onCloseToast).not.toHaveBeenCalled();
 
-            toastComponent.simulate('mouseEnter');
+            component.simulate('mouseEnter');
             jest.advanceTimersByTime(dismissDelay);
 
             expect(onCloseToast).not.toHaveBeenCalled();
 
-            toastComponent.simulate('mouseLeave');
+            component.simulate('mouseLeave');
             jest.advanceTimersByTime(dismissDelay);
 
             expect(onCloseToast).not.toHaveBeenCalled();

--- a/packages/vapor/scss/components/toast.scss
+++ b/packages/vapor/scss/components/toast.scss
@@ -47,8 +47,9 @@ $toast-info-token-padding: 12px 16px 12px 8px;
 
     .toast {
         // Default Style
-        display: block;
+        display: flex;
         min-width: var(--min-width);
+        max-width: var(--max-width);
         margin: $toast-margin;
         padding: var(--padding);
         color: var(--text-color);
@@ -62,6 +63,7 @@ $toast-info-token-padding: 12px 16px 12px 8px;
         // variables
         --background-color: var(--success-60);
         --min-width: 280px;
+        --max-width: 632px;
         --padding: 20px;
         --text-color: var(--white);
 
@@ -106,6 +108,14 @@ $toast-info-token-padding: 12px 16px 12px 8px;
         }
     }
 
+    .toast:not(.mod-small):not(.toast-download) .toast-content-container {
+        display: flex;
+        flex: 1 1 auto;
+        flex-direction: column;
+        justify-content: center;
+        min-height: 55px;
+    }
+
     .toast-title {
         font-weight: $toast-title-font-weight;
         font-size: $toast-text-font-size;
@@ -113,7 +123,10 @@ $toast-info-token-padding: 12px 16px 12px 8px;
     }
 
     .toast-description {
-        margin-top: 10px;
+        display: flex;
+        align-items: center;
+        height: 100%;
+        padding-right: 10px;
         font-size: $toast-text-font-size;
     }
 
@@ -123,13 +136,11 @@ $toast-info-token-padding: 12px 16px 12px 8px;
         flex-direction: row;
         align-items: center;
         justify-content: center;
-        float: left;
         padding: $toast-info-token-padding;
     }
 
     .toast-close {
         position: static;
-        float: right;
         padding-left: $toast-close-padding-left;
         cursor: pointer;
         fill: var(--text-color);
@@ -147,6 +158,10 @@ $toast-info-token-padding: 12px 16px 12px 8px;
         border-radius: 6px;
         box-shadow: var(--high-elevation-on-neutral);
 
+        .toast-download-container {
+            width: 100%;
+        }
+
         .toast-title,
         .toast-close {
             padding: $toast-download-padding;
@@ -162,6 +177,10 @@ $toast-info-token-padding: 12px 16px 12px 8px;
             border-bottom-right-radius: inherit;
             border-bottom-left-radius: inherit;
             filter: drop-shadow(0px 8px 17px rgba(142, 142, 142, 0.22));
+
+            > div {
+                width: 100%;
+            }
 
             .spinner-container {
                 width: 16px;


### PR DESCRIPTION
### Proposed Changes

[ADUI-6990](https://coveord.atlassian.net/browse/ADUI-6990)

I updated the Toast component in 2 ways:

1. I replaced instances of `block` and `float` with `flexbox` to make it more aligned with the UX mockups. As a result I had to do a minor refactor to separate functionality between the `isDownload` / `isSmall` versions and the main version, with a small refactor of the `isDownload` version itself
2. While I was at it, I refactored the component to be a Functional Component and. updated the tests accordingly

NOTE: I had to skip one test which I would greatly appreciate help with

### Potential Breaking Changes

None that I can see but I'll say this: this component now has 3 marked deprecated function props (`content`, `onDestroy` & `onRender`). I can find only a couple of places in RV and the Admin where `content` and `onRender` are used but nowhere where `onDestoy` is used outside of the tests. I've left them in for now as I wouldn't consider the search exhaustive, though I felt I was fairly thorough. But I don't want to break something in a distant part of the admin

I also added a small JsDoc regarding suggested content length as per a discussion with Gustavo

### Test

Go and check all of the Toast / ToastContainer components

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
