### PR TITLE
Clear TextInput state when unmounting

### DIFF
--- a/packages/react-vapor/src/components/form/index.ts
+++ b/packages/react-vapor/src/components/form/index.ts
@@ -1,3 +1,4 @@
 export * from './Form';
 export * from './FormGroup';
 export {FormProvider} from '../form/FormProvider';
+export * from './useFormComponent';

--- a/packages/react-vapor/src/components/form/useFormComponent.ts
+++ b/packages/react-vapor/src/components/form/useFormComponent.ts
@@ -1,6 +1,6 @@
 import {useContext, useMemo} from 'react';
-import {TextInputState} from './TextInputReducer';
-import {FormComponent, FormContext} from '../form/FormProvider';
+import {TextInputState} from '../textInput/TextInputReducer';
+import {FormComponent, FormContext} from './FormProvider';
 
 export const useFormComponent = (component: FormComponent): {state: Record<string, TextInputState>} => {
     const formContext = useContext(FormContext);

--- a/packages/react-vapor/src/components/textInput/TextInput.tsx
+++ b/packages/react-vapor/src/components/textInput/TextInput.tsx
@@ -90,6 +90,9 @@ export const TextInput: React.FunctionComponent<TextInputProps & React.HTMLProps
         if (showValidationOnMount) {
             dispatch({type: 'show-validation'});
         }
+        return () => {
+            dispatch({type: 'reset'});
+        };
     }, []);
 
     return (

--- a/packages/react-vapor/src/components/textInput/TextInputReducer.tsx
+++ b/packages/react-vapor/src/components/textInput/TextInputReducer.tsx
@@ -9,7 +9,8 @@ export type TextInputAction =
     | {type: 'set-warning'}
     | {type: 'set-message'; payload: string}
     | {type: 'set-dirty'}
-    | {type: 'set-pristine'};
+    | {type: 'set-pristine'}
+    | {type: 'reset'};
 
 export type TextInputState = {
     value: string;
@@ -50,6 +51,8 @@ export const textInputReducer: React.Reducer<TextInputState, TextInputAction> = 
             return {...state, isDirty: true};
         case 'set-pristine':
             return {...state, isDirty: false};
+        case 'reset':
+            return textInputDefaultState;
         default:
             throw new Error(`Unhandled action type: ${(action as {type: 'string'}).type}.`);
     }

--- a/packages/react-vapor/src/components/textInput/index.ts
+++ b/packages/react-vapor/src/components/textInput/index.ts
@@ -1,3 +1,2 @@
 export * from './TextInput';
 export * from './useTextInput';
-export * from './useForm';

--- a/packages/react-vapor/src/components/textInput/tests/TextInput.spec.tsx
+++ b/packages/react-vapor/src/components/textInput/tests/TextInput.spec.tsx
@@ -1,8 +1,9 @@
-import * as React from 'react';
-import {render, expectToThrow, screen, fireEvent} from '@test-utils';
+import {expectToThrow, fireEvent, render, screen} from '@test-utils';
 import userEvent from '@testing-library/user-event';
-import {TextInput, InputValidator} from '../TextInput';
+import * as React from 'react';
+
 import {FormProvider} from '../../form/FormProvider';
+import {InputValidator, TextInput} from '../TextInput';
 
 describe('TextInput', () => {
     it('throws an error if the rendering a TextInput outside a FormProvider', () => {
@@ -196,5 +197,29 @@ describe('TextInput', () => {
         expect(firstNameInput).toBeValid();
         expect(lastNameInput).toHaveValue('Doe');
         expect(lastNameInput).toBeValid();
+    });
+
+    it('resets its state when unmounting and remounting with the same id', () => {
+        const Fixture = () => {
+            const [isMounted, toggleMounted] = React.useState(true);
+            return (
+                <>
+                    <button onClick={() => toggleMounted(!isMounted)}>toggle input</button>
+                    {isMounted ? <TextInput id="🆔" type="text" label="Name" /> : null}
+                </>
+            );
+        };
+
+        render(
+            <FormProvider>
+                <Fixture />
+            </FormProvider>
+        );
+
+        userEvent.type(screen.getByRole('textbox', {name: /name/i}), 'some value');
+        expect(screen.getByRole('textbox', {name: /name/i})).toHaveValue('some value');
+        userEvent.click(screen.getByRole('button', {name: /toggle input/i})); // unmount
+        userEvent.click(screen.getByRole('button', {name: /toggle input/i})); // mount again
+        expect(screen.getByRole('textbox', {name: /name/i})).toHaveValue('');
     });
 });


### PR DESCRIPTION
### Proposed Changes

- move useFormComponent hook from `textInput` to `form` folder
- reset TextInput state to initial state when unmounting

### Potential Breaking Changes

None

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
