### PR TITLE
fix: change the padding bottom for the icon

### DIFF
--- a/packages/vapor/scss/components/facet.scss
+++ b/packages/vapor/scss/components/facet.scss
@@ -166,7 +166,7 @@
     right: 0;
     width: $facet-exclude-padding-right;
     height: 100%;
-    padding-bottom: 3px;
+    padding-bottom: 2px;
     cursor: pointer;
 
     + .checkbox-label > .exclude-box,


### PR DESCRIPTION
### Proposed Changes

I changed the padding-bottom from 3px to 2px so the icon is now centered with the label. 
Go in FacetConnected and hover on a row, the exclude icon will appear.


### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
