### PR TITLE
fix: downgrade esm build target to es2015

### DIFF
--- a/packages/react-vapor/tsconfig.esm.json
+++ b/packages/react-vapor/tsconfig.esm.json
@@ -4,7 +4,7 @@
         "outDir": "dist/esm",
         "rootDir": "src",
         "module": "ESNext",
-        "target": "ESNext"
+        "target": "ES2015"
     },
     "references": [],
     "include": ["src"],


### PR DESCRIPTION
### Proposed Changes

Targeting `esnext` is a bit too eager, build tools down the line don't handle all the features well.

