### PR TITLE
fix(typekit,tooltip): set the text color to white

### DIFF
--- a/packages/vapor/scss/components/tooltip.scss
+++ b/packages/vapor/scss/components/tooltip.scss
@@ -108,6 +108,12 @@
         word-wrap: break-word;
         background-color: var(--digital-blue-100);
         border-radius: 2px;
+
+        .body-m-book,
+        p,
+        .p {
+            --color: var(--white);
+        }
     }
 }
 


### PR DESCRIPTION
### Proposed Changes

For tooltips, if we use P tags for the title, the text becomes white again as it was originally

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
