### PR TITLE
Enable links in disabled radio card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1835,22 +1835,7 @@ breaking.
 
 
 
-<<<<<<< HEAD
 # [23.0.0-next.15](https://github.com/coveo/react-vapor/compare/v23.0.0-next.14...v23.0.0-next.15) (2021-06-22)
-=======
-# [22.21.0](https://github.com/coveo/react-vapor/compare/v22.20.3...v22.21.0) (2021-07-22)
-
-
-### Features
-
-* **limit:** +onClick method on history icon ([0c12782](https://github.com/coveo/react-vapor/commit/0c12782070d0d686f8410bf29943627b69b23b97))
-
-
-
-
-
-## [22.20.3](https://github.com/coveo/react-vapor/compare/v22.20.2...v22.20.3) (2021-07-21)
->>>>>>> master
 
 **Note:** Version bump only for package root
 
@@ -1858,7 +1843,6 @@ breaking.
 
 
 
-<<<<<<< HEAD
 # [23.0.0-next.14](https://github.com/coveo/react-vapor/compare/v22.17.0...v23.0.0-next.14) (2021-06-22)
 
 
@@ -1888,61 +1872,20 @@ breaking.
 
 
 # [23.0.0-next.10](https://github.com/coveo/react-vapor/compare/v22.9.6...v23.0.0-next.10) (2021-06-08)
-=======
-## [22.20.2](https://github.com/coveo/react-vapor/compare/v22.20.1...v22.20.2) (2021-07-21)
-
-**Note:** Version bump only for package root
-
-
-
-
-
-## [22.20.1](https://github.com/coveo/react-vapor/compare/v22.20.0...v22.20.1) (2021-07-21)
-
-**Note:** Version bump only for package root
-
-
-
-
-
-# [22.20.0](https://github.com/coveo/react-vapor/compare/v22.19.5...v22.20.0) (2021-07-15)
-
-
-### Features
-
-* **svg:** add new side nav icons ([#2080](https://github.com/coveo/react-vapor/issues/2080)) ([830e07f](https://github.com/coveo/react-vapor/commit/830e07fe5b1a513dea0a0f5aebbf31438cc60a84))
-
-
-
-
-
-## [22.19.5](https://github.com/coveo/react-vapor/compare/v22.19.4...v22.19.5) (2021-07-15)
->>>>>>> master
 
 
 ### Bug Fixes
 
-<<<<<<< HEAD
 * fix svg alignment in optionCycle ([3532e26](https://github.com/coveo/react-vapor/commit/3532e26a1f2ee5b60accf82b968c2c5a54326c08))
 * fixed size for label in chart ([4978b23](https://github.com/coveo/react-vapor/commit/4978b23cb25d94f3b5a6b706f24c7fb909003b19))
 
 
 
 # [23.0.0-next.9](https://github.com/coveo/react-vapor/compare/v23.0.0-next.8...v23.0.0-next.9) (2021-06-08)
-=======
-* **tabs:** allow multiple independent tab navigations at the same time ([0548f87](https://github.com/coveo/react-vapor/commit/0548f87c675f9250857ea0cd595a4d9e40a607f7))
-
-
-
-
-
-## [22.19.4](https://github.com/coveo/react-vapor/compare/v22.19.3...v22.19.4) (2021-07-15)
->>>>>>> master
 
 
 ### Bug Fixes
 
-<<<<<<< HEAD
 * applied review from another pr ([369f4df](https://github.com/coveo/react-vapor/commit/369f4dfa1b680647e3459d042f15543aca0c2cf6))
 
 
@@ -1956,32 +1899,10 @@ breaking.
 
 
 # [23.0.0-next.6](https://github.com/coveo/react-vapor/compare/v22.9.3...v23.0.0-next.6) (2021-06-07)
-=======
-* **tabs:** allow onSelect prop on TabConnected ([#2081](https://github.com/coveo/react-vapor/issues/2081)) ([3610f83](https://github.com/coveo/react-vapor/commit/3610f83f0f6ead996a352195774defe2ff683d0a))
-
-
-
-
-
-## [22.19.3](https://github.com/coveo/react-vapor/compare/v22.19.2...v22.19.3) (2021-07-14)
 
 
 ### Bug Fixes
 
-* **focus:** override outline for Firefox ([81d32dc](https://github.com/coveo/react-vapor/commit/81d32dc71b1bca98f8e664600152531bc20e5c9e))
-* **focus:** override outline for Firefox ([7e48066](https://github.com/coveo/react-vapor/commit/7e48066d74507b145be86e4e1caa0fb98a678c54))
-
-
-
-
-
-## [22.19.2](https://github.com/coveo/react-vapor/compare/v22.19.1...v22.19.2) (2021-07-12)
->>>>>>> master
-
-
-### Bug Fixes
-
-<<<<<<< HEAD
 * fix date picker style for new typekit ([dcdd5ee](https://github.com/coveo/react-vapor/commit/dcdd5eed29227fa9ec3ea517230402c9a04d5836))
 * fix general guidelines demo ([827b3e6](https://github.com/coveo/react-vapor/commit/827b3e652c1a34ee7c3b27e76103cc30841c58c9))
 * fix some nitpick things ([a448a25](https://github.com/coveo/react-vapor/commit/a448a2549befee9a9936fbc54a5e6152f85f3513))
@@ -2014,50 +1935,10 @@ breaking.
 
 
 # [23.0.0-next.3](https://github.com/coveo/react-vapor/compare/v23.0.0-next.2...v23.0.0-next.3) (2021-06-01)
-=======
-* **option-picker:** alignement when used as a button ([bc6341a](https://github.com/coveo/react-vapor/commit/bc6341a4b34c821eea6681225cc2798895cbb132))
-
-
-
-
-
-## [22.19.1](https://github.com/coveo/react-vapor/compare/v22.19.0...v22.19.1) (2021-07-12)
-
-**Note:** Version bump only for package root
-
-
-
-
-
-# [22.19.0](https://github.com/coveo/react-vapor/compare/v22.18.0...v22.19.0) (2021-07-07)
-
-
-### Features
-
-* **svg:** add `associate` icon ([39b375d](https://github.com/coveo/react-vapor/commit/39b375d04fbf31462e8cbef7b5c2b31cb53c556b))
-
-
-
-
-
-# [22.18.0](https://github.com/coveo/react-vapor/compare/v22.17.3...v22.18.0) (2021-07-05)
-
-
-### Features
-
-* **tabs:** improve accessibility of tabs ([36be341](https://github.com/coveo/react-vapor/commit/36be341841ad293e2be79301278225f880892ac0))
-
-
-
-
-
-## [22.17.3](https://github.com/coveo/react-vapor/compare/v22.17.2...v22.17.3) (2021-06-29)
->>>>>>> master
 
 
 ### Bug Fixes
 
-<<<<<<< HEAD
 * **header:** change h1 for h4 in title component ([df7027f](https://github.com/coveo/react-vapor/commit/df7027f725041a1a86f5885d8a0ef109c7a48315))
 
 
@@ -2079,28 +1960,6 @@ breaking.
 
 
 # [23.0.0-next.1](https://github.com/coveo/react-vapor/compare/v22.8.0...v23.0.0-next.1) (2021-05-31)
-=======
-* **singleselect:** wrapped section children ([87bf515](https://github.com/coveo/react-vapor/commit/87bf51506699b5a00212caef0ca7fb390124fa16))
-
-
-
-
-
-## [22.17.2](https://github.com/coveo/react-vapor/compare/v22.17.1...v22.17.2) (2021-06-28)
-
-**Note:** Version bump only for package root
-
-
-
-
-
-## [22.17.1](https://github.com/coveo/react-vapor/compare/v22.17.0...v22.17.1) (2021-06-22)
-
-
-### Bug Fixes
-
-* **demo:** remove fibers dependency ([#2063](https://github.com/coveo/react-vapor/issues/2063)) ([c71676b](https://github.com/coveo/react-vapor/commit/c71676bae63d82aa0a3053d23ce62c4fc12c3aac))
->>>>>>> master
 
 
 

--- a/packages/react-vapor/CHANGELOG.md
+++ b/packages/react-vapor/CHANGELOG.md
@@ -1463,7 +1463,6 @@ need to simply provide an icon name (string) via the new icon prop. You can also
 
 
 
-<<<<<<< HEAD
 # [23.0.0-next.15](https://github.com/coveo/react-vapor/compare/v23.0.0-next.14...v23.0.0-next.15) (2021-06-22)
 
 **Note:** Version bump only for package react-vapor
@@ -1505,77 +1504,20 @@ need to simply provide an icon name (string) via the new icon prop. You can also
 
 
 # [23.0.0-next.6](https://github.com/coveo/react-vapor/compare/v22.9.3...v23.0.0-next.6) (2021-06-07)
-=======
-# [22.21.0](https://github.com/coveo/react-vapor/compare/v22.20.3...v22.21.0) (2021-07-22)
-
-
-### Features
-
-* **limit:** +onClick method on history icon ([0c12782](https://github.com/coveo/react-vapor/commit/0c12782070d0d686f8410bf29943627b69b23b97))
-
-
-
-
-
-## [22.20.3](https://github.com/coveo/react-vapor/compare/v22.20.2...v22.20.3) (2021-07-21)
-
-**Note:** Version bump only for package react-vapor
-
-
-
-
-
-## [22.20.2](https://github.com/coveo/react-vapor/compare/v22.20.1...v22.20.2) (2021-07-21)
-
-**Note:** Version bump only for package react-vapor
-
-
-
-
-
-## [22.20.1](https://github.com/coveo/react-vapor/compare/v22.20.0...v22.20.1) (2021-07-21)
-
-**Note:** Version bump only for package react-vapor
-
-
-
-
-
-# [22.20.0](https://github.com/coveo/react-vapor/compare/v22.19.5...v22.20.0) (2021-07-15)
-
-**Note:** Version bump only for package react-vapor
-
-
-
-
-
-## [22.19.5](https://github.com/coveo/react-vapor/compare/v22.19.4...v22.19.5) (2021-07-15)
->>>>>>> master
 
 
 ### Bug Fixes
 
-<<<<<<< HEAD
 * fix date picker style for new typekit ([dcdd5ee](https://github.com/coveo/react-vapor/commit/dcdd5eed29227fa9ec3ea517230402c9a04d5836))
 * fix titles sizes ([47b3367](https://github.com/coveo/react-vapor/commit/47b336791bb3f0a628bba3e9ccee39a35cfa4e22))
 
 
 
 # [23.0.0-next.5](https://github.com/coveo/react-vapor/compare/v22.9.1...v23.0.0-next.5) (2021-06-04)
-=======
-* **tabs:** allow multiple independent tab navigations at the same time ([0548f87](https://github.com/coveo/react-vapor/commit/0548f87c675f9250857ea0cd595a4d9e40a607f7))
-
-
-
-
-
-## [22.19.4](https://github.com/coveo/react-vapor/compare/v22.19.3...v22.19.4) (2021-07-15)
->>>>>>> master
 
 
 ### Bug Fixes
 
-<<<<<<< HEAD
 * fix description style in headers ([0f12035](https://github.com/coveo/react-vapor/commit/0f12035990cf32d298f015be550ed0555eacfd77))
 
 
@@ -1590,28 +1532,10 @@ need to simply provide an icon name (string) via the new icon prop. You can also
 
 
 # [23.0.0-next.3](https://github.com/coveo/react-vapor/compare/v23.0.0-next.2...v23.0.0-next.3) (2021-06-01)
-=======
-* **tabs:** allow onSelect prop on TabConnected ([#2081](https://github.com/coveo/react-vapor/issues/2081)) ([3610f83](https://github.com/coveo/react-vapor/commit/3610f83f0f6ead996a352195774defe2ff683d0a))
-
-
-
-
-
-## [22.19.3](https://github.com/coveo/react-vapor/compare/v22.19.2...v22.19.3) (2021-07-14)
-
-**Note:** Version bump only for package react-vapor
-
-
-
-
-
-## [22.19.2](https://github.com/coveo/react-vapor/compare/v22.19.1...v22.19.2) (2021-07-12)
->>>>>>> master
 
 
 ### Bug Fixes
 
-<<<<<<< HEAD
 * **header:** change h1 for h4 in title component ([df7027f](https://github.com/coveo/react-vapor/commit/df7027f725041a1a86f5885d8a0ef109c7a48315))
 
 
@@ -1621,63 +1545,6 @@ need to simply provide an icon name (string) via the new icon prop. You can also
 
 
 # [23.0.0-next.1](https://github.com/coveo/react-vapor/compare/v22.8.0...v23.0.0-next.1) (2021-05-31)
-=======
-* **option-picker:** alignement when used as a button ([bc6341a](https://github.com/coveo/react-vapor/commit/bc6341a4b34c821eea6681225cc2798895cbb132))
-
-
-
-
-
-## [22.19.1](https://github.com/coveo/react-vapor/compare/v22.19.0...v22.19.1) (2021-07-12)
-
-**Note:** Version bump only for package react-vapor
-
-
-
-
-
-# [22.19.0](https://github.com/coveo/react-vapor/compare/v22.18.0...v22.19.0) (2021-07-07)
-
-**Note:** Version bump only for package react-vapor
-
-
-
-
-
-# [22.18.0](https://github.com/coveo/react-vapor/compare/v22.17.3...v22.18.0) (2021-07-05)
-
-
-### Features
-
-* **tabs:** improve accessibility of tabs ([36be341](https://github.com/coveo/react-vapor/commit/36be341841ad293e2be79301278225f880892ac0))
-
-
-
-
-
-## [22.17.3](https://github.com/coveo/react-vapor/compare/v22.17.2...v22.17.3) (2021-06-29)
-
-**Note:** Version bump only for package react-vapor
-
-
-
-
-
-## [22.17.2](https://github.com/coveo/react-vapor/compare/v22.17.1...v22.17.2) (2021-06-28)
-
-**Note:** Version bump only for package react-vapor
-
-
-
-
-
-## [22.17.1](https://github.com/coveo/react-vapor/compare/v22.17.0...v22.17.1) (2021-06-22)
-
-
-### Bug Fixes
-
-* **demo:** remove fibers dependency ([#2063](https://github.com/coveo/react-vapor/issues/2063)) ([c71676b](https://github.com/coveo/react-vapor/commit/c71676bae63d82aa0a3053d23ce62c4fc12c3aac))
->>>>>>> master
 
 
 

--- a/packages/vapor/CHANGELOG.md
+++ b/packages/vapor/CHANGELOG.md
@@ -1025,7 +1025,6 @@ breaking.
 
 
 
-<<<<<<< HEAD
 # [23.0.0-next.15](https://github.com/coveo/react-vapor/compare/v23.0.0-next.14...v23.0.0-next.15) (2021-06-22)
 
 **Note:** Version bump only for package coveo-styleguide
@@ -1057,36 +1056,10 @@ breaking.
 
 
 # [23.0.0-next.6](https://github.com/coveo/react-vapor/compare/v22.9.3...v23.0.0-next.6) (2021-06-07)
-=======
-# [22.21.0](https://github.com/coveo/react-vapor/compare/v22.20.3...v22.21.0) (2021-07-22)
-
-
-### Features
-
-* **limit:** +onClick method on history icon ([0c12782](https://github.com/coveo/react-vapor/commit/0c12782070d0d686f8410bf29943627b69b23b97))
-
-
-
-
-
-# [22.20.0](https://github.com/coveo/react-vapor/compare/v22.19.5...v22.20.0) (2021-07-15)
-
-
-### Features
-
-* **svg:** add new side nav icons ([#2080](https://github.com/coveo/react-vapor/issues/2080)) ([830e07f](https://github.com/coveo/react-vapor/commit/830e07fe5b1a513dea0a0f5aebbf31438cc60a84))
-
-
-
-
-
-## [22.19.3](https://github.com/coveo/react-vapor/compare/v22.19.2...v22.19.3) (2021-07-14)
->>>>>>> master
 
 
 ### Bug Fixes
 
-<<<<<<< HEAD
 * fix style of wizard demo ([90c39d8](https://github.com/coveo/react-vapor/commit/90c39d8b7151ab50b49ec34527a4e73e3df69170))
 
 
@@ -1101,21 +1074,10 @@ breaking.
 
 
 # [23.0.0-next.4](https://github.com/coveo/react-vapor/compare/v22.8.1...v23.0.0-next.4) (2021-06-01)
-=======
-* **focus:** override outline for Firefox ([81d32dc](https://github.com/coveo/react-vapor/commit/81d32dc71b1bca98f8e664600152531bc20e5c9e))
-* **focus:** override outline for Firefox ([7e48066](https://github.com/coveo/react-vapor/commit/7e48066d74507b145be86e4e1caa0fb98a678c54))
-
-
-
-
-
-## [22.19.2](https://github.com/coveo/react-vapor/compare/v22.19.1...v22.19.2) (2021-07-12)
->>>>>>> master
 
 
 ### Bug Fixes
 
-<<<<<<< HEAD
 * **section:** change section titles to lower headings levels ([8b53b0f](https://github.com/coveo/react-vapor/commit/8b53b0f9638d5a007a14b4587a2cf938ee3f83de))
 
 
@@ -1146,31 +1108,6 @@ breaking.
 
 
 # [23.0.0-next.1](https://github.com/coveo/react-vapor/compare/v22.8.0...v23.0.0-next.1) (2021-05-31)
-=======
-* **option-picker:** alignement when used as a button ([bc6341a](https://github.com/coveo/react-vapor/commit/bc6341a4b34c821eea6681225cc2798895cbb132))
-
-
-
-
-
-# [22.19.0](https://github.com/coveo/react-vapor/compare/v22.18.0...v22.19.0) (2021-07-07)
-
-
-### Features
-
-* **svg:** add `associate` icon ([39b375d](https://github.com/coveo/react-vapor/commit/39b375d04fbf31462e8cbef7b5c2b31cb53c556b))
-
-
-
-
-
-# [22.18.0](https://github.com/coveo/react-vapor/compare/v22.17.3...v22.18.0) (2021-07-05)
-
-
-### Features
-
-* **tabs:** improve accessibility of tabs ([36be341](https://github.com/coveo/react-vapor/commit/36be341841ad293e2be79301278225f880892ac0))
->>>>>>> master
 
 
 

--- a/packages/vapor/scss/controls/radios.scss
+++ b/packages/vapor/scss/controls/radios.scss
@@ -139,7 +139,7 @@ $labelIndent: $radio-button-size + $radio-button-option-height;
         transform: none;
         cursor: not-allowed !important;
 
-        * {
+        *:not(a) {
             color: var(--grey-60);
         }
     }

--- a/packages/vapor/scss/controls/radios.scss
+++ b/packages/vapor/scss/controls/radios.scss
@@ -139,7 +139,7 @@ $labelIndent: $radio-button-size + $radio-button-option-height;
         transform: none;
         cursor: not-allowed !important;
 
-        *:not(a) {
+        *:not(a):not(.enabled *) {
             color: var(--grey-60);
         }
     }


### PR DESCRIPTION
### Proposed Changes

Radio card makes everything inside it disabled if the option is disabled, but we would still want to show documentation links, or at least have the option to highlight informations even if the radio card is disabled.

### Potential Breaking Changes

<!-- List all changes that might be breaking to react-vapor's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
