### PR TITLE
[SEARCHAPI-6060] feat(svg): add `associate` icon

### DIFF
--- a/packages/vapor/resources/icons/svg/associate.svg
+++ b/packages/vapor/resources/icons/svg/associate.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 24 24" stroke="#282829" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M5.5 20C5.5 20.8284 4.82843 21.5 4 21.5C3.17157 21.5 2.5 20.8284 2.5 20C2.5 19.1716 3.17157 18.5 4 18.5C4.82843 18.5 5.5 19.1716 5.5 20Z" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M5 19C7.14788 17.0474 10.5 14 10.5 14" stroke-linejoin="round" />
+    <path d="M12 5.5C12 7.45262 12 11.5 12 11.5" stroke-linejoin="round" />
+    <path d="M19 19L13.5 14" stroke-linejoin="round" />
+    <path d="M21.5 20C21.5 20.8284 20.8284 21.5 20 21.5C19.1716 21.5 18.5 20.8284 18.5 20C18.5 19.1716 19.1716 18.5 20 18.5C20.8284 18.5 21.5 19.1716 21.5 20Z" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M13.5 13C13.5 13.8284 12.8284 14.5 12 14.5C11.1716 14.5 10.5 13.8284 10.5 13C10.5 12.1716 11.1716 11.5 12 11.5C12.8284 11.5 13.5 12.1716 13.5 13Z" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M13.5 4C13.5 4.82843 12.8284 5.5 12 5.5C11.1716 5.5 10.5 4.82843 10.5 4C10.5 3.17157 11.1716 2.5 12 2.5C12.8284 2.5 13.5 3.17157 13.5 4Z" stroke-linecap="round" stroke-linejoin="round" />
+</svg>


### PR DESCRIPTION

### Proposed Changes

<!-- Explain what are your changes. -->

Add the `associate` icon to Vapor 

It's coming from: https://www.figma.com/file/bMtrzk73CdW9OKnYlZfjiW/Platform-Library?node-id=32%3A7795
And have been ask by @acverrette 


https://coveord.atlassian.net/browse/SEARCHAPI-6005

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
