### PR TITLE
ci: deploy demo in RD bucket

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -3,15 +3,10 @@
     "team_name": "admin-ui",
     "general": {
         "environments_order": {
-            "sequential": [
-                "qa",
-                "prd"
-            ]
+            "sequential": ["rd", "prd"]
         },
         "notifications": {
-            "slack_channels": [
-                "admin-ui-builds"
-            ]
+            "slack_channels": ["admin-ui-builds"]
         },
         "team_jenkins": "jsadminbuilds",
         "start_environment_automatically": true
@@ -36,7 +31,8 @@
         {
             "id": "deploy-minified-files",
             "s3": {
-                "bucket": "coveo-nqa-jsadmin",
+                "disable": true,
+                "bucket": "coveo-nrd-jsadmin",
                 "directory": "react-vapor",
                 "parameters": {
                     "include": "*.min.*",
@@ -44,29 +40,31 @@
                     "content-encoding": "gzip"
                 },
                 "source": "packages/demo/dist",
-                "prd": {
-                    "bucket": "coveo-nprd-jsadmin"
+                "rd": {
+                    "disable": false
                 }
             }
         },
         {
             "id": "deploy-non-minified-files",
             "s3": {
-                "bucket": "coveo-nqa-jsadmin",
+                "disable": true,
+                "bucket": "coveo-nrd-jsadmin",
                 "directory": "react-vapor",
                 "parameters": {
                     "exclude": "*.min.*",
                     "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff"
                 },
                 "source": "packages/demo/dist",
-                "prd": {
-                    "bucket": "coveo-nprd-jsadmin"
+                "rd": {
+                    "disable": false
                 }
             }
         },
         {
             "id": "deploy-styleguide-minified-files",
             "s3": {
+                "disable": true,
                 "bucket": "coveo-public-content",
                 "directory": "styleguide/v$[VERSION]",
                 "parameters": {
@@ -76,14 +74,15 @@
                     "content-encoding": "gzip"
                 },
                 "source": "packages/vapor/dist",
-                "qa": {
-                    "disabled": true
+                "prd": {
+                    "disabled": false
                 }
             }
         },
         {
             "id": "deploy-styleguide-non-minified-files",
             "s3": {
+                "disable": true,
                 "bucket": "coveo-public-content",
                 "directory": "styleguide/v$[VERSION]",
                 "parameters": {
@@ -92,8 +91,8 @@
                     "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff"
                 },
                 "source": "packages/vapor/dist",
-                "qa": {
-                    "disabled": true
+                "prd": {
+                    "disabled": false
                 }
             }
         }

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -166,13 +166,13 @@ pipeline {
             def SOURCE_LINK = ""
             def pullRequestURL = getCommitPullRequestURL()
             if (pullRequestURL != "") {
-              postCommentOnGithub("https://vaporqa.cloud.coveo.com/feature/${env.BRANCH_NAME}/index.html");
+              postCommentOnGithub("https://vapor.coveo.com/feature/${env.BRANCH_NAME}/index.html");
               SOURCE_LINK = pullRequestURL
             } else {
               SOURCE_LINK = "https://github.com/coveo/react-vapor/tree/${env.BRANCH_NAME}"
             }
 
-            def message = "Build succeeded for <${SOURCE_LINK}|${env.BRANCH_NAME}>: https://vaporqa.cloud.coveo.com/feature/${env.BRANCH_NAME}/index.html"
+            def message = "Build succeeded for <${SOURCE_LINK}|${env.BRANCH_NAME}>: https://vapor.coveo.com/feature/${env.BRANCH_NAME}/index.html"
             notify.sendSlackWithThread(
                 color: "#00FF00", message: message,
                 ["admin-ui-builds"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=flat-square&logo=appveyor)](https://conventionalcommits.org)
 
-React-Vapor is Coveo's collection of UI styles used in Coveo Cloud Administration Console. All components and their documentation are available in [the demo page](https://vapor.cloud.coveo.com/). Vapor package contains the generic style classes used across the components and react-vapor is a react implementation of multiple visual and behavioural components.
+React-Vapor is Coveo's collection of UI styles used in Coveo Cloud Administration Console. All components and their documentation are available in [the demo page](https://vapor.coveo.com/). Vapor package contains the generic style classes used across the components and react-vapor is a react implementation of multiple visual and behavioural components.
 
 ## Usage
 

--- a/build/deploy-demo.sh
+++ b/build/deploy-demo.sh
@@ -5,9 +5,9 @@ set -e
 BRANCH="$1"
 
 DESTINATION=react-vapor/feature
-BUCKET=coveo-nqa-jsadmin
+BUCKET=coveo-nrd-jsadmin
 
 echo "Pushing new demo of ${BRANCH} to ${BUCKET}/${DESTINATION}/${BRANCH}."
 aws s3 sync ./packages/demo/dist s3://${BUCKET}/${DESTINATION}/${BRANCH}
 
-echo "Branch successfully deployed to https://vaporqa.cloud.coveo.com/feature/${BRANCH}/?dev"
+echo "Branch successfully deployed to https://vapor.coveo.com/feature/${BRANCH}/"

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -15,7 +15,7 @@
     },
     "author": "Coveo",
     "license": "Apache-2.0",
-    "homepage": "https://vapor.cloud.coveo.com/",
+    "homepage": "https://vapor.coveo.com/",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/coveo/react-vapor.git"

--- a/packages/react-vapor/README.md
+++ b/packages/react-vapor/README.md
@@ -8,7 +8,7 @@
 
 [Coveo Administration Console](https://platform.cloud.coveo.com/admin/)'s design system.
 
-[Have a look at `react-vapor`'s demo page!](https://vapor.cloud.coveo.com/)
+[Have a look at `react-vapor`'s demo page!](https://vapor.coveo.com/)
 
 ## Getting started
 


### PR DESCRIPTION
### Proposed Changes

The demo website will now be hosted in the RD environment at url `vapor.coveo.com`.

### Potential Breaking Changes

The demo might not work for a short while until IT adjust the DNS

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
