### PR TITLE
chore(form): added line to export context

### DIFF
--- a/packages/react-vapor/src/components/form/index.ts
+++ b/packages/react-vapor/src/components/form/index.ts
@@ -1,4 +1,4 @@
 export * from './Form';
 export * from './FormGroup';
-export {FormProvider} from '../form/FormProvider';
+export {FormProvider, FormContext} from '../form/FormProvider';
 export * from './useFormComponent';


### PR DESCRIPTION
I need the FormContext in a class component

### Proposed Changes

ADUI-7504-temporaryaccessmodal

Blocking ADUI-7504

### Potential Breaking Changes

A simple export of the FormContext so I can use it in a class component (no hooks allowed in a class component, and refactoring the whole class was way out of scope).

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
