### PR TITLE
build(tokens): make package private

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@coveord/design-tokens",
     "version": "30.4.0",
+    "private": true,
     "description": "Design tokens of the Vapor Design System",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Proposed Changes

Making the package private while the publish issue gets fixed by npm's support.

### Potential Breaking Changes

`@coveord/design-tokens` will not be released on npm anymore
