### PR TITLE
feat(new navigation): added new side nav, style changes

### DIFF
--- a/packages/demo/src/OneDemoToRuleThemAll.tsx
+++ b/packages/demo/src/OneDemoToRuleThemAll.tsx
@@ -2,25 +2,18 @@ import '@demo-styling/main.scss';
 
 import loadable from '@loadable/component';
 import * as React from 'react';
-import {HashRouter as Router, Redirect, Route} from 'react-router-dom';
-import {Loading, TabNavigation} from 'react-vapor';
+import {HashRouter as Router, Route} from 'react-router-dom';
+import {Loading} from 'react-vapor';
 
 import logo from '../resources/vapor_logo.svg';
 import ScrollToTop from './demo-building-blocs/ScrollTop';
-import TopNavLink from './demo-building-blocs/TopNavLink';
-
-/* And to Vapor bind them */
-const TopNav = () => (
-    <TabNavigation className="mod-no-border top-navigation">
-        <TopNavLink name="Styles" href="/styles" />
-        <TopNavLink name="Components" href="/components" />
-    </TabNavigation>
-);
+import Brand from './plasma/Brand';
+import Home from './plasma/Home';
+import {Navigation} from './plasma/navigation/SideNavigation';
 
 const Header = () => (
-    <div id="header" className="flex flex-center space-between p2" style={{minHeight: '90px'}}>
+    <div id="header" className="flex flex-center space-between" style={{minHeight: '90px'}}>
         <img src={logo} className="header-title" />
-        <TopNav />
     </div>
 );
 
@@ -33,9 +26,11 @@ const Demo = () => (
         <ScrollToTop />
         <Header />
         <div className="flex flex-auto pb4" style={{height: 'calc(100vh - 90px)'}}>
+            <Navigation />
             <Route path="/components" component={LoadableComponents} />
             <Route path="/styles" component={LoadableStyles} />
-            <Route exact path="/" component={() => <Redirect to="/components" />} />
+            <Route path="/brand" component={Brand} />
+            <Route exact path="/" component={Home} />
         </div>
     </Router>
 );

--- a/packages/demo/src/components/NotFound.tsx
+++ b/packages/demo/src/components/NotFound.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const NotFound: React.FC = () => (
+    <div className="mod-width-100 p20 flex center-align">
+        <h3>Page Not Found</h3>
+    </div>
+);

--- a/packages/demo/src/components/NotFound.tsx
+++ b/packages/demo/src/components/NotFound.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
+import {useRouteMatch} from 'react-router';
 
-export const NotFound: React.FC = () => (
-    <div className="mod-width-100 p20 flex center-align">
-        <h3>Page Not Found</h3>
-    </div>
-);
+export const NotFound: React.FC = () => {
+    const match = useRouteMatch();
+
+    return (
+        <div className="mod-width-100 p20 flex flex-column center-align">
+            <h3>Page Not Found</h3>
+            <p>{match.url}</p>
+        </div>
+    );
+};

--- a/packages/demo/src/components/index.tsx
+++ b/packages/demo/src/components/index.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import {Redirect, Route, RouteComponentProps, Switch} from 'react-router-dom';
+import {Route, RouteComponentProps, Switch} from 'react-router-dom';
 import {Loading} from 'react-vapor';
 import * as _ from 'underscore';
 
 import ComponentPage from './ComponentPage';
 import {IComponent} from './ComponentsInterface';
-import SideMenu from './Menu';
+import {NotFound} from './NotFound';
 
 const componentFiles = require.context('./examples', true, /Examples?\.js?$/i, 'lazy');
 
@@ -48,15 +48,12 @@ const Components: React.FunctionComponent<RouteComponentProps> = ({match}) => {
     }
 
     return (
-        <>
-            <SideMenu components={components} />
-            <div className="coveo-form flex-auto relative shadow-2 ml4 overflow-auto demo-content">
-                <Switch>
-                    {routes}
-                    <Route path="/" component={() => <Redirect to={`${match.url}/${components[0].name}`} />} />
-                </Switch>
-            </div>
-        </>
+        <div className="coveo-form flex-auto relative overflow-auto demo-content">
+            <Switch>
+                {routes}
+                <Route path="*" component={NotFound} />
+            </Switch>
+        </div>
     );
 };
 

--- a/packages/demo/src/demo-styling/main.scss
+++ b/packages/demo/src/demo-styling/main.scss
@@ -4,13 +4,13 @@
 @import 'syntax-highlighting';
 
 #App {
-    margin: 0 auto;
     color: var(--default-text-color);
     font-weight: var(--main-font-regular);
     font-size: var(--default-font-size);
 
     .header-title {
         height: 27px;
+        margin-left: 2em;
     }
 
     .header-height {

--- a/packages/demo/src/index.html
+++ b/packages/demo/src/index.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" href="https://use.typekit.net/wqe4zqp.css" />
     </head>
     <body>
-        <div id="App" class="mod-width-70">
+        <div id="App">
             Loading ...
         </div>
         <div id="Modals"></div>

--- a/packages/demo/src/plasma/Brand.tsx
+++ b/packages/demo/src/plasma/Brand.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Brand = () => (
+    <div>
+        <h2>Brand</h2>
+    </div>
+);
+
+export default Brand;

--- a/packages/demo/src/plasma/Home.tsx
+++ b/packages/demo/src/plasma/Home.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Home: React.FC = () => (
+    <div>
+        <h2>Plasma</h2>
+    </div>
+);
+
+export default Home;

--- a/packages/demo/src/plasma/navigation/SideNavigation.tsx
+++ b/packages/demo/src/plasma/navigation/SideNavigation.tsx
@@ -41,9 +41,11 @@ const CollapsibleSideSection: React.FC<{nav: NavItem}> = ({nav}) => {
             onClick={() => setExpanded(!expanded)}
             title={<NavLink label={nav.groupTitle} />}
         >
-            {nav.children.map((navChild) => (
-                <NavLink label={navChild.label} href={navChild.href} disabled={navChild.disabled} />
-            ))}
+            {nav.children
+                .sort((a, b) => a.label.localeCompare(b.label))
+                .map((navChild) => (
+                    <NavLink label={navChild.label} href={navChild.href} disabled={navChild.disabled} />
+                ))}
         </SideNavigationMenuSection>
     );
 };

--- a/packages/demo/src/plasma/navigation/SideNavigation.tsx
+++ b/packages/demo/src/plasma/navigation/SideNavigation.tsx
@@ -1,0 +1,62 @@
+/* eslint-disable arrow-body-style */
+import React, {useState} from 'react';
+import {RouteChildrenProps} from 'react-router';
+import {Link, Route} from 'react-router-dom';
+import {SideNavigation, SideNavigationItem, SideNavigationMenuSection} from 'react-vapor';
+
+import {NavItem, NavItems} from './nav-items';
+
+interface NavLinkProps {
+    href?: string;
+    label: string;
+    disabled?: boolean;
+}
+
+const NavLink: React.FunctionComponent<NavLinkProps> = ({href, label, disabled}) => {
+    return (
+        <Route
+            path={href}
+            children={(routeProps: RouteChildrenProps) => (
+                <SideNavigationItem isActive={!!routeProps.match} disabled={disabled} href={href}>
+                    {disabled ? (
+                        <div className="navigation-menu-section">{label}</div>
+                    ) : (
+                        <Link to={href}>
+                            <div className="navigation-menu-section">{label}</div>
+                        </Link>
+                    )}
+                </SideNavigationItem>
+            )}
+        />
+    );
+};
+
+const CollapsibleSideSection: React.FC<{nav: NavItem}> = ({nav}) => {
+    const [expanded, setExpanded] = useState(true);
+
+    return (
+        <SideNavigationMenuSection
+            expandable
+            expanded={expanded}
+            onClick={() => setExpanded(!expanded)}
+            title={<NavLink label={nav.groupTitle} />}
+        >
+            {nav.children.map((navChild) => (
+                <NavLink label={navChild.label} href={navChild.href} disabled={navChild.disabled} />
+            ))}
+        </SideNavigationMenuSection>
+    );
+};
+
+export const Navigation: React.FunctionComponent = () => {
+    const sideNav = NavItems.map((nav) => {
+        if (nav.label) {
+            return <SideNavigationMenuSection title={<NavLink href={nav.href} label={nav.label} />} />;
+        }
+        if (nav.children) {
+            return <CollapsibleSideSection nav={nav} />;
+        }
+    });
+
+    return <SideNavigation className="demo-side-nav">{sideNav}</SideNavigation>;
+};

--- a/packages/demo/src/plasma/navigation/SideNavigation.tsx
+++ b/packages/demo/src/plasma/navigation/SideNavigation.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable arrow-body-style */
 import React, {useState} from 'react';
-import {RouteChildrenProps} from 'react-router';
+import {RouteChildrenProps, useLocation} from 'react-router';
 import {Link, Route} from 'react-router-dom';
 import {SideNavigation, SideNavigationItem, SideNavigationMenuSection} from 'react-vapor';
 
@@ -51,14 +51,21 @@ const CollapsibleSideSection: React.FC<{nav: NavItem}> = ({nav}) => {
 };
 
 export const Navigation: React.FunctionComponent = () => {
+    const {pathname} = useLocation();
+
     const sideNav = NavItems.map((nav) => {
         if (nav.label) {
-            return <SideNavigationMenuSection title={<NavLink href={nav.href} label={nav.label} />} />;
+            return (
+                <SideNavigationMenuSection
+                    isActive={pathname.includes(nav.href)}
+                    title={<NavLink href={nav.href} label={nav.label} />}
+                />
+            );
         }
         if (nav.children) {
             return <CollapsibleSideSection nav={nav} />;
         }
     });
 
-    return <SideNavigation className="demo-side-nav">{sideNav}</SideNavigation>;
+    return <SideNavigation className="navigation-menu-sections">{sideNav}</SideNavigation>;
 };

--- a/packages/demo/src/plasma/navigation/nav-items.ts
+++ b/packages/demo/src/plasma/navigation/nav-items.ts
@@ -1,11 +1,10 @@
-interface NavItem {
+export interface NavItem {
     groupTitle?: string;
     label?: string;
     href?: string;
     selected?: boolean;
     children?: NavItem[];
     disabled?: boolean;
-    new?: boolean;
 }
 
 /**
@@ -52,19 +51,19 @@ export const NavItems: NavItem[] = [
     },
     {
         label: 'Brand',
-        href: '/Brand',
+        href: '/brand',
     },
     {
         groupTitle: 'Foundations',
         children: [
             {
                 label: 'Palette',
-                href: '/styles/Palette',
+                href: '/components/Palette',
                 disabled: true,
             },
             {
                 label: 'Typekit',
-                href: '/styles/Typekit',
+                href: '/components/Typekit',
                 disabled: true,
             },
             {
@@ -73,12 +72,12 @@ export const NavItems: NavItem[] = [
             },
             {
                 label: 'Illustration',
-                href: '/styles/Illustration',
+                href: '/components/Illustration',
                 disabled: true,
             },
             {
                 label: 'Effects',
-                href: '/styles/Effects',
+                href: '/components/Effects',
                 disabled: true,
             },
         ],
@@ -359,7 +358,6 @@ export const NavItems: NavItem[] = [
     {
         groupTitle: 'Not included',
         children: [
-            {label: 'Actionable Item', href: '/components/ActionableItem'},
             {label: 'Action Bar Connected', href: '/components/ActionBarConnected'},
             {label: 'Blankslate', href: '/components/BlankSlate'},
             {label: 'Bordered Line', href: '/components/BorderedLine'},

--- a/packages/demo/src/plasma/navigation/nav-items.ts
+++ b/packages/demo/src/plasma/navigation/nav-items.ts
@@ -57,13 +57,8 @@ export const NavItems: NavItem[] = [
         groupTitle: 'Foundations',
         children: [
             {
-                label: 'Palette',
-                href: '/components/Palette',
-                disabled: true,
-            },
-            {
-                label: 'Typekit',
-                href: '/components/Typekit',
+                label: 'Effects',
+                href: '/components/Effects',
                 disabled: true,
             },
             {
@@ -76,8 +71,13 @@ export const NavItems: NavItem[] = [
                 disabled: true,
             },
             {
-                label: 'Effects',
-                href: '/components/Effects',
+                label: 'Palette',
+                href: '/components/Palette',
+                disabled: true,
+            },
+            {
+                label: 'Typekit',
+                href: '/components/Typekit',
                 disabled: true,
             },
         ],
@@ -145,6 +145,7 @@ export const NavItems: NavItem[] = [
     },
     {
         groupTitle: 'Input',
+
         children: [
             {
                 label: 'Action Button',
@@ -237,11 +238,6 @@ export const NavItems: NavItem[] = [
         groupTitle: 'Navigation',
         children: [
             {
-                label: 'Page Title / Breadcrumbs',
-                href: '/components/Header',
-                disabled: true,
-            },
-            {
                 label: 'Flat Select',
                 href: '/components/FlatSelect',
             },
@@ -250,12 +246,21 @@ export const NavItems: NavItem[] = [
                 href: '/components/OptionsCycle',
             },
             {
+                label: 'Page Title / Breadcrumbs',
+                href: '/components/Header',
+                disabled: true,
+            },
+            {
                 label: 'Pagination',
                 href: '/components/Pagination',
             },
             {
                 label: 'Sidebar Navigation',
                 href: '/components/SideNavigation',
+            },
+            {
+                label: 'Subnavigation',
+                href: '/components/Subnavigation',
             },
             {
                 label: 'Tabs',
@@ -267,16 +272,12 @@ export const NavItems: NavItem[] = [
         groupTitle: 'Feedback and Info',
         children: [
             {
-                label: 'Toast',
-                href: '/components/Toast',
+                label: 'Info Token',
+                href: '/components/InfoToken',
             },
             {
                 label: 'InfoBox',
                 href: '/components/InfoBox',
-            },
-            {
-                label: 'Info Token',
-                href: '/components/InfoToken',
             },
             {
                 label: 'Limit Card',
@@ -322,6 +323,10 @@ export const NavItems: NavItem[] = [
                 href: '/components/Badge',
             },
             {
+                label: 'Toast',
+                href: '/components/Toast',
+            },
+            {
                 label: 'Tooltip',
                 href: '/components/Tooltip',
             },
@@ -358,61 +363,218 @@ export const NavItems: NavItem[] = [
     {
         groupTitle: 'Not included',
         children: [
-            {label: 'Action Bar Connected', href: '/components/ActionBarConnected'},
-            {label: 'Blankslate', href: '/components/BlankSlate'},
-            {label: 'Bordered Line', href: '/components/BorderedLine'},
-            {label: 'Browser Preview', href: '/components/BrowserPreview'},
-            {label: 'Card Home', href: '/styles/cards/home'},
-            {label: 'Card Material', href: '/styles/cards/material'},
-            {label: 'Card Wizard', href: '/styles/cards/wizard'},
-            {label: 'Chart', href: '/components/Chart'},
-            {label: 'Colour Bar', href: '/components/ColorBar'},
-            {label: 'Colour Picker', href: '/components/ColorPicker'},
-            {label: 'Date Picker', href: '/components/DatePicker'},
-            {label: 'Facet Connected', href: '/components/FacetConnected'},
-            {label: 'File Picker', href: '/components/Filepicker'},
-            {label: 'Footer', href: '/components/Footer'},
-            {label: 'Icon Badge', href: '/components/IconBadge'},
-            {label: 'Item Filter', href: '/components/Item Filter'},
-            {label: 'Item Filter Connected', href: '/components/ItemFilterConnected'},
-            {label: 'JSON Editor', href: '/components/JSONEditor'},
-            {label: 'Labeled Value', href: '/components/LabeledValue'},
-            {label: 'Last Updated', href: '/components/LastUpdated'},
-            {label: 'Last Updated Connected', href: '/components/LastUpdatedConnected'},
-            {label: 'Link Svg', href: '/components/LinkSvg'},
-            {label: 'List Box', href: '/components/ListBox'},
-            {label: 'Member', href: '/styles/components/member'},
-            {label: 'Modal Wizard', href: '/components/ModalWizard'},
-            {label: 'Multi Select', href: '/components/MultiSelect'},
-            {label: 'Pagination Connected', href: '/components/PaginationConnected'},
-            {label: 'Partialstring Match', href: '/components/PartialstringMatch'},
-            {label: 'Popover', href: '/components/Popover'},
-            {label: 'Refesh', href: '/components/Refresh'},
-            {label: 'Section', href: '/components/Section'},
-            {label: 'Separator', href: '/components/Separator'},
-            {label: 'Sidenavigation Loading', href: '/components/SidenavigationLoading'},
-            {label: 'Slidey', href: '/components/Slidey'},
-            {label: 'Spaced Box', href: '/styles/layout/spaced-box'},
-            {label: 'Subnavigation', href: '/components/Subnavigation'},
-            {label: 'SVG', href: '/components/SVG'},
-            {label: 'Sync', href: '/components/Sync'},
-            {label: 'Table Loading', href: '/components/TableHOCLoading'},
-            {label: 'Table Server', href: '/components/TableHOCServer'},
-            {label: 'Table Blank Slate', href: '/components/TableHOCwithBlankSlate'},
-            {label: 'Tabs Connected', href: '/components/TabsConnected'},
-            {label: 'Text Area', href: '/components/TextArea'},
-            {label: 'Toast Connected', href: '/components/ToastConnected'},
-            {label: 'Toast Content', href: '/components/ToastContent'},
-            {label: 'Transparency', href: '/styles/transparency'},
-            {label: 'Typekit - Headings', href: '/styles/typography/headings'},
-            {label: 'Typekit - Utilities', href: '/styles/typography/utilities'},
-            {label: 'Typekit - Lists', href: '/styles/typography/lists'},
-            {label: 'Typekit - Text Size', href: '/styles/utility/line-height'},
-            {label: 'Typekit - Text Colors', href: '/styles/utility/text-colors'},
-            {label: 'Typekit - Icon Colors', href: '/styles/utility/icon-colors'},
-            {label: 'Typekit - Whitespace', href: '/styles/utility/whitespace'},
-            {label: 'Cursor', href: '/styles/utility/cursor'},
-            {label: 'Color Dots', href: '/styles/utility/color-dots'},
+            {
+                label: 'Action Bar Connected',
+                href: '/components/ActionBarConnected',
+            },
+            {
+                label: 'Blankslate',
+                href: '/components/BlankSlate',
+            },
+            {
+                label: 'Browser Preview',
+                href: '/components/BrowserPreview',
+            },
+            {
+                label: 'Card Home',
+                href: '/styles/cards/home',
+            },
+            {
+                label: 'Card Material',
+                href: '/styles/cards/material',
+            },
+            {
+                label: 'Card Wizard',
+                href: '/styles/cards/wizard',
+            },
+            {
+                label: 'Chart',
+                href: '/components/Chart',
+            },
+            {
+                label: 'Color Dots',
+                href: '/styles/utility/color-dots',
+            },
+            {
+                label: 'Colour Bar',
+                href: '/components/ColorBar',
+            },
+            {
+                label: 'Colour Picker',
+                href: '/components/ColorPicker',
+            },
+            {
+                label: 'Cursor',
+                href: '/styles/utility/cursor',
+            },
+            {
+                label: 'Date Picker',
+                href: '/components/DatePicker',
+            },
+            {
+                label: 'Facet Connected',
+                href: '/components/FacetConnected',
+            },
+            {
+                label: 'File Picker',
+                href: '/components/Filepicker',
+            },
+            {
+                label: 'Footer',
+                href: '/components/Footer',
+            },
+            {
+                label: 'Icon Badge',
+                href: '/components/IconBadge',
+            },
+            {
+                label: 'Item Filter',
+                href: '/components/Item Filter',
+            },
+            {
+                label: 'Item Filter Connected',
+                href: '/components/ItemFilterConnected',
+            },
+            {
+                label: 'JSON Editor',
+                href: '/components/JSONEditor',
+            },
+            {
+                label: 'Labeled Value',
+                href: '/components/LabeledValue',
+            },
+            {
+                label: 'Last Updated',
+                href: '/components/LastUpdated',
+            },
+            {
+                label: 'Last Updated Connected',
+                href: '/components/LastUpdatedConnected',
+            },
+            {
+                label: 'Link Svg',
+                href: '/components/LinkSvg',
+            },
+            {
+                label: 'List Box',
+                href: '/components/ListBox',
+            },
+            {
+                label: 'Member',
+                href: '/styles/components/member',
+            },
+            {
+                label: 'Modal Wizard',
+                href: '/components/ModalWizard',
+            },
+            {
+                label: 'Multi Select',
+                href: '/components/MultiSelect',
+            },
+            {
+                label: 'Pagination Connected',
+                href: '/components/PaginationConnected',
+            },
+            {
+                label: 'Partialstring Match',
+                href: '/components/PartialstringMatch',
+            },
+            {
+                label: 'Popover',
+                href: '/components/Popover',
+            },
+            {
+                label: 'Refesh',
+                href: '/components/Refresh',
+            },
+            {
+                label: 'Section',
+                href: '/components/Section',
+            },
+            {
+                label: 'Separator',
+                href: '/components/Separator',
+            },
+            {
+                label: 'Sidenavigation Loading',
+                href: '/components/SidenavigationLoading',
+            },
+            {
+                label: 'Slidey',
+                href: '/components/Slidey',
+            },
+            {
+                label: 'Spaced Box',
+                href: '/styles/layout/spaced-box',
+            },
+            {
+                label: 'SVG',
+                href: '/components/SVG',
+            },
+            {
+                label: 'Sync',
+                href: '/components/Sync',
+            },
+            {
+                label: 'Table Blank Slate',
+                href: '/components/TableHOCwithBlankSlate',
+            },
+            {
+                label: 'Table Loading',
+                href: '/components/TableHOCLoading',
+            },
+            {
+                label: 'Table Server',
+                href: '/components/TableHOCServer',
+            },
+            {
+                label: 'Tabs Connected',
+                href: '/components/TabsConnected',
+            },
+            {
+                label: 'Text Area',
+                href: '/components/TextArea',
+            },
+            {
+                label: 'Toast Connected',
+                href: '/components/ToastConnected',
+            },
+            {
+                label: 'Toast Content',
+                href: '/components/ToastContent',
+            },
+            {
+                label: 'Transparency',
+                href: '/styles/transparency',
+            },
+            {
+                label: 'Typekit - Headings',
+                href: '/styles/typography/headings',
+            },
+            {
+                label: 'Typekit - Icon Colors',
+                href: '/styles/utility/icon-colors',
+            },
+            {
+                label: 'Typekit - Lists',
+                href: '/styles/typography/lists',
+            },
+            {
+                label: 'Typekit - Text Colors',
+                href: '/styles/utility/text-colors',
+            },
+            {
+                label: 'Typekit - Text Size',
+                href: '/styles/utility/line-height',
+            },
+            {
+                label: 'Typekit - Utilities',
+                href: '/styles/typography/utilities',
+            },
+            {
+                label: 'Typekit - Whitespace',
+                href: '/styles/utility/whitespace',
+            },
         ],
     },
 ];

--- a/packages/demo/src/plasma/navigation/nav-items.ts
+++ b/packages/demo/src/plasma/navigation/nav-items.ts
@@ -145,7 +145,6 @@ export const NavItems: NavItem[] = [
     },
     {
         groupTitle: 'Input',
-
         children: [
             {
                 label: 'Action Button',

--- a/packages/demo/src/styles/index.tsx
+++ b/packages/demo/src/styles/index.tsx
@@ -10,30 +10,26 @@ import GeneralGuidelines from './general-guidelines';
 import Headers from './headers';
 import Icons from './icons';
 import Layout from './Layout';
-import SideMenu from './Menu';
 import Transparency from './transparency';
 import Typography from './typography';
 import Utility from './utility';
 
 const Styles: React.FunctionComponent<RouteComponentProps> = ({match}) => (
-    <>
-        <SideMenu />
-        <div className="coveo-form flex-auto relative shadow-2 ml4 overflow-auto demo-content">
-            <Route path={`${match.url}/general-guidelines`} component={GeneralGuidelines} />
-            <Route path={`${match.url}/borders`} component={Borders} />
-            <Route path={`${match.url}/cards`} component={Cards} />
-            <Route path={`${match.url}/components`} component={Components} />
-            <Route path={`${match.url}/filtering`} component={Filtering} />
-            <Route path={`${match.url}/form-controls`} component={FormControls} />
-            <Route path={`${match.url}/headers`} component={Headers} />
-            <Route path={`${match.url}/icons`} component={Icons} />
-            <Route path={`${match.url}/layout`} component={Layout} />
-            <Route path={`${match.url}/transparency`} component={Transparency} />
-            <Route path={`${match.url}/typography`} component={Typography} />
-            <Route path={`${match.url}/utility`} component={Utility} />
-            <Route exact path={`${match.url}/`} component={() => <Redirect to={`${match.url}/general-guidelines`} />} />
-        </div>
-    </>
+    <div className="coveo-form flex-auto relative overflow-auto demo-content">
+        <Route path={`${match.url}/general-guidelines`} component={GeneralGuidelines} />
+        <Route path={`${match.url}/borders`} component={Borders} />
+        <Route path={`${match.url}/cards`} component={Cards} />
+        <Route path={`${match.url}/components`} component={Components} />
+        <Route path={`${match.url}/filtering`} component={Filtering} />
+        <Route path={`${match.url}/form-controls`} component={FormControls} />
+        <Route path={`${match.url}/headers`} component={Headers} />
+        <Route path={`${match.url}/icons`} component={Icons} />
+        <Route path={`${match.url}/layout`} component={Layout} />
+        <Route path={`${match.url}/transparency`} component={Transparency} />
+        <Route path={`${match.url}/typography`} component={Typography} />
+        <Route path={`${match.url}/utility`} component={Utility} />
+        <Route exact path={`${match.url}/`} component={() => <Redirect to={`${match.url}/general-guidelines`} />} />
+    </div>
 );
 
 export default Styles;

--- a/packages/react-vapor/src/components/sideNavigation/SideNavigationItem.tsx
+++ b/packages/react-vapor/src/components/sideNavigation/SideNavigationItem.tsx
@@ -10,6 +10,7 @@ export interface ISideNavigationItemProps {
 
 export interface SideNavigationItemProps extends Partial<ISideNavigationItemProps> {
     isActive?: boolean;
+    disabled?: boolean;
 }
 
 export const SideNavigationItem: React.FunctionComponent<SideNavigationItemProps> = ({
@@ -18,6 +19,7 @@ export const SideNavigationItem: React.FunctionComponent<SideNavigationItemProps
     title,
     children,
     target,
+    disabled,
 }) => {
     const ref = React.useRef(null);
 
@@ -27,7 +29,7 @@ export const SideNavigationItem: React.FunctionComponent<SideNavigationItemProps
         }
     }, [isActive]);
 
-    const itemClasses = classNames('navigation-menu-section-item', {'state-active': isActive});
+    const itemClasses = classNames('navigation-menu-section-item', {'state-active': isActive, disabled});
 
     // Rendering an anchor tag from href and title support for retrocompatibility
     return href && title ? (

--- a/packages/vapor/scss/components/navigation.scss
+++ b/packages/vapor/scss/components/navigation.scss
@@ -97,8 +97,7 @@
                     }
                     .navigation-menu-section-header-no-icon {
                         height: $navigation-menu-section-height;
-                        margin-right: $navigation-right-margin;
-                        padding-left: $navigation-section-icon-margin-left;
+                        padding-left: $sidenavigation-padding-left;
                     }
                 }
 
@@ -115,9 +114,17 @@
 
                     .navigation-menu-section-item {
                         font-weight: var(--main-font-regular);
-                        border-left: $navigation-active-border-width solid transparent;
-
                         cursor: pointer;
+
+                        &.disabled {
+                            cursor: default;
+                            .navigation-menu-section-item-link {
+                                color: var(--grey-60);
+                            }
+                            &:hover {
+                                background: none;
+                            }
+                        }
 
                         .navigation-menu-section-item-link {
                             display: flex;
@@ -126,7 +133,7 @@
                             height: $navigation-menu-section-height;
                             margin-right: $navigation-right-margin;
                             padding-right: 2px;
-                            padding-left: $navigation-horizontal-space;
+                            padding-left: $sidenavigation-padding-left;
                             color: var(--navy-blue-80);
                             font-size: var(--default-font-size);
                             letter-spacing: 0.05em;

--- a/packages/vapor/scss/components/navigation.scss
+++ b/packages/vapor/scss/components/navigation.scss
@@ -97,7 +97,7 @@
                     }
                     .navigation-menu-section-header-no-icon {
                         height: $navigation-menu-section-height;
-                        padding-left: $sidenavigation-padding-left;
+                        padding-left: $sidenavigation-padding-left + $navigation-active-border-width;
                     }
                 }
 
@@ -114,6 +114,7 @@
 
                     .navigation-menu-section-item {
                         font-weight: var(--main-font-regular);
+                        border-left: $navigation-active-border-width solid transparent;
                         cursor: pointer;
 
                         &.disabled {

--- a/packages/vapor/scss/variables.scss
+++ b/packages/vapor/scss/variables.scss
@@ -247,6 +247,8 @@ $navigation-loading-background-size: 300% 104px;
 $navigation-loading-bullet-width: 12px;
 $navigation-toggle-duration: 0.1s;
 
+$sidenavigation-padding-left: 30px;
+
 // Application
 $application-container-min-height: 400px;
 


### PR DESCRIPTION
### Proposed Changes

Added new sidenav, plus a section at the bottom for pages not included in the mockup so we still have access to them until  we can discuss where they go or if they're deprecated.

New items in the side nav have been disabled, since their pages don't exist

Also added placeholder pages for Home, Brand and NotFound. 

Links still have the `/components` or `/styles` link since rerouting is out of scope

![image](https://user-images.githubusercontent.com/22773767/142287590-270a0692-53b2-448e-8540-17869412f555.png)

![image](https://user-images.githubusercontent.com/22773767/142288133-a5666005-cfc5-487b-9456-c80b3b67024d.png)

![image](https://user-images.githubusercontent.com/22773767/142288955-2f06f7f1-6af3-4274-96f9-68da77b55543.png)


### Potential Breaking Changes

All links should work as normal.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
