### PR TITLE
fix: add mr1 on documentation link to avoid truncating the focus

### DIFF
--- a/packages/demo/src/components/examples/ExamplesUtils.ts
+++ b/packages/demo/src/components/examples/ExamplesUtils.ts
@@ -18,6 +18,11 @@ export const documentationLink: ILinkSvgProps = {
         svgClass: 'documentation-link icon mod-20',
         className: 'flex',
     },
+    tooltip: {
+        title: "I'm a tooltip!",
+        placement: 'bottom',
+        container: 'body',
+    },
 };
 
 export const defaultTitle: ITitleProps = {

--- a/packages/react-vapor/src/components/title/Title.tsx
+++ b/packages/react-vapor/src/components/title/Title.tsx
@@ -15,7 +15,10 @@ export interface ITitleProps {
 }
 
 export const Title: React.FunctionComponent<ITitleProps> = (props) => {
-    const linkClasses = classNames('inline-doc-link', props.documentationLink && props.documentationLink.linkClasses);
+    const linkClasses = classNames(
+        'inline-doc-link mr1',
+        props.documentationLink && props.documentationLink.linkClasses
+    );
     const titleClasses: string = classNames('bolder', 'mr1', 'truncate', props.classes);
     const prefixClasses: string = classNames({mr1: !_.isEmpty(props.prefix)});
 

--- a/packages/react-vapor/src/components/title/tests/Title.spec.tsx
+++ b/packages/react-vapor/src/components/title/tests/Title.spec.tsx
@@ -86,13 +86,12 @@ describe('<Title/>', () => {
             expect(titleComponent.find(Tooltip).length).toBe(1);
         });
 
-        it('should render the documentation link with the inline-doc-link and mr1 classes by default', () => {
+        it('should render the documentation link SVG', () => {
             renderTitle({
                 documentationLink,
             });
 
             expect(titleComponent.find(LinkSvg).length).toBe(1);
-            expect(titleComponent.find(LinkSvg).prop('linkClasses')).toContain('inline-doc-link mr1');
         });
     });
 

--- a/packages/react-vapor/src/components/title/tests/Title.spec.tsx
+++ b/packages/react-vapor/src/components/title/tests/Title.spec.tsx
@@ -83,13 +83,13 @@ describe('<Title/>', () => {
             expect(titleComponent.find(Tooltip).length).toBe(1);
         });
 
-        it('should render the documentation link with the inline-doc-link class by default', () => {
+        it('should render the documentation link with the inline-doc-link and mr1 classes by default', () => {
             renderTitle({
                 documentationLink,
             });
 
             expect(titleComponent.find(LinkSvg).length).toBe(1);
-            expect(titleComponent.find(LinkSvg).prop('linkClasses')).toContain('inline-doc-link');
+            expect(titleComponent.find(LinkSvg).prop('linkClasses')).toContain('inline-doc-link mr1');
         });
     });
 });


### PR DESCRIPTION
### Proposed Changes
The focus border on the SVG was truncated by the breadcrumbs. Now it's not! 

You need to select the focus option in the dev tool on the <a> to get the focus effect in React-Vapor
![image](https://user-images.githubusercontent.com/63734941/134976918-95066861-a68a-4acc-ad6f-ad5647c78f14.png)


Before:
![image](https://user-images.githubusercontent.com/63734941/134976717-b85b520d-7fd8-4343-b2c3-6f3f57a0b09d.png)


After:
![image](https://user-images.githubusercontent.com/63734941/134976402-be6d6734-c355-4b23-8443-9fc48fd215d9.png)



### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
