### PR TITLE
ci(jenkins): dont notify for skipped builds

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -302,7 +302,7 @@ pipeline {
   post {
     fixed {
       script {
-        if(env.BRANCH_NAME ==~ /(master|release-.*)/){
+        if(!skipRemainingStages && env.BRANCH_NAME ==~ /(master|release-.*)/){
           def message = "Build is back to normal for <${env.BUILD_URL}|${env.JOB_NAME}>";
           def color = "#2ECC71"; // green
           notify.sendSlackWithThread(


### PR DESCRIPTION
### Proposed Changes

Don't notify build back to normal when the build has skipped stages. 
![image](https://user-images.githubusercontent.com/35579930/130856060-96f910cf-aa86-4b81-9879-1600f965432b.png)

A skipped build doesn't mean that the branch status is back to normal, the error is still there.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
