### PR TITLE
build(npm): bump to v27.0.1

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -272,7 +272,7 @@ pipeline {
 
           sh "pnpm install --lockfile-only"
           sh "git add pnpm-lock.yaml"
-          sh "git commit --amend --no-edit"
+          sh "git commit -m \"chore(release): [version bump] - v${NEW_VERSION}\""
           sh "git tag -a -m \"v${NEW_VERSION}\" v${NEW_VERSION}"
           sh "git push -u origin ${env.BRANCH_NAME} --follow-tags --force"
           sh "git reset --hard"

--- a/lerna.json
+++ b/lerna.json
@@ -1,29 +1,17 @@
 {
-    "version": "27.0.0",
-    "packages": [
-        "packages/*"
-    ],
+    "version": "27.0.1",
+    "packages": ["packages/*"],
     "command": {
         "publish": {
             "conventionalCommits": true,
-            "allowBranch": [
-                "master",
-                "next",
-                "release-*"
-            ]
+            "allowBranch": ["master", "next", "release-*"]
         },
         "version": {
-            "conventionalCommits": true,
-            "message": "chore(release): [version bump] - %s"
+            "conventionalCommits": true
         },
         "bootstrap": {
             "hoist": true,
-            "nohoist": [
-                "unidiff",
-                "query-string",
-                "strict-uri-encode",
-                "split-on-first"
-            ]
+            "nohoist": ["unidiff", "query-string", "strict-uri-encode", "split-on-first"]
         }
     }
 }

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-vapor-demo",
-    "version": "24.14.6",
+    "version": "27.0.1",
     "private": true,
     "description": "Vapor Design System",
     "main": "src/Index.ts",
@@ -23,7 +23,7 @@
     "dependencies": {
         "classnames": "2.3.1",
         "codemirror": "5.63.3",
-        "coveo-styleguide": "27.0.0",
+        "coveo-styleguide": "27.0.1",
         "d3": "3.5.17",
         "faker": "4.1.0",
         "jquery": "3.6.0",
@@ -36,7 +36,7 @@
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",
         "react-syntax-highlighter": "15.4.4",
-        "react-vapor": "27.0.0",
+        "react-vapor": "27.0.1",
         "redux": "4.1.2",
         "redux-devtools-extension": "2.13.9",
         "redux-promise-middleware": "6.1.2",

--- a/packages/e2eTesting/package.json
+++ b/packages/e2eTesting/package.json
@@ -1,7 +1,7 @@
 {
     "name": "e2etesting",
     "private": true,
-    "version": "24.10.1",
+    "version": "27.0.1",
     "description": "End to end tests for react-vapor",
     "main": "index.js",
     "scripts": {

--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-vapor",
-    "version": "27.0.0",
+    "version": "27.0.1",
     "description": "Vapor CSS components implemented with React!",
     "keywords": [
         "coveo",
@@ -109,7 +109,7 @@
         "codecov": "3.8.2",
         "codemirror": "5.63.3",
         "concurrently": "5.3.0",
-        "coveo-styleguide": "27.0.0",
+        "coveo-styleguide": "27.0.1",
         "d3": "3.5.17",
         "del": "5.1.0",
         "dnd-core": "2.5.1",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@coveord/design-tokens",
-    "version": "27.0.0",
+    "version": "27.0.1",
     "description": "Design tokens of the Vapor Design System",
     "repository": {
         "type": "git",

--- a/packages/vapor/package.json
+++ b/packages/vapor/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo-styleguide",
-    "version": "27.0.0",
+    "version": "27.0.1",
     "description": "Yet another CSS framework - but it's awesome & built by Coveo.",
     "keywords": [
         "coveo",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
       codemirror: 5.63.3
       concurrently: 6.3.0
       copy-webpack-plugin: 6.4.1
-      coveo-styleguide: 27.0.0
+      coveo-styleguide: 27.0.1
       css-loader: 3.6.0
       d3: 3.5.17
       faker: 4.1.0
@@ -90,7 +90,7 @@ importers:
       react-router: 5.2.1
       react-router-dom: 5.3.0
       react-syntax-highlighter: 15.4.4
-      react-vapor: 27.0.0
+      react-vapor: 27.0.1
       redux: 4.1.2
       redux-devtools-extension: 2.13.9
       redux-promise-middleware: 6.1.2
@@ -226,7 +226,7 @@ importers:
       codecov: 3.8.2
       codemirror: 5.63.3
       concurrently: 5.3.0
-      coveo-styleguide: 27.0.0
+      coveo-styleguide: 27.0.1
       d3: 3.5.17
       del: 5.1.0
       dnd-core: 2.5.1


### PR DESCRIPTION
### Proposed Changes

27.0.1 is already published to the npm registry and so we cannot publish over it

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
