### PR TITLE
UITOOL-306/fix active tab drop

### DIFF
--- a/packages/demo/src/components/examples/TabExamples.tsx
+++ b/packages/demo/src/components/examples/TabExamples.tsx
@@ -24,7 +24,6 @@ const DefaultExmaple: React.FunctionComponent = () => (
             <TabConnected groupId="patate" id="tab1" title="Pikachu" />
             <TabConnected groupId="patate" id="tab2" title="Gyarados" tooltip="I have a toolip!" />
             <TabConnected groupId="patate" id="tab3" title="Charmander" />
-            <TabConnected groupId="patate" id="tab4" title="Rapidash" tooltip="I'm disabled" disabled />
             <TabConnected
                 groupId="patate"
                 id="tab13"
@@ -32,6 +31,7 @@ const DefaultExmaple: React.FunctionComponent = () => (
                 tooltip="I have a badge!"
                 badge={<Badge label="Beta" extraClasses={['mod-beta mod-small ml1']} />}
             />
+            <TabConnected groupId="patate" id="tab4" title="Rapidash" tooltip="I'm disabled" disabled />
         </TabNavigation>
         <TabContent>
             <TabPaneConnected groupId="patate" id="tab1">
@@ -59,7 +59,6 @@ const WithIconsExmaple: React.FunctionComponent = () => (
             <TabConnected groupId="banane" id="tab5" title="Pikachu" icon={'lightning'} />
             <TabConnected groupId="banane" id="tab6" title="Gyarados" icon={'crawlingBotStroked16'} iconModStroke />
             <TabConnected groupId="banane" id="tab7" title="Charmander" icon={'check'} />
-            <TabConnected groupId="banane" id="tab8" title="Rapidash" icon={'details'} disabled />
             <TabConnected
                 groupId="banane"
                 id="tab14"
@@ -68,6 +67,7 @@ const WithIconsExmaple: React.FunctionComponent = () => (
                 icon="email"
                 badge={<Badge label="Success" extraClasses={['mod-success mod-small ml1']} />}
             />
+            <TabConnected groupId="banane" id="tab8" title="Rapidash" icon={'details'} disabled />
         </TabNavigation>
         <TabContent>
             <TabPaneConnected groupId="banane" id="tab5">

--- a/packages/react-vapor/src/components/tab/Tab.tsx
+++ b/packages/react-vapor/src/components/tab/Tab.tsx
@@ -75,11 +75,9 @@ export const Tab: React.FunctionComponent<ITabProps> = ({
                 aria-controls={`panel-${id}`}
                 id={`tab-${id}`}
                 tabIndex={isActive ? 0 : -1}
-                className={classNames('tab', {
+                className={classNames('tab body-m', {
                     enabled: !disabled,
                     disabled: disabled,
-                    'body-m': isActive,
-                    'body-m-book': !isActive,
                 })}
                 onClick={handleSelect}
                 disabled={disabled}

--- a/packages/vapor/scss/components/tab.scss
+++ b/packages/vapor/scss/components/tab.scss
@@ -34,6 +34,7 @@
     }
 
     .active-tab-bottom-line {
+        height: 4px;
         margin-left: 0.5rem;
         border: solid transparent;
         border-radius: $tab-bottom-border-height;


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/UITOOL-306

After discussion with the tooling team and Gustavo, we agreed to put back the bold text for all tabs, not just the active one.


### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
