### PR TITLE
fix(toast): remove word-break attribute

### DIFF
--- a/packages/vapor/scss/components/toast.scss
+++ b/packages/vapor/scss/components/toast.scss
@@ -120,7 +120,6 @@ $toast-info-token-padding: 12px 16px 12px 8px;
         font-weight: $toast-title-font-weight;
         font-size: $toast-text-font-size;
         line-height: 20px;
-        word-break: break-all;
     }
 
     .toast-description {

--- a/packages/vapor/scss/components/toast.scss
+++ b/packages/vapor/scss/components/toast.scss
@@ -120,6 +120,7 @@ $toast-info-token-padding: 12px 16px 12px 8px;
         font-weight: $toast-title-font-weight;
         font-size: $toast-text-font-size;
         line-height: 20px;
+        overflow-wrap: anywhere;
     }
 
     .toast-description {


### PR DESCRIPTION
### Proposed Changes

Bug: https://coveord.atlassian.net/browse/ADUI-7490

Remove the `word-break` attribute as it is preferable to display a full word on a second line than break it.

Before:

![before_remove_word_break_toast](https://user-images.githubusercontent.com/58052881/134424056-2c9b89fa-f0f4-4f6a-b082-da1431ba3c52.png)

After:

![after_remove_word_break_toast](https://user-images.githubusercontent.com/58052881/134424098-9c00a478-cdcf-46eb-987d-85cae3b28cbb.png)

### Potential Breaking Changes
Shouldn't be the case.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
