### PR TITLE
fix(css,color-dot): add margin top & bottom auto for center the dot

### DIFF
--- a/packages/demo/src/styles/utility/ColorDot.tsx
+++ b/packages/demo/src/styles/utility/ColorDot.tsx
@@ -45,7 +45,7 @@ export default () => (
         </Section>
 
         <Section level={2} title="Color dot aligned with text">
-            <span className="inline-flex label">
+            <span className="flex label">
                 <i className="color-dot mr1" />
                 Success
             </span>

--- a/packages/vapor/scss/elements/color-dot.scss
+++ b/packages/vapor/scss/elements/color-dot.scss
@@ -7,6 +7,7 @@
     min-width: var(--size);
     height: var(--size);
     min-height: var(--size);
+    margin: auto 0;
     background-color: var(--background-color);
     border-radius: 100%;
 


### PR DESCRIPTION
### Proposed Changes

Currently the point is not centered. This allows it to be centered vertically.

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
