### PR TITLE
feat(browserpreview): +title props

### DIFF
--- a/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
+++ b/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
@@ -13,6 +13,16 @@ export const BrowserPreviewExamples: React.FunctionComponent = () => (
                 }
             />
         </Section>
+        <Section level={2} title="Browser Preview with custom title">
+            <SplitLayout
+                leftChildren={<div />}
+                rightChildren={
+                    <div className="p3">
+                        <BrowserPreview title={'Custom title!'} />
+                    </div>
+                }
+            />
+        </Section>
         <Section level={2} title="Browser Preview with custom content">
             <SplitLayout
                 leftChildren={<div />}

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreview.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreview.tsx
@@ -6,19 +6,26 @@ import {Tooltip} from '../tooltip';
 
 export interface BrowserPreviewProps {
     headerDescription?: string;
+    title?: string;
 }
 
-export const BrowserPreview: React.FunctionComponent<BrowserPreviewProps> = ({children, headerDescription}) => (
+export const BrowserPreview: React.FunctionComponent<BrowserPreviewProps> = ({children, headerDescription, title}) => (
     <div className="browser-preview flex flex-column">
-        <BrowserPreviewHeader tooltipTitle={headerDescription ?? DefaultHeaderDescription} />
+        <BrowserPreviewHeader
+            tooltipTitle={headerDescription ?? DefaultHeaderDescription}
+            title={title ?? DefaultHeaderTitle}
+        />
         <div className="browser-preview__content flex flex-column flex-auto px4 py3">{children}</div>
     </div>
 );
 
-const BrowserPreviewHeader: React.FunctionComponent<{tooltipTitle: string}> = ({tooltipTitle}) => (
+const BrowserPreviewHeader: React.FunctionComponent<{tooltipTitle: string; title?: string}> = ({
+    title,
+    tooltipTitle,
+}) => (
     <div className="browser-preview__header flex space-between px2 py1">
         <div>
-            <span className="bolder">Preview</span>
+            <span className="bolder">{title}</span>
             <Tooltip title={tooltipTitle} placement={TooltipPlacement.Right}>
                 <Svg svgName="info" svgClass="icon mod-14 ml1" />
             </Tooltip>
@@ -33,3 +40,4 @@ const BrowserPreviewHeader: React.FunctionComponent<{tooltipTitle: string}> = ({
 
 const DefaultHeaderDescription =
     'The final look in your search page may differ due to the customization you made in your page.';
+const DefaultHeaderTitle = 'Preview';

--- a/packages/react-vapor/src/components/browserPreview/tests/BrowserPreview.spec.tsx
+++ b/packages/react-vapor/src/components/browserPreview/tests/BrowserPreview.spec.tsx
@@ -1,20 +1,26 @@
-import {mount, shallow} from 'enzyme';
+import {render, screen} from '@test-utils';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
-import {Tooltip} from '../../tooltip';
 import {BrowserPreview} from '../BrowserPreview';
 
 describe('BrowserPreview', () => {
-    it('renders without errors', () => {
-        expect(() => {
-            shallow(<BrowserPreview />);
-        }).not.toThrow();
+    it('renders the specified header description as tooltip title', async () => {
+        const headerDescription = '🥰';
+        render(<BrowserPreview headerDescription={headerDescription} />);
+        userEvent.hover(
+            screen.getByRole('img', {
+                name: /info icon/i,
+            })
+        );
+
+        expect(await screen.findByText(headerDescription)).toBeVisible();
     });
 
-    it('renders the specified header description as tooltip title', () => {
-        const headerDescription = '🥰';
-        const component = mount(<BrowserPreview headerDescription={headerDescription} />);
+    it('renders the specific title when provided', () => {
+        const headerTitle = 'La CacouSoudane';
+        render(<BrowserPreview title={headerTitle} />);
 
-        expect(component.find(Tooltip).prop('title')).toEqual(headerDescription);
+        expect(screen.getByText(/la cacousoudane/i)).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/ADUI-7141

Added a prop to the BrowserPreview component so it can receive a Title instead of using a hardcoded value.

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
