### PR TITLE
fix(svg): conflict with SVGs that require fill attribute

### DIFF
--- a/packages/vapor/resources/icons/svg/arrow-top-slim.svg
+++ b/packages/vapor/resources/icons/svg/arrow-top-slim.svg
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg viewBox="0 0 29 43" stroke="#282829" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
-    <path d="M14.4,41.2v-39"/>
-    <path d="M2.1,15.7L14.4,2.2l12.3,13.5"/>
+<svg viewBox="0 0 29 43" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
+    <style type="text/css">
+        .svgArrowTopSlimPaths {stroke: #282829;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;fill:none;}
+    </style>
+    <path class="svgArrowTopSlimPaths" d="M14.4,41.2v-39"/>
+    <path class="svgArrowTopSlimPaths" d="M2.1,15.7L14.4,2.2l12.3,13.5"/>
 </svg>


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/SFINT-4088

Reopened the issue because I found a side-effect (displaying `arrow-top-slim`) in the Admin UI.

![browser-preview-glitch](https://user-images.githubusercontent.com/10946843/135680247-471b6971-41bb-456a-a7c0-63589ffa15d4.png)

The issue is also visible in the BrowserPreview demo page.

![demo-page-svg-with-no-fill](https://user-images.githubusercontent.com/10946843/135680586-1a6f54e6-fd2c-4ceb-bd93-fe7870f9f32f.png)

It turns out the `fill` attribute is required for some icons (e.g., `arrow-left-return`), while it can break other icons (e.g., `arrow-top-slim`).

The proposed solution is to put back a `style` element with a specific class name into `arrow-top-slim.svg` so it forces `fill: none` without preventing use of the `fill` attribute with other icons.

#### With the fix

**Demo page (icon styled with `fill` attribute)**

![demo-page-svg-using-fill](https://user-images.githubusercontent.com/10946843/135681453-d574012d-7029-4317-b1ef-679dbfa09951.png)

**Demo page (`arrow-top-slim`)**

![demo-page-svg-with-no-fill-fix](https://user-images.githubusercontent.com/10946843/135681598-cb5af2e6-9b1d-40d1-b1e4-797b69390000.png)

**`arrow-top-slim` in icons page**

![fix-arrow-top-slim](https://user-images.githubusercontent.com/10946843/135681685-c6373008-7afd-4563-8fe3-4cab08a95430.png)


### Potential Breaking Changes

A page that includes `arrow-top-slim` and relies on a CSS class named `svgArrowTopSlimPaths` could be impacted, but that is very unlikely to happen.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
