### PR TITLE
feat(form): +customhook to get the state of all specific forms

### DIFF
--- a/packages/react-vapor/src/components/form/FormProvider.tsx
+++ b/packages/react-vapor/src/components/form/FormProvider.tsx
@@ -18,7 +18,7 @@ const componentReducers = {
     TextInput: generateRecordReducer(textInputReducer),
 };
 
-type FormComponent = keyof typeof componentReducers;
+export type FormComponent = keyof typeof componentReducers;
 type FormComponentReducer = typeof componentReducers[FormComponent];
 type FormAction = {type: FormComponent} & React.ReducerAction<FormComponentReducer>;
 type FormState = Record<FormComponent, React.ReducerState<FormComponentReducer>>;

--- a/packages/react-vapor/src/components/textInput/index.ts
+++ b/packages/react-vapor/src/components/textInput/index.ts
@@ -1,2 +1,3 @@
 export * from './TextInput';
 export * from './useTextInput';
+export * from './useForm';

--- a/packages/react-vapor/src/components/textInput/useForm.ts
+++ b/packages/react-vapor/src/components/textInput/useForm.ts
@@ -1,0 +1,12 @@
+import {useContext, useMemo} from 'react';
+import {TextInputState} from './TextInputReducer';
+import {FormComponent, FormContext} from '../form/FormProvider';
+
+export const useFormComponent = (component: FormComponent): {state: Record<string, TextInputState>} => {
+    const formContext = useContext(FormContext);
+    if (formContext === undefined) {
+        throw new Error('useFormComponent must be used within a FormProvider.');
+    }
+    const state = formContext.state[component] || {};
+    return useMemo(() => ({state}), [state]);
+};


### PR DESCRIPTION
### Proposed Changes

added a custom hook that, by passing it a specific type of Form, will return the state of all forms. For example, useTextInput need an id so it can return the state of that specific TextInput. In my case, I want to use a hook that returns all of the TextInput of a component (really useful for validation and also when juggling with TextInput with guid() rather than hardcoded ids.

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
