### PR TITLE
fix(svg): arrow right link not respecting mod-stroke rules

### DIFF
--- a/packages/vapor/resources/icons/svg/arrow-right-link.svg
+++ b/packages/vapor/resources/icons/svg/arrow-right-link.svg
@@ -1,1 +1,1 @@
-<svg fill="none" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g stroke="#282829" stroke-linecap="round" stroke-linejoin="round"><path d="m1.5 8h12"/><path d="m10.5 4.5 4 3.5-4 3.5"/></g></svg>
+<svg fill="none" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" stroke="#282829" stroke-linecap="round" stroke-linejoin="round"><path d="m1.5 8h12"/><path d="m10.5 4.5 4 3.5-4 3.5"/></svg>


### PR DESCRIPTION
### Proposed Changes

The svg was currently bugged as I could not change the colour with the classes we had in our admin-ui, moving the stroke to svg element will fix this issue.

### Potential Breaking Changes
N/A

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
