### PR TITLE
ci(deploy): fix typo in deployment config

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -31,7 +31,7 @@
         {
             "id": "deploy-minified-files",
             "s3": {
-                "disable": true,
+                "disabled": true,
                 "bucket": "coveo-nrd-jsadmin",
                 "directory": "react-vapor",
                 "parameters": {
@@ -41,14 +41,14 @@
                 },
                 "source": "packages/demo/dist",
                 "rd": {
-                    "disable": false
+                    "disabled": false
                 }
             }
         },
         {
             "id": "deploy-non-minified-files",
             "s3": {
-                "disable": true,
+                "disabled": true,
                 "bucket": "coveo-nrd-jsadmin",
                 "directory": "react-vapor",
                 "parameters": {
@@ -57,14 +57,14 @@
                 },
                 "source": "packages/demo/dist",
                 "rd": {
-                    "disable": false
+                    "disabled": false
                 }
             }
         },
         {
             "id": "deploy-styleguide-minified-files",
             "s3": {
-                "disable": true,
+                "disabled": true,
                 "bucket": "coveo-public-content",
                 "directory": "styleguide/v$[VERSION]",
                 "parameters": {
@@ -82,7 +82,7 @@
         {
             "id": "deploy-styleguide-non-minified-files",
             "s3": {
-                "disable": true,
+                "disabled": true,
                 "bucket": "coveo-public-content",
                 "directory": "styleguide/v$[VERSION]",
                 "parameters": {


### PR DESCRIPTION
### Proposed Changes

`disable` key doesn't exist in the deployment config schema, its `disabled`.

### Potential Breaking Changes

none, should fix the master deployment on s3

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
