### PR TITLE
ci: release on npm after certifiers are green

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -3,15 +3,10 @@
     "team_name": "admin-ui",
     "general": {
         "environments_order": {
-            "sequential": [
-                "qa",
-                "prd"
-            ]
+            "sequential": ["prd"]
         },
         "notifications": {
-            "slack_channels": [
-                "admin-ui-builds"
-            ]
+            "slack_channels": ["admin-ui-builds"]
         },
         "team_jenkins": "jsadminbuilds",
         "start_environment_automatically": true
@@ -32,36 +27,33 @@
         "no_container_images": true,
         "configurations": []
     },
+    "package_rollout": {
+        "only_consider_changesets_after": "$[CHANGESET]"
+    },
     "ordered_phases": [
         {
             "id": "deploy-minified-files",
             "s3": {
-                "bucket": "coveo-nqa-jsadmin",
+                "bucket": "coveo-nprd-jsadmin",
                 "directory": "react-vapor",
                 "parameters": {
                     "include": "*.min.*",
                     "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
                     "content-encoding": "gzip"
                 },
-                "source": "packages/demo/dist",
-                "prd": {
-                    "bucket": "coveo-nprd-jsadmin"
-                }
+                "source": "packages/demo/dist"
             }
         },
         {
             "id": "deploy-non-minified-files",
             "s3": {
-                "bucket": "coveo-nqa-jsadmin",
+                "bucket": "coveo-nprd-jsadmin",
                 "directory": "react-vapor",
                 "parameters": {
                     "exclude": "*.min.*",
                     "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff"
                 },
-                "source": "packages/demo/dist",
-                "prd": {
-                    "bucket": "coveo-nprd-jsadmin"
-                }
+                "source": "packages/demo/dist"
             }
         },
         {
@@ -75,10 +67,7 @@
                     "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
                     "content-encoding": "gzip"
                 },
-                "source": "packages/vapor/dist",
-                "qa": {
-                    "disabled": true
-                }
+                "source": "packages/vapor/dist"
             }
         },
         {
@@ -91,10 +80,13 @@
                     "acl": "public-read",
                     "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff"
                 },
-                "source": "packages/vapor/dist",
-                "qa": {
-                    "disabled": true
-                }
+                "source": "packages/vapor/dist"
+            }
+        },
+        {
+            "id": "update-npm-tags",
+            "team_jenkins": {
+                "job_name": "vapor-production-release"
             }
         }
     ],

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -253,6 +253,7 @@ pipeline {
             sh "npx lerna publish \
             --conventional-commits \
             --create-release github \
+            --dist-tag alpha \
             --no-commit-hooks \
             --force-publish \
             --no-push \
@@ -343,8 +344,17 @@ pipeline {
       steps {
         script {
           setLastStageName();
+
+          CURRENT_CHANGESET = sh(
+            script: "git rev-parse HEAD",
+            returnStdout: true
+          )
           
-          deploymentPackage.command(command: "package create --version ${NEW_VERSION} --resolve VERSION=${NEW_VERSION} --with-deploy")
+          deploymentPackage.command(command: "package create \
+          --version ${NEW_VERSION} \
+          --resolve VERSION=${NEW_VERSION} \
+          --resolve CHANGESET=${CURRENT_CHANGESET} \
+          --with-deploy")
         }
       }
     }

--- a/build/ReleaseProd.groovy
+++ b/build/ReleaseProd.groovy
@@ -1,0 +1,46 @@
+#!groovy
+// Run only if certifiers are all green (veracode, snyk, etc)
+
+pipeline {
+  agent { label "build && docker && linux" }
+  environment {
+    NPM_TOKEN = credentials("npmjs_com_token")
+    GIT = credentials("github-coveobot")
+    GH_TOKEN = credentials("github-coveobot_token")
+  }
+  options {
+    ansiColor("xterm")
+    timestamps()
+    disableConcurrentBuilds()
+    timeout(time: 60, unit: 'MINUTES')
+  }
+  stages {
+    stage('Prepare') {
+      steps {
+        script {
+          def commitHash = params.packageName.substring(params.packageName.lastIndexOf('/') + 1)
+
+          checkout([
+            $class: 'GitSCM',
+            branches: [[name: commitHash ]],
+            extensions: [],
+            userRemoteConfigs: [[credentialsId: "github-coveobot", url: "https://github.com/coveo/react-vapor.git"]]
+          ])
+
+          sh "npm config set //registry.npmjs.org/:_authToken=${env.NPM_TOKEN}"
+          sh "rm -rf node_modules"
+          sh "npm install -g pnpm"
+          sh "pnpm install"
+        }
+      }
+    }
+    stage('Update NPM latest') {
+      steps {
+        script {
+          // Publishes packages tagged in the current commit
+          sh "lerna publish from-git"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Proposed Changes

Changed a bit the way we release our stuff:

- Removed qa environment for the main demo. Only deploy the demo in prod. PRs will still be deployed in QA
- Bypass the package_rollout certifier (I will double check with everyone that this is ok) so we can have https://vapor.cloud.coveo.com/ up-to-date without spamming @gprovostqa 

Here is the package journey when releasing a new version `X.Y.Z`:
1. A pull request is made
2. The demo is deployed in the QA bucket as usual
3. Once reviewed, it is merged on master which triggers a build
4. Master builds:
    1. Lerna takes care of bumping the version according to the commit messages (lets say `X.Y.Z`)
    2. A git tag called `vX.Y.Z` is created for the current changeset and pushed to github
    3. A github release is created for the version `X.Y.Z`
    4. `X.Y.Z` is tagged as `alpha` on npm. So anyone who installs `react-vapor` without specifying a version will not be downloading the new version. A person in a hurry that doesn't want to wait for the certifiers could decide to install `react-vapor@alpha` to tryout the new version.
5. At the end of the master build, the deployment pipeline is triggered
6. If the certifiers (snyk + veracode) are green:
    1. Version `X.Y.Z` of the demo package is deployed in S3 in the prod bucket
    2. Vapor (coveo-styleguide) is deployed in its usual place (same as before)
    3. Version `X.Y.Z` is tagged as `latest` on npm by the new jenkins job I created called `vapor-production-release`

### Potential Breaking Changes

I could not test this without merging it so it might break the deployment process. I will take care of fixing it if that happens.
