### PR TITLE
ci(codeowners): add ui-tooling team to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@
 # review when someone opens a pull request.
 # see https://help.github.com/articles/about-codeowners/ for more details
 
-* @coveo/admin-console
+* @coveo/admin-console @coveo/ui-tooling
 
 # Prevent PRs that only modify package.json from notifying everyone
 package.json @ghost


### PR DESCRIPTION
### Proposed Changes

Add [UI Tooling](https://github.com/orgs/coveo/teams/ui-tooling) as codeowners of react-vapor.

### Potential Breaking Changes

none, not code related

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
