### PR TITLE
build(react-vapor): distribute the main as common js

### DIFF
--- a/packages/demo/webpack.config.js
+++ b/packages/demo/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
     resolve: {
         extensions: ['.js', '.jsx'],
         alias: {
-            'react-vapor': path.resolve(__dirname, '../react-vapor/dist/Entry.js'),
+            'react-vapor': path.resolve(__dirname, '../react-vapor/dist/cjs/Entry.js'),
             '@demo-styling': path.resolve(__dirname, 'src/demo-styling'),
             '@examples': path.resolve(__dirname, 'src/components/examples'),
         },

--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -13,15 +13,15 @@
     "homepage": "https://github.com/coveo/react-vapor#readme",
     "author": "Coveo",
     "license": "Apache-2.0",
-    "main": "dist/Entry.js",
-    "types": "dist/Entry.d.ts",
+    "main": "dist/cjs/Entry.js",
+    "module": "dist/esm/Entry.js",
+    "types": "dist/definitions/Entry.d.ts",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/coveo/react-vapor.git"
     },
     "scripts": {
-        "start": "tsc --build --watch tsconfig.build.json",
-        "build": "tsc --build tsconfig.build.json",
+        "build": "tsc --build tsconfig.build.json && tsc --build tsconfig.esm.json",
         "test": "jest --clearCache && jest",
         "test:watch": "jest --watchAll",
         "test:debug": "jest --clearCache && node --inspect node_modules/jest/bin/jest --runInBand --watchAll",

--- a/packages/react-vapor/tsconfig.build.json
+++ b/packages/react-vapor/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "rootDir": "src"
+        "outDir": "dist/cjs",
+        "rootDir": "src",
+        "module": "CommonJS",
+        "target": "ES5"
     },
     "references": [],
     "include": ["src"],

--- a/packages/react-vapor/tsconfig.esm.json
+++ b/packages/react-vapor/tsconfig.esm.json
@@ -1,0 +1,12 @@
+{
+    "extends": "./tsconfig",
+    "compilerOptions": {
+        "outDir": "dist/esm",
+        "rootDir": "src",
+        "module": "ESNext",
+        "target": "ESNext"
+    },
+    "references": [],
+    "include": ["src"],
+    "exclude": ["**/*.spec.*", "./src/utils/tests"]
+}

--- a/packages/react-vapor/tsconfig.json
+++ b/packages/react-vapor/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "extends": "../tsconfig-base",
     "compilerOptions": {
-        "outDir": "dist",
         "tsBuildInfoFile": "./dist/.tsbuildinfo",
+        "declarationDir": "./dist/definitions",
         "baseUrl": ".",
         "paths": {
             "@test-utils": ["jest/utils.tsx"],


### PR DESCRIPTION
### Proposed Changes

- `main` field of `packages/react-vapor/package.json` will now point to `dist/cjs/Entry.js` 
- `module` field of `packages/react-vapor/package.json` will now point to `dist/esm/Entry.js` 

`dist` will now look like this
![image](https://user-images.githubusercontent.com/35579930/143597791-06fae220-e288-44a8-9648-63acc0258197.png)
