### PR TITLE
feat(table-hoc): added action bar prefix

### DIFF
--- a/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableHOC.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
 
+import {IContentProps} from '../../Entry';
 import {WithServerSideProcessingProps} from '../../hoc/withServerSideProcessing/withServerSideProcessing';
 import {ActionBarConnected} from '../actions/ActionBar';
 import {TableLoading} from '../loading/components/TableLoading';
@@ -19,6 +20,7 @@ export interface ITableHOCOwnProps {
     data: any[];
     renderBody: (data: any[]) => React.ReactNode;
     actions?: React.ReactNode[];
+    actionBarPrefixContent?: IContentProps;
     tableHeader?: React.ReactNode;
     onUpdate?: () => void;
     containerClassName?: string;
@@ -38,6 +40,7 @@ export interface ITableHOCProps extends ITableHOCOwnProps {}
 export const TableHOC: React.FunctionComponent<ITableHOCProps & React.HTMLAttributes<HTMLTableElement>> = ({
     hasActionButtons = false,
     actions = [],
+    actionBarPrefixContent,
     showBorderTop = false,
     showBorderBottom = true,
     id,
@@ -56,10 +59,10 @@ export const TableHOC: React.FunctionComponent<ITableHOCProps & React.HTMLAttrib
         numberOfSubRow: 3,
     },
 }) => {
-    const hasActions = () => hasActionButtons || actions.length;
+    const hasActionBar = () => hasActionButtons || actions.length || actionBarPrefixContent;
 
-    const renderActions = () => {
-        if (hasActions()) {
+    const renderActionBar = () => {
+        if (hasActionBar()) {
             return (
                 <ActionBarConnected
                     id={id}
@@ -74,6 +77,7 @@ export const TableHOC: React.FunctionComponent<ITableHOCProps & React.HTMLAttrib
                         }
                     ).split(' ')}
                     disabled={isLoading}
+                    prefixContent={actionBarPrefixContent}
                 >
                     {actions}
                 </ActionBarConnected>
@@ -83,7 +87,7 @@ export const TableHOC: React.FunctionComponent<ITableHOCProps & React.HTMLAttrib
     };
 
     const table = (
-        <table className={classNames(className)} style={{marginTop: hasActions() ? '-1px' : 0}}>
+        <table className={classNames(className)} style={{marginTop: hasActionBar() ? '-1px' : 0}}>
             {tableHeader}
             <tbody key={`table-body-${id}`} className={classNames({hidden: isLoading}, tbodyClassName)}>
                 {renderBody(data || [])}
@@ -102,7 +106,7 @@ export const TableHOC: React.FunctionComponent<ITableHOCProps & React.HTMLAttrib
 
     return (
         <div className={classNames('table-container', containerClassName)}>
-            {renderActions()}
+            {renderActionBar()}
             {table}
             {children}
         </div>

--- a/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
+++ b/packages/react-vapor/src/components/table-hoc/tests/TableHOC.spec.tsx
@@ -123,6 +123,19 @@ describe('TableHOC', () => {
             expect(wrapper.find(ActionBarConnected).exists()).toBe(true);
         });
 
+        it('should render an ActionBarConnected if the table prop has an action bar prefix', () => {
+            const wrapper = shallow(<TableHOC {...defaultProps} actionBarPrefixContent={{content: <div />}} />);
+
+            expect(wrapper.find(ActionBarConnected).exists()).toBe(true);
+        });
+
+        it('should pass the action bar prefix to ActionBarConnected', () => {
+            const content = {content: <div id="someContent" />};
+            const wrapper = shallow(<TableHOC {...defaultProps} actionBarPrefixContent={content} />);
+
+            expect(wrapper.find(ActionBarConnected).props().prefixContent).toBe(content);
+        });
+
         it('should keep the tbody with rows data during the loading', () => {
             const wrapper = shallow(<TableHOC {...defaultProps} isLoading />);
 


### PR DESCRIPTION
### Proposed Changes

Expose the prefixContent from ActionBar on TableHOC. We need it to migrate the Salesforce Table to TableHOC.

### Potential Breaking Changes

N/A

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
