### PR TITLE
ci: remove guild channel from master build failure list

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -70,7 +70,7 @@ pipeline {
         script {
           setLastStageName();
 
-          MASTER_RELEASE_FAILURE_CHANNELS = ["admin-ui-builds", "cloudadmindev", "admin-ui-guild"]
+          MASTER_RELEASE_FAILURE_CHANNELS = ["admin-ui-builds", "cloudadmindev"]
           PR_CHANNELS = ["admin-ui-builds"]
           NEW_VERSION = ""
           SCOPE = ""


### PR DESCRIPTION
### Proposed Changes
https://coveord.atlassian.net/browse/UITOOL-351

Stop sending alert in the guild channel for master build failure.

### Potential Breaking Changes

none

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
