### PR TITLE
style(sidenavigation): implemented new focus styles

### DIFF
--- a/packages/demo/src/components/examples/SideNavigationExample.tsx
+++ b/packages/demo/src/components/examples/SideNavigationExample.tsx
@@ -16,11 +16,19 @@ export const SideNavigationExample: React.FunctionComponent = () => {
         <Form>
             <Section level={2} title="Side Navigation">
                 <SideNavigation>
-                    <SideNavigationMenuSection title="Section 1" svgName={svg.coveoIcon16px.name}>
-                        <SideNavigationItem isActive href="http://coveo.com" title="Link to Coveo" />
-                        <SideNavigationItem href="http://coveo.com" title="Another link to Coveo" />
+                    <SideNavigationMenuSection title="Regular Section" svgName={svg.coveoIcon16px.name}>
+                        <SideNavigationItem isActive>
+                            <a href="http://coveo.com" title="Link to Coveo">
+                                Link to Coveo
+                            </a>
+                        </SideNavigationItem>
+                        <SideNavigationItem>
+                            <a href="http://coveo.com" title="Link to Coveo">
+                                Another link to Coveo
+                            </a>
+                        </SideNavigationItem>
                     </SideNavigationMenuSection>
-                    <SideNavigationMenuSection title="Section 2">
+                    <SideNavigationMenuSection title="Loading Section">
                         <SideNavigationLoadingItem className="mod-width-30" />
                         <SideNavigationLoadingItem className="mod-width-50" />
                         <SideNavigationLoadingItem className="mod-width-40" />

--- a/packages/demo/src/components/examples/TabConnectedExample.tsx
+++ b/packages/demo/src/components/examples/TabConnectedExample.tsx
@@ -11,7 +11,7 @@ const TAB11_ID = 'tab11';
 const TAB22_ID = 'tab22';
 const TAB33_ID = 'tab33';
 
-export const TabsConnectedExamples: React.FC = () => (
+export const TabsConnectedExamples: React.FunctionComponent = () => (
     <Section>
         <Section level={3} title="Basic Tabs">
             <div>

--- a/packages/demo/src/components/examples/TabConnectedExample.tsx
+++ b/packages/demo/src/components/examples/TabConnectedExample.tsx
@@ -11,82 +11,67 @@ const TAB11_ID = 'tab11';
 const TAB22_ID = 'tab22';
 const TAB33_ID = 'tab33';
 
-export class TabsExamples extends React.Component<any, any> {
-    render() {
-        return (
-            <Section>
-                <Section level={3} title="Basic Tabs">
-                    <div>
-                        <TabNavigation>
-                            <TabConnected id={TAB1_ID} title="A Tab" />
-                            <TabConnected id={TAB2_ID} title="Another Tab" tooltip="I am an enabled tab" />
-                            <TabConnected id={TAB3_ID} title="Tab with an icon">
-                                <Svg svgName={'help'} svgClass={'icon documentation-link mod-16 mr1'} />
-                            </TabConnected>
-                            <TabConnected
-                                id={TAB4_ID}
-                                title=" Another Tab with an icon"
-                                children={<Svg svgName={'info'} svgClass={'icon documentation-link mod-16 mr1'} />}
-                            />
-                            <TabConnected id={TAB5_ID} title="A Disabled Tab" tooltip="I am a disabled tab" disabled />
-                        </TabNavigation>
-                        <TabContent>
-                            <TabPaneConnected id={TAB1_ID}>
-                                <div className="mod-header-padding mod-form-top-bottom-padding">
-                                    Content of the first tab.
-                                </div>
-                            </TabPaneConnected>
-                            <TabPaneConnected id={TAB2_ID}>
-                                <div className="mod-header-padding mod-form-top-bottom-padding">
-                                    Content of the second tab.
-                                </div>
-                            </TabPaneConnected>
-                            <TabPaneConnected id={TAB3_ID}>
-                                <div className="mod-header-padding mod-form-top-bottom-padding">
-                                    Content of the tab with an icon.
-                                </div>
-                            </TabPaneConnected>
-                            <TabPaneConnected id={TAB4_ID}>
-                                <div className="mod-header-padding mod-form-top-bottom-padding">
-                                    Content of the other tab with an icon.
-                                </div>
-                            </TabPaneConnected>
-                            <TabPaneConnected id={TAB5_ID}>
-                                <div className="mod-header-padding mod-form-top-bottom-padding">
-                                    Last tab. You shouldn't be able to see this because the tab is disabled.
-                                </div>
-                            </TabPaneConnected>
-                        </TabContent>
-                    </div>
-                </Section>
-                <Section level={3} title="Tabs with custom attributes on element (use the inspector to see changes)">
-                    <div>
-                        <TabNavigation
-                            className={'tab-navigation-custom-class'}
-                            style={{backgroundColor: 'var(--grey-20)'}}
-                        >
-                            <TabConnected id={TAB11_ID} title="A Tab" />
-                            <TabConnected id={TAB22_ID} title="Another Tab" />
-                            <TabConnected id={TAB33_ID} title="Yet Another Tab" />
-                        </TabNavigation>
-                        <TabContent className={'tab-content-custom-class'}>
-                            <TabPaneConnected id={TAB11_ID}>
-                                <div className="mod-header-padding mod-form-top-bottom-padding">
-                                    Content of the first tab.
-                                </div>
-                            </TabPaneConnected>
-                            <TabPaneConnected id={TAB22_ID}>
-                                <div className="mod-header-padding mod-form-top-bottom-padding">
-                                    Content of the second tab.
-                                </div>
-                            </TabPaneConnected>
-                            <TabPaneConnected id={TAB33_ID}>
-                                <div className="mod-header-padding mod-form-top-bottom-padding">Last tab.</div>
-                            </TabPaneConnected>
-                        </TabContent>
-                    </div>
-                </Section>
-            </Section>
-        );
-    }
-}
+export const TabsConnectedExamples: React.FC = () => (
+    <Section>
+        <Section level={3} title="Basic Tabs">
+            <div>
+                <TabNavigation>
+                    <TabConnected id={TAB1_ID} title="A Tab" />
+                    <TabConnected id={TAB2_ID} title="Another Tab" tooltip="I am an enabled tab" />
+                    <TabConnected id={TAB3_ID} title="Tab with an icon">
+                        <Svg svgName={'help'} svgClass={'icon documentation-link mod-16 mr1'} />
+                    </TabConnected>
+                    <TabConnected
+                        id={TAB4_ID}
+                        title=" Another Tab with an icon"
+                        children={<Svg svgName={'info'} svgClass={'icon documentation-link mod-16 mr1'} />}
+                    />
+                    <TabConnected id={TAB5_ID} title="A Disabled Tab" tooltip="I am a disabled tab" disabled />
+                </TabNavigation>
+                <TabContent>
+                    <TabPaneConnected id={TAB1_ID}>
+                        <div className="mod-header-padding mod-form-top-bottom-padding">Content of the first tab.</div>
+                    </TabPaneConnected>
+                    <TabPaneConnected id={TAB2_ID}>
+                        <div className="mod-header-padding mod-form-top-bottom-padding">Content of the second tab.</div>
+                    </TabPaneConnected>
+                    <TabPaneConnected id={TAB3_ID}>
+                        <div className="mod-header-padding mod-form-top-bottom-padding">
+                            Content of the tab with an icon.
+                        </div>
+                    </TabPaneConnected>
+                    <TabPaneConnected id={TAB4_ID}>
+                        <div className="mod-header-padding mod-form-top-bottom-padding">
+                            Content of the other tab with an icon.
+                        </div>
+                    </TabPaneConnected>
+                    <TabPaneConnected id={TAB5_ID}>
+                        <div className="mod-header-padding mod-form-top-bottom-padding">
+                            Last tab. You shouldn't be able to see this because the tab is disabled.
+                        </div>
+                    </TabPaneConnected>
+                </TabContent>
+            </div>
+        </Section>
+        <Section level={3} title="Tabs with custom attributes on element (use the inspector to see changes)">
+            <div>
+                <TabNavigation className={'tab-navigation-custom-class'} style={{backgroundColor: 'var(--grey-20)'}}>
+                    <TabConnected id={TAB11_ID} title="A Tab" />
+                    <TabConnected id={TAB22_ID} title="Another Tab" />
+                    <TabConnected id={TAB33_ID} title="Yet Another Tab" />
+                </TabNavigation>
+                <TabContent className={'tab-content-custom-class'}>
+                    <TabPaneConnected id={TAB11_ID}>
+                        <div className="mod-header-padding mod-form-top-bottom-padding">Content of the first tab.</div>
+                    </TabPaneConnected>
+                    <TabPaneConnected id={TAB22_ID}>
+                        <div className="mod-header-padding mod-form-top-bottom-padding">Content of the second tab.</div>
+                    </TabPaneConnected>
+                    <TabPaneConnected id={TAB33_ID}>
+                        <div className="mod-header-padding mod-form-top-bottom-padding">Last tab.</div>
+                    </TabPaneConnected>
+                </TabContent>
+            </div>
+        </Section>
+    </Section>
+);

--- a/packages/vapor/scss/components/navigation.scss
+++ b/packages/vapor/scss/components/navigation.scss
@@ -133,9 +133,8 @@
                             border: 2px solid transparent; // transparent border needed for outline
                             border-radius: 8px;
 
-                            &:focus,
                             &:focus-visible {
-                                @include focus-border(2px);
+                                @include focus-border();
                             }
 
                             &.state-locked {

--- a/packages/vapor/scss/components/navigation.scss
+++ b/packages/vapor/scss/components/navigation.scss
@@ -137,7 +137,7 @@
                                 background: var(--navy-blue-10);
                                 border: 2px solid var(--cerulean-blue-50);
                                 outline: none;
-                                box-shadow: 0px 0px 0px 3px var(--cerulean-blue-20);
+                                box-shadow: 0 0 0 3px var(--cerulean-blue-20);
                             }
 
                             &.state-locked {

--- a/packages/vapor/scss/components/navigation.scss
+++ b/packages/vapor/scss/components/navigation.scss
@@ -130,14 +130,12 @@
                             color: var(--navy-blue-80);
                             font-size: var(--default-font-size);
                             letter-spacing: 0.05em;
-                            border: 2px solid transparent;
+                            border: 2px solid transparent; // transparent border needed for outline
                             border-radius: 8px;
 
+                            &:focus,
                             &:focus-visible {
-                                background: var(--navy-blue-10);
-                                border: 2px solid var(--cerulean-blue-50);
-                                outline: none;
-                                box-shadow: 0 0 0 3px var(--cerulean-blue-20);
+                                @include focus-border(2px);
                             }
 
                             &.state-locked {

--- a/packages/vapor/scss/components/navigation.scss
+++ b/packages/vapor/scss/components/navigation.scss
@@ -107,7 +107,7 @@
                 }
 
                 .navigation-menu-section-items {
-                    overflow-x: auto;
+                    overflow-x: visible;
 
                     &:not(.mb0) {
                         margin-bottom: 1em;
@@ -125,10 +125,20 @@
                             justify-content: space-between;
                             height: $navigation-menu-section-height;
                             margin-right: $navigation-right-margin;
+                            padding-right: 2px;
                             padding-left: $navigation-horizontal-space;
                             color: var(--navy-blue-80);
                             font-size: var(--default-font-size);
                             letter-spacing: 0.05em;
+                            border: 2px solid transparent;
+                            border-radius: 8px;
+
+                            &:focus-visible {
+                                background: var(--navy-blue-10);
+                                border: 2px solid var(--cerulean-blue-50);
+                                outline: none;
+                                box-shadow: 0px 0px 0px 3px var(--cerulean-blue-20);
+                            }
 
                             &.state-locked {
                                 color: $navigation-locked-color;

--- a/packages/vapor/scss/components/tab.scss
+++ b/packages/vapor/scss/components/tab.scss
@@ -29,6 +29,10 @@
             --color: var(--deprecated-medium-grey);
             pointer-events: none;
         }
+
+        &:focus-visible {
+            @include focus-outline();
+        }
     }
 
     & > * {

--- a/packages/vapor/scss/controls/dropdown.scss
+++ b/packages/vapor/scss/controls/dropdown.scss
@@ -115,6 +115,10 @@
     &.mod-search {
         text-align: left;
     }
+
+    &:focus {
+        @include focus-border(var(--white), 0, $button-border-width);
+    }
 }
 
 .dropdown-toggle .value-icon,

--- a/packages/vapor/scss/controls/filter-box.scss
+++ b/packages/vapor/scss/controls/filter-box.scss
@@ -62,10 +62,6 @@
         padding-right: 40px;
         padding-left: 20px;
 
-        &:focus {
-            outline-color: var(--bright-turquoise-40);
-        }
-
         &::-ms-clear {
             display: none;
         }

--- a/packages/vapor/scss/controls/inputs.scss
+++ b/packages/vapor/scss/controls/inputs.scss
@@ -25,6 +25,10 @@ input[type='color'] {
     font-family: var(--main-font);
     border: 1px solid var(--deprecated-medium-grey);
     border-radius: 2px;
+
+    &:focus-visible {
+        @include focus-outline();
+    }
 }
 
 input[type='text'],

--- a/packages/vapor/scss/controls/numeric-input.scss
+++ b/packages/vapor/scss/controls/numeric-input.scss
@@ -21,7 +21,7 @@ $numeric-input-buttons-border-radius: 4px;
         box-shadow: inset 0 0 3px 0 rgba(var(--black-rgb), $transparency-5);
 
         &:focus {
-            @include focus-border(0);
+            @include focus-outline();
         }
     }
 
@@ -43,10 +43,11 @@ $numeric-input-buttons-border-radius: 4px;
         &:hover {
             background-color: var(--digital-blue-100);
         }
+    }
 
-        &:focus {
-            @include focus-border(0);
-        }
+    input:focus,
+    button:focus {
+        @include focus-outline();
     }
 }
 // override the style of the focus for numeric inputs in Firefox

--- a/packages/vapor/scss/controls/text-input.scss
+++ b/packages/vapor/scss/controls/text-input.scss
@@ -46,7 +46,7 @@
         border: none;
 
         &:focus {
-            @include focus-outline();
+            outline: none;
         }
     }
 

--- a/packages/vapor/scss/controls/text-input.scss
+++ b/packages/vapor/scss/controls/text-input.scss
@@ -46,7 +46,7 @@
         border: none;
 
         &:focus {
-            outline: none;
+            @include focus-outline();
         }
     }
 

--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -1,9 +1,3 @@
-@mixin button-focus($offset) {
-    background-color: var(--deprecated-light-grey);
-
-    @include focus-border($offset);
-}
-
 .btn {
     display: inline-flex;
     align-items: center;
@@ -40,7 +34,7 @@
     }
 
     &:focus {
-        @include button-focus(0px);
+        @include focus-border(var(--white), 0, $button-border-width);
         color: var(--navy-blue-80);
         text-decoration: none;
         background-color: var(--white);

--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -34,7 +34,7 @@
     }
 
     &:focus {
-        @include focus-border(var(--white), 0, $button-border-width);
+        @include focus-border(var(--white), $border-radius, $button-border-width);
         color: var(--navy-blue-80);
         text-decoration: none;
         background-color: var(--white);

--- a/packages/vapor/scss/elements/links.scss
+++ b/packages/vapor/scss/elements/links.scss
@@ -31,7 +31,7 @@ a {
     }
 
     &:focus {
-        @include focus-border(5px);
+        @include focus-outline(5px);
     }
 
     &:hover {

--- a/packages/vapor/scss/helpers.scss
+++ b/packages/vapor/scss/helpers.scss
@@ -16,9 +16,18 @@ $browser-context: 13; // Default
     }
 }
 
-@mixin focus-border($offset) {
-    background: var(--navy-blue-10);
-    border: 2px solid var(--cerulean-blue-50);
+@mixin focus-outline($offset: 0) {
+    outline-width: 2px;
+    outline-style: solid;
+    outline-color: var(--cerulean-blue-50);
+    outline-offset: $offset;
+}
+
+// args are to prevent elements shifting due to differing border dimensions
+@mixin focus-border($background: var(--navy-blue-10), $border-radius: 0px, $border-width: 2px) {
+    background: $background;
+    border: $border-width solid var(--cerulean-blue-50);
+    border-radius: $border-radius;
     outline: none;
     box-shadow: 0 0 0 3px var(--cerulean-blue-20);
 }

--- a/packages/vapor/scss/helpers.scss
+++ b/packages/vapor/scss/helpers.scss
@@ -17,8 +17,8 @@ $browser-context: 13; // Default
 }
 
 @mixin focus-border($offset) {
-    outline-width: 2px;
-    outline-style: auto;
-    outline-color: var(--bright-turquoise-40);
-    outline-offset: $offset;
+    background: var(--navy-blue-10);
+    border: 2px solid var(--cerulean-blue-50);
+    outline: none;
+    box-shadow: 0 0 0 3px var(--cerulean-blue-20);
 }

--- a/packages/vapor/scss/helpers.scss
+++ b/packages/vapor/scss/helpers.scss
@@ -18,7 +18,7 @@ $browser-context: 13; // Default
 
 @mixin focus-outline($offset: 0) {
     outline-width: 2px;
-    outline-style: solid;
+    outline-style: auto;
     outline-color: var(--cerulean-blue-50);
     outline-offset: $offset;
 }


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/ADUI-7505

[Slack thread](https://coveo.slack.com/archives/GLS6Z9RPD/p1632768959073000)

This was originally done in AdminUI but better to have the changes here. Also took the liberty to clarify the demo for SideNavigation, though this will eventually all be replaced by Plasma

https://user-images.githubusercontent.com/22773767/135301202-6d650ad9-6561-4a5b-8ac7-1785255fc7ae.mov

EDIT: After discussion with UX the focus will not have rounded corners for now, since it looks terrible with the left bar of the nav when its active. The future restyle will fix this issue by removing the left bar and making all the navs more rounded, and the new mixin has the option to provide a border-radius in the future

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
