### PR TITLE
style(dropdown): adjusted vertical alignment

### DIFF
--- a/packages/vapor/scss/controls/dropdown.scss
+++ b/packages/vapor/scss/controls/dropdown.scss
@@ -91,9 +91,7 @@
     .dropdown-toggle-arrow,
     .dropdown-toggle-arrow-style {
         position: absolute;
-        top: calc(
-            50% - (#{$dropdown-arrow-icon-size} - 2px) / 2
-        ); // Remove the approximated svg inner top/bottom padding
+        top: calc(50% - ($dropdown-arrow-icon-size / 2)); // Remove the approximated svg inner top/bottom padding
         right: $button-padding-x;
         width: $dropdown-arrow-icon-size;
         height: $dropdown-arrow-icon-size;


### PR DESCRIPTION
### Proposed Changes

`.dropdown-toggle-arrow-style` was too low, should be center aligned with text

Should have been fixed as part of https://coveord.atlassian.net/browse/ADUI-7504?focusedCommentId=483565&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-483565

See dropdown icons in SingleSelect, MultiSelect, DatePickerDropDown (DropdownSearch is deprecated but the class is used)

Before

<img width="104" alt="Screen Shot 2021-10-08 at 11 21 07 AM" src="https://user-images.githubusercontent.com/22773767/136586340-19749a11-d871-4fb6-8349-94ba67cb71cf.png">

![image](https://user-images.githubusercontent.com/22773767/136586840-30c5a0ba-3681-426f-9eba-bc9d5a84e888.png)


After

<img width="245" alt="Screen Shot 2021-10-08 at 11 34 36 AM" src="https://user-images.githubusercontent.com/22773767/136586351-ca260607-ba7f-4f88-9a62-16c60ebce91d.png">

![image](https://user-images.githubusercontent.com/22773767/136586659-6d89272b-fb78-4445-a08e-5b013cf77742.png)


### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
