### PR TITLE
fix(tabs): allow onSelect prop on TabConnected

### DIFF
--- a/packages/react-vapor/src/components/tab/Tab.tsx
+++ b/packages/react-vapor/src/components/tab/Tab.tsx
@@ -6,7 +6,7 @@ import {createStructuredSelector} from 'reselect';
 import {ConnectedProps, IDispatch, UrlUtils} from '../../utils';
 import {TooltipPlacement} from '../../utils/TooltipUtils';
 import {Tooltip} from '../tooltip/Tooltip';
-import {addTab, removeTab, selectTab} from './TabActions';
+import {TabActions} from './TabActions';
 import {TabSelectors} from './TabSelectors';
 
 export interface ITabOwnProps {
@@ -17,14 +17,15 @@ export interface ITabOwnProps {
     tooltip?: string;
     children?: React.ReactNode;
     url?: string;
+    onSelect?: (e: React.MouseEvent) => void;
 }
 
 const enhance = connect(
     createStructuredSelector({isActive: TabSelectors.getIsTabSelected}),
     (dispatch: IDispatch, ownProps: ITabOwnProps) => ({
-        onRender: (): void => void dispatch(addTab(ownProps.id, ownProps.groupId)),
-        onDestroy: (): void => void dispatch(removeTab(ownProps.id, ownProps.groupId)),
-        onSelect: (e: React.MouseEvent): void => void dispatch(selectTab(ownProps.id, ownProps.groupId)),
+        onRender: (): void => void dispatch(TabActions.addTab(ownProps.id, ownProps.groupId)),
+        onDestroy: (): void => void dispatch(TabActions.removeTab(ownProps.id, ownProps.groupId)),
+        selectTab: (): void => void dispatch(TabActions.selectTab(ownProps.id, ownProps.groupId)),
     })
 );
 
@@ -40,6 +41,7 @@ export const Tab: React.FunctionComponent<ITabProps> = ({
     onRender,
     onDestroy,
     onSelect,
+    selectTab,
 }) => {
     React.useEffect(() => {
         onRender?.();
@@ -48,6 +50,7 @@ export const Tab: React.FunctionComponent<ITabProps> = ({
 
     const handleSelect = (e: React.MouseEvent) => {
         if (!disabled) {
+            selectTab?.();
             onSelect?.(e);
             if (url) {
                 UrlUtils.redirectToUrl(url);

--- a/packages/react-vapor/src/components/tab/TabActions.ts
+++ b/packages/react-vapor/src/components/tab/TabActions.ts
@@ -34,3 +34,9 @@ export const removeTab = (id: string, groupId?: string): IReduxAction<ITabAction
         id,
     },
 });
+
+export const TabActions = {
+    selectTab,
+    addTab,
+    removeTab,
+};

--- a/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
+++ b/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
@@ -25,6 +25,13 @@ describe('Tab', () => {
         spy.mockRestore();
     });
 
+    it('calls the onSlect callback when clicking on the tab', () => {
+        const onSelectSpy = jest.fn();
+        render(<TabConnected id="🆔" title="Title" onSelect={onSelectSpy} />);
+        userEvent.click(screen.getByRole('tab', {name: /title/i}));
+        expect(onSelectSpy).toHaveBeenCalled();
+    });
+
     describe('Navigation', () => {
         beforeEach(() => {
             render(

--- a/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
+++ b/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
@@ -25,7 +25,8 @@ describe('Tab', () => {
         spy.mockRestore();
     });
 
-    it('calls the onSlect callback when clicking on the tab', () => {
+    it('calls the onSelect callback when clicking on the tab', () => {
+
         const onSelectSpy = jest.fn();
         render(<TabConnected id="🆔" title="Title" onSelect={onSelectSpy} />);
         userEvent.click(screen.getByRole('tab', {name: /title/i}));


### PR DESCRIPTION
### Proposed Changes

Following the tab component refactoring (https://github.com/coveo/react-vapor/pull/2072), we lost the ability to specify a callback when clicking on a TabConnected.

### Potential Breaking Changes

None hopefully this time 🙏 

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
