### PR TITLE
feat(top-bar): create icon badge component

### DIFF
--- a/packages/demo/src/components/examples/IconBadgeExamples.tsx
+++ b/packages/demo/src/components/examples/IconBadgeExamples.tsx
@@ -4,6 +4,27 @@ import {IconBadge, IconBadgeType, Section} from 'react-vapor';
 
 export const IconBadgeExamples: React.FunctionComponent = () => (
     <Section>
+        <Section level={2} title="IconBadge without the navigation style">
+            <IconBadge
+                svgName={svg.bellStrokedMedium.name}
+                type={IconBadgeType.New}
+                svgClass="mod-stroke"
+                className="mr1"
+            />
+            <IconBadge
+                svgName={svg.bellStrokedMedium.name}
+                type={IconBadgeType.Information}
+                svgClass="mod-stroke"
+                className="mr1"
+            />
+            <IconBadge
+                svgName={svg.bellStrokedMedium.name}
+                type={IconBadgeType.Warning}
+                svgClass="mod-stroke"
+                className="mr1"
+            />
+            <IconBadge svgName={svg.bellStrokedMedium.name} type={IconBadgeType.Major} svgClass="mod-stroke" />
+        </Section>
         <Section level={2} title="IconBadge on the top bar with different status">
             <div className="header" style={{background: 'var(--grape-purple-70)'}}>
                 <div className="header-section mod-icon flex center-align">

--- a/packages/demo/src/components/examples/IconBadgeExamples.tsx
+++ b/packages/demo/src/components/examples/IconBadgeExamples.tsx
@@ -1,0 +1,40 @@
+import {svg} from 'coveo-styleguide';
+import * as React from 'react';
+import {IconBadge, IconBadgeType, Section} from 'react-vapor';
+
+export const IconBadgeExamples: React.FunctionComponent = () => (
+    <Section>
+        <Section level={2} title="IconBadge on the top bar with different status">
+            <div className="header" style={{background: 'var(--grape-purple-70)'}}>
+                <div className="header-section mod-icon flex center-align">
+                    <IconBadge
+                        svgName={svg.bellStrokedMedium.name}
+                        type={IconBadgeType.New}
+                        className="mod-navigation"
+                    />
+                </div>
+                <div className="header-section mod-icon flex center-align">
+                    <IconBadge
+                        svgName={svg.bellStrokedMedium.name}
+                        type={IconBadgeType.Information}
+                        className="mod-navigation"
+                    />
+                </div>
+                <div className="header-section mod-icon flex center-align">
+                    <IconBadge
+                        svgName={svg.bellStrokedMedium.name}
+                        type={IconBadgeType.Warning}
+                        className="mod-navigation"
+                    />
+                </div>
+                <div className="header-section mod-icon flex center-align">
+                    <IconBadge
+                        svgName={svg.bellStrokedMedium.name}
+                        type={IconBadgeType.Major}
+                        className="mod-navigation"
+                    />
+                </div>
+            </div>
+        </Section>
+    </Section>
+);

--- a/packages/react-vapor/src/components/iconBadge/IconBadge.tsx
+++ b/packages/react-vapor/src/components/iconBadge/IconBadge.tsx
@@ -1,0 +1,48 @@
+import classNames from 'classnames';
+import * as React from 'react';
+
+import {Svg} from '../svg';
+
+export enum IconBadgeSize {
+    Medium,
+}
+
+export enum IconBadgeType {
+    New,
+    Information,
+    Warning,
+    Major,
+}
+
+export interface IconBadgeProps {
+    svgName: string;
+    type: IconBadgeType;
+    size?: IconBadgeSize;
+    svgClass?: string;
+    className?: string;
+}
+
+const SizeClassMapping: Record<IconBadgeSize, string> = {
+    [IconBadgeSize.Medium]: 'mod-24',
+};
+
+const TypeColorMapping: Record<IconBadgeType, string> = {
+    [IconBadgeType.New]: 'mod-new',
+    [IconBadgeType.Information]: 'mod-info',
+    [IconBadgeType.Warning]: 'mod-warning',
+    [IconBadgeType.Major]: 'mod-major',
+};
+
+export const IconBadge: React.FunctionComponent<IconBadgeProps> = ({
+    svgName,
+    type,
+    size = IconBadgeSize.Medium,
+    svgClass,
+    className,
+}) => (
+    <Svg
+        className={classNames('icon-badge', SizeClassMapping[size], TypeColorMapping[type], className)}
+        svgName={svgName}
+        svgClass={classNames('icon align-middle', SizeClassMapping[size], svgClass)}
+    />
+);

--- a/packages/react-vapor/src/components/iconBadge/index.ts
+++ b/packages/react-vapor/src/components/iconBadge/index.ts
@@ -1,0 +1,1 @@
+export * from './IconBadge';

--- a/packages/react-vapor/src/components/iconBadge/tests/IconBadge.spec.tsx
+++ b/packages/react-vapor/src/components/iconBadge/tests/IconBadge.spec.tsx
@@ -1,0 +1,40 @@
+import {render, screen} from '@test-utils';
+import {svg} from 'coveo-styleguide';
+import * as React from 'react';
+
+import {IconBadge, IconBadgeType} from '../IconBadge';
+
+describe('IconBadge', () => {
+    it('renders the specified icon with the type New, and size Medium by default', () => {
+        render(<IconBadge svgName={svg.bellStrokedMedium.name} type={IconBadgeType.New} />);
+
+        const iconBadge = screen.getByRole('img', {name: 'bellStrokedMedium icon'}).parentElement;
+        expect(iconBadge).toBeInTheDocument();
+        expect(iconBadge).toHaveClass('mod-24');
+        expect(iconBadge).toHaveClass('mod-new');
+    });
+
+    it('renders the specified icon with the type Information', () => {
+        render(<IconBadge svgName={svg.bellStrokedMedium.name} type={IconBadgeType.Information} />);
+
+        const iconBadge = screen.getByRole('img', {name: 'bellStrokedMedium icon'}).parentElement;
+        expect(iconBadge).toBeInTheDocument();
+        expect(iconBadge).toHaveClass('mod-info');
+    });
+
+    it('renders the specified icon with the type Warning', () => {
+        render(<IconBadge svgName={svg.bellStrokedMedium.name} type={IconBadgeType.Warning} />);
+
+        const iconBadge = screen.getByRole('img', {name: 'bellStrokedMedium icon'}).parentElement;
+        expect(iconBadge).toBeInTheDocument();
+        expect(iconBadge).toHaveClass('mod-warning');
+    });
+
+    it('renders the specified icon with the type Major', () => {
+        render(<IconBadge svgName={svg.bellStrokedMedium.name} type={IconBadgeType.Major} />);
+
+        const iconBadge = screen.getByRole('img', {name: 'bellStrokedMedium icon'}).parentElement;
+        expect(iconBadge).toBeInTheDocument();
+        expect(iconBadge).toHaveClass('mod-major');
+    });
+});

--- a/packages/react-vapor/src/components/index.ts
+++ b/packages/react-vapor/src/components/index.ts
@@ -30,6 +30,7 @@ export * from './filterBox';
 export * from './flatSelect';
 export * from './flippable';
 export * from './form';
+export * from './iconBadge';
 export * from './iconCard';
 export * from './headers';
 export * from './info-token';

--- a/packages/vapor/scss/components/header.scss
+++ b/packages/vapor/scss/components/header.scss
@@ -17,6 +17,12 @@
 
     &.mod-icon {
         width: $header-height;
+        cursor: pointer;
+
+        &:hover,
+        &.open {
+            background-color: var(--navy-blue-100);
+        }
     }
 }
 

--- a/packages/vapor/scss/components/icon-badge.scss
+++ b/packages/vapor/scss/components/icon-badge.scss
@@ -1,0 +1,52 @@
+.icon-badge {
+    position: relative;
+    display: inline-block;
+    --fill: var(--grey-80);
+    --stroke: var(--grey-80);
+
+    &:after {
+        position: absolute;
+        border-radius: 50%;
+        content: '';
+    }
+
+    &.mod-24:after {
+        top: 4px;
+        right: 2px;
+        width: 8px;
+        height: 8px;
+    }
+
+    &.mod-navigation {
+        svg.icon {
+            fill: none;
+            stroke: var(--white);
+        }
+
+        &:after {
+            width: 10px;
+            height: 10px;
+            border: 2px solid var(--grape-purple-70);
+        }
+    }
+
+    &.mod-new:after {
+        background-color: var(--bright-turquoise-30);
+    }
+    &.mod-info:after {
+        background-color: var(--navy-blue-20);
+    }
+    &.mod-warning:after {
+        background-color: var(--turbo-yellow-50);
+    }
+    &.mod-major:after {
+        background-color: var(--critical-70);
+    }
+}
+
+.header-section.mod-icon.open,
+.header-section.mod-icon:hover {
+    .icon-badge.mod-navigation:after {
+        border: 2px solid var(--navy-blue-100);
+    }
+}

--- a/packages/vapor/scss/guide.scss
+++ b/packages/vapor/scss/guide.scss
@@ -115,6 +115,7 @@
     @import 'components/badge';
     @import 'components/corner-ribbon';
     @import 'components/code-editor.scss';
+    @import 'components/icon-badge';
     @import 'components/icon-card';
     @import 'components/flippable';
     @import 'components/material-card';


### PR DESCRIPTION
### Proposed Changes

We will need the IconBadge component for the Notification header section on the Top Bar `.mod-navigation`. More modes will be added later for other sections of the platform.

Mockup: https://www.figma.com/proto/J32OAeoVopRQxvXP1zlojf/Top-bar-simplification?node-id=293%3A299&scaling=min-zoom&page-id=0%3A1
![image](https://user-images.githubusercontent.com/52677246/121712455-c185fe80-caa9-11eb-8f6e-9ee3c9a1466e.png)

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
