### PR TITLE
feat(multiboxwithremovebutton): *remove button

### DIFF
--- a/packages/react-vapor/src/components/multilineBox/hoc/MultilineBoxWithRemoveButton.tsx
+++ b/packages/react-vapor/src/components/multilineBox/hoc/MultilineBoxWithRemoveButton.tsx
@@ -59,20 +59,21 @@ export const multilineBoxWithRemoveButton = (
         };
 
         private getRemoveButtonNode(
-            data: Partial<IMultilineSingleBoxProps<T>> = {},
-            props: Partial<IButtonProps> = {}
+            data: Array<Partial<IMultilineSingleBoxProps<T>>>,
+            props: Partial<IButtonProps> = {},
+            index: number
         ) {
             return (
                 <Button
                     classes={[
                         classNames(defaultMultilineBoxRemoveButtonClasses, {
-                            'cursor-pointer': !data.isLast,
+                            'cursor-pointer': !data[index]?.isLast,
                         }),
                     ]}
                     style={{
-                        visibility: !data.isLast ? 'visible' : 'hidden',
+                        visibility: data.length > 1 ? 'visible' : 'hidden',
                     }}
-                    onClick={() => !data.isLast && !this.props.disabled && this.props.removeBox(data.id)}
+                    onClick={() => !this.props.disabled && this.props.removeBox(data[index].id)}
                     enabled={!this.props.disabled}
                     {...props}
                 >
@@ -80,7 +81,7 @@ export const multilineBoxWithRemoveButton = (
                         svgName={VaporSVG.svg.remove.name}
                         className="icon mod-18"
                         style={{
-                            visibility: !data.isLast ? 'visible' : 'hidden',
+                            visibility: data.length > 1 ? 'visible' : 'hidden',
                         }}
                     />
                 </Button>
@@ -91,7 +92,7 @@ export const multilineBoxWithRemoveButton = (
             return React.Children.map(children, (child: React.ReactNode, index: number) =>
                 HocUtils.supplyConfig(supplier).containerNode(
                     child,
-                    (props?: Partial<IButtonProps>) => this.getRemoveButtonNode(data[index], props),
+                    (props?: Partial<IButtonProps>) => this.getRemoveButtonNode(data, props, index),
                     data,
                     index
                 )

--- a/packages/react-vapor/src/components/multilineBox/tests/MultilineBoxWithRemoveButton.spec.tsx
+++ b/packages/react-vapor/src/components/multilineBox/tests/MultilineBoxWithRemoveButton.spec.tsx
@@ -8,7 +8,8 @@ import {RTestUtils} from '../../../utils/tests/RTestUtils';
 import {getStoreMock, ReactVaporMockStore} from '../../../utils/tests/TestUtils';
 import {Button, IButtonProps} from '../../button/Button';
 import {multilineBoxWithRemoveButton} from '../hoc/MultilineBoxWithRemoveButton';
-import {IMultilineBoxOwnProps, MultilineBox} from '../MultilineBox';
+import {IMultilineBoxOwnProps, IMultilineSingleBoxProps, MultilineBox} from '../MultilineBox';
+import {render, screen} from '../../../TestUtils';
 
 describe('Multiline box with remove button', () => {
     describe('<MultilineBoxWithRemoveButton/>', () => {
@@ -183,6 +184,32 @@ describe('Multiline box with remove button', () => {
                     );
 
                     expect(wrapper.find('.pick-me-plz').length).toBe(1);
+                });
+
+                it('should render a remove button for all the elements returned from the renderBody prop', () => {
+                    render(
+                        <ModifiedMultilineBoxWithRemoveButton
+                            id="allo"
+                            data={[
+                                {name: 'potatos', displayName: 'soudane'},
+                                {name: 'potatas', displayName: 'cromonasse'},
+                                {name: 'help', displayName: 'me'},
+                            ]}
+                            renderBody={(data: IMultilineSingleBoxProps[]) => data.map((test) => <div>{'mommy'}</div>)}
+                        />
+                    );
+                    expect(screen.getAllByRole('button', {name: /remove icon/i}).length).toBe(4);
+                });
+
+                it('should not render a remove button if one element is returned from the renderBody prop', () => {
+                    render(
+                        <ModifiedMultilineBoxWithRemoveButton
+                            id="allo"
+                            data={[]}
+                            renderBody={(data: IMultilineSingleBoxProps[]) => data.map((test) => <div>{'mommy'}</div>)}
+                        />
+                    );
+                    expect(screen.queryAllByRole('button', {name: /remove icon/i}).length).toBe(0);
                 });
             });
         });


### PR DESCRIPTION
### Proposed Changes

remove button is now hidden only when the MultiBox has one child. In any other cases, the remove button will be visible. 

The current behaviour usually expects us to add a method where we call `parentProps.addNewBox()` inside the child component, which can lead to unwanted display like _You just wrote something in the first child (let's say you are rendering inputs). With the expected implementation, a new input will be rendered, but without a remove button_ . I think it would be better to give the option to the user to delete the last child.

it's only a change in visibility/style. No big refactor

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
