### PR TITLE
style(modelwizard): making progress bar sticky fix

### DIFF
--- a/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
+++ b/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
@@ -70,9 +70,10 @@ const ModalWizardDisconneted: React.FunctionComponent<ModalWizardProps & Connect
             {({promptBefore}) => (
                 <ModalCompositeConnected
                     id={id}
+                    modalHeaderChildren={<StepProgressBar numberOfSteps={numberOfSteps} currentStep={currentStep} />}
+                    modalHeaderClasses={['p0 flex flex-column flex-start space-between full-content-x']}
                     modalBodyChildren={
                         <>
-                            <StepProgressBar numberOfSteps={numberOfSteps} currentStep={currentStep} />
                             {steps.map((step: React.ReactElement, index: number) => {
                                 const hidden = index !== currentStep;
                                 return (

--- a/packages/vapor/scss/components/modal-wizard.scss
+++ b/packages/vapor/scss/components/modal-wizard.scss
@@ -1,0 +1,4 @@
+header.modal-header h4[id^='modal-'][id$='-title'] {
+    margin: 2rem;
+    padding-left: 0.5rem;
+}

--- a/packages/vapor/scss/components/step-progress-bar.scss
+++ b/packages/vapor/scss/components/step-progress-bar.scss
@@ -1,6 +1,7 @@
 .step-progress-bar-container {
     display: flex;
     align-items: flex-start;
+    width: 100%;
 }
 
 .step-progress-bar {

--- a/packages/vapor/scss/guide.scss
+++ b/packages/vapor/scss/guide.scss
@@ -129,6 +129,7 @@
     @import 'components/split-multiline-input';
     @import 'components/separator';
     @import 'components/table-hoc';
+    @import 'components/modal-wizard';
     // Forms
     @import 'forms/form-sections';
     @import 'forms/form-child';

--- a/packages/vapor/scss/utility/flex.scss
+++ b/packages/vapor/scss/utility/flex.scss
@@ -22,6 +22,10 @@
     align-items: stretch;
 }
 
+.flex-start {
+    align-items: start;
+}
+
 .flex-auto {
     flex-basis: auto;
     flex-grow: 1;


### PR DESCRIPTION
**Problem**

The progress bar would scroll with the modal body.
Refactoring the styling to bring the progress bar to the header and allow for it to be sticky at the top.

### Proposed Changes

- Moved the Step Progress Bar to the header
- Added additional CSS classes to align the title and progress bar in the Modal Header component
- Added specific CSS target for the title to add padding (I was not able to do this with the additional CSS classes so I created a custom file called `modal-wizard.scss` to align the title targeting `model-{id}-title` h4 element)

**Before:**

https://user-images.githubusercontent.com/66333175/133631629-0ca1eb49-51c1-4a2d-8d39-9ecb116c4672.mp4

**After:**


https://user-images.githubusercontent.com/66333175/133632102-e5d520fc-c32d-44f0-b5dc-52881d026d85.mp4


### Potential Breaking Changes

None


How to test:
1. Go to the ModalWizard section
2. Open up any of the Wizards
3. Duplicate the content to make the body scrollable
4. The progress bar should not scroll with the body

https://user-images.githubusercontent.com/66333175/133632460-0411b06f-a8f5-4cda-941d-67d9bb7591d1.mp4

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
