### PR TITLE
test(tablehoc): tableHOC was missing a ternery

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
@@ -86,7 +86,7 @@ export const TableHOC: React.FunctionComponent<ITableHOCProps & React.HTMLAttrib
         <table className={classNames(className)} style={{marginTop: hasActions() ? '-1px' : 0}}>
             {tableHeader}
             <tbody key={`table-body-${id}`} className={classNames({hidden: isLoading}, tbodyClassName)}>
-                {renderBody(data)}
+                {renderBody(data || [])}
             </tbody>
             {isLoading && (
                 <TableLoading.Body

--- a/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
@@ -1,3 +1,4 @@
+import {render} from '@test-utils';
 import {shallow} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
@@ -18,6 +19,18 @@ describe('TableHOC', () => {
         it('should not throw', () => {
             expect(() => shallow(<TableHOC id="table" data={[]} renderBody={_.identity} />)).not.toThrow();
             expect(() => shallow(<TableHOC id="table-2" data={null} renderBody={_.identity} />)).not.toThrow();
+        });
+
+        it('should call renderBody with an array when data is null', () => {
+            const renderBody = jest.fn();
+            render(<TableHOC id="table-2" data={null} renderBody={renderBody} />);
+            expect(renderBody).toHaveBeenCalledWith([]);
+        });
+
+        it('should call renderBody with an array when data is undefined', () => {
+            const renderBody = jest.fn();
+            render(<TableHOC id="table-2" data={undefined} renderBody={renderBody} />);
+            expect(renderBody).toHaveBeenCalledWith([]);
         });
 
         it('should render a table', () => {


### PR DESCRIPTION
In the refactor I missed out on a default option when passing data. I added tests since this was a
corner case previously missed

https://coveord.atlassian.net/browse/UITOOL-112

### Proposed Changes

Adding default `[]`
Added tests to check that `null` and `undefined` are tested against

How to test:

It should be good, but the final confirmation will be with data in the Admin

### Potential Breaking Changes


### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
