### PR TITLE
fix(toast): fix info token in toast

### DIFF
--- a/packages/vapor/scss/components/toast.scss
+++ b/packages/vapor/scss/components/toast.scss
@@ -132,9 +132,6 @@ $toast-info-token-padding: 12px 16px 12px 8px;
 
     .info-token {
         position: static;
-        flex-direction: row;
-        align-items: center;
-        justify-content: center;
         padding: $toast-info-token-padding;
     }
 

--- a/packages/vapor/scss/components/toast.scss
+++ b/packages/vapor/scss/components/toast.scss
@@ -132,7 +132,6 @@ $toast-info-token-padding: 12px 16px 12px 8px;
 
     .info-token {
         position: static;
-        display: flex;
         flex-direction: row;
         align-items: center;
         justify-content: center;


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/ADUI-7173

Something went wrong when merging the toast fix (https://github.com/coveo/react-vapor/pull/2022) into Next branch.

I removed the flex and the infoToken is back where it should be :woman_shrugging: 

![image](https://user-images.githubusercontent.com/63734941/121938923-64dd4a80-cd1a-11eb-8046-0da350dc2fd7.png)

### Potential Breaking Changes

Should be none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
