### PR TITLE
feat(iconcard): allow IconCard to have children

### DIFF
--- a/packages/demo/src/components/examples/IconCardExamples.tsx
+++ b/packages/demo/src/components/examples/IconCardExamples.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {IconCard, Section} from 'react-vapor';
+import {IconCard, Section, Svg} from 'react-vapor';
 
 export const IconCardExamples: React.FunctionComponent = () => (
     // start-print
@@ -40,6 +40,16 @@ export const IconCardExamples: React.FunctionComponent = () => (
                     onClick={(choice) => alert(choice)}
                     style={{width: '368px'}}
                 />
+                <IconCard
+                    small
+                    title="Web"
+                    svgName="sourceWeb"
+                    animateOnHover
+                    onClick={() => alert('You clicked the card')}
+                    style={{width: '368px'}}
+                >
+                    <Svg svgName="cloud" svgClass="icon mod-24 mod-stroke mod-black" />
+                </IconCard>
             </Section>
             <Section level={3} title="Disbled">
                 <IconCard

--- a/packages/react-vapor/src/components/iconCard/IconCard.tsx
+++ b/packages/react-vapor/src/components/iconCard/IconCard.tsx
@@ -24,6 +24,7 @@ export interface IconCardProps {
     tooltip?: ITooltipProps;
     choices?: IconCardChoice[];
     small?: boolean;
+    animateOnHover?: boolean;
 }
 
 export const IconCard: React.FunctionComponent<IconCardProps & Omit<React.HTMLProps<HTMLDivElement>, 'onClick'>> = ({
@@ -35,8 +36,10 @@ export const IconCard: React.FunctionComponent<IconCardProps & Omit<React.HTMLPr
     svgName,
     tooltip,
     choices,
+    animateOnHover,
     className,
     small,
+    children,
     ...restProps
 }) => {
     const [isOpen, setIsOpen] = React.useState<boolean>(false);
@@ -67,7 +70,7 @@ export const IconCard: React.FunctionComponent<IconCardProps & Omit<React.HTMLPr
             className={classNames(
                 'icon-card',
                 {
-                    'mod-drawer': hasChoices && !disabled,
+                    animateOnHover: (hasChoices || animateOnHover) && !disabled,
                     open: isOpen,
                     disabled,
                 },
@@ -95,7 +98,13 @@ export const IconCard: React.FunctionComponent<IconCardProps & Omit<React.HTMLPr
                         <h6 className="title">{title}</h6>
                         {description && <p className="description">{description}</p>}
                     </div>
-                    {badgeComponents.length > 0 ? <div className="flex center-align">{...badgeComponents}</div> : null}
+
+                    {badgeComponents.length > 0 || React.Children.count(children) > 0 ? (
+                        <div className="flex center-align">
+                            {children}
+                            {...badgeComponents}
+                        </div>
+                    ) : null}
                 </button>
             </Tooltip>
             {choices?.length ? (

--- a/packages/react-vapor/src/components/iconCard/tests/IconCard.spec.tsx
+++ b/packages/react-vapor/src/components/iconCard/tests/IconCard.spec.tsx
@@ -197,4 +197,29 @@ describe('IconCard', () => {
         expect(drawer).toHaveClass('mod-small');
         expect(card).toHaveClass('mod-small');
     });
+
+    it('renders the children inside the card if specified', () => {
+        render(
+            <IconCard title="Title" svgName="home" small>
+                child
+            </IconCard>
+        );
+
+        const card = screen.getByRole('button', {name: /title/i});
+        expect(within(card).getByText(/child/i)).toBeInTheDocument();
+    });
+
+    it('animates the card on hover if animateOnHover prop is true', () => {
+        const {container} = render(<IconCard title="Title" svgName="home" animateOnHover />);
+
+        const card = container.querySelector('.icon-card');
+        expect(card).toHaveClass('animateOnHover');
+    });
+
+    it('does not animates the card on hover if disabled', () => {
+        const {container} = render(<IconCard title="Title" svgName="home" animateOnHover disabled />);
+
+        const card = container.querySelector('.icon-card');
+        expect(card).not.toHaveClass('animateOnHover');
+    });
 });

--- a/packages/vapor/scss/components/icon-card.scss
+++ b/packages/vapor/scss/components/icon-card.scss
@@ -37,7 +37,7 @@
         }
     }
 
-    &.mod-drawer {
+    &.animateOnHover {
         &:hover {
             transform: translate3d(0px, -8px, 0px);
 

--- a/packages/vapor/scss/icons/icons.scss
+++ b/packages/vapor/scss/icons/icons.scss
@@ -16,6 +16,11 @@
         stroke: var(--stroke);
     }
 
+    &.mod-black {
+        --fill: var(--grey-100);
+        --stroke: var(--grey-100);
+    }
+
     &.mod-info {
         --fill: var(--info-60);
         --stroke: var(--info-60);


### PR DESCRIPTION
### Proposed Changes

Allowing to display children inside icon cards (here a cloud icon).

![image](https://user-images.githubusercontent.com/35579930/122139365-d00c4700-ce16-11eb-82b1-2da50b4a0ab1.png)

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
