### PR TITLE
fix: moved the m1 to the linkClasses

### DIFF
--- a/packages/react-vapor/src/components/title/Title.tsx
+++ b/packages/react-vapor/src/components/title/Title.tsx
@@ -19,10 +19,10 @@ export const Title: React.FunctionComponent<ITitleProps> = (props) => {
 
     const [isTruncated, setIsTruncated] = React.useState(false);
     const linkClasses = classNames(
-        'inline-doc-link mr1',
+        'inline-doc-link m1',
         props.documentationLink && props.documentationLink.linkClasses
     );
-    const titleClasses: string = classNames('bolder', 'm1', 'truncate', props.classes);
+    const titleClasses: string = classNames('bolder', 'truncate', props.classes);
     const prefixClasses: string = classNames({mr1: !_.isEmpty(props.prefix)});
     const linkIcon = props.documentationLink && <LinkSvg {...props.documentationLink} linkClasses={[linkClasses]} />;
     const tooltipProps = _.isString(props.text) ? {title: props.text} : {};


### PR DESCRIPTION
### Proposed Changes
This [pr](https://github.com/coveo/react-vapor/pull/2138) created an problems with titles in headers like this:
![image](https://user-images.githubusercontent.com/63734941/136397523-8ceb017e-77e6-4625-8634-0759726de52b.png)

By moving the m1 to the link icon, [it fixes the OG issue](https://github.com/coveo/react-vapor/pull/2137) + the new one :see_no_evil: 

After:
![image](https://user-images.githubusercontent.com/63734941/136398290-edde252c-e438-461a-a255-3cc2f37b6c7f.png)


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
