### PR TITLE
Adui-7096/fix: fix description style in headers

### DIFF
--- a/packages/react-vapor/src/components/headers/HeaderWrapper.tsx
+++ b/packages/react-vapor/src/components/headers/HeaderWrapper.tsx
@@ -25,7 +25,9 @@ export class HeaderWrapper extends React.Component<IHeaderWrapperProps> {
                 <div className={this.classes}>
                     <div className="truncate mr2">
                         {this.props.children}
-                        <h4 className="admin-description normal-white-space">{this.props.description}</h4>
+                        <h4 className="admin-description h4-book-subdued normal-white-space">
+                            {this.props.description}
+                        </h4>
                     </div>
                     <div className="action-bar">{this.actions}</div>
                 </div>

--- a/packages/vapor/scss/components/panel-header.scss
+++ b/packages/vapor/scss/components/panel-header.scss
@@ -13,7 +13,6 @@
     }
 
     .admin-description {
-        margin-top: $description-margin-top;
         font-size: var(--default-font-size);
     }
 


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/ADUI-7096

With the new typekit, the style of the description in headers was too heavy. 

Before:
![image](https://user-images.githubusercontent.com/63734941/120826164-2381b980-c528-11eb-952a-8d6cd9cd8f44.png)

After:
![image](https://user-images.githubusercontent.com/63734941/120826298-4613d280-c528-11eb-9887-d806df3d27ca.png)


### Potential Breaking Changes

None :thinking: 

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
