### PR TITLE
fix(date-picker): allow minimal range limit

### DIFF
--- a/packages/demo/src/components/examples/DatePickerExamples.tsx
+++ b/packages/demo/src/components/examples/DatePickerExamples.tsx
@@ -65,6 +65,20 @@ const DatePickerComponents: React.FunctionComponent = () => (
                     selectionRules={CALENDAR_SELECTION_RULES}
                 />
             </Section>
+            <Section level={3} title="DatePicker dropdown with a minimal range limit of 5 minutes">
+                <DatePickerDropdownConnected
+                    id="date-picker-dropdown-2"
+                    datesSelectionBoxes={[
+                        {
+                            ...FOUR_SELECTION_BOXES[0],
+                            minimalRangeLimit: {
+                                minutes: 5,
+                                message: 'You need a range of at least 5 minutes from the start to the end',
+                            },
+                        },
+                    ]}
+                />
+            </Section>
             <Section level={3} title="Date picker dropdown disabled">
                 <DatePickerDropdownConnected
                     id="date-picker-dropdown-disabled"
@@ -75,7 +89,7 @@ const DatePickerComponents: React.FunctionComponent = () => (
             </Section>
             <Section level={3} title="Clearable date picker dropdown initially unselected with Redux state">
                 <DatePickerDropdownConnected
-                    id="date-picker-dropdown-2"
+                    id="date-picker-dropdown-3"
                     datesSelectionBoxes={FOUR_SELECTION_BOXES}
                     selectionRules={[]}
                     isClearable
@@ -84,7 +98,7 @@ const DatePickerComponents: React.FunctionComponent = () => (
             </Section>
             <Section level={3} title="Date picker dropdown with drop">
                 <DatePickerDropdownConnected
-                    id="date-picker-dropdown-3"
+                    id="date-picker-dropdown-4"
                     datesSelectionBoxes={FOUR_SELECTION_BOXES}
                     selectionRules={[]}
                     isClearable
@@ -96,7 +110,7 @@ const DatePickerComponents: React.FunctionComponent = () => (
                 <ChildForm>
                     <Section level={2} title="My date picker label">
                         <DatePickerDropdownConnected
-                            id="date-picker-dropdown-4"
+                            id="date-picker-dropdown-5"
                             datesSelectionBoxes={[{...FOUR_SELECTION_BOXES[0], isRange: false}]}
                             selectionRules={[]}
                             isClearable

--- a/packages/react-vapor/src/components/datePicker/DatePicker.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePicker.tsx
@@ -1,9 +1,11 @@
+import moment from 'moment';
 import classNames from 'classnames';
 import * as React from 'react';
 
 import {DateUtils} from '../../utils/DateUtils';
 import {DateLimits} from './DatePickerActions';
 import {DEFAULT_DATE_PICKER_COLOR} from './DatePickerConstants';
+import {IRangeLimit} from './DatesSelection';
 import {SetToNowButton} from './SetToNowButton';
 
 export interface IDatePickerProps extends React.ClassAttributes<DatePicker> {
@@ -13,6 +15,7 @@ export interface IDatePickerProps extends React.ClassAttributes<DatePicker> {
     withTime?: boolean;
     hasSetToNowButton?: boolean;
     upperLimit?: boolean;
+    minimalRangeLimit?: IRangeLimit;
     date?: Date;
     setToNowTooltip?: string;
     isSelecting?: string;
@@ -39,8 +42,22 @@ export class DatePicker extends React.PureComponent<IDatePickerProps, {isSelecte
 
     private setToToday = () => {
         const date = new Date();
-        this.dateInput.value = this.getStringFromDate(date);
+        this.dateInput.value = this.props.minimalRangeLimit
+            ? this.getStringFromDate(this.updateDateBasedOnMinimalLimit(date))
+            : this.getStringFromDate(date);
         this.handleChangeDate();
+    };
+
+    private updateDateBasedOnMinimalLimit = (date: Date) => {
+        const {weeks, days, hours, minutes} = this.props.minimalRangeLimit;
+        const minimalLimitInMinutes: number =
+            (weeks ? weeks * 10080 : 0) + (days ? days * 1440 : 0) + (hours ? hours * 60 : 0) + (minutes ? minutes : 0);
+        const diff = moment().diff(moment(date), 'minutes');
+        if (Math.abs(diff) < minimalLimitInMinutes) {
+            return moment(date).add(minimalLimitInMinutes, 'minutes').toDate();
+        }
+
+        return date;
     };
 
     private handleChangeDate = () => {

--- a/packages/react-vapor/src/components/datePicker/DatePicker.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePicker.tsx
@@ -49,9 +49,7 @@ export class DatePicker extends React.PureComponent<IDatePickerProps, {isSelecte
     };
 
     private updateDateBasedOnMinimalLimit = (date: Date) => {
-        const {weeks, days, hours, minutes} = this.props.minimalRangeLimit;
-        const minimalLimitInMinutes: number =
-            (weeks ? weeks * 10080 : 0) + (days ? days * 1440 : 0) + (hours ? hours * 60 : 0) + (minutes ? minutes : 0);
+        const minimalLimitInMinutes: number = DateUtils.convertRangeToMinutes(this.props.minimalRangeLimit);
         const diff = moment().diff(moment(date), 'minutes');
         if (Math.abs(diff) < minimalLimitInMinutes) {
             return moment(date).add(minimalLimitInMinutes, 'minutes').toDate();

--- a/packages/react-vapor/src/components/datePicker/DatePickerActions.ts
+++ b/packages/react-vapor/src/components/datePicker/DatePickerActions.ts
@@ -47,13 +47,13 @@ export const addDatePicker = (
     id: string,
     isRange: boolean,
     rangeLimit: IRangeLimit = undefined,
-    minimalRangeLimit: IRangeLimit = undefined,
     color: string = DEFAULT_DATE_PICKER_COLOR,
     calendarId: string = '',
     initiallyUnselected = false,
     isClearable = false,
     simple = false,
-    initialDateRange?: DatePickerDateRange
+    initialDateRange?: DatePickerDateRange,
+    minimalRangeLimit: IRangeLimit = undefined
 ): IReduxAction<IAddDatePickerPayload> => ({
     type: DatePickerActions.add,
     payload: {
@@ -62,11 +62,11 @@ export const addDatePicker = (
         calendarId,
         isRange,
         rangeLimit,
-        minimalRangeLimit,
         initiallyUnselected,
         isClearable,
         simple,
         initialDateRange,
+        minimalRangeLimit,
     },
 });
 

--- a/packages/react-vapor/src/components/datePicker/DatePickerActions.ts
+++ b/packages/react-vapor/src/components/datePicker/DatePickerActions.ts
@@ -23,6 +23,7 @@ export interface IAddDatePickerPayload extends IDatePickerPayload {
     calendarId: string;
     isRange: boolean;
     rangeLimit?: IRangeLimit;
+    minimalRangeLimit?: IRangeLimit;
     initiallyUnselected?: boolean;
     isClearable?: boolean;
     simple?: boolean;
@@ -46,6 +47,7 @@ export const addDatePicker = (
     id: string,
     isRange: boolean,
     rangeLimit: IRangeLimit = undefined,
+    minimalRangeLimit: IRangeLimit = undefined,
     color: string = DEFAULT_DATE_PICKER_COLOR,
     calendarId: string = '',
     initiallyUnselected = false,
@@ -60,6 +62,7 @@ export const addDatePicker = (
         calendarId,
         isRange,
         rangeLimit,
+        minimalRangeLimit,
         initiallyUnselected,
         isClearable,
         simple,

--- a/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
@@ -18,6 +18,7 @@ export interface IDatesSelectionBox {
     quickOptions?: IOption[];
     isRange?: boolean;
     rangeLimit?: IRangeLimit;
+    minimalRangeLimit?: IRangeLimit;
     withTime?: boolean;
     hasSetToNowButton?: boolean;
     color?: string;
@@ -143,6 +144,7 @@ export class DatePickerBox extends React.Component<IDatePickerBoxProps, any> {
                 isRange: datesSelectionBox.isRange,
                 isClearable: this.props.isClearable,
                 rangeLimit: datesSelectionBox.rangeLimit,
+                minimalRangeLimit: datesSelectionBox.minimalRangeLimit,
                 color: datesSelectionBox.color,
                 calendarId: DatePickerBox.getCalendarId(this.props.id),
                 lowerLimitPlaceholder: this.props.lowerLimitPlaceholder,

--- a/packages/react-vapor/src/components/datePicker/DatePickerDropdown.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePickerDropdown.tsx
@@ -287,7 +287,7 @@ export class DatePickerDropdown extends React.Component<IDatePickerDropdownProps
     }
 
     private hasNotReachTheMinimalRangeLimit(): boolean {
-        if (this.props.datePicker && this.props.datePicker.minimalRangeLimit) {
+        if (this.props.datePicker?.minimalRangeLimit) {
             const {limit, diff} = this.getLimitAndDiffInMinutes(this.props.datePicker.minimalRangeLimit);
             return Math.abs(diff) < limit;
         }
@@ -295,7 +295,7 @@ export class DatePickerDropdown extends React.Component<IDatePickerDropdownProps
     }
 
     private hasExceededRangeLimit(): boolean {
-        if (this.props.datePicker && this.props.datePicker.rangeLimit) {
+        if (this.props.datePicker?.rangeLimit) {
             const {limit, diff} = this.getLimitAndDiffInMinutes(this.props.datePicker.rangeLimit);
             return diff > limit;
         }

--- a/packages/react-vapor/src/components/datePicker/DatePickerDropdown.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePickerDropdown.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import * as VaporSVG from 'coveo-styleguide';
+import {TooltipPlacement} from '../../utils';
 import {DateUtils} from '../../utils/DateUtils';
 import {IReduxStatePossibleProps} from '../../utils/ReduxUtils';
 import {Button} from '../button/Button';
@@ -15,6 +16,7 @@ import {DatePickerBox, IDatePickerBoxChildrenProps, IDatePickerBoxProps, IDatesS
 import {DatePickerDateRange} from './DatePickerConstants';
 import {IDatePickerState} from './DatePickerReducers';
 import {Svg} from '../svg';
+import {IRangeLimit} from './DatesSelection';
 
 export interface IDatePickerDropdownOwnProps extends React.ClassAttributes<DatePickerDropdown> {
     label?: string;
@@ -273,24 +275,50 @@ export class DatePickerDropdown extends React.Component<IDatePickerDropdownProps
             : DateUtils.getSimpleDate(date);
     }
 
+    private getLimitAndDiffInMinutes(range: IRangeLimit): {limit: number; diff: number} {
+        const {weeks, days, hours, minutes} = range;
+        const limit: number =
+            (weeks ? weeks * 10080 : 0) + (days ? days * 1440 : 0) + (hours ? hours * 60 : 0) + (minutes ? minutes : 0);
+        const diff: number = moment(this.props.datePicker.inputUpperLimit).diff(
+            moment(this.props.datePicker.inputLowerLimit),
+            'minutes'
+        );
+        return {limit, diff};
+    }
+
+    private hasNotReachTheMinimalRangeLimit(): boolean {
+        if (this.props.datePicker && this.props.datePicker.minimalRangeLimit) {
+            const {limit, diff} = this.getLimitAndDiffInMinutes(this.props.datePicker.minimalRangeLimit);
+            return Math.abs(diff) < limit;
+        }
+        return false;
+    }
+
     private hasExceededRangeLimit(): boolean {
         if (this.props.datePicker && this.props.datePicker.rangeLimit) {
-            const {weeks, days, hours} = this.props.datePicker.rangeLimit;
-            const limitInMinutes: number =
-                (weeks ? weeks * 10080 : 0) + (days ? days * 1440 : 0) + (hours ? hours * 60 : 0);
-            const diffInMinutes: number = moment(this.props.datePicker.inputUpperLimit).diff(
-                moment(this.props.datePicker.inputLowerLimit),
-                'minutes'
-            );
-            return diffInMinutes > limitInMinutes;
+            const {limit, diff} = this.getLimitAndDiffInMinutes(this.props.datePicker.rangeLimit);
+            return diff > limit;
         }
 
         return false;
     }
 
+    private getApplyButtonTooltip(hasExceededRangeLimit: boolean, hasNotReachTheMinimalRangeLimit: boolean): string {
+        if (hasExceededRangeLimit) {
+            return this.props.datePicker.rangeLimit.message;
+        }
+
+        if (hasNotReachTheMinimalRangeLimit) {
+            return this.props.datePicker.minimalRangeLimit.message;
+        }
+
+        return '';
+    }
+
     private getDatePickerBox(): JSX.Element {
         if (this.props.isOpened || this.props.renderDatePickerWhenClosed) {
             const hasExceededRangeLimit = this.hasExceededRangeLimit();
+            const hasNotReachTheMinimalRangeLimit = this.hasNotReachTheMinimalRangeLimit();
             const datePickerBoxProps: IDatePickerBoxProps = {
                 setToNowTooltip: this.props.setToNowTooltip,
                 datesSelectionBoxes: this.props.datesSelectionBoxes,
@@ -314,12 +342,12 @@ export class DatePickerDropdown extends React.Component<IDatePickerDropdownProps
                 footer: (
                     <ModalFooter classes={['mod-small']}>
                         <Button
-                            enabled={!hasExceededRangeLimit}
+                            enabled={!hasExceededRangeLimit && !hasNotReachTheMinimalRangeLimit}
                             name={this.props.applyLabel}
                             small={true}
                             primary={true}
-                            tooltip={hasExceededRangeLimit ? this.props.datePicker.rangeLimit.message : ''}
-                            tooltipPlacement={'left'}
+                            tooltip={this.getApplyButtonTooltip(hasExceededRangeLimit, hasNotReachTheMinimalRangeLimit)}
+                            tooltipPlacement={TooltipPlacement.Left}
                             onClick={() => this.handleApply()}
                         />
                         <Button

--- a/packages/react-vapor/src/components/datePicker/DatePickerDropdown.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePickerDropdown.tsx
@@ -276,9 +276,7 @@ export class DatePickerDropdown extends React.Component<IDatePickerDropdownProps
     }
 
     private getLimitAndDiffInMinutes(range: IRangeLimit): {limit: number; diff: number} {
-        const {weeks, days, hours, minutes} = range;
-        const limit: number =
-            (weeks ? weeks * 10080 : 0) + (days ? days * 1440 : 0) + (hours ? hours * 60 : 0) + (minutes ? minutes : 0);
+        const limit: number = DateUtils.convertRangeToMinutes(range);
         const diff: number = moment(this.props.datePicker.inputUpperLimit).diff(
             moment(this.props.datePicker.inputLowerLimit),
             'minutes'

--- a/packages/react-vapor/src/components/datePicker/DatePickerReducers.ts
+++ b/packages/react-vapor/src/components/datePicker/DatePickerReducers.ts
@@ -14,6 +14,7 @@ export interface IDatePickerState {
     inputLowerLimit: Date;
     inputUpperLimit: Date;
     rangeLimit?: IRangeLimit;
+    minimalRangeLimit?: IRangeLimit;
     isRange: boolean;
     isClearable: boolean;
     selected: string;
@@ -50,6 +51,7 @@ const addDatePicker = (state: IDatePickerState, action: IReduxAction<IAddDatePic
         color: action.payload.color,
         isRange: action.payload.isRange,
         rangeLimit: action.payload.rangeLimit,
+        minimalRangeLimit: action.payload.minimalRangeLimit,
         lowerLimit: appliedLowerLimit || mayBeNull(state.lowerLimit),
         upperLimit: appliedUpperLimit || mayBeNull(state.upperLimit),
         inputLowerLimit: appliedLowerLimit || mayBeNull(state.inputLowerLimit),
@@ -100,6 +102,10 @@ const applyDates = (state: IDatePickerState, action: IReduxAction<IReduxActionsP
         state.upperLimit || !state.isClearable
             ? state.upperLimit || state.inputUpperLimit || state.appliedUpperLimit
             : null;
+
+    if (state.isRange && !upperLimit) {
+        upperLimit = lowerLimit ? moment(lowerLimit).endOf('day').toDate() : upperLimit;
+    }
     upperLimit = upperLimit >= lowerLimit ? upperLimit : lowerLimit;
 
     return state.id.indexOf(action.payload.id) !== 0

--- a/packages/react-vapor/src/components/datePicker/DatesSelection.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatesSelection.tsx
@@ -7,6 +7,7 @@ export interface IRangeLimit {
     weeks?: number;
     days?: number;
     hours?: number;
+    minutes?: number;
     message?: string;
 }
 
@@ -17,6 +18,7 @@ export interface IDatesSelectionOwnProps extends React.ClassAttributes<DatesSele
     isRange?: boolean;
     isClearable?: boolean;
     rangeLimit?: IRangeLimit;
+    minimalRangeLimit?: IRangeLimit;
     color?: string;
     calendarId?: string;
     defaultLowerLimit?: Date;
@@ -126,6 +128,7 @@ export class DatesSelection extends React.Component<IDatesSelectionProps, any> {
             onBlur: (date: Date, isUpperLimit: boolean) => this.handleOnBlur(date, isUpperLimit),
             placeholder: '',
         };
+        const endDatePickerProps = {...datePickerProps, minimalRangeLimit: this.props.minimalRangeLimit};
         const separatorClasses: string[] = ['date-separator'];
         if (isLarge) {
             separatorClasses.push('mod-vertical');
@@ -139,7 +142,7 @@ export class DatesSelection extends React.Component<IDatesSelectionProps, any> {
             <DatePicker
                 upperLimit
                 date={this.props.upperLimit}
-                {...datePickerProps}
+                {...endDatePickerProps}
                 placeholder={this.props.upperLimitPlaceholder}
             />
         ) : null;

--- a/packages/react-vapor/src/components/datePicker/DatesSelectionConnected.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatesSelectionConnected.tsx
@@ -44,13 +44,13 @@ const mapDispatchToProps = (
                 ownProps.id,
                 ownProps.isRange,
                 ownProps.rangeLimit,
-                ownProps.minimalRangeLimit,
                 ownProps.color,
                 ownProps.calendarId,
                 ownProps.initiallyUnselected,
                 ownProps.isClearable,
                 undefined,
-                ownProps.initialDateRange
+                ownProps.initialDateRange,
+                ownProps.minimalRangeLimit
             )
         );
     },

--- a/packages/react-vapor/src/components/datePicker/DatesSelectionConnected.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatesSelectionConnected.tsx
@@ -44,6 +44,7 @@ const mapDispatchToProps = (
                 ownProps.id,
                 ownProps.isRange,
                 ownProps.rangeLimit,
+                ownProps.minimalRangeLimit,
                 ownProps.color,
                 ownProps.calendarId,
                 ownProps.initiallyUnselected,

--- a/packages/react-vapor/src/components/datePicker/tests/DatePicker.spec.tsx
+++ b/packages/react-vapor/src/components/datePicker/tests/DatePicker.spec.tsx
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import {mount, ReactWrapper, shallow} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
@@ -289,6 +290,23 @@ describe('Date picker', () => {
                 document.getElementById('CalendarDay').click();
 
                 expect(dateProps.onBlur).not.toHaveBeenCalled();
+            });
+
+            it('updates the date based on the minimal range limit if the property is set', () => {
+                const today: Date = new Date();
+                const expectedDate: Date = moment(today).add(5, 'days').toDate();
+                const withoutTimeProps: IDatePickerProps = _.extend({}, DATE_PICKER_BASIC_PROPS, {
+                    minimalRangeLimit: {days: 5},
+                    hasSetToNowButton: true,
+                    upperLimit: true,
+                });
+                datePicker.setProps(withoutTimeProps);
+
+                expect(datePickerInstance['dateInput'].value).toBe('');
+
+                datePicker.find('button').simulate('click');
+
+                expect(datePickerInstance['dateInput'].value).toBe(DateUtils.getSimpleDate(expectedDate));
             });
         });
     });

--- a/packages/react-vapor/src/components/datePicker/tests/DatePickerDropdown.spec.tsx
+++ b/packages/react-vapor/src/components/datePicker/tests/DatePickerDropdown.spec.tsx
@@ -483,7 +483,7 @@ describe('Date picker', () => {
                 });
             };
 
-            it('should disabled the primary button if the the inputLowerLimit has exceeded the range limit with the inputUpperLimit', () => {
+            it('should disabled the primary button if the inputLowerLimit has exceeded the range limit with the inputUpperLimit', () => {
                 const date: Date = new Date();
                 date.setFullYear(date.getFullYear() + 1);
                 changeDatePickerState({
@@ -496,6 +496,24 @@ describe('Date picker', () => {
 
                 expect(datePickerBoxWrapper.find(Button).first().props().enabled).toBe(false);
                 expect(datePickerBoxWrapper.find(Button).first().props().tooltip).toBe('test');
+            });
+
+            it('disables the primary button if the minimal range limit is not met between the lowerLimit and the upperLimit', () => {
+                const lowerDate = new Date(2021, 2, 11);
+                const upperDate = new Date(2021, 2, 12);
+
+                const datePickerState = {
+                    inputLowerLimit: lowerDate,
+                    inputUpperLimit: upperDate,
+                    minimalRangeLimit: {
+                        days: 5,
+                    },
+                } as IDatePickerState;
+                render(<DatePickerDropdown datePicker={datePickerState} />);
+
+                const applyButton = screen.getByRole('button', {name: /Apply/});
+                expect(applyButton).toBeVisible();
+                expect(applyButton).toHaveClass('disabled');
             });
 
             it('should enabled the primary button if the the inputLowerLimit does not exceeded the range limit with the inputUpperLimit', () => {

--- a/packages/react-vapor/src/components/datePicker/tests/DatePickerDropdown.spec.tsx
+++ b/packages/react-vapor/src/components/datePicker/tests/DatePickerDropdown.spec.tsx
@@ -483,7 +483,7 @@ describe('Date picker', () => {
                 });
             };
 
-            it('should disabled the primary button if the inputLowerLimit has exceeded the range limit with the inputUpperLimit', () => {
+            it('should disable the primary button if the inputLowerLimit has exceeded the range limit with the inputUpperLimit', () => {
                 const date: Date = new Date();
                 date.setFullYear(date.getFullYear() + 1);
                 changeDatePickerState({

--- a/packages/react-vapor/src/components/datePicker/tests/DatePickerReducers.spec.ts
+++ b/packages/react-vapor/src/components/datePicker/tests/DatePickerReducers.spec.ts
@@ -894,6 +894,22 @@ describe('Date picker', () => {
 
                 expect(newDatePicker.appliedUpperLimit).toBe(oldDatePicker.lowerLimit);
             });
+
+            it('should set the upperLimit to the end of the day value if the state is set as a range and the upperLimit is undefined', () => {
+                const lowerLimit = new Date(2021, 3, 12);
+                const expectedUpperLimit = moment(lowerLimit).endOf('day').toDate();
+
+                oldDatePicker = {
+                    ...BASE_DATE_PICKER_STATE,
+                    lowerLimit,
+                    isRange: true,
+                    upperLimit: null,
+                    isClearable: true,
+                };
+                newDatePicker = datePickerReducer(oldDatePicker, action);
+
+                expect(newDatePicker.inputUpperLimit).toEqual(expectedUpperLimit);
+            });
         });
     });
 });

--- a/packages/react-vapor/src/utils/DateUtils.spec.tsx
+++ b/packages/react-vapor/src/utils/DateUtils.spec.tsx
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import {IRangeLimit} from '../components';
 import {DateUtils} from './DateUtils';
 
 describe('DateUtils', () => {
@@ -49,6 +50,25 @@ describe('DateUtils', () => {
             expect(DateUtils.isDifferent(moment(), moment().add(1, 'day'))).toBe(true);
             expect(DateUtils.isDifferent(moment().subtract(1, 'second'), moment())).toBe(true);
             expect(DateUtils.isDifferent('2018-01-01', '2018-12-31')).toBe(true);
+        });
+    });
+
+    describe('convertRangeToMinutes', () => {
+        it('returns 0 if the range value does not have any values set', () => {
+            const emptyRange: IRangeLimit = {};
+
+            expect(DateUtils.convertRangeToMinutes(emptyRange)).toBe(0);
+        });
+
+        it('returns the number of minutes based on the range value', () => {
+            const rangeWithoutHours: IRangeLimit = {weeks: 2, days: 3, minutes: 10};
+            const rangeWithoutWeeks: IRangeLimit = {days: 2, hours: 5, minutes: 16};
+
+            const expectedNumberOfMinutesRangeWithoutHours = 2 * 10080 + 3 * 1440 + 10;
+            const expectedNumberOfMinutesRangeWithoutWeeks = 2 * 1440 + 5 * 60 + 16;
+
+            expect(DateUtils.convertRangeToMinutes(rangeWithoutHours)).toBe(expectedNumberOfMinutesRangeWithoutHours);
+            expect(DateUtils.convertRangeToMinutes(rangeWithoutWeeks)).toBe(expectedNumberOfMinutesRangeWithoutWeeks);
         });
     });
 });

--- a/packages/react-vapor/src/utils/DateUtils.ts
+++ b/packages/react-vapor/src/utils/DateUtils.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import * as _ from 'underscore';
+import {IRangeLimit} from '../components';
 
 import {IDay} from '../components/calendar/CalendarDay';
 
@@ -89,6 +90,19 @@ export class DateUtils {
 
     static getDateFromSimpleDateString(date: string): Date {
         return moment(date, SIMPLE_DATE_FORMAT, true).toDate();
+    }
+
+    static convertRangeToMinutes(range: IRangeLimit): number {
+        const {weeks, days, hours, minutes} = range;
+
+        return moment
+            .duration({
+                weeks: weeks ? weeks : 0,
+                days: days ? days : 0,
+                hours: hours ? hours : 0,
+                minutes: minutes ? minutes : 0,
+            })
+            .asMinutes();
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes

First part to fix this bug: https://coveord.atlassian.net/browse/SEARCHAPI-6055

This PR includes three changes for the date-picker:
1. If the date picker includes a range, and the "end" date is empty when the user apply the changes, the date is set as the end of today, instead of the current time.

Before:

https://user-images.githubusercontent.com/58052881/129240570-5dc0d1e5-ee69-4068-aea4-a8caac439f21.mp4

After:

https://user-images.githubusercontent.com/58052881/129240587-922c6cf1-5547-40a3-bb4a-4de9e8587e95.mp4

2. A new option (optional) is added, which allows a minimal range limit. If this minimum is not reached, the apply button is disabled. That way, it indicates to the user that an minimum range has to be set to save their selection.

Demo:

https://user-images.githubusercontent.com/58052881/129241340-271d033d-bbdd-4b5e-a0f9-6ed26f413cca.mp4

3. When a minimal range is set, and the user wants the start date as "now", the end date is set to the minimal date that would respect the minimal range limit.

Demo:

https://user-images.githubusercontent.com/58052881/129240737-a8e881b0-b38c-4edf-aa9a-51d983b67a08.mp4

To test it:
1. Access the "DatePicker" section.
2. Play around with the `DatePicker dropdown with a minimal range limit of 5 minutes` component included for this demo.

### Potential Breaking Changes
Because this option is optional, nothing should be breaking.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
