### PR TITLE
refactor(tab): height is 32px in figma not 44

### DIFF
--- a/packages/vapor/scss/components/tab.scss
+++ b/packages/vapor/scss/components/tab.scss
@@ -7,7 +7,7 @@
     .tab {
         position: relative;
         display: inline-block;
-        height: 44px;
+        height: 32px;
         margin-left: 0.5rem;
         text-transform: none;
         cursor: pointer;


### PR DESCRIPTION
### Proposed Changes

UITOOL-156

Me have a tit coco I picked the wrong height in my OG pr for the tabs :see_no_evil:

![image](https://user-images.githubusercontent.com/63734941/140957196-33076006-20c6-4faa-be8e-db3aa950dedb.png)
 
### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
