### PR TITLE
fix(form): prevent the default behaviour of submitting on forms

### DIFF
--- a/packages/react-vapor/src/components/form/Form.tsx
+++ b/packages/react-vapor/src/components/form/Form.tsx
@@ -10,11 +10,16 @@ export interface IFormProps {
     noMargin?: boolean;
 }
 
-export const Form: React.FunctionComponent<IFormProps> = ({children, className, title, mods, noMargin}) => (
-    <form>
-        <fieldset className={classNames('coveo-form mod-padding-children', {my2: !noMargin}, mods, className)}>
-            {title && <h2 className="mb2">{title}</h2>}
-            {children}
-        </fieldset>
-    </form>
-);
+export const Form: React.FunctionComponent<IFormProps> = ({children, className, title, mods, noMargin}) => {
+    const onSubmit = (submitEvent: React.FormEvent) => {
+        submitEvent.preventDefault();
+    };
+    return (
+        <form onSubmit={onSubmit}>
+            <fieldset className={classNames('coveo-form mod-padding-children', {my2: !noMargin}, mods, className)}>
+                {title && <h2 className="mb2">{title}</h2>}
+                {children}
+            </fieldset>
+        </form>
+    );
+};

--- a/packages/react-vapor/src/components/form/tests/Form.spec.tsx
+++ b/packages/react-vapor/src/components/form/tests/Form.spec.tsx
@@ -1,7 +1,8 @@
+import userEvent from '@testing-library/user-event';
 import {shallow} from 'enzyme';
 import * as React from 'react';
 
-import {render} from '@test-utils';
+import {render, screen} from '@test-utils';
 import {Form} from '../Form';
 
 describe('Form', () => {
@@ -60,6 +61,22 @@ describe('Form', () => {
             expect(formCollection.getElementsByClassName('my2').length).toBe(0);
             expect(formCollection.getElementsByClassName('mt2').length).toBe(0);
             expect(formCollection.getElementsByClassName('mb2').length).toBe(0);
+        });
+
+        it('does not change the url when the user press enter inside a form', () => {
+            const initialHREF = window.location.href;
+
+            render(
+                <Form>
+                    <input defaultValue="" name="patate" />
+                    <input type="submit" value="submit" />
+                </Form>
+            );
+
+            userEvent.type(screen.getByRole('textbox'), 'hello world');
+            userEvent.click(screen.getByRole('button'));
+
+            expect(window.location.href).toBe(initialHREF);
         });
     });
 });


### PR DESCRIPTION
### Proposed Changes

The UTs in admin-ui are running forever because the Form of react-vapor submit action is not handled. Since we have no action on the form, the default one is to reload the page with different query parameters.

I added a unit test to make sure we handle the submit

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
