### PR TITLE
fix(datepicker): added valid date check

### DIFF
--- a/packages/demo/src/components/examples/DatePickerExamples.tsx
+++ b/packages/demo/src/components/examples/DatePickerExamples.tsx
@@ -12,6 +12,7 @@ import * as _ from 'underscore';
 
 import {ExampleComponent} from '../ComponentsInterface';
 import {
+    CALENDAR_ADVANCED_SELECTION_RULES,
     CALENDAR_SELECTION_RULES,
     DATE_RANGE_EXAMPLE,
     FOUR_SELECTION_BOXES,
@@ -53,7 +54,7 @@ const DatePickerComponents: React.FunctionComponent = () => (
                     id="date-picker-dropdown"
                     datesSelectionBoxes={SELECTION_BOXES}
                     selectionRules={CALENDAR_SELECTION_RULES}
-                    initialDateRange={DATE_RANGE_EXAMPLE} // optionnal
+                    initialDateRange={DATE_RANGE_EXAMPLE} // optional
                 />
             </Section>
             <Section level={3} title="DatePicker dropdown with a range limit of 3 days">
@@ -63,6 +64,18 @@ const DatePickerComponents: React.FunctionComponent = () => (
                         _.extend({}, SELECTION_BOXES[0], {rangeLimit: {days: 3, message: 'Date limit exceeded'}}),
                     ]}
                     selectionRules={CALENDAR_SELECTION_RULES}
+                />
+            </Section>
+            <Section
+                level={3}
+                title="DatePicker dropdown that allows s start date within the last two weeks for a maximum range of 7 days"
+            >
+                <DatePickerDropdownConnected
+                    id="date-picker-dropdown-log-browser"
+                    datesSelectionBoxes={[
+                        _.extend({}, SELECTION_BOXES[0], {rangeLimit: {days: 7, message: 'Date limit exceeded'}}),
+                    ]}
+                    selectionRules={CALENDAR_ADVANCED_SELECTION_RULES}
                 />
             </Section>
             <Section level={3} title="DatePicker dropdown with a minimal range limit of 5 minutes">

--- a/packages/demo/src/components/examples/DatePickerExamples.tsx
+++ b/packages/demo/src/components/examples/DatePickerExamples.tsx
@@ -68,7 +68,7 @@ const DatePickerComponents: React.FunctionComponent = () => (
             </Section>
             <Section
                 level={3}
-                title="DatePicker dropdown that allows s start date within the last two weeks for a maximum range of 7 days"
+                title="DatePicker dropdown that allows a start date within the last two weeks for a maximum range of 7 days"
             >
                 <DatePickerDropdownConnected
                     id="date-picker-dropdown-log-browser"

--- a/packages/demo/src/components/examples/DatePickerExamplesCommon.ts
+++ b/packages/demo/src/components/examples/DatePickerExamplesCommon.ts
@@ -154,6 +154,21 @@ export const CALENDAR_SELECTION_RULES: ICalendarSelectionRule[] = [
     },
 ];
 
+export const CALENDAR_ADVANCED_SELECTION_RULES: ICalendarSelectionRule[] = [
+    {
+        test: (date: Date) => date <= new Date() && date >= moment().subtract(2, 'weeks').toDate(), // is the date within the last two weeks
+        isFor: CalendarSelectionRuleType.all,
+    },
+    {
+        test: (date: Date, endDate: Date) => moment(endDate).diff(moment(date), 'day') >= 0, // The end of your selection cannot be before the start of your selection
+        isFor: CalendarSelectionRuleType.upper,
+    },
+    {
+        test: (date: Date, endDate: Date) => moment(endDate).diff(moment(date), 'day') <= 7, // You cannot select more than 7 days at a time
+        isFor: CalendarSelectionRuleType.lower,
+    },
+];
+
 export const SELECTION_BOX: IDatesSelectionBox[] = [
     {
         title: 'Select date',

--- a/packages/react-vapor/src/components/datePicker/DatePicker.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePicker.tsx
@@ -67,15 +67,17 @@ export class DatePicker extends React.PureComponent<IDatePickerProps, {isSelecte
             // and we need the value immediately to decide whether to to call props.onBlur
             let isDatePermitted = true;
 
-            this.props.selectionRules?.forEach((rule: ICalendarSelectionRule) => {
-                if (
-                    (rule.isFor === CalendarSelectionRuleType.lower && this.props.isSelecting === DateLimits.lower) ||
-                    (rule.isFor === CalendarSelectionRuleType.upper && this.props.isSelecting === DateLimits.upper)
-                ) {
+            this.props.selectionRules
+                ?.filter(
+                    (rule: ICalendarSelectionRule) =>
+                        (rule.isFor === CalendarSelectionRuleType.lower &&
+                            this.props.isSelecting === DateLimits.lower) ||
+                        (rule.isFor === CalendarSelectionRuleType.upper && this.props.isSelecting === DateLimits.upper)
+                )
+                .forEach((rule: ICalendarSelectionRule) => {
                     isDatePermitted = rule.test(date);
                     this.setState({isDatePermitted});
-                }
-            });
+                });
 
             if (isDatePermitted && date.getDate()) {
                 this.props.onBlur(date, this.props.upperLimit);

--- a/packages/react-vapor/src/components/datePicker/DatePicker.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePicker.tsx
@@ -61,6 +61,10 @@ export class DatePicker extends React.PureComponent<IDatePickerProps, {isSelecte
     };
 
     private handleChangeDate = () => {
+        if (!moment(this.dateInput.value).isValid()) {
+            return;
+        }
+
         if (this.dateInput.value !== '') {
             const date: Date = this.getDateFromString(this.dateInput.value);
             // setting isDatePermitted as let and in component state, since setState is async and triggers rerender of component
@@ -70,18 +74,18 @@ export class DatePicker extends React.PureComponent<IDatePickerProps, {isSelecte
             this.props.selectionRules
                 ?.filter(
                     (rule: ICalendarSelectionRule) =>
-                        (rule.isFor === CalendarSelectionRuleType.lower &&
-                            this.props.isSelecting === DateLimits.lower) ||
-                        (rule.isFor === CalendarSelectionRuleType.upper && this.props.isSelecting === DateLimits.upper)
+                        (rule.isFor === CalendarSelectionRuleType.all && this.props.isSelecting === DateLimits.lower) ||
+                        (rule.isFor === CalendarSelectionRuleType.all && this.props.isSelecting === DateLimits.upper)
                 )
                 .forEach((rule: ICalendarSelectionRule) => {
                     isDatePermitted = rule.test(date);
-                    this.setState({isDatePermitted});
                 });
 
-            if (isDatePermitted && date.getDate()) {
-                this.props.onBlur(date, this.props.upperLimit);
-            }
+            this.setState({isDatePermitted}, () => {
+                if (isDatePermitted && date.getDate()) {
+                    this.props.onBlur(date, this.props.upperLimit);
+                }
+            });
         }
     };
 

--- a/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatePickerBox.tsx
@@ -151,7 +151,9 @@ export class DatePickerBox extends React.Component<IDatePickerBoxProps, any> {
                 upperLimitPlaceholder: this.props.upperLimitPlaceholder,
                 initiallyUnselected: this.props.initiallyUnselected,
                 initialDateRange: this.props.initialDateRange,
+                selectionRules: this.props.selectionRules,
             };
+
             const dateSelection: JSX.Element = this.props.withReduxState ? (
                 <DatesSelectionConnected {...datesSelectionProps} />
             ) : (

--- a/packages/react-vapor/src/components/datePicker/DatesSelection.tsx
+++ b/packages/react-vapor/src/components/datePicker/DatesSelection.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+
 import {DATES_SEPARATOR, DateUtils} from '../../utils/DateUtils';
+import {ICalendarSelectionRule} from '../calendar/Calendar';
 import {DatePicker, IDatePickerProps} from './DatePicker';
 import {DatePickerDateRange} from './DatePickerConstants';
 
@@ -27,6 +29,7 @@ export interface IDatesSelectionOwnProps extends React.ClassAttributes<DatesSele
     upperLimitPlaceholder?: string;
     initiallyUnselected?: boolean;
     initialDateRange?: DatePickerDateRange;
+    selectionRules?: ICalendarSelectionRule[];
 }
 
 export interface IDatesSelectionStateProps {
@@ -120,6 +123,7 @@ export class DatesSelection extends React.Component<IDatesSelectionProps, any> {
         const isLarge = this.props.withTime || (this.props.isRange && this.props.hasSetToNowButton);
         const wrapperClasses: string = !isSmallSplit || isLarge ? '' : 'mod-inline flex';
         const datePickerProps: IDatePickerProps = {
+            selectionRules: this.props.selectionRules,
             withTime: this.props.withTime,
             hasSetToNowButton: this.props.hasSetToNowButton,
             setToNowTooltip: this.props.setToNowTooltip,

--- a/packages/vapor/scss/components/calendar.scss
+++ b/packages/vapor/scss/components/calendar.scss
@@ -344,6 +344,10 @@
             border-color: var(--digital-blue-60);
             border-style: solid;
             border-width: 2px;
+
+            &.invalid {
+                border-color: var(--critical-70);
+            }
         }
 
         &.date-picked {


### PR DESCRIPTION
### Proposed Changes

Initial bug: user could enter an invalid date range
Extra bug: While manually typing an invalid date, the `setState` triggered by `componentDidMount` would trigger an infinte loop as parent components tried to validate it and then update the component

How to test:

Datepicker:

- The bug applies to the datepicker dropdown, but worth testing in every example.
- I made a new example in the demo to mimic the bug in Log Browser (see screenshot)
- For any datepicker with `selectionRules`, if you try and manually enter a date that's outside of what's specified in its rules, then it will stay selected, use the last valid date as display (but not set it), and show a red `invalid` border

![image](https://user-images.githubusercontent.com/22773767/139930215-5aac08ae-1601-40b7-a755-ac859741c26b.png)

https://user-images.githubusercontent.com/22773767/139930393-12f55da7-2d0d-499f-b9fb-8f1da5897999.mov

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
