### PR TITLE
style(header): padding adjustment on header

### DIFF
--- a/packages/react-vapor/src/components/headers/HeaderWrapper.tsx
+++ b/packages/react-vapor/src/components/headers/HeaderWrapper.tsx
@@ -44,7 +44,7 @@ export class HeaderWrapper extends React.Component<IHeaderWrapperProps> {
 
     private get classes(): string {
         return classNames(
-            'flex flex-center space-between header-height panel-header',
+            'flex flex-center space-between panel-header',
             {
                 'mod-no-border-bottom': !this.props.hasBorderBottom || this.props.tabs,
                 px0: !this.props.hasPadding,

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -156,7 +156,7 @@ $flat-select-option-size: 26px;
 $header-height: 72px;
 $header-padding: 40px;
 $header-height-padding: 20px;
-$header-padding-y: 5px;
+$header-padding-y: 16px;
 $panel-header-height: 100px;
 $panel-header-action-padding-horizontal: 12px;
 $panel-header-action-padding-vertical: 8px;


### PR DESCRIPTION
### Proposed Changes

- Removing the `header-height` class from `HeaderWrapper` since this limits the height to `100px`
- Adjusting the `header-padding-y` to `16px`, its initial value did not provide enough padding on the top and bottom and will simply help fill the inner div spacing, no major changes will be seen.

**Padding adjustment at 5px:**
![image](https://user-images.githubusercontent.com/66333175/139919619-eb7f5647-1ad7-439e-a1d5-46bd62812846.png)


**Padding adjustment at 16px:**
![image](https://user-images.githubusercontent.com/66333175/139919675-0706e186-c64d-4a5d-bf59-880597aa5428.png)


**Reason for change:**
There's currently a bug that happens when the Dimensions header is under `1597px` width, the sub text will break causing a push of the title and making it too close to the navbar and not have enough padding underneath

**Bug:**
![image](https://user-images.githubusercontent.com/66333175/139920233-5c3089c9-af68-4742-92bf-4af25aa23ab9.png)


**After the changes proposed (tested locally using link with admin-ui)**
![image](https://user-images.githubusercontent.com/66333175/139920307-d402baec-f94d-425c-bdd1-22afd0e6d715.png)

**No changes will be observed by modal heading (5px vs 16px)**
![image](https://user-images.githubusercontent.com/66333175/139928826-0d315bce-c3c6-4ee5-b227-60a394ea14a6.png)

![image](https://user-images.githubusercontent.com/66333175/139928859-56350b4b-cbaf-4d14-b5a8-82074fa60b3e.png)




### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
