### PR TITLE
test: remove renderModal util

### DIFF
--- a/packages/react-vapor/jest.config.js
+++ b/packages/react-vapor/jest.config.js
@@ -3,9 +3,10 @@ module.exports = {
     moduleNameMapper: {
         '\\.(scss|css)$': '<rootDir>/jest/identity-obj-proxy-esm.js',
         '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': 'identity-obj-proxy',
-        '^@test-utils$': '<rootDir>/src/TestUtils.tsx',
+        '^@test-utils$': '<rootDir>/jest/utils.tsx',
     },
-    setupFilesAfterEnv: ['<rootDir>/jest/setup.ts'],
+    setupFiles: ['<rootDir>/jest/setup.ts'],
+    setupFilesAfterEnv: ['<rootDir>/jest/entry.tsx'],
     reporters: ['default'],
     transform: {
         '^.+\\.(jsx?|tsx?)$': 'ts-jest',

--- a/packages/react-vapor/jest/entry.tsx
+++ b/packages/react-vapor/jest/entry.tsx
@@ -1,0 +1,10 @@
+import '@testing-library/jest-dom';
+
+import {cleanup, setup} from '@test-utils';
+import * as Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({adapter: new Adapter()});
+
+beforeEach(setup);
+afterEach(cleanup);

--- a/packages/react-vapor/jest/setup.ts
+++ b/packages/react-vapor/jest/setup.ts
@@ -1,6 +1,3 @@
-import * as Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-import '@testing-library/jest-dom';
 import _ from 'underscore';
 
 import * as ReactDOM from 'react-dom';
@@ -13,11 +10,8 @@ global.$ = global.jQuery = $;
 import 'chosen-js';
 
 global._ = _;
-
 global.window.React = React;
 global.window.ReactDOM = ReactDOM;
-
-Enzyme.configure({adapter: new Adapter()});
 
 document.createRange = () => {
     const range = new Range();
@@ -32,19 +26,3 @@ document.createRange = () => {
 
     return range;
 };
-
-/**
- * Prevents modal `unmount` timeout to remove ModalRoot and cause error.
- *
- * Solution to:
- * Uncaught NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
- */
-const flushAllPendingTimers = () => {
-    let id = window.setTimeout((): void => null, 0);
-    while (id--) {
-        window.clearTimeout(id);
-    }
-};
-
-afterEach(jest.restoreAllMocks);
-afterEach(flushAllPendingTimers);

--- a/packages/react-vapor/jest/utils.tsx
+++ b/packages/react-vapor/jest/utils.tsx
@@ -5,10 +5,26 @@ import {AnyAction, applyMiddleware, combineReducers, createStore, Store} from 'r
 import promise from 'redux-promise-middleware';
 import thunk from 'redux-thunk';
 
-import {Defaults} from './Defaults';
-import {ReactVaporReducers} from './ReactVaporReducers';
-import {IReactVaporState} from './ReactVaporState';
-import {IDispatch} from './utils/ReduxUtils';
+import {Defaults} from '../src/Defaults';
+import {ReactVaporReducers} from '../src/ReactVaporReducers';
+import {IReactVaporState} from '../src/ReactVaporState';
+import {IDispatch} from '../src/utils/ReduxUtils';
+
+const TEST_CONTAINER_ID = 'app';
+const MODAL_ROOT_ID = 'modals';
+const DROP_ROOT_ID = 'dropdowns';
+
+const setup = () => {
+    document.body.innerHTML = `<div id="${TEST_CONTAINER_ID}"></div><div id="${MODAL_ROOT_ID}"></div><div id="${DROP_ROOT_ID}"></div>`;
+    Defaults.APP_ELEMENT = '#' + TEST_CONTAINER_ID;
+    Defaults.MODAL_ROOT = '#' + MODAL_ROOT_ID;
+    Defaults.DROP_ROOT = '#' + DROP_ROOT_ID;
+    Defaults.MODAL_TIMEOUT = 0;
+};
+
+const cleanup = () => {
+    jest.restoreAllMocks();
+};
 
 const customRender = (
     ui: React.ReactElement,
@@ -19,6 +35,7 @@ const customRender = (
             initialState,
             applyMiddleware(thunk, promise)
         ),
+        container = document.getElementById(TEST_CONTAINER_ID),
         ...renderOptions
     }: Omit<RenderOptions, 'queries'> & {
         initialState?: IReactVaporState;
@@ -29,15 +46,7 @@ const customRender = (
 ): RenderResult => {
     const TestWrapper: React.FunctionComponent = ({children}) => <Provider store={store}>{children}</Provider>;
 
-    return render(ui, {wrapper: TestWrapper, ...renderOptions});
-};
-
-const renderModal: typeof customRender = (ui, renderOptions) => {
-    const appRoot = document.createElement('div');
-    appRoot.id = 'root';
-    document.body.appendChild(appRoot);
-    Defaults.APP_ELEMENT = appRoot;
-    return customRender(ui, {...renderOptions, container: appRoot});
+    return render(ui, {wrapper: TestWrapper, container, ...renderOptions});
 };
 
 /**
@@ -60,4 +69,4 @@ const expectToThrow = (func: () => unknown, error?: JestToErrorArg): void => {
 type JestToErrorArg = Parameters<jest.Matchers<unknown, () => unknown>['toThrow']>[0];
 
 export * from '@testing-library/react';
-export {customRender as render, renderModal, expectToThrow};
+export {customRender as render, expectToThrow, cleanup, setup};

--- a/packages/react-vapor/src/Defaults.spec.ts
+++ b/packages/react-vapor/src/Defaults.spec.ts
@@ -2,17 +2,16 @@ import ReactModal from 'react-modal';
 
 import {Defaults} from './Defaults';
 
-jest.mock('react-modal');
-
 describe('Defaults', () => {
     describe('APP_ELEMENT', () => {
         it('should call ReactModal.setAppElement', () => {
+            const setAppElementSpy = jest.spyOn(ReactModal, 'setAppElement').mockImplementation(() => null);
             const expectedAppElement = '#app-element';
 
             Defaults.APP_ELEMENT = expectedAppElement;
 
-            expect(ReactModal.setAppElement).toHaveBeenCalledTimes(1);
-            expect(ReactModal.setAppElement).toHaveBeenCalledWith(expectedAppElement);
+            expect(setAppElementSpy).toHaveBeenCalledTimes(1);
+            expect(setAppElementSpy).toHaveBeenCalledWith(expectedAppElement);
         });
     });
 });

--- a/packages/react-vapor/src/components/chart/tests/ChartTooltip.spec.tsx
+++ b/packages/react-vapor/src/components/chart/tests/ChartTooltip.spec.tsx
@@ -24,10 +24,6 @@ describe('<ChartTooltip />', () => {
         mockedReact.useContext.mockReturnValue(XYChartContextMock);
     });
 
-    afterEach(() => {
-        jest.clearAllMocks();
-    });
-
     it('should not throw', () => {
         expect(() => {
             shallow(<ChartTooltip />);

--- a/packages/react-vapor/src/components/chart/tests/ChartTooltipContent.spec.tsx
+++ b/packages/react-vapor/src/components/chart/tests/ChartTooltipContent.spec.tsx
@@ -16,12 +16,8 @@ jest.mock('react', () => {
 const mockedReact = mocked(React);
 
 describe('<ChartTooltipContent />', () => {
-    beforeAll(() => {
+    beforeEach(() => {
         mockedReact.useContext.mockReturnValue(XYChartContextMock);
-    });
-
-    afterEach(() => {
-        jest.clearAllMocks();
     });
 
     it('should not throw', () => {

--- a/packages/react-vapor/src/components/modal/tests/ConfirmationModalProvider.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/ConfirmationModalProvider.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
-import {renderModal, screen} from '@test-utils';
+import {render, screen} from '@test-utils';
 
 import {ConfirmationModalProvider} from '../ConfirmationModalProvider';
 import {ModalCompositeConnected} from '../ModalComposite';
@@ -8,7 +8,7 @@ import {ModalCompositeConnected} from '../ModalComposite';
 describe('ConfirmationModalProvider', () => {
     describe('when shouldConfirm prop is true:', () => {
         it('should open the ConfirmationModal to interrupt the leaving action if isDirty is true', () => {
-            renderModal(
+            render(
                 <ConfirmationModalProvider
                     shouldConfirm
                     confirmationModalId="👾-unsaved-changes"
@@ -41,7 +41,7 @@ describe('ConfirmationModalProvider', () => {
 
     describe('when shouldConfirm prop is false:', () => {
         it('should not open the ConfirmationModal to interrupt the leaving action if isDirty is true', () => {
-            renderModal(
+            render(
                 <ConfirmationModalProvider
                     shouldConfirm={false}
                     confirmationModalId="👾-unsaved-changes"

--- a/packages/react-vapor/src/components/modal/tests/Modal.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/Modal.spec.tsx
@@ -1,92 +1,62 @@
-import {mount, ReactWrapper, shallow} from 'enzyme';
+import {render, screen, waitFor} from '@test-utils';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
-import {Defaults} from '../../../Defaults';
-import {IModalProps, Modal} from '../Modal';
+import {Modal} from '../Modal';
 
 describe('Modal', () => {
-    const id: string = 'modal';
+    it('calls onRender prop when mounting', () => {
+        const renderSpy = jest.fn();
+        render(<Modal id="🆔" onRender={renderSpy} />);
 
-    it('should render without errors', () => {
-        expect(() => {
-            shallow(<Modal id={id} />);
-        }).not.toThrow();
+        expect(renderSpy).toHaveBeenCalledTimes(1);
     });
 
-    describe('<Modal />', () => {
-        let modal: ReactWrapper<IModalProps, any>;
-        let modalInstance: Modal;
+    it('should call prop onDestroy on unmounting if set', () => {
+        const destroySpy = jest.fn();
+        const {unmount} = render(<Modal id="🆔" onDestroy={destroySpy} />);
 
-        beforeEach(() => {
-            modal = mount(<Modal id={id} />, {attachTo: document.getElementById('App')});
-            modalInstance = modal.instance() as Modal;
-        });
+        unmount();
 
-        it('should call prop onRender on mounting if set', () => {
-            const renderSpy = jest.fn();
+        expect(destroySpy).toHaveBeenCalledTimes(1);
+    });
 
-            modal.setProps({id: id, onRender: renderSpy});
-            modal.unmount();
-            modal.mount();
+    it('should call the prop closeCallback if it exists when closing the modal', async () => {
+        const closeCallbackSpy = jest.fn();
+        const ModalFixture = () => {
+            const [isOpened, setIsOpened] = React.useState(true);
+            return (
+                <>
+                    <button onClick={() => setIsOpened(false)}>close</button>
+                    <Modal id="🆔" isOpened={isOpened} closeCallback={closeCallbackSpy} />
+                </>
+            );
+        };
+        render(<ModalFixture />);
+        userEvent.click(screen.getByRole('button', {name: /close/i}));
 
-            expect(renderSpy.mock.calls.length).toBe(1);
-        });
+        await waitFor(() => expect(closeCallbackSpy).toHaveBeenCalledTimes(1));
+    });
 
-        it('should call prop onDestroy on unmounting if set', () => {
-            const destroySpy = jest.fn();
+    it('should call the prop closeCallback with a timeout if specified when closing the modal', () => {
+        jest.useFakeTimers();
+        const closeCallbackSpy = jest.fn();
+        const ModalFixture = () => {
+            const [isOpened, setIsOpened] = React.useState(true);
+            return (
+                <>
+                    <button onClick={() => setIsOpened(false)}>close</button>
+                    <Modal id="🆔" isOpened={isOpened} closeCallback={closeCallbackSpy} closeTimeout={500} />
+                </>
+            );
+        };
+        render(<ModalFixture />);
+        userEvent.click(screen.getByRole('button', {name: /close/i}));
+        expect(closeCallbackSpy).toHaveBeenCalledTimes(0);
+        jest.advanceTimersByTime(500);
 
-            expect(() => modalInstance.componentWillUnmount()).not.toThrow();
+        expect(closeCallbackSpy).toHaveBeenCalledTimes(1);
 
-            modal.setProps({id: id, onDestroy: destroySpy});
-            modal.mount();
-            modal.unmount();
-
-            expect(destroySpy.mock.calls.length).toBe(1);
-        });
-
-        it('should call the prop closeCallback if it exists when closing the modal', () => {
-            jest.useFakeTimers();
-
-            const closeCallbackSpy: jest.Mock<any, any> = jest.fn();
-            modal.setProps({isOpened: true, closeCallback: closeCallbackSpy});
-            modal.update();
-            modal.setProps({isOpened: false});
-            modal.update();
-
-            jest.advanceTimersByTime(Defaults.MODAL_TIMEOUT);
-
-            expect(closeCallbackSpy).toHaveBeenCalledTimes(1);
-            jest.clearAllTimers();
-        });
-
-        it('should call the prop closeCallback with a timeout if specified when closing the modal', () => {
-            jest.useFakeTimers();
-
-            const closeCallbackSpy: jest.Mock<any, any> = jest.fn();
-            modal.setProps({isOpened: true, closeCallback: closeCallbackSpy, closeTimeout: 5});
-            modal.update();
-            modal.setProps({isOpened: false});
-            modal.update();
-
-            expect(closeCallbackSpy).toHaveBeenCalledTimes(0);
-
-            jest.advanceTimersByTime(5);
-
-            expect(closeCallbackSpy).toHaveBeenCalledTimes(1);
-
-            jest.clearAllTimers();
-        });
-
-        it('should set container class when the container class is specified', () => {
-            const containerClass = 'mod-small';
-            const classes = [containerClass];
-
-            expect(modal.find('div').first().html()).not.toContain(containerClass);
-
-            modal.setProps({id, classes});
-            modal.mount();
-
-            expect(modal.find('div').first().html()).toContain(containerClass);
-        });
+        jest.clearAllTimers();
     });
 });

--- a/packages/react-vapor/src/components/modal/tests/ModalComposite.spec.tsx
+++ b/packages/react-vapor/src/components/modal/tests/ModalComposite.spec.tsx
@@ -1,4 +1,4 @@
-import {renderModal, screen} from '@test-utils';
+import {render, screen} from '@test-utils';
 import {shallow} from 'enzyme';
 import * as React from 'react';
 import ReactModal from 'react-modal';
@@ -55,13 +55,13 @@ describe('ModalComposite', () => {
     });
 
     it('renders an accessible heading', () => {
-        renderModal(<ModalComposite isOpened title="my title" />);
+        render(<ModalComposite isOpened title="my title" />);
 
         expect(screen.getByRole('dialog', {name: 'my title'})).toBeVisible();
     });
 
     it('is possible to access modals by their title', () => {
-        renderModal(
+        render(
             <>
                 <ModalComposite id="first" isOpened title="first modal title" />
                 <ModalComposite id="second" isOpened title="second modal title" />

--- a/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
+++ b/packages/react-vapor/src/components/modalWizard/tests/ModalWizard.spec.tsx
@@ -1,13 +1,13 @@
 import userEvent, {specialChars} from '@testing-library/user-event';
 import * as React from 'react';
-import {renderModal, screen, waitForElementToBeRemoved} from '@test-utils';
+import {render, screen, waitForElementToBeRemoved} from '@test-utils';
 
 import {ModalWizard} from '../ModalWizard';
 
 describe('ModalWizard', () => {
     it('closes the modal and execute the onCancel prop if passed when clicking on "cancel"', async () => {
         const cancelSpy = jest.fn();
-        renderModal(
+        render(
             <div>
                 <ModalWizard id="🧙‍♂️" onCancel={cancelSpy}>
                     <div>Step 1</div>
@@ -38,7 +38,7 @@ describe('ModalWizard', () => {
             }
         }
 
-        renderModal(
+        render(
             <ModalWizard id="🧙‍♂️" onNext={nextSpy} onPrevious={previousSpy}>
                 <div>Step 1: ReactElement</div>
                 <FunctionComponentStep />
@@ -76,7 +76,7 @@ describe('ModalWizard', () => {
     it('calls the "onFinish" prop and the modal stays open when clicking on the "finish" button', () => {
         const finishSpy = jest.fn();
 
-        renderModal(
+        render(
             <ModalWizard id="🧙‍♂️" onFinish={finishSpy}>
                 <div>Step 1</div>
                 <div>Step 2</div>
@@ -92,7 +92,7 @@ describe('ModalWizard', () => {
     });
 
     it('calls the "onFinish" prop and the modal closes when clicking on the "finish" button', async () => {
-        renderModal(
+        render(
             <ModalWizard
                 id="🧙‍♂️"
                 onFinish={(close) => {
@@ -113,7 +113,7 @@ describe('ModalWizard', () => {
     });
 
     it('disables the next button if the current step is invalid', () => {
-        renderModal(
+        render(
             <ModalWizard id="🧙‍♂️" validateStep={() => ({isValid: false})}>
                 <div>Step 1</div>
                 <div>Step 2</div>
@@ -125,7 +125,7 @@ describe('ModalWizard', () => {
     });
 
     it('prevents from closing the modal accidently if it has pending changes', () => {
-        renderModal(
+        render(
             <ModalWizard id="🧙‍♂️" isDirty>
                 <div>Step 1</div>
                 <div>Step 2</div>
@@ -142,7 +142,7 @@ describe('ModalWizard', () => {
     });
 
     it('does not prevent from closing the modal accidently if it has no pending changes', async () => {
-        renderModal(
+        render(
             <ModalWizard id="🧙‍♂️" isDirty={false}>
                 <div>Step 1</div>
                 <div>Step 2</div>
@@ -157,7 +157,7 @@ describe('ModalWizard', () => {
     });
 
     it('changes the title depending on the step if a function was provided as title', () => {
-        renderModal(
+        render(
             <ModalWizard id="🧙‍♂️" title={(currentStep: number) => (currentStep === 0 ? 'Title 1' : 'Title 2')}>
                 <div>Step 1</div>
                 <div>Step 2</div>
@@ -175,7 +175,7 @@ describe('ModalWizard', () => {
     });
 
     it('changes the footer depending on the step if a function was provided as modalFooterChildren', () => {
-        renderModal(
+        render(
             <ModalWizard
                 id="🧙‍♂️"
                 modalFooterChildren={(currentStep: number) =>

--- a/packages/react-vapor/src/components/modalWizard/tests/ModalWizardWithValidations.spec.tsx
+++ b/packages/react-vapor/src/components/modalWizard/tests/ModalWizardWithValidations.spec.tsx
@@ -1,12 +1,12 @@
 import userEvent, {specialChars} from '@testing-library/user-event';
 import * as React from 'react';
-import {renderModal, screen, waitForElementToBeRemoved} from '@test-utils';
+import {render, screen, waitForElementToBeRemoved} from '@test-utils';
 
 import {ModalWizardWithValidations} from '../ModalWizardWithValidations';
 
 describe('ModalWizardWithValidations', () => {
     it('validates each steps using validation ids', () => {
-        renderModal(
+        render(
             <ModalWizardWithValidations id="🌶🧙‍♂️" validationIdsByStep={[['step-1'], ['step-2-a', 'step-2-b']]}>
                 <div>Step 1</div>
                 <div>Step 2</div>
@@ -37,7 +37,7 @@ describe('ModalWizardWithValidations', () => {
     });
 
     it('prevents from closing the modal accidently if any step is dirty', () => {
-        renderModal(
+        render(
             <ModalWizardWithValidations id="🌶🧙‍♂️" validationIdsByStep={[['step-1'], ['step-2']]}>
                 <div>Step 1</div>
                 <div>Step 2</div>
@@ -65,7 +65,7 @@ describe('ModalWizardWithValidations', () => {
     });
 
     it('does not prevent from closing the modal accidently if it has no pending changes', async () => {
-        renderModal(
+        render(
             <ModalWizardWithValidations id="🌶🧙‍♂️" validationIdsByStep={[['step-1'], ['step-2']]}>
                 <div>Step 1</div>
                 <div>Step 2</div>

--- a/packages/react-vapor/src/components/multilineBox/tests/MultilineBoxWithRemoveButton.spec.tsx
+++ b/packages/react-vapor/src/components/multilineBox/tests/MultilineBoxWithRemoveButton.spec.tsx
@@ -1,5 +1,6 @@
-import {ShallowWrapper} from 'enzyme';
 import {shallowWithState, shallowWithStore} from '@helpers/enzyme-redux';
+import {render, screen} from '@test-utils';
+import {ShallowWrapper} from 'enzyme';
 import * as React from 'react';
 import * as _ from 'underscore';
 
@@ -9,7 +10,6 @@ import {getStoreMock, ReactVaporMockStore} from '../../../utils/tests/TestUtils'
 import {Button, IButtonProps} from '../../button/Button';
 import {multilineBoxWithRemoveButton} from '../hoc/MultilineBoxWithRemoveButton';
 import {IMultilineBoxOwnProps, IMultilineSingleBoxProps, MultilineBox} from '../MultilineBox';
-import {render, screen} from '../../../TestUtils';
 
 describe('Multiline box with remove button', () => {
     describe('<MultilineBoxWithRemoveButton/>', () => {

--- a/packages/react-vapor/src/components/numericInput/tests/NumericInputConnected.spec.tsx
+++ b/packages/react-vapor/src/components/numericInput/tests/NumericInputConnected.spec.tsx
@@ -1,8 +1,8 @@
 import {shallowWithStore} from '@helpers/enzyme-redux';
+import {render, screen} from '@test-utils';
 import {ShallowWrapper} from 'enzyme';
 import * as React from 'react';
 
-import {render, screen} from '../../../TestUtils';
 import {keyCode} from '../../../utils/InputUtils';
 import {getStoreMock, ReactVaporMockStore} from '../../../utils/tests/TestUtils';
 import {NumericInputActions} from '../NumericInputActions';

--- a/packages/react-vapor/src/components/popover/tests/Popover.spec.tsx
+++ b/packages/react-vapor/src/components/popover/tests/Popover.spec.tsx
@@ -19,15 +19,8 @@ describe('<Popover>', () => {
             <Popover {...props}>
                 <span id={popoverToggleId}>Toggle</span>
                 <span id={popoverElementId}>Tether element</span>
-            </Popover>,
-            {attachTo: document.getElementById('App')}
+            </Popover>
         ));
-
-    beforeAll(() => {
-        const app = document.createElement('div');
-        app.id = 'App';
-        document.body.appendChild(app);
-    });
 
     beforeEach(() => {
         popoverProps = {
@@ -190,7 +183,7 @@ describe('<Popover>', () => {
             });
 
             it('should close the popover when clicking outside Popover', () => {
-                document.getElementById('App').click();
+                document.body.click();
 
                 expect(toggleOpenedSpy.mock.calls.length).toBe(1);
 
@@ -216,7 +209,7 @@ describe('<Popover>', () => {
             });
 
             it('should close the popover when clicking outside Popover', () => {
-                document.getElementById('App').click();
+                document.body.click();
 
                 expect(toggleOpenedSpy).toHaveBeenCalledTimes(1);
 
@@ -234,7 +227,7 @@ describe('<Popover>', () => {
             });
 
             it('should not update if already closed', () => {
-                document.getElementById('App').click();
+                document.body.click();
 
                 expect(toggleOpenedSpy).not.toHaveBeenCalled();
             });
@@ -251,7 +244,7 @@ describe('<Popover>', () => {
             });
 
             it('should not update if already closed', () => {
-                document.getElementById('App').click();
+                document.body.click();
 
                 expect(toggleOpenedSpy).not.toHaveBeenCalled();
             });

--- a/packages/react-vapor/src/components/tooltip/tests/Tooltip.spec.tsx
+++ b/packages/react-vapor/src/components/tooltip/tests/Tooltip.spec.tsx
@@ -1,29 +1,11 @@
-import {shallow, ShallowWrapper} from 'enzyme';
 import {mountWithState} from '@helpers/enzyme-redux';
+import {shallow} from 'enzyme';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import {OverlayTrigger} from 'react-bootstrap';
-import {mocked} from 'ts-jest/utils';
 
 import {ITooltipProps, Tooltip} from '../Tooltip';
 
-jest.mock('react-dom');
-jest.mock('react', () => {
-    const originReact = jest.requireActual('react');
-    return {
-        ...originReact,
-        createRef: jest.fn(() => ({current: null})),
-    };
-});
-
-const mockedReact = mocked(React);
-const mockedReactDOM = mocked(ReactDOM);
-
 describe('Tooltip', () => {
-    afterEach(() => {
-        jest.clearAllMocks();
-    });
-
     const TOOLTIP_PROPS: ITooltipProps = {
         title: 'My test tooltip!',
     };
@@ -102,63 +84,5 @@ describe('Tooltip', () => {
         );
 
         expect(tooltipWrapper.find('li').parent().type()).not.toBe('span');
-    });
-
-    describe('behaviour on unmount', () => {
-        let el: HTMLElement;
-        let containsSpy: jest.SpyInstance;
-        let appendChildSpy: jest.SpyInstance;
-        let tooltipWrapper: ShallowWrapper;
-
-        beforeEach(() => {
-            el = document.createElement('div');
-
-            mockedReact.createRef.mockReturnValue({
-                current: el,
-            });
-            mockedReactDOM.findDOMNode.mockReturnValue(el);
-            containsSpy = jest.spyOn(document.body, 'contains').mockReturnValue(false);
-            appendChildSpy = jest.spyOn(document.body, 'appendChild');
-        });
-
-        afterEach(() => {
-            jest.clearAllMocks();
-        });
-
-        it('should re-add the tooltip element on unmount if its not in the DOM', () => {
-            tooltipWrapper = shallow(<Tooltip {...TOOLTIP_PROPS}>Hello</Tooltip>);
-            tooltipWrapper.unmount();
-
-            expect(appendChildSpy).toHaveBeenCalledWith(el);
-        });
-
-        it('should not re-add the tooltip element on unmount if the DOM already contain the node', () => {
-            containsSpy.mockReturnValue(true);
-
-            tooltipWrapper = shallow(<Tooltip {...TOOLTIP_PROPS}>Hello</Tooltip>);
-            tooltipWrapper.unmount();
-
-            expect(appendChildSpy).not.toHaveBeenCalled();
-        });
-
-        it('should not re-add the tooltip element on unmount if the html node does not exists', () => {
-            mockedReactDOM.findDOMNode.mockReturnValue(null);
-
-            tooltipWrapper = shallow(<Tooltip {...TOOLTIP_PROPS}>Hello</Tooltip>);
-            tooltipWrapper.unmount();
-
-            expect(appendChildSpy).not.toHaveBeenCalled();
-        });
-
-        it('should not re-add the tooltip element on unmount if the ref has no current view', () => {
-            mockedReact.createRef.mockReturnValue({
-                current: null,
-            });
-
-            tooltipWrapper = shallow(<Tooltip {...TOOLTIP_PROPS}>Hello</Tooltip>);
-            tooltipWrapper.unmount();
-
-            expect(appendChildSpy).not.toHaveBeenCalled();
-        });
     });
 });

--- a/packages/react-vapor/tsconfig.build.json
+++ b/packages/react-vapor/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
     "extends": "./tsconfig",
+    "compilerOptions": {
+        "rootDir": "src"
+    },
     "references": [],
-    "exclude": ["**/*.spec.*", "./src/utils/tests", "./src/TestUtils.tsx"]
+    "exclude": ["**/*.spec.*", "./src/utils/tests", "jest"]
 }

--- a/packages/react-vapor/tsconfig.json
+++ b/packages/react-vapor/tsconfig.json
@@ -2,13 +2,13 @@
     "extends": "../tsconfig-base",
     "compilerOptions": {
         "outDir": "dist",
-        "rootDir": "src",
         "tsBuildInfoFile": "./dist/.tsbuildinfo",
         "baseUrl": ".",
         "paths": {
-            "@test-utils": ["src/TestUtils.tsx"],
+            "@test-utils": ["jest/utils.tsx"],
             "*": ["types/*", "*"]
         }
     },
-    "include": ["src"]
+    "include": ["src", "jest"],
+    "exclude": ["**/*.js"]
 }


### PR DESCRIPTION
### Proposed Changes

- Removed `renderModal` util
- Cleaned up DOM between each test
- Simplified test config

Before:
![image](https://user-images.githubusercontent.com/35579930/135538669-ad232204-e10a-4cee-bd45-8b6dee54be52.png)

After:
![image](https://user-images.githubusercontent.com/35579930/135538258-9182fc79-4d9f-4a75-8f72-060d8b594cee.png)


### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
