### PR TITLE
fix(title): tooltip appear if truncated

### DIFF
--- a/packages/react-vapor/src/components/title/Title.tsx
+++ b/packages/react-vapor/src/components/title/Title.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';

--- a/packages/react-vapor/src/components/title/Title.tsx
+++ b/packages/react-vapor/src/components/title/Title.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import classNames from 'classnames';
 import * as React from 'react';
 import * as _ from 'underscore';
@@ -15,23 +16,33 @@ export interface ITitleProps {
 }
 
 export const Title: React.FunctionComponent<ITitleProps> = (props) => {
+    const ref = React.useRef<HTMLHRElement>();
+    const [isTruncated, setIsTruncated] = React.useState(false);
     const linkClasses = classNames('inline-doc-link', props.documentationLink && props.documentationLink.linkClasses);
     const titleClasses: string = classNames('bolder', 'mr1', 'truncate', props.classes);
     const prefixClasses: string = classNames({mr1: !_.isEmpty(props.prefix)});
-
     const linkIcon = props.documentationLink && <LinkSvg {...props.documentationLink} linkClasses={[linkClasses]} />;
     const tooltipProps = _.isString(props.text) ? {title: props.text} : {};
-    const title = props.withTitleTooltip ? (
-        <Tooltip {...tooltipProps} placement="left">
-            {props.text}
-        </Tooltip>
-    ) : (
-        props.text
-    );
+
+    const detection = () => {
+        const titleOffSetWidth = ref.current.offsetWidth;
+        const titleScrollWidth = ref.current.scrollWidth;
+
+        setIsTruncated(titleOffSetWidth < titleScrollWidth);
+    };
+
+    const title =
+        props.withTitleTooltip || isTruncated ? (
+            <Tooltip {...tooltipProps} placement="left">
+                {props.text}
+            </Tooltip>
+        ) : (
+            props.text
+        );
 
     return (
-        <div className="flex flex-center full-content-x">
-            <h4 className={titleClasses} id={props.htmlId}>
+        <div className="flex flex-center full-content-x" onMouseEnter={detection}>
+            <h4 ref={ref} className={titleClasses} id={props.htmlId}>
                 <span className={prefixClasses}>{props.prefix}</span>
                 {title}
             </h4>

--- a/packages/react-vapor/src/components/title/Title.tsx
+++ b/packages/react-vapor/src/components/title/Title.tsx
@@ -15,7 +15,8 @@ export interface ITitleProps {
 }
 
 export const Title: React.FunctionComponent<ITitleProps> = (props) => {
-    const ref = React.useRef<HTMLHRElement>();
+    const ref = React.useRef<HTMLHeadingElement>();
+
     const [isTruncated, setIsTruncated] = React.useState(false);
     const linkClasses = classNames('inline-doc-link', props.documentationLink && props.documentationLink.linkClasses);
     const titleClasses: string = classNames('bolder', 'mr1', 'truncate', props.classes);


### PR DESCRIPTION
### Proposed Changes

Using `useRef` to check if the header in the title is getting truncated
if it is, a tooltip with the whole text will appear on hover

### Potential Breaking Changes

none that I know of 

### To Test

In the Header section of the Demo, the Breadcrumbs all finish with a Title component. So if you reduce your screen size to make the title truncate you will be able to test the behavior.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
