### PR TITLE
fix(action): properly use iconClass

### DIFF
--- a/packages/react-vapor/src/components/actions/Action.tsx
+++ b/packages/react-vapor/src/components/actions/Action.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import * as React from 'react';
 
 import {TooltipPlacement} from '../../utils/TooltipUtils';
@@ -54,11 +55,15 @@ export class Action extends React.Component<IActionProps, any> {
     };
 
     render() {
-        const {icon, id, name, tooltipPlacement, tooltip} = this.props.action;
+        const {icon, iconClass, id, name, tooltipPlacement, tooltip} = this.props.action;
         const actionIcon: JSX.Element = icon ? (
-            <Svg svgName={icon} className="action-icon" svgClass="icon" />
+            <Svg svgName={icon} className={classNames(iconClass, 'action-icon')} svgClass="icon" />
         ) : (
-            <Svg svgName="more" className="action-icon action-icon-more" svgClass="icon icon-medium" />
+            <Svg
+                svgName="more"
+                className={classNames(iconClass, 'action-icon action-icon-more')}
+                svgClass="icon icon-medium"
+            />
         );
         const inside: string | JSX.Element = this.props.simple ? (
             name

--- a/packages/react-vapor/src/components/actions/tests/Action.spec.tsx
+++ b/packages/react-vapor/src/components/actions/tests/Action.spec.tsx
@@ -33,6 +33,13 @@ describe('Actions', () => {
         expect(component.find('.action-label').prop('data-trigger')).toBe(expectedId);
     });
 
+    it('should add the iconClass of the action on the icon class', () => {
+        const iconClass = 'bloup';
+        const component = shallow(<Action action={{...action, icon: 'link', iconClass}} />);
+
+        expect(component.find(Svg).prop('className')).toContain(iconClass);
+    });
+
     it('should add the name of the action on a data-trigger attribute if the id is not defined', () => {
         const component = shallow(<Action action={action} />);
 


### PR DESCRIPTION
[COM-1330]

### Proposed Changes

I had to apply a specific class to a specific action to work around an issue that we have with a specific icon.

So I found `iconClass` in the props and it pretty much looked like it would fit my use case.

But the prop is completely unused, so here we go...

### Potential Breaking Changes

None, really.

### Acceptance Criteria

-   [x] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [x] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[COM-1330]: https://coveord.atlassian.net/browse/COM-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ