### PR TITLE
fix(slider): change sldier handle tooltip position

### DIFF
--- a/packages/react-vapor/src/components/slider/SliderHandle.tsx
+++ b/packages/react-vapor/src/components/slider/SliderHandle.tsx
@@ -25,7 +25,7 @@ const SliderHandle: React.FunctionComponent<{
     <Tooltip
         prefixCls="rc-slider-tooltip"
         overlay={handleCustomProps.customTooltip ?? handleCustomProps.rangeOutput}
-        placement="top"
+        placement="bottom"
         visible={handleCustomProps.hasTooltip ? handleProps.dragging : false}
         {...tooltipProps}
     >


### PR DESCRIPTION
### Proposed Changes

Change slider handle tooltip position to bottom instead of top. That way the tooltip will never intersect with the marks labels.

Before
![image](https://user-images.githubusercontent.com/35579930/134398981-464a352d-22f0-4994-a84f-4dedca13d151.png)

After
![image](https://user-images.githubusercontent.com/35579930/134398940-9a848059-af02-433a-aea9-9d3c2d6e2a15.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
