### PR TITLE
fix(tabs): allow multiple independent tab navigations at the same time

### DIFF
--- a/packages/demo/src/components/examples/ExamplesUtils.ts
+++ b/packages/demo/src/components/examples/ExamplesUtils.ts
@@ -1,12 +1,4 @@
-import {
-    Button,
-    IBreadcrumbLinkProps,
-    IBreadcrumbProps,
-    IContentProps,
-    ILinkSvgProps,
-    ITabProps,
-    ITitleProps,
-} from 'react-vapor';
+import {Button, IBreadcrumbLinkProps, IBreadcrumbProps, IContentProps, ILinkSvgProps, ITitleProps} from 'react-vapor';
 
 export const link1: IBreadcrumbLinkProps = {
     name: 'Pikachu',
@@ -60,10 +52,3 @@ export const defaultBreadcrumbLongTitle: IBreadcrumbProps = {
     },
     links: [link1, link2],
 };
-
-export const defaultTabs: ITabProps[] = [
-    {id: 'tab1', title: 'Digimon'},
-    {id: 'tab2', title: 'Beyblade'},
-    {id: 'tab3', title: 'Pokemon'},
-    {id: 'tab4', title: 'Perdu', url: 'http://www.perdu.com'},
-];

--- a/packages/demo/src/components/examples/HeaderExamples.tsx
+++ b/packages/demo/src/components/examples/HeaderExamples.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {BasicHeader, BreadcrumbHeader, Button, Section, Svg} from 'react-vapor';
 
 import {ExampleComponent} from '../ComponentsInterface';
-import {actions, defaultBreadcrumb, defaultTabs, defaultTitle, link1, link2} from './ExamplesUtils';
+import {actions, defaultBreadcrumb, defaultTitle, link1, link2} from './ExamplesUtils';
 
 export const HeaderExamples: ExampleComponent = () => (
     <Section>
@@ -20,7 +20,12 @@ const SimpleHeader: React.FunctionComponent = () => (
                 title={defaultTitle}
                 description="Simple description for the title"
                 actions={actions}
-                tabs={defaultTabs}
+                tabs={[
+                    {groupId: 'example1', id: 'tab1', title: 'Digimon'},
+                    {groupId: 'example1', id: 'tab2', title: 'Beyblade'},
+                    {groupId: 'example1', id: 'tab3', title: 'Pokemon'},
+                    {groupId: 'example1', id: 'tab4', title: 'Perdu', url: 'http://www.perdu.com'},
+                ]}
             />
         </Section>
     </Section>
@@ -32,7 +37,12 @@ const BreadcrumbHeaders: React.FunctionComponent = () => (
             <BreadcrumbHeader
                 breadcrumb={defaultBreadcrumb}
                 description="Simple description for the title"
-                tabs={defaultTabs}
+                tabs={[
+                    {groupId: 'example2', id: 'tab1', title: 'Digimon'},
+                    {groupId: 'example2', id: 'tab2', title: 'Beyblade'},
+                    {groupId: 'example2', id: 'tab3', title: 'Pokemon'},
+                    {groupId: 'example2', id: 'tab4', title: 'Perdu', url: 'http://www.perdu.com'},
+                ]}
                 actions={[
                     {
                         content: (

--- a/packages/react-vapor/src/components/tab/TabSelectors.ts
+++ b/packages/react-vapor/src/components/tab/TabSelectors.ts
@@ -15,10 +15,11 @@ const getSelectedTab = createSelector(
     (tabGroup: ITabGroupState): ITabState => _.findWhere(tabGroup?.tabs, {isSelected: true})
 );
 
-const getTab = (state: IReactVaporState, {id}: CherryPick<ITabOwnProps, 'id'>): ITabState =>
-    state.tabs
-        ?.reduce((accumulator, tabGroup): ITabState[] => [...accumulator, ...tabGroup.tabs], [])
-        .find((tab) => tab.id === id);
+const getTab = createSelector(
+    getTabGroup,
+    (state, {id}: CherryPick<ITabOwnProps, 'id'>) => id,
+    (tabGroup: ITabGroupState, id: string): ITabState => _.findWhere(tabGroup?.tabs, {id})
+);
 
 const getIsTabSelected = createSelector(getTab, (tab) => tab?.isSelected ?? false);
 

--- a/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
+++ b/packages/react-vapor/src/components/tab/tests/Tab.spec.tsx
@@ -26,11 +26,42 @@ describe('Tab', () => {
     });
 
     it('calls the onSelect callback when clicking on the tab', () => {
-
         const onSelectSpy = jest.fn();
         render(<TabConnected id="🆔" title="Title" onSelect={onSelectSpy} />);
         userEvent.click(screen.getByRole('tab', {name: /title/i}));
         expect(onSelectSpy).toHaveBeenCalled();
+    });
+
+    it('manages 2 tab groups independently from each other', () => {
+        render(
+            <div>
+                <TabNavigation>
+                    <TabConnected groupId="X" id="A" title="Tab 1" />
+                    <TabConnected groupId="X" id="B" title="Tab 2" />
+                </TabNavigation>
+                <TabNavigation>
+                    <TabConnected groupId="Y" id="A" title="Tab 3" />
+                    <TabConnected groupId="Y" id="B" title="Tab 4" />
+                </TabNavigation>
+            </div>
+        );
+
+        const tab1 = screen.getByRole('tab', {name: /Tab 1/i});
+        const tab2 = screen.getByRole('tab', {name: /Tab 2/i});
+        const tab3 = screen.getByRole('tab', {name: /Tab 3/i});
+        const tab4 = screen.getByRole('tab', {name: /Tab 4/i});
+
+        expect(tab1).toHaveAttribute('aria-selected', 'true');
+        expect(tab2).toHaveAttribute('aria-selected', 'false');
+        expect(tab3).toHaveAttribute('aria-selected', 'true');
+        expect(tab4).toHaveAttribute('aria-selected', 'false');
+
+        userEvent.click(tab2);
+
+        expect(tab1).toHaveAttribute('aria-selected', 'false');
+        expect(tab2).toHaveAttribute('aria-selected', 'true');
+        expect(tab3).toHaveAttribute('aria-selected', 'true');
+        expect(tab4).toHaveAttribute('aria-selected', 'false');
     });
 
     describe('Navigation', () => {


### PR DESCRIPTION
### Proposed Changes

The header example had 2 tab navigation rendered at the same time, but they we're not independent from each other. Meaning that when selecting a tab in the first it would also select the tab in the second and vice-versa.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
