### PR TITLE
UITOOL-209/bump-typescript-to-v4-in-demo-package

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -75,8 +75,8 @@
         "snyk": "1.763.0",
         "source-map-loader": "1.1.3",
         "style-loader": "1.3.0",
-        "tslib": "1.14.1",
-        "typescript": "3.8.3",
+        "tslib": "2.3.1",
+        "typescript": "4.5.2",
         "webpack": "4.46.0",
         "webpack-cli": "3.3.12",
         "webpack-dev-server": "3.11.3"

--- a/packages/demo/src/demo-building-blocs/ScrollTop.tsx
+++ b/packages/demo/src/demo-building-blocs/ScrollTop.tsx
@@ -14,4 +14,4 @@ const ScrollToTop: React.FunctionComponent<RouteComponentProps> = ({history}) =>
     return null;
 };
 
-export default withRouter(ScrollToTop);
+export default withRouter(ScrollToTop) as any;

--- a/packages/demo/src/plasma/routes/input/pages/ButtonExamples.tsx
+++ b/packages/demo/src/plasma/routes/input/pages/ButtonExamples.tsx
@@ -34,6 +34,14 @@ export const ButtonExamples: React.FunctionComponent = () => {
             withSource
         >
             <Section>
+                <Section level={2} title="Search bar button">
+                    <Button enabled={true} classes={['mod-search-bar']}>
+                        <Svg svgName={'search'} className="icon mod-stroke" />
+                    </Button>
+                    <Button enabled={false} classes={['mod-search-bar']}>
+                        <Svg svgName={'search'} className="icon mod-stroke" />
+                    </Button>
+                </Section>
                 <Section level={2} title="Usability">
                     <Button enabled={true} name="Enabled button" />
                     <Button enabled={false} name="Disabled button" />

--- a/packages/react-vapor/package.json
+++ b/packages/react-vapor/package.json
@@ -135,7 +135,7 @@
         "rimraf": "3.0.2",
         "snyk": "1.763.0",
         "ts-jest": "27.0.7",
-        "tslib": "1.14.1",
+        "tslib": "2.3.1",
         "typescript": "3.8.3",
         "underscore": "1.13.1",
         "underscore.string": "3.3.5"

--- a/packages/react-vapor/src/components/tab/TabSelectors.ts
+++ b/packages/react-vapor/src/components/tab/TabSelectors.ts
@@ -17,7 +17,7 @@ const getSelectedTab = createSelector(
 
 const getTab = createSelector(
     getTabGroup,
-    (state, {id}: CherryPick<ITabOwnProps, 'id'>) => id,
+    (state: any, {id}: CherryPick<ITabOwnProps, 'id'>) => id,
     (tabGroup: ITabGroupState, id: string): ITabState => _.findWhere(tabGroup?.tabs, {id})
 );
 

--- a/packages/react-vapor/src/components/table-hoc/TableWithUrlState.tsx
+++ b/packages/react-vapor/src/components/table-hoc/TableWithUrlState.tsx
@@ -71,7 +71,7 @@ function tableWithUrlState<P extends ITableHOCOwnProps>(Component: React.Compone
         mapStateToProps,
         mapDispatchToProps
         // @ts-ignore
-    )(WrappedComponentDisconnected);
+    )(WrappedComponentDisconnected as any);
 }
 
 const getQuery = (state: IReactVaporState, tableId: string): string => {

--- a/packages/vapor/scss/elements/btn.scss
+++ b/packages/vapor/scss/elements/btn.scss
@@ -2,6 +2,7 @@
     display: inline-flex;
     align-items: center;
     box-sizing: border-box;
+    width: auto;
     height: $button-height;
     padding: $button-padding-y $button-padding-x;
     color: var(--navy-blue-80);
@@ -109,6 +110,13 @@
         .icon {
             fill: var(--white);
         }
+    }
+
+    &.mod-search-bar {
+        @extend .mod-primary;
+        width: 48px;
+        height: 48px;
+        border-radius: 0px 8px 8px 0px;
     }
 
     &.mod-danger {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
       snyk: 1.763.0
       source-map-loader: 1.1.3
       style-loader: 1.3.0
-      tslib: 1.14.1
-      typescript: 3.8.3
+      tslib: 2.3.1
+      typescript: 4.5.2
       underscore: 1.13.1
       underscore.string: 3.3.5
       webpack: 4.46.0
@@ -163,8 +163,8 @@ importers:
       snyk: 1.763.0
       source-map-loader: 1.1.3_webpack@4.46.0
       style-loader: 1.3.0_webpack@4.46.0
-      tslib: 1.14.1
-      typescript: 3.8.3
+      tslib: 2.3.1
+      typescript: 4.5.2
       webpack: 4.46.0_webpack-cli@3.3.12
       webpack-cli: 3.3.12_webpack@4.46.0
       webpack-dev-server: 3.11.3_46edf965869dcc7c8d09e022f331d1ea
@@ -258,7 +258,7 @@ importers:
       split-on-first: 1.x.x
       strict-uri-encode: 2.x.x
       ts-jest: 27.0.7
-      tslib: 1.14.1
+      tslib: 2.3.1
       typescript: 3.8.3
       underscore: 1.13.1
       underscore.string: 3.3.5
@@ -353,7 +353,7 @@ importers:
       rimraf: 3.0.2
       snyk: 1.763.0
       ts-jest: 27.0.7_01b74691ac702485cc287326e37bd587
-      tslib: 1.14.1
+      tslib: 2.3.1
       typescript: 3.8.3
       underscore: 1.13.1
       underscore.string: 3.3.5
@@ -4980,6 +4980,7 @@ packages:
   /chokidar/3.5.2:
     resolution: {integrity: sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==}
     engines: {node: '>= 8.10.0'}
+    requiresBuild: true
     dependencies:
       anymatch: 3.1.2
       braces: 3.0.2


### PR DESCRIPTION
### Proposed Changes

First PR for the new standalone search Bar for Plasma!

To be able to use @coveo/headless for the search, I had to bump typescript first.

There's also a little new button for the future search bar :eyes: no biggie, just visual stuff for now.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
