### PR TITLE
feat: commits + author to failing master build slackbot notifs

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -408,7 +408,7 @@ def getBuildChangeSets() {
         for (int j = 0; j < entries.length; j++) {
             def entry = entries[j]
             truncated_msg = entry.msg.take(MAX_MSG_LEN)
-            changeString += " - ${truncated_msg} [${entry.author}]\n"
+            changeString += "- ${truncated_msg} [${entry.author}]\n"
         }
     }
 


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-147
Same change as https://github.com/coveo/admin-ui/pull/3422 but for React-Vapor

When a master build fails, it pushes a notification in the guild saying that master is broken. Its nice because everyone can know immediately that there is a problem, but its doesn't really give any clue about who should be the owner of that failure.

We now list all the commits from the current build so we have at first glance an idea of the potential owner of the failure.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
