### PR TITLE
refactor(textinput): replace custom style with typekit

### DIFF
--- a/packages/react-vapor/src/components/textInput/TextInput.tsx
+++ b/packages/react-vapor/src/components/textInput/TextInput.tsx
@@ -105,27 +105,29 @@ export const TextInput: React.FunctionComponent<TextInputProps & React.HTMLProps
             )}
         >
             {inputProps.title && <h6>{inputProps.title}</h6>}
-            {description && <p className="text-input-description mb2">{description}</p>}
+            {description && <p className="body-m-book-subdued mb2">{description}</p>}
             <div className="flex flex-center">
                 <div
                     className="text-input-box flex flex-column justify-center"
                     onClick={() => inputElement.current.focus()}
                 >
-                    <label htmlFor={id}>{inputProps.required ? label : `${label} (Optional)`}</label>
+                    <label className="body-s-book-subdued cursor-text" htmlFor={id}>
+                        {inputProps.required ? label : `${label} (Optional)`}
+                    </label>
                     <input
                         {...omit(inputProps, 'value')}
                         id={id}
                         onChange={handleChange}
                         onBlur={handleOnBlur}
                         value={state.value}
-                        className="flex-auto"
+                        className="flex-auto body-m-book"
                         ref={inputElement}
                         aria-invalid={state.status === 'invalid'}
                     />
                 </div>
                 <HelpTooltip message={tooltip} />
             </div>
-            {helpText && <div className="mt1 ml2 text-input-help-text">{helpText}</div>}
+            {helpText && <div className="mt1 ml2 body-s-book-subdued">{helpText}</div>}
             <ValidationMessage inputId={id} />
         </div>
     );
@@ -164,7 +166,7 @@ const ValidationMessage: React.FunctionComponent<{inputId: string}> = ({inputId}
     return (
         <div className="mt1 ml2 inline-flex flex-center">
             <InfoToken mode={InfoTokenMode.Stroked} size={InfoTokenSize.Small} type={statusIconMapping[state.status]} />
-            <span className="text-input-message">{state.message}</span>
+            <span className="text-input-message body-s-book">{state.message}</span>
         </div>
     );
 };

--- a/packages/vapor/scss/components/labeled-value.scss
+++ b/packages/vapor/scss/components/labeled-value.scss
@@ -24,7 +24,6 @@
     }
 }
 
-label,
 .label {
     color: var(--title-text-color);
 }

--- a/packages/vapor/scss/controls/text-input.scss
+++ b/packages/vapor/scss/controls/text-input.scss
@@ -1,40 +1,8 @@
-%body-s {
-    // replace with .book-s once typekit is ready
-    font-weight: 400;
-    font-size: 12px;
-    line-height: 16px;
-    letter-spacing: 0.003em;
-}
-
-%body-m {
-    // replace with .book-m once typekit is ready
-    font-weight: 400;
-    font-size: 14px;
-    line-height: 20px;
-    letter-spacing: 0.003em;
-}
-
-%body-l {
-    // replace with .book-l once typekit is ready
-    font-weight: 400;
-    font-size: 16px;
-    line-height: 24px;
-    letter-spacing: 0.003em;
-}
-
-%h6 {
-    // replace with .book-l once typekit is ready
-    font-size: 16px;
-    line-height: 24px;
-    letter-spacing: 0.011em;
-}
-
 .text-input {
     --status-color: transparent;
     --status-text-color: var(--grey-80);
     --stroke: var(--status-color);
     --input-text-color: var(--grey-100);
-    --label-text-color: var(--grey-80);
     --border-color: var(--default-border-color);
     --background-color: var(--white);
     --transition: all 0.2s ease;
@@ -71,14 +39,7 @@
         }
     }
 
-    h6 {
-        @extend %h6;
-        color: var(--grey-100);
-        font-weight: 500;
-    }
-
     input {
-        @extend %body-m;
         padding: 0;
         color: var(--input-text-color);
         background-color: var(--background-color);
@@ -89,28 +50,9 @@
         }
     }
 
-    label {
-        @extend %body-s;
-        color: var(--label-text-color);
-        cursor: text;
-    }
-
-    .text-input-description {
-        @extend %body-m;
-        color: var(--grey-80);
-        font-weight: 400;
-    }
-
     .text-input-message {
-        @extend %body-s;
         margin-left: 4px;
         color: var(--status-text-color);
-    }
-
-    .text-input-help-text {
-        // replace with .body-s-book-subdued
-        @extend %body-s;
-        color: var(--grey-80);
     }
 
     &.invalid {
@@ -130,8 +72,12 @@
 
     &.disabled .text-input-box {
         --background-color: var(--grey-20);
-        --label-text-color: var(--grey-60);
         --input-text-color: var(--grey-60);
+
+        label {
+            color: var(--grey-60);
+        }
+
         pointer-events: none;
     }
 


### PR DESCRIPTION
### Proposed Changes

At the time of implementation, the typekit wasn't available to use for the TextInput so I had to add custom style that did the same thing. Now that the typekit is available, we can remove that style in favor of the official typekit classes.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
