### PR TITLE
Chore/ad UI 7296 improve accessibility of select components

### DIFF
--- a/packages/react-vapor/src/components/filterBox/FilterBox.tsx
+++ b/packages/react-vapor/src/components/filterBox/FilterBox.tsx
@@ -102,6 +102,7 @@ export class FilterBox extends React.Component<IFilterBoxProps, any> {
                         onKeyUp={this.props.onKeyUp}
                         style={inputMaxWidth}
                         autoFocus={this.props.isAutoFocus}
+                        aria-label={`${this.props.id}-name`}
                     />
                     <Svg
                         svgName="clear"

--- a/packages/react-vapor/src/components/filterBox/FilterBox.tsx
+++ b/packages/react-vapor/src/components/filterBox/FilterBox.tsx
@@ -102,7 +102,6 @@ export class FilterBox extends React.Component<IFilterBoxProps, any> {
                         onKeyUp={this.props.onKeyUp}
                         style={inputMaxWidth}
                         autoFocus={this.props.isAutoFocus}
-                        aria-label={`${this.props.id}-name`}
                     />
                     <Svg
                         svgName="clear"

--- a/packages/react-vapor/src/components/itemBox/ItemBox.tsx
+++ b/packages/react-vapor/src/components/itemBox/ItemBox.tsx
@@ -84,6 +84,7 @@ export class ItemBox extends React.Component<IItemBoxProps> {
                     onClick={() => this.handleOnOptionClick()}
                     data-value={this.props.value}
                     aria-hidden={this.props.hidden}
+                    role="option"
                 >
                     {this.props.prepend ? <Content {...this.props.prepend} /> : null}
                     <PartialStringMatch partialMatch={this.props.highlight} caseInsensitive>

--- a/packages/react-vapor/src/components/listBox/ListBox.tsx
+++ b/packages/react-vapor/src/components/listBox/ListBox.tsx
@@ -127,7 +127,7 @@ export class ListBox extends React.Component<IListBoxProps> {
         const items = this.props.isLoading ? this.getLoadingItems() : this.getItems();
         return (
             <>
-                <ul className={this.getClasses()} id={`${this.props.id}-container`}>
+                <ul className={this.getClasses()} id={`${this.props.id}-container`} role="listbox" tabIndex={0}>
                     {this.props.wrapItems(items)}
                 </ul>
                 {this.props.footer}

--- a/packages/react-vapor/src/components/select/hoc/tests/MultiSelectWithFilter.spec.tsx
+++ b/packages/react-vapor/src/components/select/hoc/tests/MultiSelectWithFilter.spec.tsx
@@ -1,4 +1,5 @@
 import {render, screen} from '@test-utils';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
 import {MultiSelectWithFilter} from '../SelectComponents';
@@ -8,24 +9,23 @@ describe('Select', () => {
         const id: string = 'multi-select-with-filter';
 
         it('should add a duplicate if the filterValue is already selected', () => {
-            const filterValue: string = 'a';
-            const duplicateText: string = 'duplicate';
+            const duplicateText: string = 'a';
 
             render(
                 <MultiSelectWithFilter
                     id={id}
                     duplicateText={duplicateText}
                     items={[
-                        {value: filterValue, selected: true},
-                        {value: filterValue, selected: true},
+                        {value: duplicateText, selected: true},
+                        {value: duplicateText, selected: true},
                     ]}
-                />,
-                {
-                    initialState: {},
-                }
+                />
             );
 
+            userEvent.click(screen.getByText(/select an option/i));
+
             const listItems = screen.getAllByRole('listitem');
+            screen.logTestingPlaygroundURL();
 
             expect(listItems.length).toBe(2);
             expect(listItems[0]).toHaveTextContent(listItems[1].textContent);
@@ -34,18 +34,13 @@ describe('Select', () => {
         it('should open the dropdown even if the list is empty with customValue', () => {
             const noItemsText = 'not an item text';
 
-            render(<MultiSelectWithFilter id={id} noItemsText={noItemsText} customValues items={[]} />, {
-                initialState: {},
-            });
+            render(<MultiSelectWithFilter id={id} noItemsText={noItemsText} customValues items={[]} />);
+            userEvent.click(screen.getByText(/select an option/i));
 
-            expect(
-                screen.getByRole('option', {
-                    hidden: true,
-                })
-            ).toHaveTextContent(noItemsText);
+            expect(screen.getByRole('option')).toHaveTextContent(noItemsText);
         });
 
-        it('should set the noItems in noResultItem if items is not empty and all values are selected', () => {
+        it('should set the noItemsText in noResultItem if items is not empty and all values are selected', () => {
             const noItemsText = 'not an item text';
 
             render(
@@ -57,17 +52,12 @@ describe('Select', () => {
                         {value: 'a', selected: true},
                         {value: 'b', selected: true},
                     ]}
-                />,
-                {
-                    initialState: {},
-                }
+                />
             );
 
-            expect(
-                screen.getByRole('option', {
-                    hidden: true,
-                })
-            ).toHaveTextContent(noItemsText);
+            userEvent.click(screen.getByText(/select an option/i));
+
+            expect(screen.getByRole('option', {name: noItemsText})).toBeInTheDocument();
         });
     });
 });

--- a/packages/react-vapor/src/components/select/hoc/tests/MultiSelectWithFilter.spec.tsx
+++ b/packages/react-vapor/src/components/select/hoc/tests/MultiSelectWithFilter.spec.tsx
@@ -1,88 +1,73 @@
-import {mount, ReactWrapper} from 'enzyme';
+import {render, screen} from '@test-utils';
 import * as React from 'react';
-import {Provider} from 'react-redux';
-import {Store} from 'redux';
 
-import {IReactVaporState} from '../../../../ReactVaporState';
-import {clearState} from '../../../../utils/ReduxUtils';
-import {TestUtils} from '../../../../utils/tests/TestUtils';
-import {filterThrough} from '../../../filterBox/FilterBoxActions';
-import {ItemBox} from '../../../itemBox/ItemBox';
-import {toggleSelect} from '../../SelectActions';
-import {ISelectOwnProps, SelectConnected} from '../../SelectConnected';
 import {MultiSelectWithFilter} from '../SelectComponents';
-import {ISelectWithFilterOwnProps} from '../SelectWithFilter';
 
 describe('Select', () => {
     describe('MultiSelectWithFilter', () => {
-        let wrapper: ReactWrapper<any, any>;
-        let store: Store<IReactVaporState>;
-
         const id: string = 'multi-select-with-filter';
-
-        const mountMultiSelect = (props: Partial<ISelectOwnProps & ISelectWithFilterOwnProps> = {items: []}) => {
-            wrapper = mount(
-                <Provider store={store}>
-                    <MultiSelectWithFilter id={id} {...props} />
-                </Provider>,
-                {attachTo: document.getElementById('App')}
-            );
-
-            store.dispatch(toggleSelect(id, true));
-            wrapper.update();
-        };
-
-        beforeEach(() => {
-            store = TestUtils.buildStore();
-        });
-
-        afterEach(() => {
-            store.dispatch(clearState());
-            wrapper?.unmount();
-        });
-
-        beforeAll(() => {
-            TestUtils.makeDebounceStatic();
-        });
 
         it('should add a duplicate if the filterValue is already selected', () => {
             const filterValue: string = 'a';
             const duplicateText: string = 'duplicate';
 
-            mountMultiSelect({items: [{value: filterValue, selected: true}], duplicateText});
-            store.dispatch(filterThrough(id, filterValue));
+            render(
+                <MultiSelectWithFilter
+                    id={id}
+                    duplicateText={duplicateText}
+                    items={[
+                        {value: filterValue, selected: true},
+                        {value: filterValue, selected: true},
+                    ]}
+                />,
+                {
+                    initialState: {},
+                }
+            );
 
-            wrapper.update();
-            const itemBox = wrapper.find(SelectConnected).find(ItemBox).first();
+            const listItems = screen.getAllByRole('listitem');
 
-            expect(itemBox.props().value).toBe(duplicateText);
+            expect(listItems.length).toBe(2);
+            expect(listItems[0]).toHaveTextContent(listItems[1].textContent);
         });
 
         it('should open the dropdown even if the list is empty with customValue', () => {
             const noItemsText = 'not an item text';
 
-            mountMultiSelect({items: [], noItemsText, customValues: true});
+            render(<MultiSelectWithFilter id={id} noItemsText={noItemsText} customValues items={[]} />, {
+                initialState: {},
+            });
 
-            const itemBox = wrapper.find(SelectConnected).find(ItemBox).first();
-
-            expect(itemBox.props().value).toBe(noItemsText);
+            expect(
+                screen.getByRole('option', {
+                    hidden: true,
+                })
+            ).toHaveTextContent(noItemsText);
         });
 
         it('should set the noItems in noResultItem if items is not empty and all values are selected', () => {
             const noItemsText = 'not an item text';
 
-            mountMultiSelect({
-                items: [
-                    {value: 'a', selected: true},
-                    {value: 'b', selected: true},
-                ],
-                noItemsText,
-                customValues: true,
-            });
+            render(
+                <MultiSelectWithFilter
+                    id={id}
+                    noItemsText={noItemsText}
+                    customValues
+                    items={[
+                        {value: 'a', selected: true},
+                        {value: 'b', selected: true},
+                    ]}
+                />,
+                {
+                    initialState: {},
+                }
+            );
 
-            const itemBox = wrapper.find(SelectConnected).find(ItemBox).first();
-
-            expect(itemBox.props().value).toBe(noItemsText);
+            expect(
+                screen.getByRole('option', {
+                    hidden: true,
+                })
+            ).toHaveTextContent(noItemsText);
         });
     });
 });

--- a/packages/react-vapor/src/components/select/hoc/tests/MultiSelectWithPredicateAndFilter.spec.tsx
+++ b/packages/react-vapor/src/components/select/hoc/tests/MultiSelectWithPredicateAndFilter.spec.tsx
@@ -33,8 +33,7 @@ describe('MultiSelectWithPredicateAndFilter', () => {
                     options={defaultFlatSelectOptions}
                     matchPredicate={matchPredicate}
                 />
-            </Provider>,
-            {attachTo: document.getElementById('App')}
+            </Provider>
         );
     };
 

--- a/packages/react-vapor/src/components/select/hoc/tests/MultiSelectWithPredicateAndFilter.spec.tsx
+++ b/packages/react-vapor/src/components/select/hoc/tests/MultiSelectWithPredicateAndFilter.spec.tsx
@@ -11,69 +11,67 @@ import {IFlatSelectOptionProps} from '../../../flatSelect/FlatSelectOption';
 import {IItemBoxProps} from '../../../itemBox/ItemBox';
 import {MultiSelectWithPredicateAndFilter} from '../SelectComponents';
 
-describe('Select', () => {
-    describe('<MultiSelectWithPredicateAndFilter/>', () => {
-        let wrapper: ReactWrapper<any, any>;
-        let store: Store<IReactVaporState>;
+describe('MultiSelectWithPredicateAndFilter', () => {
+    let wrapper: ReactWrapper<any, any>;
+    let store: Store<IReactVaporState>;
 
-        const id: string = 'multi-select-with-predicate-and-filter';
+    const id: string = 'multi-select-with-predicate-and-filter';
 
-        const defaultFlatSelectOptions: IFlatSelectOptionProps[] = [
-            {id: UUID.generate(), option: {content: 'All'}, selected: true},
-            {id: UUID.generate(), option: {content: 'None'}},
-        ];
+    const defaultFlatSelectOptions: IFlatSelectOptionProps[] = [
+        {id: UUID.generate(), option: {content: 'All'}, selected: true},
+        {id: UUID.generate(), option: {content: 'None'}},
+    ];
 
-        const matchPredicate = (predicate: string, item: IItemBoxProps) => predicate === defaultFlatSelectOptions[0].id;
+    const matchPredicate = (predicate: string, item: IItemBoxProps) => predicate === defaultFlatSelectOptions[0].id;
 
-        const mountMultiSelect = () => {
-            wrapper = mount(
-                <Provider store={store}>
-                    <MultiSelectWithPredicateAndFilter
-                        id={id}
-                        items={[]}
-                        options={defaultFlatSelectOptions}
-                        matchPredicate={matchPredicate}
-                    />
-                </Provider>,
-                {attachTo: document.getElementById('App')}
-            );
-        };
+    const mountMultiSelect = () => {
+        wrapper = mount(
+            <Provider store={store}>
+                <MultiSelectWithPredicateAndFilter
+                    id={id}
+                    items={[]}
+                    options={defaultFlatSelectOptions}
+                    matchPredicate={matchPredicate}
+                />
+            </Provider>,
+            {attachTo: document.getElementById('App')}
+        );
+    };
 
-        beforeEach(() => {
-            store = TestUtils.buildStore();
+    beforeEach(() => {
+        store = TestUtils.buildStore();
+    });
+
+    afterEach(() => {
+        store.dispatch(clearState());
+    });
+
+    describe('mount and unmount', () => {
+        it('should not throw on mount', () => {
+            expect(() => mountMultiSelect()).not.toThrow();
         });
 
-        afterEach(() => {
-            store.dispatch(clearState());
+        it('should not throw on unmount', () => {
+            mountMultiSelect();
+
+            expect(() => wrapper.unmount()).not.toThrow();
         });
 
-        describe('mount and unmount', () => {
-            it('should not throw on mount', () => {
-                expect(() => mountMultiSelect()).not.toThrow();
-            });
+        it('should add the list box to the state when mounted', () => {
+            expect(store.getState().selects.length).toBe(0);
 
-            it('should not throw on unmount', () => {
-                mountMultiSelect();
+            mountMultiSelect();
 
-                expect(() => wrapper.unmount()).not.toThrow();
-            });
+            expect(store.getState().selects.length).toBe(1);
+        });
 
-            it('should add the list box to the state when mounted', () => {
-                expect(store.getState().selects.length).toBe(0);
+        it('should remove the list box from the state when the component unmount', () => {
+            mountMultiSelect();
 
-                mountMultiSelect();
+            expect(store.getState().selects.length).toBe(1);
+            wrapper.unmount();
 
-                expect(store.getState().selects.length).toBe(1);
-            });
-
-            it('should remove the list box from the state when the component unmount', () => {
-                mountMultiSelect();
-
-                expect(store.getState().selects.length).toBe(1);
-                wrapper.unmount();
-
-                expect(store.getState().selects.length).toBe(0);
-            });
+            expect(store.getState().selects.length).toBe(0);
         });
     });
 });

--- a/packages/react-vapor/src/components/select/hoc/tests/SelectWithInfiniteScroll.spec.tsx
+++ b/packages/react-vapor/src/components/select/hoc/tests/SelectWithInfiniteScroll.spec.tsx
@@ -17,7 +17,7 @@ describe('SelectWithInfiniteScroll', () => {
         // open the dropdown
         userEvent.click(screen.getByRole('button', {name: /select an option/i}));
 
-        const listitems = screen.getAllByRole('listitem');
+        const listitems = screen.getAllByRole('option');
         expect(listitems.length).toBe(3);
         expect(listitems[0]).toHaveTextContent('🏹');
         expect(listitems[1]).toHaveTextContent('💘');
@@ -33,7 +33,7 @@ describe('SelectWithInfiniteScroll', () => {
         // open the dropdown
         userEvent.click(screen.getByRole('button', {name: /select an option/i}));
 
-        const list = screen.getByRole('list');
+        const list = screen.getByRole('listbox');
         const scrollEvent = new Event('scroll');
         list.dispatchEvent(scrollEvent);
 
@@ -49,7 +49,7 @@ describe('SelectWithInfiniteScroll', () => {
         // open the dropdown
         userEvent.click(screen.getByRole('button', {name: /select an option/i}));
 
-        const list = screen.getByRole('list');
+        const list = screen.getByRole('listbox');
         const scrollEvent = new Event('scroll');
         list.dispatchEvent(scrollEvent);
 
@@ -64,7 +64,7 @@ describe('SelectWithInfiniteScroll', () => {
         // open the dropdown
         userEvent.click(screen.getByRole('button', {name: /select an option/i}));
 
-        const list = screen.getByRole('list');
+        const list = screen.getByRole('listbox');
         const scrollEvent = new Event('scroll');
         list.dispatchEvent(scrollEvent);
 
@@ -79,7 +79,7 @@ describe('SelectWithInfiniteScroll', () => {
         // open the dropdown
         userEvent.click(screen.getByRole('button', {name: /select an option/i}));
 
-        const list = screen.getByRole('list');
+        const list = screen.getByRole('listbox');
         const scrollEvent = new Event('scroll');
         list.dispatchEvent(scrollEvent);
 

--- a/packages/react-vapor/src/components/select/tests/MultiSelectConnected.spec.tsx
+++ b/packages/react-vapor/src/components/select/tests/MultiSelectConnected.spec.tsx
@@ -68,11 +68,21 @@ describe('Select', () => {
             // open the dropdown
             userEvent.click(screen.getByRole('button', {name: /select an option/i}));
 
-            const lists = screen.getAllByRole('list');
-
-            expect(within(lists[1]).getByText(':seed:')).toBeVisible();
-            expect(within(lists[1]).getByText(':potato:')).toBeVisible();
-            expect(within(lists[1]).getByText('🍟')).toBeVisible();
+            expect(
+                screen.getByRole('option', {
+                    name: /:seed:/i,
+                })
+            ).toBeVisible();
+            expect(
+                screen.getByRole('option', {
+                    name: /:seed:/i,
+                })
+            ).toBeVisible();
+            expect(
+                screen.getByRole('option', {
+                    name: /🍟/i,
+                })
+            ).toBeVisible();
         });
 
         it('hides items that are hidden', () => {
@@ -82,8 +92,11 @@ describe('Select', () => {
             // open the dropdown
             userEvent.click(screen.getByRole('button', {name: /select an option/i}));
 
-            const lists = screen.getAllByRole('list');
-            expect(within(lists[1]).queryByText('first')).not.toBeInTheDocument();
+            expect(
+                screen.queryByRole('option', {
+                    name: /first/i,
+                })
+            ).not.toBeInTheDocument();
         });
 
         it('is possible to remove a selected item', () => {
@@ -141,26 +154,47 @@ describe('Select', () => {
             // open the dropdown
             userEvent.click(screen.getByRole('button', {name: /select an option/i}));
 
-            let lists = screen.getAllByRole('list');
-            expect(within(lists[0]).getByText('🥔')).toBeVisible();
+            // pre-selected option is in the listbos
+            expect(screen.getByText(/🥔/i)).toBeInTheDocument();
 
-            expect(within(lists[1]).getByText('🌱')).toBeVisible();
-            expect(within(lists[1]).queryByText('🥔')).not.toBeInTheDocument();
-            expect(within(lists[1]).getByText('🍟')).toBeVisible();
+            expect(
+                screen.getByRole('option', {
+                    name: /🌱/i,
+                })
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole('option', {
+                    name: /🍟/i,
+                })
+            ).toBeInTheDocument();
 
-            userEvent.click(within(lists[1]).getByText('🍟'));
-
-            lists = screen.getAllByRole('list');
-            expect(within(lists[0]).getByText('🥔')).toBeVisible();
-            expect(within(lists[0]).getByText('🍟')).toBeVisible();
+            // select 🍟
+            userEvent.click(
+                screen.getByRole('option', {
+                    name: /🍟/i,
+                })
+            );
+            expect(screen.getByText(/🥔/i)).toBeInTheDocument();
+            expect(screen.getByText(/🍟/i)).toBeInTheDocument();
 
             // open the dropdown
             userEvent.click(screen.getByRole('button', {name: /select an option/i}));
 
-            lists = screen.getAllByRole('list');
-            expect(within(lists[1]).getByText('🌱')).toBeVisible();
-            expect(within(lists[1]).queryByText('🥔')).not.toBeInTheDocument();
-            expect(within(lists[1]).queryByText('🍟')).not.toBeInTheDocument();
+            expect(
+                screen.getByRole('option', {
+                    name: /🌱/i,
+                })
+            ).toBeVisible();
+            expect(
+                screen.queryByRole('option', {
+                    name: /🥔/i,
+                })
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByRole('option', {
+                    name: /🍟/i,
+                })
+            ).not.toBeInTheDocument();
         });
 
         it('does not open the dropdown if there is no unselected items', () => {

--- a/packages/react-vapor/src/components/select/tests/MultiSelectConnected.spec.tsx
+++ b/packages/react-vapor/src/components/select/tests/MultiSelectConnected.spec.tsx
@@ -35,34 +35,30 @@ describe('Select', () => {
         });
 
         it('describes the item with a custom tooltip', async () => {
-            const items = [{value: '🌱', selected: true, selectedTooltip: {title: ':seed:'}}, {value: '🍟'}];
+            const items = [{value: '🌱', selected: true, selectedTooltip: {title: '🌱'}}, {value: '🍟'}];
             render(<MultiSelectConnected id={id} items={items} />);
 
             fireEvent.mouseOver(screen.getByText('🌱'));
 
-            expect(await screen.findByLabelText(/:seed:/)).toBeVisible();
+            expect(await screen.findByLabelText(/🌱/)).toBeVisible();
         });
 
         it('displays the displayValue in the selected items', () => {
             const items = [
-                {value: '🌱', selected: true, displayValue: ':seed:'},
-                {value: '🥔', selected: true, displayValue: ':potato:'},
+                {value: '🌱', selected: true, displayValue: '🌱'},
+                {value: '🥔', selected: true, displayValue: '🥔'},
                 {value: '🍟'},
             ];
             render(<MultiSelectConnected id={id} items={items} />);
 
             const listitems = screen.getAllByRole('listitem');
             expect(listitems.length).toBe(2);
-            expect(listitems[0]).toHaveTextContent(':seed:');
-            expect(listitems[1]).toHaveTextContent(':potato:');
+            expect(listitems[0]).toHaveTextContent('🌱');
+            expect(listitems[1]).toHaveTextContent('🥔');
         });
 
         it('displays the displayValue in the dropdown list', () => {
-            const items = [
-                {value: '🌱', displayValue: ':seed:'},
-                {value: '🥔', displayValue: ':potato:'},
-                {value: '🍟'},
-            ];
+            const items = [{value: '🌱', displayValue: '🌱'}, {value: '🥔', displayValue: '🥔'}, {value: '🍟'}];
             render(<MultiSelectConnected id={id} items={items} />);
 
             // open the dropdown
@@ -70,12 +66,12 @@ describe('Select', () => {
 
             expect(
                 screen.getByRole('option', {
-                    name: /:seed:/i,
+                    name: /🌱/i,
                 })
             ).toBeVisible();
             expect(
                 screen.getByRole('option', {
-                    name: /:seed:/i,
+                    name: /🌱/i,
                 })
             ).toBeVisible();
             expect(
@@ -154,7 +150,7 @@ describe('Select', () => {
             // open the dropdown
             userEvent.click(screen.getByRole('button', {name: /select an option/i}));
 
-            // pre-selected option is in the listbos
+            // pre-selected option is in the listbox
             expect(screen.getByText(/🥔/i)).toBeInTheDocument();
 
             expect(

--- a/packages/react-vapor/src/components/select/tests/SingleSelectConnected.spec.tsx
+++ b/packages/react-vapor/src/components/select/tests/SingleSelectConnected.spec.tsx
@@ -213,33 +213,34 @@ describe('Select', () => {
             it('should open the dropdown when the user press enter on the button', () => {
                 render(<SingleSelectConnected id={id} items={[{value: 'a'}, {value: 'b'}]} />);
 
-                expect(screen.queryByRole('list')).not.toBeInTheDocument();
+                screen.logTestingPlaygroundURL();
+                expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
 
                 fireEvent.keyDown(screen.getByRole('button'), {key: 'Enter', code: 'Enter', keyCode: keyCode.enter});
                 fireEvent.keyUp(screen.getByRole('button'), {key: 'Enter', code: 'Enter', keyCode: keyCode.enter});
 
-                expect(screen.queryByRole('list')).toBeVisible();
+                expect(screen.queryByRole('listbox')).toBeVisible();
             });
 
             it('should close the dropdown when the user press escape on the button and the dropdown is open', () => {
                 render(<SingleSelectConnected id={id} items={[{value: 'a'}, {value: 'b'}]} />);
 
-                expect(screen.queryByRole('list')).not.toBeInTheDocument();
+                expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
 
                 fireEvent.keyDown(screen.getByRole('button'), {key: 'Escape', code: 'Escape', keyCode: keyCode.escape});
                 fireEvent.keyUp(screen.getByRole('button'), {key: 'Escape', code: 'Escape', keyCode: keyCode.escape});
 
-                expect(screen.queryByRole('list')).not.toBeInTheDocument();
+                expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
 
                 fireEvent.keyDown(screen.getByRole('button'), {key: 'Enter', code: 'Enter', keyCode: keyCode.enter});
                 fireEvent.keyUp(screen.getByRole('button'), {key: 'Enter', code: 'Enter', keyCode: keyCode.enter});
 
-                expect(screen.queryByRole('list')).toBeVisible();
+                expect(screen.queryByRole('listbox')).toBeVisible();
 
                 fireEvent.keyDown(screen.getByRole('button'), {key: 'Escape', code: 'Escape', keyCode: keyCode.escape});
                 fireEvent.keyUp(screen.getByRole('button'), {key: 'Escape', code: 'Escape', keyCode: keyCode.escape});
 
-                expect(screen.queryByRole('list')).not.toBeInTheDocument();
+                expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
             });
         });
         describe('footer props', () => {

--- a/packages/react-vapor/src/components/select/tests/SingleSelectConnected.spec.tsx
+++ b/packages/react-vapor/src/components/select/tests/SingleSelectConnected.spec.tsx
@@ -213,7 +213,6 @@ describe('Select', () => {
             it('should open the dropdown when the user press enter on the button', () => {
                 render(<SingleSelectConnected id={id} items={[{value: 'a'}, {value: 'b'}]} />);
 
-                screen.logTestingPlaygroundURL();
                 expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
 
                 fireEvent.keyDown(screen.getByRole('button'), {key: 'Enter', code: 'Enter', keyCode: keyCode.enter});

--- a/packages/react-vapor/src/components/table-hoc/tests/TableWithPredicate.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableWithPredicate.spec.tsx
@@ -199,12 +199,30 @@ describe('Table HOC', () => {
         it('should show values when opened', () => {
             render(<TableWithPredicate {...defaultProps} />);
 
+            expect(
+                screen.queryByRole('option', {
+                    name: /all/i,
+                })
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByRole('option', {
+                    name: /test/i,
+                })
+            ).not.toBeInTheDocument();
+
             // Click on the dropdown
             userEvent.click(screen.getByRole('button'));
-            const listitems = screen.getAllByRole('listitem');
-            expect(listitems.length).toBe(2);
-            expect(listitems[0]).toHaveTextContent('All');
-            expect(listitems[1]).toHaveTextContent('test');
+
+            expect(
+                screen.getByRole('option', {
+                    name: /all/i,
+                })
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole('option', {
+                    name: /test/i,
+                })
+            ).toBeInTheDocument();
         });
     });
 });


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-72

Improved the accessibility of select components by adding `listbox` and `option` to ListBox components, and updated the tests

eg BEFORE

```tsx
let lists = screen.getAllByRole('list');

expect(within(lists[1]).queryByText('first')).not.toBeInTheDocument();
```

AFTER

```tsx
expect(
    screen.getByRole('option', {
        name: /first/i,
    })
).toBeInTheDocument();
```

### Potential Breaking Changes

None: functionality is the same, only testing is easier

NOTE: I was unable to update `MultiSelectWithPredicateAndFilter.spec.tsx` to RTL, the input won't change when using RTL and attempts to debug were taking too long. I will open another ticket & PR for documenting debugging Jest tests in React Vapor)

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
