### PR TITLE
ci: create tag for release after amend

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -237,6 +237,7 @@ pipeline {
             --no-push \
             --no-private \
             --no-git-reset \
+            --no-git-tag-version \
             --yes"
           } else if (env.BRANCH_NAME == "next") {
             // next
@@ -251,6 +252,7 @@ pipeline {
             --no-push \
             --no-private \
             --no-git-reset \
+            --no-git-tag-version \
             --yes"
           } else {
             // master
@@ -262,19 +264,20 @@ pipeline {
             --no-push \
             --no-private \
             --no-git-reset \
+            --no-git-tag-version \
             --yes"
           }
-
-          sh "pnpm install --lockfile-only"
-          sh "git add pnpm-lock.yaml"
-          sh "git commit --amend --no-edit"
-          sh "git push -u origin ${env.BRANCH_NAME} --force"
 
           NEW_VERSION = sh(
             script: "node -p -e 'require(`./lerna.json`).version;'",
             returnStdout: true
           ).trim()
 
+          sh "pnpm install --lockfile-only"
+          sh "git add pnpm-lock.yaml"
+          sh "git commit --amend --no-edit"
+          sh "git tag -a -m \"v${NEW_VERSION}\" v${NEW_VERSION}"
+          sh "git push -u origin ${env.BRANCH_NAME} --follow-tags --force"
           sh "git reset --hard"
         }
       }

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -235,7 +235,6 @@ pipeline {
             --no-commit-hooks \
             --force-publish \
             --no-push \
-            --no-private \
             --no-git-reset \
             --no-git-tag-version \
             --yes"
@@ -250,7 +249,6 @@ pipeline {
             --no-commit-hooks \
             --force-publish \
             --no-push \
-            --no-private \
             --no-git-reset \
             --no-git-tag-version \
             --yes"
@@ -262,7 +260,6 @@ pipeline {
             --no-commit-hooks \
             --force-publish \
             --no-push \
-            --no-private \
             --no-git-reset \
             --no-git-tag-version \
             --yes"

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "classnames": "2.3.1",
         "codemirror": "5.63.3",
-        "coveo-styleguide": "26.0.0",
+        "coveo-styleguide": "27.0.0",
         "d3": "3.5.17",
         "faker": "4.1.0",
         "jquery": "3.6.0",
@@ -36,7 +36,7 @@
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",
         "react-syntax-highlighter": "15.4.4",
-        "react-vapor": "^24.14.6",
+        "react-vapor": "27.0.0",
         "redux": "4.1.2",
         "redux-devtools-extension": "2.13.9",
         "redux-promise-middleware": "6.1.2",

--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -109,7 +109,7 @@
         "codecov": "3.8.2",
         "codemirror": "5.63.3",
         "concurrently": "5.3.0",
-        "coveo-styleguide": "^27.0.0",
+        "coveo-styleguide": "27.0.0",
         "d3": "3.5.17",
         "del": "5.1.0",
         "dnd-core": "2.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
       codemirror: 5.63.3
       concurrently: 6.3.0
       copy-webpack-plugin: 6.4.1
-      coveo-styleguide: 26.0.0
+      coveo-styleguide: 27.0.0
       css-loader: 3.6.0
       d3: 3.5.17
       faker: 4.1.0
@@ -90,7 +90,7 @@ importers:
       react-router: 5.2.1
       react-router-dom: 5.3.0
       react-syntax-highlighter: 15.4.4
-      react-vapor: ^24.14.6
+      react-vapor: 27.0.0
       redux: 4.1.2
       redux-devtools-extension: 2.13.9
       redux-promise-middleware: 6.1.2
@@ -112,7 +112,7 @@ importers:
     dependencies:
       classnames: 2.3.1
       codemirror: 5.63.3
-      coveo-styleguide: 26.0.0
+      coveo-styleguide: link:../vapor
       d3: 3.5.17
       faker: 4.1.0
       jquery: 3.6.0
@@ -125,7 +125,7 @@ importers:
       react-router: 5.2.1_react@16.14.0
       react-router-dom: 5.3.0_react@16.14.0
       react-syntax-highlighter: 15.4.4_react@16.14.0
-      react-vapor: 24.37.0_c1a750d61710d9130e0e63969c33e83a
+      react-vapor: link:../react-vapor
       redux: 4.1.2
       redux-devtools-extension: 2.13.9_redux@4.1.2
       redux-promise-middleware: 6.1.2_redux@4.1.2
@@ -226,7 +226,7 @@ importers:
       codecov: 3.8.2
       codemirror: 5.63.3
       concurrently: 5.3.0
-      coveo-styleguide: ^27.0.0
+      coveo-styleguide: 27.0.0
       d3: 3.5.17
       del: 5.1.0
       dnd-core: 2.5.1
@@ -355,9 +355,9 @@ importers:
       enzyme: 3.11.0
       enzyme-adapter-react-16: 1.15.6_4f82faf5e8cab057bc46d4d95079ec42
       escape-string-regexp: 1.0.5
-      eslint-plugin-jest: 24.7.0_eslint@7.32.0+typescript@3.8.3
-      eslint-plugin-jest-dom: 3.9.2_eslint@7.32.0
-      eslint-plugin-testing-library: 3.10.2_eslint@7.32.0+typescript@3.8.3
+      eslint-plugin-jest: 24.7.0_typescript@3.8.3
+      eslint-plugin-jest-dom: 3.9.2
+      eslint-plugin-testing-library: 3.10.2_typescript@3.8.3
       faker: 4.1.0
       fancy-log: 1.3.3
       identity-obj-proxy: 3.0.0
@@ -3064,7 +3064,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/3.10.1_eslint@7.32.0+typescript@3.8.3:
+  /@typescript-eslint/experimental-utils/3.10.1_typescript@3.8.3:
     resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -3073,7 +3073,6 @@ packages:
       '@types/json-schema': 7.0.7
       '@typescript-eslint/types': 3.10.1
       '@typescript-eslint/typescript-estree': 3.10.1_typescript@3.8.3
-      eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
     transitivePeerDependencies:
@@ -3081,7 +3080,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.22.0_eslint@7.32.0+typescript@3.8.3:
+  /@typescript-eslint/experimental-utils/4.22.0_typescript@3.8.3:
     resolution: {integrity: sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -3091,7 +3090,6 @@ packages:
       '@typescript-eslint/scope-manager': 4.22.0
       '@typescript-eslint/types': 4.22.0
       '@typescript-eslint/typescript-estree': 4.22.0_typescript@3.8.3
-      eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
     transitivePeerDependencies:
@@ -5611,17 +5609,6 @@ packages:
       underscore: 1.13.1
     dev: true
 
-  /coveo-styleguide/26.0.0:
-    resolution: {integrity: sha512-ocP5fqZAWU52QPerjnXEXVl09RRD1vQTxEdy0PzCw0nrFo8pFNOCmx5iOrGwo99xmADdH2Z1SkezbC2ansAL0Q==}
-    peerDependencies:
-      chosen-npm: ^1.4.2
-      coveo-slider: ^1.0.1
-      materialize-css: ^0.98.2
-    dependencies:
-      codemirror: 5.63.3
-      rc-slider: 8.7.1
-    dev: false
-
   /create-ecdh/4.0.4:
     resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
     dependencies:
@@ -6943,7 +6930,7 @@ packages:
       tsconfig-paths: 3.9.0
     dev: true
 
-  /eslint-plugin-jest-dom/3.9.2_eslint@7.32.0:
+  /eslint-plugin-jest-dom/3.9.2:
     resolution: {integrity: sha512-DKNW6nxYkBvwv36WcYFxapCalGjOGSWUu5PREpDVuXGbEns3S5jhr+mZ5W2N6MxbOWw/2U61C1JVLH31gwVjOQ==}
     engines: {node: ^10.12.0 || >=12.0.0, npm: '>=6', yarn: '>=1'}
     peerDependencies:
@@ -6951,11 +6938,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.16.0
       '@testing-library/dom': 7.31.2
-      eslint: 7.32.0
       requireindex: 1.2.0
     dev: true
 
-  /eslint-plugin-jest/24.7.0_eslint@7.32.0+typescript@3.8.3:
+  /eslint-plugin-jest/24.7.0_typescript@3.8.3:
     resolution: {integrity: sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -6965,8 +6951,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.22.0_eslint@7.32.0+typescript@3.8.3
-      eslint: 7.32.0
+      '@typescript-eslint/experimental-utils': 4.22.0_typescript@3.8.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7045,14 +7030,13 @@ packages:
       string.prototype.matchall: 4.0.4
     dev: true
 
-  /eslint-plugin-testing-library/3.10.2_eslint@7.32.0+typescript@3.8.3:
+  /eslint-plugin-testing-library/3.10.2_typescript@3.8.3:
     resolution: {integrity: sha512-WAmOCt7EbF1XM8XfbCKAEzAPnShkNSwcIsAD2jHdsMUT9mZJPjLCG7pMzbcC8kK366NOuGip8HKLDC+Xk4yIdA==}
     engines: {node: ^10.12.0 || >=12.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^5 || ^6 || ^7
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.10.1_eslint@7.32.0+typescript@3.8.3
-      eslint: 7.32.0
+      '@typescript-eslint/experimental-utils': 3.10.1_typescript@3.8.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -14315,52 +14299,6 @@ packages:
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0
       react-lifecycles-compat: 3.0.4
-    dev: false
-
-  /react-vapor/24.37.0_c1a750d61710d9130e0e63969c33e83a:
-    resolution: {integrity: sha512-3phJESWWsD7BUoK3koNlo2KAVNX6Qpb9/RzvbJBed9qQqKwCO4pUryLSXtskigfxVJ186q4KbJJMKZbwxIG+Zg==}
-    peerDependencies:
-      codemirror: ^5.39.2
-      d3: ^3.5.17
-      jquery: '>= 2.0.0 =< 3'
-      react: ^16.8.0
-      react-dom: ^16.8.0
-      react-redux: ^7.2.4
-      redux: ^4.0.1
-      underscore: ^1.8.3
-      underscore.string: ^3.3.5
-    dependencies:
-      '@types/codemirror': 0.0.109
-      '@types/rc-slider': 8.6.6
-      chosen-js: 1.8.7
-      codemirror: 5.63.3
-      d3: 3.5.17
-      jquery: 3.6.0
-      query-string: 6.14.1
-      rc-slider: 8.7.1
-      rc-tooltip: 3.7.3
-      react: 16.14.0
-      react-bootstrap: 0.33.1_react-dom@16.14.0+react@16.14.0
-      react-codemirror2: 7.2.1_codemirror@5.63.3+react@16.14.0
-      react-color: 2.19.3_react@16.14.0
-      react-diff-viewer: 3.1.1_react-dom@16.14.0+react@16.14.0
-      react-dnd: 2.6.0_react@16.14.0
-      react-dnd-html5-backend: 2.6.0
-      react-dom: 16.14.0_react@16.14.0
-      react-infinite-scroll-component: 4.5.3_react@16.14.0
-      react-modal: 3.14.3_react-dom@16.14.0+react@16.14.0
-      react-redux: 7.2.6_react-dom@16.14.0+react@16.14.0
-      react-tether: 1.0.5_react-dom@16.14.0+react@16.14.0
-      react-textarea-autosize: 8.3.3_5283d3c8d694c64e162d21c7dd1475fb
-      redux: 4.1.2
-      split-on-first: 1.1.0
-      strict-uri-encode: 2.0.0
-      underscore: 1.13.1
-      underscore.string: 3.3.5
-      unidiff: 0.0.4
-    transitivePeerDependencies:
-      - '@types/react'
-      - prop-types
     dev: false
 
   /react/16.14.0:


### PR DESCRIPTION
### Proposed Changes

- Adding the `--no-git-tag-version` option so that we don't create 2 tags for each release
- Creating the release tag after the commit has been amended
- Added `--follow-tags` to the push command so that it pushes the commit along with its tag all at once

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
