### PR TITLE
ci: add lockfileMaintenance config to renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,5 +12,11 @@
       "automergeType": "branch",
       "semanticCommitType": "chore"
     }
-  ]
+  ],
+  "lockFileMaintenance": {
+    "description": "Regenerate the pnpm-lock.yaml file",
+    "enabled": true,
+    "automerge": true,
+    "extends": ["schedule:weekly"]
+  }
 }


### PR DESCRIPTION
### Proposed Changes

add lockfile maintenance config to renovate. It will re-generate the pnpm-lockfile from scratch and automerge if it passes. This is useful to bump dependencies of dependencies

### Potential Breaking Changes

None
