### PR TITLE
feat(modal composite): prop for content classes

### DIFF
--- a/packages/react-vapor/src/components/modal/ModalComposite.tsx
+++ b/packages/react-vapor/src/components/modal/ModalComposite.tsx
@@ -28,6 +28,7 @@ export interface IModalCompositeOwnProps
     modalBodyClasses?: IClassName;
     modalFooterChildren?: React.ReactNode;
     modalFooterClasses?: IClassName;
+    contentClasses?: IClassName;
     isPrompt?: boolean;
     validateShouldNavigate?: (isDirty: boolean) => boolean;
 }
@@ -67,6 +68,7 @@ const modalPropsToOmit = [
     'title',
     'validateShouldNavigate',
     'withReduxState',
+    'contentClasses',
 ];
 
 export class ModalComposite extends React.PureComponent<
@@ -107,7 +109,7 @@ export class ModalComposite extends React.PureComponent<
                 onAfterClose={this.props.closeCallback}
                 {...reactModalprops}
             >
-                <div className="modal-content" id={this.props.id}>
+                <div className={classNames('modal-content', this.props.contentClasses)} id={this.props.id}>
                     {this.getModalHeader()}
                     {this.getModalBody()}
                     {this.getModalFooter()}

--- a/packages/react-vapor/src/components/modal/tests/ModalComposite.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/ModalComposite.spec.tsx
@@ -123,4 +123,9 @@ describe('ModalComposite', () => {
 
         expect((modalComposite.prop('className') as ReactModal.Classes).base).toContain('mod-prompt');
     });
+
+    it('passes the contentClasses prop to the modal classNames', () => {
+        const modalComposite = shallow(<ModalComposite isOpened isPrompt contentClasses="content-class" />);
+        expect(modalComposite.find('.content-class').exists()).toBe(true);
+    });
 });


### PR DESCRIPTION
### Proposed Changes

A simple prop to pass classNames to the modal content.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
