### PR TITLE
style: labeled-value font-size to match labeled-input

### DIFF
--- a/packages/vapor/scss/components/labeled-value.scss
+++ b/packages/vapor/scss/components/labeled-value.scss
@@ -14,7 +14,7 @@
 
     .label {
         padding: 5px 0px 5px 5px;
-        font-size: var(--small-font-size);
+        font-size: $form-control-label-font-size;
     }
 
     .value {


### PR DESCRIPTION
The reason for this change originates from UI updates from [this](https://coveord.atlassian.net/browse/DA-6699) JIRA, but the font issue affects all usages of the `LabeledValue` component.

### Proposed Changes

Use the same font size for `labeled-value` component that is used by `labeled-input` component so visually they look the same.

Currently the `labeled-value` component had a "label" font size of 12px as can be seen [here](https://vapor.coveo.com/#/legacy/LabeledValue)

By using `$form-control-label-font-size` it'll match the `labeled-input` of 13px.

Where is this font size of 13px styling coming from?

It comes from [here](https://github.com/coveo/react-vapor/blob/master/packages/vapor/scss/controls/input-field.scss#L39) which extends `.active` which comes to [here](https://github.com/coveo/react-vapor/blob/master/packages/vapor/scss/controls/input-field.scss#L98).

| Labeled Input font-size (it is currently 13px) | Labeled Value font-size (it is currently 12px) |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/5728044/146422365-e0e2caa1-c9d2-4a45-a863-918963c31432.png" alt="labeled input font size" height="400"/> | <img src="https://user-images.githubusercontent.com/5728044/146422567-ffae4dfd-2809-4977-8ac6-3a79115eef2f.png" alt="labeled value font size" height="400"/> |

| OLD | NEW |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/5728044/146422001-2d0f5d9d-46f5-41ff-8803-728f8de3964e.png" alt="old" height="700"/> | <img src="https://user-images.githubusercontent.com/5728044/146422068-c3e7bb56-7188-47a8-9053-35b1b28742a2.png" alt="old" height="700"/> |

### Potential Breaking Changes

I would hope a label value increase of 1px would not break things 🎲 🎲

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/react-vapor/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
