### PR TITLE
fix(singleselect): wrapped section children

### DIFF
--- a/packages/demo/src/components/examples/SingleSelectExamples.tsx
+++ b/packages/demo/src/components/examples/SingleSelectExamples.tsx
@@ -180,19 +180,21 @@ const SingleSelectConnectedExamples: React.ComponentType = () => (
             </div>
         </Section>
         <Section level={3} title="A single select with dirty management">
-            <SingleSelectWithDirty id="select-dirty" items={defaultItems} canClear />
-            <SingleSelectWithDirty
-                id="select-dirty-with-initial-value"
-                items={defaultItems}
-                initialValue={defaultItems[1].value}
-                canClear
-                footer={<div className="select-footer">This one already has an initial value</div>}
-            />
-            <SaveButton
-                enabled
-                validationIds={['select-dirty', 'select-dirty-with-initial-value']}
-                name="An example button bound to the select"
-            />
+            <div>
+                <SingleSelectWithDirty id="select-dirty" items={defaultItems} canClear />
+                <SingleSelectWithDirty
+                    id="select-dirty-with-initial-value"
+                    items={defaultItems}
+                    initialValue={defaultItems[1].value}
+                    canClear
+                    footer={<div className="select-footer">This one already has an initial value</div>}
+                />
+                <SaveButton
+                    enabled
+                    validationIds={['select-dirty', 'select-dirty-with-initial-value']}
+                    name="An example button bound to the select"
+                />
+            </div>
         </Section>
     </Section>
 );


### PR DESCRIPTION
### Proposed Changes

Simplest fix was to wrap the Section Children instead of rewriting how the section component scss handles children of levels

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
