### PR TITLE
fix(option-picker): alignement when used as a button

### DIFF
--- a/packages/react-vapor/src/components/optionsCycle/OptionsCycle.tsx
+++ b/packages/react-vapor/src/components/optionsCycle/OptionsCycle.tsx
@@ -74,7 +74,7 @@ export class OptionsCycle extends React.Component<IOptionsCycleProps> {
                     onClick={() => this.goToPreviousOption()}
                     disabled={!this.props.wrapAround && this.props.currentOption === 0}
                 >
-                    <Svg svgName="arrow-left-rounded" svgClass="icon mod-16" />
+                    <Svg svgName="arrow-left-rounded" className="icon mod-16" />
                 </button>
                 <span className={classNames('options-cycle-option', this.props.buttonClassName)}>
                     {this.props.options[this.props.currentOption]}
@@ -85,7 +85,7 @@ export class OptionsCycle extends React.Component<IOptionsCycleProps> {
                     onClick={() => this.goToNextOption()}
                     disabled={!this.props.wrapAround && this.props.currentOption === this.props.options.length - 1}
                 >
-                    <Svg svgName="arrow-right-rounded" svgClass="icon mod-16" />
+                    <Svg svgName="arrow-right-rounded" className="icon mod-16" />
                 </button>
             </div>
         );

--- a/packages/vapor/scss/components/calendar.scss
+++ b/packages/vapor/scss/components/calendar.scss
@@ -249,12 +249,16 @@
 }
 
 .options-cycle-button {
-    display: inline-block;
+    justify-content: center;
     padding: 0;
     background-color: var(--white);
     border: none;
 
     cursor: pointer;
+
+    &.mod-border {
+        border: $button-border-width solid var(--navy-blue-80);
+    }
 }
 
 .option-picker {


### PR DESCRIPTION
### Proposed Changes

Change the style of the Option Cycle to match the normal buttons

**Before**
![image](https://user-images.githubusercontent.com/260007/125313731-87578900-e303-11eb-90f5-aad5be3cb863.png)

**After**
![image](https://user-images.githubusercontent.com/260007/125313774-90485a80-e303-11eb-853c-5b783ecddd5a.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
