### PR TITLE
fix(toast): set additional padding for the close part

### DIFF
--- a/packages/demo/src/components/examples/ToastExamples.tsx
+++ b/packages/demo/src/components/examples/ToastExamples.tsx
@@ -236,6 +236,30 @@ const ToastsWithReduxStoreDisconnected: React.FunctionComponent<ReturnType<typeo
                 />
             </Section>
 
+            <Section level={2} title="Toasts with only title" className="flex">
+                <Label className="flex">Sometimes we want toast with only a title that can be closed</Label>
+
+                <Button
+                    enabled
+                    className="btn m0 mr1 mb1"
+                    name="Description"
+                    onClick={() => renderToast('containerId', 'Small title', {})}
+                />
+
+                <Button
+                    enabled
+                    className="btn m0 mr1 mb1"
+                    name="Longer description"
+                    onClick={() =>
+                        renderToast(
+                            'containerId',
+                            'Very long title that proves that there is enough padding from the title close part of the toast',
+                            {}
+                        )
+                    }
+                />
+            </Section>
+
             <Section level={2} title="Small toasts" className="flex">
                 <Button
                     enabled

--- a/packages/vapor/scss/components/toast.scss
+++ b/packages/vapor/scss/components/toast.scss
@@ -7,7 +7,7 @@ $toast-download-padding: 20px;
 $toast-text-font-size: 14px;
 $toast-title-font-weight: 500;
 $toast-close-size: 20px;
-$toast-close-padding-left: 5px;
+$toast-close-padding-left: 20px;
 $toast-info-token-padding: 12px 16px 12px 8px;
 
 .toast-container {


### PR DESCRIPTION
### Proposed Changes
Add additional padding, because many toast seen in the admin-ui has only title, no description and can be closed. The result was that the "X" icon was a little bit too close of the title.

Before (in the admin-UI):

![toast_padding_too_small](https://user-images.githubusercontent.com/58052881/133671279-88e2f227-2bbc-43b2-b3c2-dae8d2c53f4a.png)

After (seen in the current toast examples):

https://user-images.githubusercontent.com/58052881/133671325-f23b8f26-cc88-4581-8b5e-0d85ce73cae1.mp4


### Potential Breaking Changes
I don't it will breaks anything.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
