### PR TITLE
fix(datepicker): datepicker should open when clicking on the svg

### DIFF
--- a/packages/vapor/scss/controls/dropdown.scss
+++ b/packages/vapor/scss/controls/dropdown.scss
@@ -99,6 +99,7 @@
         height: $dropdown-arrow-icon-size;
 
         &.icon {
+            pointer-events: none;
             fill: var(--grey-80);
         }
     }


### PR DESCRIPTION
### Proposed Changes

Disable the clicks on the save so it goes through to the button

Before


https://user-images.githubusercontent.com/260007/134249572-792ffc86-479d-486a-82b9-bcdcee888341.mov


After

https://user-images.githubusercontent.com/260007/134249579-391a3285-1ea6-41bb-bb56-cd94ddb0d510.mov

### Potential Breaking Changes

I tested all the other components with the same class (SingleSelect, MultiSelect, DropdownSearch) and they still work

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
