### PR TITLE
refactor(browserpreview): +seperate title from preview string

### DIFF
--- a/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
+++ b/packages/demo/src/components/examples/BrowserPreviewExamples.tsx
@@ -18,7 +18,7 @@ export const BrowserPreviewExamples: React.FunctionComponent = () => (
                 leftChildren={<div />}
                 rightChildren={
                     <div className="p3">
-                        <BrowserPreview title={'Custom title!'} />
+                        <BrowserPreview title={'Custom title! Custom title!'} />
                     </div>
                 }
             />

--- a/packages/react-vapor/src/components/browserPreview/BrowserPreview.tsx
+++ b/packages/react-vapor/src/components/browserPreview/BrowserPreview.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as s from 'underscore.string';
 
 import {TooltipPlacement} from '../../utils';
 import {Svg} from '../svg';
@@ -11,10 +12,7 @@ export interface BrowserPreviewProps {
 
 export const BrowserPreview: React.FunctionComponent<BrowserPreviewProps> = ({children, headerDescription, title}) => (
     <div className="browser-preview flex flex-column">
-        <BrowserPreviewHeader
-            tooltipTitle={headerDescription ?? DefaultHeaderDescription}
-            title={title ?? DefaultHeaderTitle}
-        />
+        <BrowserPreviewHeader tooltipTitle={headerDescription ?? DefaultHeaderDescription} title={title ?? ''} />
         <div className="browser-preview__content flex flex-column flex-auto px4 py3">{children}</div>
     </div>
 );
@@ -25,10 +23,13 @@ const BrowserPreviewHeader: React.FunctionComponent<{tooltipTitle: string; title
 }) => (
     <div className="browser-preview__header flex space-between px2 py1">
         <div>
-            <span className="bolder">{title}</span>
+            <span className="bolder">Preview</span>
             <Tooltip title={tooltipTitle} placement={TooltipPlacement.Right}>
                 <Svg svgName="info" svgClass="icon mod-14 ml1" />
             </Tooltip>
+        </div>
+        <div>
+            <span className="bolder">{s.truncate(title, TitleMaxLength)}</span>
         </div>
         <div>
             <span className="white-dot" />
@@ -40,4 +41,4 @@ const BrowserPreviewHeader: React.FunctionComponent<{tooltipTitle: string; title
 
 const DefaultHeaderDescription =
     'The final look in your search page may differ due to the customization you made in your page.';
-const DefaultHeaderTitle = 'Preview';
+const TitleMaxLength = 20;

--- a/packages/react-vapor/src/components/browserPreview/tests/BrowserPreview.spec.tsx
+++ b/packages/react-vapor/src/components/browserPreview/tests/BrowserPreview.spec.tsx
@@ -23,4 +23,11 @@ describe('BrowserPreview', () => {
 
         expect(screen.getByText(/la cacousoudane/i)).toBeInTheDocument();
     });
+
+    it('renders the specific title truncated when provided, but too long', () => {
+        const headerTitle = 'La CacouSoudane FAFOU LOUDANE';
+        render(<BrowserPreview title={headerTitle} />);
+
+        expect(screen.getByText(/la cacousoudane fafo\.\.\./i)).toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
### Proposed Changes

We want to keep the preview string informative and still be able to put a custom title, so I change
the title prop to be rendered in a seperate element instead of replacing Preview string

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
