### PR TITLE
feat(vapor): add new SVG ready-to-receive-content & success in 32px

### DIFF
--- a/packages/vapor/resources/icons/svg/ready-to-receive-content-32px.svg
+++ b/packages/vapor/resources/icons/svg/ready-to-receive-content-32px.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 32 32" stroke="#282829" stroke-linecap="round" stroke-linejoin="round" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 4.50002L16 15.75M11.5 12L16 16.5L20.5 12"/>
+<path d="M12 8.5H8.5C7.39543 8.5 6.5 9.39543 6.5 10.5V25.5C6.5 26.6046 7.39543 27.5 8.5 27.5H23.5C24.6046 27.5 25.5 26.6046 25.5 25.5V10.5C25.5 9.39543 24.6046 8.5 23.5 8.5H19.5"/>
+</svg>

--- a/packages/vapor/resources/icons/svg/success-32px.svg
+++ b/packages/vapor/resources/icons/svg/success-32px.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 32 32" stroke="#282829" stroke-linecap="round" stroke-linejoin="round" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.35294 19.7134L9.47865 26.8391L27.7647 8.55303"/>
+</svg>


### PR DESCRIPTION
### Proposed Changes

Add new SGV:
- ready-to-receive-content-32px.svg
- success-32px.svg

![image](https://user-images.githubusercontent.com/966550/130233220-89fd38b2-cfc3-4d0e-9231-cc79422a15a3.png)

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
