### PR TITLE
ci(jenkins): add build back to normal notification

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -300,6 +300,18 @@ pipeline {
   }
 
   post {
+    fixed {
+      script {
+        if(env.BRANCH_NAME ==~ /(master|release-.*)/){
+          def message = "Build is back to normal for <${env.BUILD_URL}|${env.JOB_NAME}>";
+          def color = "#2ECC71"; // green
+          notify.sendSlackWithThread(
+            color: color, message: message,
+            MASTER_RELEASE_FAILURE_CHANNELS
+          )
+        }
+      }
+    }
     failure {
       script {
         def color = "FF0000";


### PR DESCRIPTION
### Proposed Changes

Should look something like this, but with `react-vapor/master` instead of just `master`.

![image](https://user-images.githubusercontent.com/35579930/126512638-e4c4bde8-4baf-433c-a6d2-369c1b85f446.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
