### PR TITLE
style(links): visiting state to be d-blue

### DIFF
--- a/packages/vapor/scss/elements/links.scss
+++ b/packages/vapor/scss/elements/links.scss
@@ -49,9 +49,9 @@ a {
     }
 
     &:visited {
-        --color: var(--grape-purple-30);
-        --fill: var(--grape-purple-30);
-        --stroke: var(--grape-purple-30);
+        --color: var(--links-color);
+        --fill: var(--links-color);
+        --stroke: var(--links-color);
         text-decoration: underline;
     }
 }


### PR DESCRIPTION
### Proposed Changes

After speaking with Gustavo, this is the preferred solution for now as we will remove the `grape-purple-30` colour on link visit since it interferes with the colour on Firefox and not on Chrome.

This should fix the reported bug for ADUI-7509 where the breadcrumb header colour is not consistent between Chrome and Firefox.

We want to keep this visit state as Firefox by default will have their own colour applied if its not overwritten. 

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
