### PR TITLE
fix(svg): css conflict with logo-white

### DIFF
--- a/packages/vapor/resources/icons/svg/arrow-top-slim.svg
+++ b/packages/vapor/resources/icons/svg/arrow-top-slim.svg
@@ -3,8 +3,8 @@
 <svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 29 43" style="enable-background:new 0 0 29 43;" xml:space="preserve">
 <style type="text/css">
-	.st0{stroke-width:3;stroke-linecap:round;stroke-linejoin:round;}
+	.svgArrowTopSlimPaths{fill:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;}
 </style>
-<path class="st0" stroke="#282829" d="M14.4,41.2v-39"/>
-<path class="st0" stroke="#282829" d="M2.1,15.7L14.4,2.2l12.3,13.5"/>
+<path class="svgArrowTopSlimPaths" stroke="#282829" d="M14.4,41.2v-39"/>
+<path class="svgArrowTopSlimPaths" stroke="#282829" d="M2.1,15.7L14.4,2.2l12.3,13.5"/>
 </svg>

--- a/packages/vapor/resources/icons/svg/arrow-top-slim.svg
+++ b/packages/vapor/resources/icons/svg/arrow-top-slim.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg viewBox="0 0 29 43" stroke="#282829" stroke-linecap="round" stroke-linejoin="round" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
+<svg viewBox="0 0 29 43" stroke="#282829" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
     <path d="M14.4,41.2v-39"/>
     <path d="M2.1,15.7L14.4,2.2l12.3,13.5"/>
 </svg>

--- a/packages/vapor/resources/icons/svg/arrow-top-slim.svg
+++ b/packages/vapor/resources/icons/svg/arrow-top-slim.svg
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 29 43" style="enable-background:new 0 0 29 43;" xml:space="preserve">
-<style type="text/css">
-	.svgArrowTopSlimPaths{fill:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;}
-</style>
-<path class="svgArrowTopSlimPaths" stroke="#282829" d="M14.4,41.2v-39"/>
-<path class="svgArrowTopSlimPaths" stroke="#282829" d="M2.1,15.7L14.4,2.2l12.3,13.5"/>
+<svg viewBox="0 0 29 43" stroke="#282829" stroke-linecap="round" stroke-linejoin="round" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
+    <path d="M14.4,41.2v-39"/>
+    <path d="M2.1,15.7L14.4,2.2l12.3,13.5"/>
 </svg>

--- a/packages/vapor/resources/icons/svg/arrow-top-slim.svg
+++ b/packages/vapor/resources/icons/svg/arrow-top-slim.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 29 43" style="enable-background:new 0 0 29 43;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;}
+	.st0{stroke-width:3;stroke-linecap:round;stroke-linejoin:round;}
 </style>
 <path class="st0" stroke="#282829" d="M14.4,41.2v-39"/>
 <path class="st0" stroke="#282829" d="M2.1,15.7L14.4,2.2l12.3,13.5"/>


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/SFINT-4088

Since `arrow-top-slim` had a CSS rule named `st0` containing `fill: none` it conflicted with `logo-white` that defines the same CSS rule but with `fill: #fff`. Including both SVG images in the same page made a part of the Coveo logo disappear.

Since `arrow-top-slim` does not contain any closed shapes, removing the `fill` attribute from the CSS rule does not impact the image rendering. But it avoids conflicts with other images.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
