### PR TITLE
feat(modal): improve accessibility by adding a labelledby property

### DIFF
--- a/packages/react-vapor/src/components/modal/ModalComposite.tsx
+++ b/packages/react-vapor/src/components/modal/ModalComposite.tsx
@@ -83,6 +83,9 @@ export class ModalComposite extends React.PureComponent<
             <ReactModal
                 key={this.props.id}
                 isOpen={this.props.isOpened}
+                aria={{
+                    labelledby: `modal-${this.props.id}-title`,
+                }}
                 className={{
                     base: classNames('modal-container --react-modal', this.props.classes, {
                         'mod-prompt': this.props.isPrompt,
@@ -140,6 +143,7 @@ export class ModalComposite extends React.PureComponent<
             title: this.props.title,
             classes: this.props.modalHeaderClasses,
             docLink: this.props.docLink,
+            htmlId: `modal-${this.props.id}-title`,
         };
 
         if (!this.props.title) {

--- a/packages/react-vapor/src/components/modal/ModalHeader.tsx
+++ b/packages/react-vapor/src/components/modal/ModalHeader.tsx
@@ -12,6 +12,7 @@ export interface IModalHeaderOwnProps {
     title: string;
     classes?: IClassName;
     docLink?: ILinkSvgProps;
+    htmlId?: string;
 }
 
 export interface IModalHeaderStateProps {
@@ -79,7 +80,12 @@ export class ModalHeader extends React.Component<IModalHeaderProps> {
         return (
             <header className={classes}>
                 <div className="truncate">
-                    <Title text={this.props.title} documentationLink={docLinkProps} classes={['regular']} />
+                    <Title
+                        text={this.props.title}
+                        documentationLink={docLinkProps}
+                        classes={['regular']}
+                        htmlId={this.props.htmlId}
+                    />
                 </div>
                 {this.props.children}
                 {closeComponent}

--- a/packages/react-vapor/src/components/modal/tests/ModalComposite.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/ModalComposite.spec.tsx
@@ -1,3 +1,4 @@
+import {renderModal, screen} from '@test-utils';
 import {shallow} from 'enzyme';
 import * as React from 'react';
 import ReactModal from 'react-modal';
@@ -51,6 +52,24 @@ describe('ModalComposite', () => {
 
         expect(modalContent.exists()).toBe(true);
         expect(modalContent.find(ModalHeader).exists()).toBe(true);
+    });
+
+    it('renders an accessible heading', () => {
+        renderModal(<ModalComposite isOpened title="my title" />);
+
+        expect(screen.getByRole('dialog', {name: 'my title'})).toBeVisible();
+    });
+
+    it('is possible to access modals by their title', () => {
+        renderModal(
+            <>
+                <ModalComposite id="first" isOpened title="first modal title" />
+                <ModalComposite id="second" isOpened title="second modal title" />
+            </>
+        );
+
+        expect(screen.getByRole('dialog', {name: 'first modal title'})).toBeVisible();
+        expect(screen.getByRole('dialog', {name: 'second modal title'})).toBeVisible();
     });
 
     it('should render modal header children inside the modal header', () => {

--- a/packages/react-vapor/src/components/title/Title.tsx
+++ b/packages/react-vapor/src/components/title/Title.tsx
@@ -11,6 +11,7 @@ export interface ITitleProps {
     withTitleTooltip?: boolean;
     documentationLink?: ILinkSvgProps;
     classes?: string[];
+    htmlId?: string;
 }
 
 export const Title: React.FunctionComponent<ITitleProps> = (props) => {
@@ -30,7 +31,7 @@ export const Title: React.FunctionComponent<ITitleProps> = (props) => {
 
     return (
         <div className="flex flex-center full-content-x">
-            <h4 className={titleClasses}>
+            <h4 className={titleClasses} id={props.htmlId}>
                 <span className={prefixClasses}>{props.prefix}</span>
                 {title}
             </h4>


### PR DESCRIPTION
### Proposed Changes

Improve the accessibility of the modal by adding a `labelledby` attribute. This allow a developer to get the dialog by it's title:

```typescript
renderModal(<ModalComposite isOpened title={'my title'} />);

expect(screen.getByRole('dialog', {name: 'my title'})).toBeVisible();
```

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
