### PR TITLE
feat(textinput): add new TextInput component

### DIFF
--- a/packages/demo/src/components/examples/TextInputExamples.tsx
+++ b/packages/demo/src/components/examples/TextInputExamples.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import {InputValidator, Section, TextInput, FormProvider, useTextInput, Button} from 'react-vapor';
+
+const nonEmptyValidation: InputValidator = (value: string) => {
+    const isEmpty = !value;
+    const isWhiteSpace = !isEmpty && !value.trim();
+    if (isWhiteSpace) {
+        return {status: 'warning', message: 'A white space is not empty, but is not ideal.'};
+    } else if (isEmpty) {
+        return {status: 'invalid', message: 'Cannot be empty.'};
+    } else {
+        return {status: 'valid'};
+    }
+};
+
+export const TextInputExamples: React.FunctionComponent = () => (
+    <FormProvider>
+        <Section>
+            <TextInput
+                required
+                showValidationOnBlur
+                validate={nonEmptyValidation}
+                type="text"
+                label="Label"
+                title="Title"
+                description="Description"
+                helpText="Help text"
+                tooltip="Tooltip"
+            />
+            <Section level={2} title="Disabled">
+                <TextInput type="email" label="Email" disabled />
+                <TextInput type="email" label="Email" defaultValue="123@abc.com" disabled />
+            </Section>
+            <Section level={2} title="useTextInput hook usage demo">
+                <div className="flex space-around">
+                    <TextInput
+                        id="favorite-dish"
+                        type="text"
+                        label="Favorite Dish"
+                        defaultValue="pizza"
+                        validate={(value) =>
+                            /pizza/i.test(value)
+                                ? {status: 'valid'}
+                                : {status: 'warning', message: "Pizza is best but that's okay."}
+                        }
+                        showValidationOnBlur
+                    />
+                    <TextInput
+                        id="favorite-animal"
+                        type="text"
+                        label="Favorite Animal"
+                        defaultValue="Tiger"
+                        required
+                        validate={nonEmptyValidation}
+                        showValidationOnBlur
+                    />
+                </div>
+                <HookUsageDemo />
+            </Section>
+        </Section>
+    </FormProvider>
+);
+
+const HookUsageDemo: React.FunctionComponent = () => {
+    const favoriteDishInput = useTextInput('favorite-dish');
+    const favoriteAnimalInput = useTextInput('favorite-animal');
+
+    return (
+        <>
+            <div className="flex space-around">
+                <p style={{whiteSpace: 'pre-wrap'}}>state = {JSON.stringify(favoriteDishInput.state, null, 4)}</p>
+                <p style={{whiteSpace: 'pre-wrap'}}>state = {JSON.stringify(favoriteAnimalInput.state, null, 4)}</p>
+            </div>
+            <p>
+                The hook gives you full access to the state of the input that has the specified id. As you can see, they
+                are both independent, one doesn't influence the state of the other. The hook also exposes dispatch,
+                which allows to interract with TextInput however we need.
+            </p>
+            <Button
+                name='Change dish for "sushis"'
+                enabled={favoriteDishInput.state.value !== 'sushis'}
+                onClick={() => favoriteDishInput.dispatch({type: 'change-value', payload: 'sushis'})}
+            />
+            <Button
+                name="Show validation"
+                onClick={() => {
+                    favoriteDishInput.dispatch({type: 'show-validation'});
+                    favoriteAnimalInput.dispatch({type: 'show-validation'});
+                }}
+            />
+            <Button
+                name="Hide validation"
+                onClick={() => {
+                    favoriteDishInput.dispatch({type: 'hide-validation'});
+                    favoriteAnimalInput.dispatch({type: 'hide-validation'});
+                }}
+            />
+        </>
+    );
+};

--- a/packages/react-vapor/src/components/form/FormProvider.tsx
+++ b/packages/react-vapor/src/components/form/FormProvider.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+
+import {textInputReducer} from '../textInput/TextInputReducer';
+
+/**
+ * Extrapolates a reducer that manages a state of type `T` into a reducer that manages a state of type `Record<string, T>`.
+ *
+ * Usefull if you want many independent states of the same component and index those states by id.
+ */
+const generateRecordReducer = <S, A>(
+    reducer: React.Reducer<S, A>
+): React.Reducer<Record<string, S>, {id: string; action: A}> => (state = {}, {id, action}) => ({
+    ...state,
+    [id]: reducer(state[id], action),
+});
+
+const componentReducers = {
+    TextInput: generateRecordReducer(textInputReducer),
+};
+
+type FormComponent = keyof typeof componentReducers;
+type FormComponentReducer = typeof componentReducers[FormComponent];
+type FormAction = {type: FormComponent} & React.ReducerAction<FormComponentReducer>;
+type FormState = Record<FormComponent, React.ReducerState<FormComponentReducer>>;
+
+const formInitialState: FormState = {
+    TextInput: {},
+};
+
+const formReducer = (state: FormState, {type, ...action}: FormAction) => ({
+    ...state,
+    [type]: componentReducers[type](state[type], action),
+});
+
+export const FormContext = React.createContext<{state: FormState; dispatch: React.Dispatch<FormAction>}>(undefined);
+
+export const FormProvider: React.FunctionComponent = ({children}) => {
+    const [state, dispatch] = React.useReducer(formReducer, formInitialState);
+    const store = React.useMemo(() => ({state, dispatch}), [state]);
+
+    return <FormContext.Provider value={store}>{children}</FormContext.Provider>;
+};

--- a/packages/react-vapor/src/components/form/index.ts
+++ b/packages/react-vapor/src/components/form/index.ts
@@ -1,2 +1,3 @@
 export * from './Form';
 export * from './FormGroup';
+export {FormProvider} from '../form/FormProvider';

--- a/packages/react-vapor/src/components/index.ts
+++ b/packages/react-vapor/src/components/index.ts
@@ -75,6 +75,7 @@ export * from './tab';
 export * from './table-hoc';
 export * from './tables';
 export * from './textarea';
+export * from './textInput';
 export * from './title';
 export * from './toast';
 export * from './tooltip';

--- a/packages/react-vapor/src/components/textInput/TextInput.tsx
+++ b/packages/react-vapor/src/components/textInput/TextInput.tsx
@@ -1,0 +1,170 @@
+import classNames from 'classnames';
+import * as React from 'react';
+import {omit, uniqueId} from 'underscore';
+
+import {TooltipPlacement} from '../../utils';
+import {InfoToken, InfoTokenMode, InfoTokenSize, InfoTokenType} from '../info-token';
+import {Tooltip} from '../tooltip';
+import {useTextInput} from './useTextInput';
+
+export type InputValidator = (value: string) => {status: 'valid' | 'invalid' | 'warning'; message?: string};
+
+interface TextInputProps {
+    type: 'email' | 'search' | 'text' | 'url' | 'password';
+    label: string;
+    description?: string;
+    helpText?: string;
+    tooltip?: string;
+    validate?: InputValidator;
+    showValidationOnMount?: boolean;
+    showValidationOnChange?: boolean;
+    showValidationOnBlur?: boolean;
+}
+
+export const TextInput: React.FunctionComponent<TextInputProps & React.HTMLProps<HTMLInputElement>> = ({
+    id: propsId,
+    label,
+    validate,
+    showValidationOnMount,
+    showValidationOnChange,
+    showValidationOnBlur,
+    onChange,
+    onBlur,
+    className,
+    defaultValue,
+    description,
+    helpText,
+    tooltip,
+    ...inputProps
+}) => {
+    const id = React.useMemo(() => propsId || uniqueId(), [propsId]);
+    const {state, dispatch} = useTextInput(id);
+    const inputElement = React.useRef<HTMLInputElement>();
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+        dispatch({type: 'change-value', payload: event.target.value});
+        if (showValidationOnChange) {
+            dispatch({type: 'show-validation'});
+        } else {
+            dispatch({type: 'hide-validation'});
+        }
+        onChange?.(event);
+    };
+
+    const handleOnBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+        if (showValidationOnBlur) {
+            dispatch({type: 'show-validation'});
+        }
+        onBlur?.(event);
+    };
+
+    React.useEffect(() => {
+        const {status, message} = validate?.(state.value) ?? {status: 'valid', message: ''};
+        dispatch({type: 'set-message', payload: message || ''});
+
+        switch (status) {
+            case 'valid':
+                dispatch({type: 'set-valid'});
+                break;
+            case 'invalid':
+                dispatch({type: 'set-invalid'});
+                break;
+            case 'warning':
+                dispatch({type: 'set-warning'});
+                break;
+            default:
+                throw new Error(`Unknown input validation status: ${status}.`);
+        }
+
+        if (state.value === defaultValue) {
+            dispatch({type: 'set-pristine'});
+        } else {
+            dispatch({type: 'set-dirty'});
+        }
+    }, [state.value]);
+
+    React.useEffect(() => {
+        if (defaultValue) {
+            dispatch({type: 'change-value', payload: defaultValue as string});
+        }
+        if (showValidationOnMount) {
+            dispatch({type: 'show-validation'});
+        }
+    }, []);
+
+    return (
+        <div
+            className={classNames(
+                'text-input mb2',
+                {
+                    disabled: inputProps.disabled,
+                    empty: !state.value,
+                    [state.status]: state.visibleStatus,
+                },
+                className
+            )}
+        >
+            {inputProps.title && <h6>{inputProps.title}</h6>}
+            {description && <p className="text-input-description mb2">{description}</p>}
+            <div className="flex flex-center">
+                <div
+                    className="text-input-box flex flex-column justify-center"
+                    onClick={() => inputElement.current.focus()}
+                >
+                    <label htmlFor={id}>{inputProps.required ? label : `${label} (Optional)`}</label>
+                    <input
+                        {...omit(inputProps, 'value')}
+                        id={id}
+                        onChange={handleChange}
+                        onBlur={handleOnBlur}
+                        value={state.value}
+                        className="flex-auto"
+                        ref={inputElement}
+                        aria-invalid={state.status === 'invalid'}
+                    />
+                </div>
+                <HelpTooltip message={tooltip} />
+            </div>
+            {helpText && <div className="mt1 ml2 text-input-help-text">{helpText}</div>}
+            <ValidationMessage inputId={id} />
+        </div>
+    );
+};
+
+const HelpTooltip: React.FunctionComponent<{message: string}> = ({message}) => {
+    if (!message) {
+        return null;
+    }
+
+    return (
+        <Tooltip placement={TooltipPlacement.Right} title={message}>
+            <InfoToken
+                mode={InfoTokenMode.Stroked}
+                type={InfoTokenType.Question}
+                size={InfoTokenSize.Medium}
+                className="ml1"
+            />
+        </Tooltip>
+    );
+};
+
+const statusIconMapping: Record<string, InfoTokenType> = {
+    valid: InfoTokenType.Success,
+    invalid: InfoTokenType.Critical,
+    warning: InfoTokenType.Warning,
+};
+
+const ValidationMessage: React.FunctionComponent<{inputId: string}> = ({inputId}) => {
+    const {state} = useTextInput(inputId);
+
+    if (!state.visibleStatus || !state.message || state.status === 'indeterminate') {
+        return null;
+    }
+
+    return (
+        <div className="mt1 ml2 inline-flex flex-center">
+            <InfoToken mode={InfoTokenMode.Stroked} size={InfoTokenSize.Small} type={statusIconMapping[state.status]} />
+            <span className="text-input-message">{state.message}</span>
+        </div>
+    );
+};

--- a/packages/react-vapor/src/components/textInput/TextInputReducer.tsx
+++ b/packages/react-vapor/src/components/textInput/TextInputReducer.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+
+export type TextInputAction =
+    | {type: 'change-value'; payload: string}
+    | {type: 'show-validation'}
+    | {type: 'hide-validation'}
+    | {type: 'set-valid'}
+    | {type: 'set-invalid'}
+    | {type: 'set-warning'}
+    | {type: 'set-message'; payload: string}
+    | {type: 'set-dirty'}
+    | {type: 'set-pristine'};
+
+export type TextInputState = {
+    value: string;
+    status: 'valid' | 'invalid' | 'warning' | 'indeterminate';
+    message: string;
+    visibleStatus: boolean;
+    isDirty: boolean;
+};
+
+export const textInputDefaultState: TextInputState = {
+    value: '',
+    status: 'indeterminate',
+    message: '',
+    visibleStatus: false,
+    isDirty: false,
+};
+
+export const textInputReducer: React.Reducer<TextInputState, TextInputAction> = (
+    state = textInputDefaultState,
+    action
+) => {
+    switch (action.type) {
+        case 'change-value':
+            return action.payload === state.value ? state : {...state, value: action.payload};
+        case 'show-validation':
+            return {...state, visibleStatus: true};
+        case 'hide-validation':
+            return {...state, visibleStatus: false};
+        case 'set-valid':
+            return {...state, status: 'valid'};
+        case 'set-invalid':
+            return {...state, status: 'invalid'};
+        case 'set-warning':
+            return {...state, status: 'warning'};
+        case 'set-message':
+            return action.payload === state.message ? state : {...state, message: action.payload};
+        case 'set-dirty':
+            return {...state, isDirty: true};
+        case 'set-pristine':
+            return {...state, isDirty: false};
+        default:
+            throw new Error(`Unhandled action type: ${(action as {type: 'string'}).type}.`);
+    }
+};

--- a/packages/react-vapor/src/components/textInput/index.ts
+++ b/packages/react-vapor/src/components/textInput/index.ts
@@ -1,0 +1,2 @@
+export * from './TextInput';
+export * from './useTextInput';

--- a/packages/react-vapor/src/components/textInput/tests/TextInput.spec.tsx
+++ b/packages/react-vapor/src/components/textInput/tests/TextInput.spec.tsx
@@ -1,0 +1,200 @@
+import * as React from 'react';
+import {render, expectToThrow, screen, fireEvent} from '@test-utils';
+import userEvent from '@testing-library/user-event';
+import {TextInput, InputValidator} from '../TextInput';
+import {FormProvider} from '../../form/FormProvider';
+
+describe('TextInput', () => {
+    it('throws an error if the rendering a TextInput outside a FormProvider', () => {
+        expectToThrow(() => {
+            render(<TextInput type="text" label="Label" />);
+        }, 'useTextInput must be used within a FormProvider.');
+    });
+
+    it('renders an input with the specified defaultValue', () => {
+        render(
+            <FormProvider>
+                <TextInput type="text" label="Label" defaultValue="🌶" />
+            </FormProvider>
+        );
+
+        const textInput = screen.getByRole('textbox', {name: /label/i});
+        expect(textInput).toBeInTheDocument();
+        expect(textInput).toHaveValue('🌶');
+    });
+
+    it('renders a title above the input when specified', () => {
+        render(
+            <FormProvider>
+                <TextInput type="text" label="Label" title="🍌" />
+            </FormProvider>
+        );
+
+        expect(screen.getByRole('heading', {name: '🍌'})).toBeInTheDocument();
+    });
+
+    it('renders a description above the input when specified', () => {
+        render(
+            <FormProvider>
+                <TextInput type="text" label="Label" description="🍌" />
+            </FormProvider>
+        );
+
+        expect(screen.getByText('🍌')).toBeInTheDocument();
+    });
+
+    it('renders the specified help text under the input when specified', () => {
+        render(
+            <FormProvider>
+                <TextInput type="text" label="Label" helpText="🍌" />
+            </FormProvider>
+        );
+
+        expect(screen.getByText('🍌')).toBeInTheDocument();
+    });
+
+    it('renders a question mark icon with a tooltip when tooltip is specified', async () => {
+        render(
+            <FormProvider>
+                <TextInput type="text" label="Label" tooltip="🍌" />
+            </FormProvider>
+        );
+
+        const icon = screen.getByRole('img', {name: /questionstrokedmedium icon/i});
+        userEvent.hover(icon);
+
+        expect(await screen.findByText('🍌')).toBeInTheDocument();
+    });
+
+    it('disables the input when disabled prop is true', () => {
+        render(
+            <FormProvider>
+                <TextInput type="text" label="Label" disabled />
+            </FormProvider>
+        );
+
+        expect(screen.getByRole('textbox', {name: /label/i})).toBeDisabled();
+    });
+
+    it('validates the input on blur when showValidationOnBlur prop is true', () => {
+        const validator: InputValidator = (val) => {
+            if (val === '✅') {
+                return {status: 'valid', message: 'valid!'};
+            } else if (val === '⚠️') {
+                return {status: 'warning', message: 'warning!'};
+            } else {
+                return {status: 'invalid', message: 'invalid!'};
+            }
+        };
+
+        render(
+            <FormProvider>
+                <TextInput type="text" label="💬" required validate={validator} showValidationOnBlur />
+            </FormProvider>
+        );
+
+        const textinput = screen.getByRole('textbox', {name: '💬'});
+        userEvent.type(textinput, '✅');
+
+        expect(textinput).toBeValid();
+        expect(screen.queryByText('valid!')).not.toBeInTheDocument();
+        expect(screen.queryByRole('img', {name: 'checkStrokedSmall icon'})).not.toBeInTheDocument();
+
+        fireEvent.blur(textinput);
+
+        expect(screen.getByText('valid!')).toBeInTheDocument();
+        expect(screen.getByRole('img', {name: 'checkStrokedSmall icon'})).toBeInTheDocument();
+
+        userEvent.clear(textinput);
+
+        expect(textinput).toBeInvalid();
+        expect(screen.queryByText('valid!')).not.toBeInTheDocument();
+        expect(screen.queryByRole('img', {name: 'checkStrokedSmall icon'})).not.toBeInTheDocument();
+
+        userEvent.type(textinput, '⚠️');
+        expect(textinput).toBeValid();
+        fireEvent.blur(textinput);
+
+        expect(screen.getByText('warning!')).toBeInTheDocument();
+        expect(screen.getByRole('img', {name: 'warningStrokedSmall icon'})).toBeInTheDocument();
+
+        userEvent.clear(textinput);
+        expect(textinput).toBeInvalid();
+        userEvent.type(textinput, '❌');
+        expect(textinput).toBeInvalid();
+        fireEvent.blur(textinput);
+
+        expect(screen.getByText('invalid!')).toBeInTheDocument();
+        expect(screen.getByRole('img', {name: 'criticalStrokedSmall icon'})).toBeInTheDocument();
+    });
+
+    it('validates the input on mount when showValidationOnMount prop is true', () => {
+        const validator: InputValidator = (val) => (val ? {status: 'valid'} : {status: 'invalid', message: 'invalid!'});
+
+        render(
+            <FormProvider>
+                <TextInput type="text" label="💬" required validate={validator} showValidationOnMount />
+            </FormProvider>
+        );
+
+        expect(screen.getByRole('textbox', {name: '💬'})).toBeInvalid();
+        expect(screen.getByText('invalid!')).toBeInTheDocument();
+        expect(screen.getByRole('img', {name: 'criticalStrokedSmall icon'})).toBeInTheDocument();
+    });
+
+    it('validates the input on change when showValidationOnChange prop is true', () => {
+        const validator: InputValidator = (val) =>
+            val ? {status: 'valid', message: 'valid!'} : {status: 'invalid', message: 'invalid!'};
+
+        render(
+            <FormProvider>
+                <TextInput type="text" label="💬" required validate={validator} showValidationOnChange />
+            </FormProvider>
+        );
+
+        const textinput = screen.getByRole('textbox', {name: '💬'});
+
+        expect(screen.queryByText('invalid!')).not.toBeInTheDocument();
+        expect(screen.queryByRole('img', {name: 'criticalStrokedSmall icon'})).not.toBeInTheDocument();
+
+        userEvent.type(textinput, '✅');
+
+        expect(textinput).toBeValid();
+        expect(screen.getByText('valid!')).toBeInTheDocument();
+        expect(screen.getByRole('img', {name: 'checkStrokedSmall icon'})).toBeInTheDocument();
+
+        userEvent.clear(textinput);
+
+        expect(textinput).toBeInvalid();
+        expect(screen.getByText('invalid!')).toBeInTheDocument();
+        expect(screen.getByRole('img', {name: 'criticalStrokedSmall icon'})).toBeInTheDocument();
+    });
+
+    it('is independant from the other inputs in the same provider', () => {
+        const validator: InputValidator = (val) => (val ? {status: 'valid'} : {status: 'invalid'});
+
+        render(
+            <FormProvider>
+                <TextInput type="text" label="first name" required validate={validator} />
+                <TextInput type="text" label="last name" required validate={validator} />
+            </FormProvider>
+        );
+
+        const firstNameInput = screen.getByRole('textbox', {name: 'first name'});
+        const lastNameInput = screen.getByRole('textbox', {name: 'last name'});
+
+        userEvent.type(firstNameInput, 'John');
+
+        expect(firstNameInput).toHaveValue('John');
+        expect(firstNameInput).toBeValid();
+        expect(lastNameInput).toHaveValue('');
+        expect(lastNameInput).toBeInvalid();
+
+        userEvent.type(lastNameInput, 'Doe');
+
+        expect(firstNameInput).toHaveValue('John');
+        expect(firstNameInput).toBeValid();
+        expect(lastNameInput).toHaveValue('Doe');
+        expect(lastNameInput).toBeValid();
+    });
+});

--- a/packages/react-vapor/src/components/textInput/useTextInput.ts
+++ b/packages/react-vapor/src/components/textInput/useTextInput.ts
@@ -1,0 +1,13 @@
+import {useContext, Dispatch, useMemo} from 'react';
+import {TextInputAction, TextInputState, textInputDefaultState} from './TextInputReducer';
+import {FormContext} from '../form/FormProvider';
+
+export const useTextInput = (id: string): {state: TextInputState; dispatch: Dispatch<TextInputAction>} => {
+    const formContext = useContext(FormContext);
+    if (formContext === undefined) {
+        throw new Error('useTextInput must be used within a FormProvider.');
+    }
+    const state = formContext.state['TextInput'][id] || textInputDefaultState;
+    const dispatch = (action: TextInputAction) => formContext.dispatch({type: 'TextInput', id, action});
+    return useMemo(() => ({state, dispatch}), [state]);
+};

--- a/packages/vapor/scss/controls/text-input.scss
+++ b/packages/vapor/scss/controls/text-input.scss
@@ -1,0 +1,147 @@
+%body-s {
+    // replace with .book-s once typekit is ready
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 16px;
+    letter-spacing: 0.003em;
+}
+
+%body-m {
+    // replace with .book-m once typekit is ready
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 20px;
+    letter-spacing: 0.003em;
+}
+
+%body-l {
+    // replace with .book-l once typekit is ready
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 24px;
+    letter-spacing: 0.003em;
+}
+
+%h6 {
+    // replace with .book-l once typekit is ready
+    font-size: 16px;
+    line-height: 24px;
+    letter-spacing: 0.011em;
+}
+
+.text-input {
+    --status-color: transparent;
+    --status-text-color: var(--grey-80);
+    --stroke: var(--status-color);
+    --input-text-color: var(--grey-100);
+    --label-text-color: var(--grey-80);
+    --border-color: var(--default-border-color);
+    --background-color: var(--white);
+    --transition: all 0.2s ease;
+
+    .text-input-box {
+        position: relative;
+        width: 310px;
+        height: 48px;
+        padding: 6px 16px 9px 16px;
+        overflow: hidden;
+        background-color: var(--background-color);
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        cursor: text;
+        transition: var(--transition);
+
+        &:hover {
+            --border-color: var(--grey-50);
+        }
+
+        &:focus-within {
+            --border-color: var(--digital-blue-40);
+            box-shadow: 0px 0px 0px 4px #c7e4ff;
+        }
+
+        &::before {
+            position: absolute;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            height: 2px;
+            background-color: var(--status-color);
+            content: '';
+        }
+    }
+
+    h6 {
+        @extend %h6;
+        color: var(--grey-100);
+        font-weight: 500;
+    }
+
+    input {
+        @extend %body-m;
+        padding: 0;
+        color: var(--input-text-color);
+        background-color: var(--background-color);
+        border: none;
+
+        &:focus {
+            outline: none;
+        }
+    }
+
+    label {
+        @extend %body-s;
+        color: var(--label-text-color);
+        cursor: text;
+    }
+
+    .text-input-description {
+        @extend %body-m;
+        color: var(--grey-80);
+        font-weight: 400;
+    }
+
+    .text-input-message {
+        @extend %body-s;
+        margin-left: 4px;
+        color: var(--status-text-color);
+    }
+
+    .text-input-help-text {
+        // replace with .body-s-book-subdued
+        @extend %body-s;
+        color: var(--grey-80);
+    }
+
+    &.invalid {
+        --status-color: var(--critical-70);
+        --status-text-color: var(--critical-100);
+    }
+
+    &.valid {
+        --status-color: var(--success-60);
+        --status-text-color: var(--success-100);
+    }
+
+    &.warning {
+        --status-color: var(--warning-70);
+        --status-text-color: var(--warning-90);
+    }
+
+    &.disabled .text-input-box {
+        --background-color: var(--grey-20);
+        --label-text-color: var(--grey-60);
+        --input-text-color: var(--grey-60);
+        pointer-events: none;
+    }
+
+    &.empty:not(:focus-within) {
+        label {
+            @extend %body-m;
+        }
+
+        input {
+            max-height: 0;
+        }
+    }
+}

--- a/packages/vapor/scss/guide.scss
+++ b/packages/vapor/scss/guide.scss
@@ -152,4 +152,5 @@
     @import 'utility/cursor';
     @import 'utility/pointers';
     @import 'utility/transparency';
+    @import 'controls/text-input';
 }


### PR DESCRIPTION
### Proposed Changes

Add a new version of the input component called `TextInput`. 

As you will see, I have tried a new state management pattern that is **free of redux**. The advantage of doing that is that we get rid of unnecessary global redux state updates each time the value of an input changes.

3 things (other than types) related to the `TextInput` are exported:
- `TextInput`: the component. Can only be rendered inside a `FormProvider`
- `FormProvider`: provides the form state. We can have as many of those as we need. Best practice is to have it as low as possible in the DOM tree => less children equals less potential unnecessary rerenders.
- `useTextInput` hook: the only way to query and interact with the text input state. Can only be used within a `FormProvider`.

### Potential Breaking Changes

None, the old input component was preserved so we can phase it out progressively.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
