### PR TITLE
fix(info-token): make InfoToken hold its height better

### DIFF
--- a/packages/react-vapor/src/components/info-token/InfoToken.tsx
+++ b/packages/react-vapor/src/components/info-token/InfoToken.tsx
@@ -28,6 +28,7 @@ export interface InfoTokenProps {
     type: InfoTokenType;
     size: InfoTokenSize;
     mode: InfoTokenMode;
+    className?: string;
 }
 
 const SvgMapping: Record<InfoTokenType, Record<InfoTokenSize, string>> = {
@@ -83,9 +84,9 @@ const ModeClassMapping: Record<InfoTokenMode, string> = {
     [InfoTokenMode.Filled]: 'filled',
 };
 
-export const InfoToken: React.FunctionComponent<InfoTokenProps> = ({mode, size, type}) => (
+export const InfoToken: React.FunctionComponent<InfoTokenProps> = ({mode, size, type, className}) => (
     <Svg
-        className={classNames('info-token', ModeClassMapping[mode])}
+        className={classNames('info-token', ModeClassMapping[mode], SizeClassMapping[size], className)}
         svgName={SvgMapping[type][size]}
         svgClass={classNames('icon mod-stroke', SizeClassMapping[size], TypeColorMapping[type])}
     />

--- a/packages/vapor/scss/components/info-token.scss
+++ b/packages/vapor/scss/components/info-token.scss
@@ -1,4 +1,18 @@
 .info-token {
+    display: inline-block;
+
+    &.mod-16 {
+        height: 16px;
+    }
+
+    &.mod-24 {
+        height: 24px;
+    }
+
+    &.mod-32 {
+        height: 32px;
+    }
+
     &.filled {
         .icon {
             fill: var(--fill);


### PR DESCRIPTION
### Proposed Changes

The info token wasn't respecting its height specification correctly when used in conjunction with line-height. Adding inline-block display seems to fix the issue.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
