### PR TITLE
fix(modal): adding extra class for specificity modal wizard title

### DIFF
--- a/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
+++ b/packages/react-vapor/src/components/modalWizard/ModalWizard.tsx
@@ -71,7 +71,7 @@ const ModalWizardDisconneted: React.FunctionComponent<ModalWizardProps & Connect
                 <ModalCompositeConnected
                     id={id}
                     modalHeaderChildren={<StepProgressBar numberOfSteps={numberOfSteps} currentStep={currentStep} />}
-                    modalHeaderClasses={['p0 flex flex-column flex-start space-between full-content-x']}
+                    modalHeaderClasses={['p0 flex flex-column flex-start space-between full-content-x modal-wizard']}
                     modalBodyChildren={
                         <>
                             {steps.map((step: React.ReactElement, index: number) => {

--- a/packages/vapor/scss/components/modal-wizard.scss
+++ b/packages/vapor/scss/components/modal-wizard.scss
@@ -1,4 +1,4 @@
-header.modal-header h4[id^='modal-'][id$='-title'] {
+header.modal-header.modal-wizard h4[id^='modal-'][id$='-title'] {
     margin: 2rem;
     padding-left: 0.5rem;
 }


### PR DESCRIPTION
### Proposed Changes

I added an extra class `modal-wizard` to the css rule so that other Modals (non wizards) are left unaffected by the title padding.

I introduced a small bug targeting other modal titles when [refactoring the StepProgressBar into the header](https://github.com/coveo/react-vapor/pull/2123) - specifically for the ModalWizard component. This change affected non modal wizards and caused unwanted padding as seen below:

**Before:**
![CleanShot 2021-09-22 at 08 41 46@2x](https://user-images.githubusercontent.com/66333175/134345495-e799b878-90cc-4db6-a400-b10d8cd10f98.png)

**After**
![CleanShot 2021-09-22 at 08 42 41@2x](https://user-images.githubusercontent.com/66333175/134345701-76b0faaf-2869-4a5e-a61f-e6a27e1dd8bd.png)

The **WizardModal** and **Modal** titles should be okay now

### Potential Breaking Changes
None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
