### PR TITLE
fix(textarea): show validation message only when appropriate

### DIFF
--- a/packages/react-vapor/src/components/textarea/TextArea.tsx
+++ b/packages/react-vapor/src/components/textarea/TextArea.tsx
@@ -58,6 +58,7 @@ const mapDispatchToProps = (dispatch: IDispatch, ownProps: ITextAreaOwnProps): I
 });
 
 export const TextArea: React.FunctionComponent<ITextAreaProps> = ({
+    id,
     value,
     validate,
     onMount,
@@ -82,7 +83,9 @@ export const TextArea: React.FunctionComponent<ITextAreaProps> = ({
     }, [value]);
 
     React.useEffect(() => {
-        setIsValid(validate?.(debouncedValue));
+        if (validate) {
+            setIsValid(validate(debouncedValue));
+        }
     }, [debouncedValue]);
 
     React.useEffect(() => {
@@ -104,6 +107,7 @@ export const TextArea: React.FunctionComponent<ITextAreaProps> = ({
     return (
         <>
             <TextareaTagName
+                id={id}
                 {...additionalAttributes}
                 disabled={disabled}
                 className={className}


### PR DESCRIPTION
### Proposed Changes

The validation message was shown even when no validate function was provided.

- Don't attempt to validate the textarea if no validate function is provided
- Set the id on the textarea tag in order to improve accessibility

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
