### PR TITLE
Fix withDirty HOC

### DIFF
--- a/packages/react-vapor/jest/setup.ts
+++ b/packages/react-vapor/jest/setup.ts
@@ -32,3 +32,19 @@ document.createRange = () => {
 
     return range;
 };
+
+/**
+ * Prevents modal `unmount` timeout to remove ModalRoot and cause error.
+ *
+ * Solution to:
+ * Uncaught NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
+ */
+const flushAllPendingTimers = () => {
+    let id = window.setTimeout((): void => null, 0);
+    while (id--) {
+        window.clearTimeout(id);
+    }
+};
+
+afterEach(jest.restoreAllMocks);
+afterEach(flushAllPendingTimers);

--- a/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
+++ b/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {connect} from 'react-redux';
 
 import {ConnectedProps, IDispatch, TooltipPlacement} from '../../utils';
+import {useMountedState} from '../../utils/useMountedState';
 import {Button} from '../button';
 import {ModalActions} from '../modal/ModalActions';
 import {IModalCompositeOwnProps, ModalCompositeConnected} from '../modal/ModalComposite';
@@ -62,6 +63,7 @@ const ModalWizardDisconneted: React.FunctionComponent<ModalWizardProps & Connect
     const isFirstStep = currentStep === 0;
     const isLastStep = currentStep === numberOfSteps - 1;
     const {isValid, message} = validateStep?.(currentStep, numberOfSteps) ?? {isValid: true};
+    const isMounted = useMountedState();
 
     return (
         <UnsavedChangesModalProvider isDirty={isDirty} confirmationModalId={`${id}-unsaved-modal`}>
@@ -116,7 +118,11 @@ const ModalWizardDisconneted: React.FunctionComponent<ModalWizardProps & Connect
                             />
                         </>
                     }
-                    onAfterOpen={() => setCurrentStep(0)}
+                    onAfterOpen={() => {
+                        if (isMounted()) {
+                            setCurrentStep(0);
+                        }
+                    }}
                     validateShouldNavigate={() => promptBefore(close)}
                     title={typeof title === 'function' ? title(currentStep, numberOfSteps) : title}
                     {...modalProps}

--- a/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
+++ b/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
@@ -5,15 +5,6 @@ import {renderModal, screen, waitForElementToBeRemoved} from '@test-utils';
 import {ModalWizard} from '../ModalWizard';
 
 describe('ModalWizard', () => {
-    beforeEach(() => {
-        jest.useFakeTimers();
-    });
-
-    afterEach(() => {
-        jest.runOnlyPendingTimers();
-        jest.useRealTimers();
-    });
-
     it('closes the modal and execute the onCancel prop if passed when clicking on "cancel"', async () => {
         const cancelSpy = jest.fn();
         renderModal(

--- a/packages/react-vapor/src/components/modalWizard/tests/ModalWizardWithValidations.spec.tsx
+++ b/packages/react-vapor/src/components/modalWizard/tests/ModalWizardWithValidations.spec.tsx
@@ -5,15 +5,6 @@ import {renderModal, screen, waitForElementToBeRemoved} from '@test-utils';
 import {ModalWizardWithValidations} from '../ModalWizardWithValidations';
 
 describe('ModalWizardWithValidations', () => {
-    beforeEach(() => {
-        jest.useFakeTimers();
-    });
-
-    afterEach(() => {
-        jest.runOnlyPendingTimers();
-        jest.useRealTimers();
-    });
-
     it('validates each steps using validation ids', () => {
         renderModal(
             <ModalWizardWithValidations id="🌶🧙‍♂️" validationIdsByStep={[['step-1'], ['step-2-a', 'step-2-b']]}>

--- a/packages/react-vapor/src/hoc/withDirty/withDirty.tsx
+++ b/packages/react-vapor/src/hoc/withDirty/withDirty.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {isBoolean} from 'underscore';
 
 import {IReactVaporState} from '../../ReactVaporState';
 import {IDispatch, ReduxConnect} from '../../utils/ReduxUtils';
@@ -28,7 +29,9 @@ export const withDirty = <T, R = any>(config: Partial<IWithDirty> = {}) => (
     Component: React.ComponentType<Partial<IWithDirtyProps> & T>
 ): React.ComponentClass<Partial<IWithDirtyProps> & T, R> => {
     const mapStateToProps = (state: IReactVaporState, ownProps: IWithDirty): IWithDirtyStateProps => ({
-        isDirty: WithDirtySelectors.getIsDirty(state, {id: ownProps.id || config.id}),
+        isDirty: isBoolean(config.isDirty)
+            ? config.isDirty
+            : WithDirtySelectors.getIsDirty(state, {id: ownProps.id || config.id}),
     });
 
     const mapDispatchToProps = (dispatch: IDispatch, ownProps: IWithDirty): IWithDirtyDispatchProps => ({

--- a/packages/react-vapor/src/utils/useMountedState.ts
+++ b/packages/react-vapor/src/utils/useMountedState.ts
@@ -1,0 +1,16 @@
+import {useRef, useEffect, useCallback} from 'react';
+
+/**
+ * Indicates whether a component is mounted
+ */
+export const useMountedState = () => {
+    const isMountedRef = useRef(true);
+    const unref = useCallback(() => isMountedRef.current, []);
+    useEffect(
+        () => () => {
+            isMountedRef.current = false;
+        },
+        []
+    );
+    return unref;
+};


### PR DESCRIPTION
### Proposed Changes

[Related issue](https://coveord.atlassian.net/browse/ADUI-7405)

`withDirty` HOC had a weird behaviour where it could override the `isDirty` value specified in the config given the right circumstances.

I also fixed some failing tests in the ModalWizard by removing the fake timers.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
