### PR TITLE
fix(focus): override outline for Firefox

### DIFF
--- a/packages/vapor/scss/controls/numeric-input.scss
+++ b/packages/vapor/scss/controls/numeric-input.scss
@@ -19,6 +19,10 @@ $numeric-input-buttons-border-radius: 4px;
         border: $default-border;
         border-radius: $border-radius;
         box-shadow: inset 0 0 3px 0 rgba(var(--black-rgb), $transparency-5);
+
+        &:focus {
+            @include focus-border(0px);
+        }
     }
 
     button {
@@ -41,7 +45,17 @@ $numeric-input-buttons-border-radius: 4px;
         }
 
         &:focus {
-            @include focus-border(2px);
+            @include focus-border(0px);
+        }
+    }
+}
+// override the style of the focus for numeric inputs in Firefox
+@supports (-moz-appearance: none) {
+    .numeric-input {
+        input:focus,
+        button:focus {
+            outline-style: solid;
+            outline-offset: -2px;
         }
     }
 }

--- a/packages/vapor/scss/controls/numeric-input.scss
+++ b/packages/vapor/scss/controls/numeric-input.scss
@@ -21,7 +21,7 @@ $numeric-input-buttons-border-radius: 4px;
         box-shadow: inset 0 0 3px 0 rgba(var(--black-rgb), $transparency-5);
 
         &:focus {
-            @include focus-border(0px);
+            @include focus-border(0);
         }
     }
 
@@ -45,7 +45,7 @@ $numeric-input-buttons-border-radius: 4px;
         }
 
         &:focus {
-            @include focus-border(0px);
+            @include focus-border(0);
         }
     }
 }

--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -44,7 +44,6 @@
         color: var(--navy-blue-80);
         text-decoration: none;
         background-color: var(--white);
-        outline-color: var(--bright-turquoise-40);
     }
 
     &:hover {
@@ -283,5 +282,13 @@ button {
 
     .btn-hover-text {
         color: var(--rain-forest-green-30);
+    }
+}
+
+// override the style of the focus for buttons in Firefox
+@supports (-moz-appearance: none) {
+    .btn:focus {
+        outline-style: solid;
+        outline-offset: -2px;
     }
 }

--- a/packages/vapor/scss/elements/links.scss
+++ b/packages/vapor/scss/elements/links.scss
@@ -55,3 +55,10 @@ a {
         text-decoration: underline;
     }
 }
+
+// override the style of the focus for links in Firefox
+@supports (-moz-appearance: none) {
+    .link:focus {
+        outline-style: solid;
+    }
+}

--- a/packages/vapor/scss/helpers.scss
+++ b/packages/vapor/scss/helpers.scss
@@ -17,6 +17,8 @@ $browser-context: 13; // Default
 }
 
 @mixin focus-border($offset) {
-    outline: 2px auto var(--digital-blue-20);
+    outline-width: 2px;
+    outline-style: auto;
+    outline-color: var(--bright-turquoise-40);
     outline-offset: $offset;
 }


### PR DESCRIPTION
### Proposed Changes

Firefox has a weird behaviour with outline-style and the auto property. It won't apply the color and the outline appears outside of the element instead of inside like chrome.

In this fix I override the outline-offset and the outline-style in Firefox for the .btn, .numeric-inputs, and .links (Left is Chrome, right is Firefox)

**.btn**
![image](https://user-images.githubusercontent.com/260007/125456491-c7682e8f-4a07-4d98-815c-7d01299995d4.png)

**.numeric-inputs**
![image](https://user-images.githubusercontent.com/260007/125456719-381695c3-7bdb-4987-9853-7c8140b4717b.png)

![image](https://user-images.githubusercontent.com/260007/125456778-69bbd538-3cda-4c2c-a3af-d68009d7b5e2.png)


**.links**

![image](https://user-images.githubusercontent.com/260007/125456315-2674ee78-8875-49d2-ad67-4f1a7a2af313.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
