### PR TITLE
chore(renovate): use branch instead of PRs to avoid unnecessary reviews

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,13 +3,13 @@
   "timezone": "America/Montreal",
   "prCreation": "immediate",
   "semanticCommitScope": "deps",
+  "commitBody": "UITOOL-284",
   "packageRules": [
     {
-      "updateTypes": [
-        "minor",
-        "patch"
-      ],
+      "description": "Automatically merge minor and patch-level updates",
+      "updateTypes": ["minor", "patch"],
       "automerge": true,
+      "automergeType": "branch",
       "semanticCommitType": "chore"
     }
   ]

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -163,7 +163,7 @@ pipeline {
             
             sh "bash ./build/deploy-demo.sh ${env.BRANCH_NAME}"
 
-            if (env.BRANCH_NAME != "next") {
+            if (env.CHANGE_ID != null) {
               postCommentOnGithub("https://vaporqa.cloud.coveo.com/feature/${env.BRANCH_NAME}/index.html");
             }
 


### PR DESCRIPTION
### Proposed Changes

Instead of opening PRs for all the bumps, Renovate can create a branch and 

- if the build is green it can merge that branch into master without any reviews.
- if the build is red, it will open a PR for us to review

I added a comment in the commits to reference a JIRA

I also had to make a small change in the Jenkinsfile for it to work, otherwise we tried to publish a comment on a non-existing PR. E.g., https://jsadminbuilds.dev.cloud.coveo.com/job/react-vapor/job/renovate%252Fjest-26.x/2/console

### Potential Breaking Changes

None, no code is modified