### PR TITLE
fix(react, date utils): make sure the date is dynamic

### DIFF
--- a/packages/react/src/utils/DateUtils.spec.tsx
+++ b/packages/react/src/utils/DateUtils.spec.tsx
@@ -3,6 +3,61 @@ import {IRangeLimit} from '../components';
 import {DateUtils} from './DateUtils';
 
 describe('DateUtils', () => {
+    describe('currentDate', () => {
+        it('returns the current system date', () => {
+            jest.useFakeTimers();
+
+            const expectedDate1 = new Date(2022, 0, 1);
+            const expectedDate2 = new Date(2002, 2, 22);
+
+            jest.setSystemTime(expectedDate1);
+
+            expect(DateUtils.currentDate).toStrictEqual(expectedDate1);
+
+            jest.setSystemTime(expectedDate2);
+
+            expect(DateUtils.currentDate).toStrictEqual(expectedDate2);
+
+            jest.useRealTimers();
+        });
+    });
+    describe('currentMonth', () => {
+        it('returns the current system month', () => {
+            jest.useFakeTimers();
+
+            const expectedDate1 = new Date(2022, 0, 1);
+            const expectedDate2 = new Date(2002, 2, 22);
+
+            jest.setSystemTime(expectedDate1);
+
+            expect(DateUtils.currentMonth).toBe(0);
+
+            jest.setSystemTime(expectedDate2);
+
+            expect(DateUtils.currentMonth).toBe(2);
+
+            jest.useRealTimers();
+        });
+    });
+    describe('currentYear', () => {
+        it('returns the current system year', () => {
+            jest.useFakeTimers();
+
+            const expectedDate1 = new Date(2022, 0, 1);
+            const expectedDate2 = new Date(2002, 2, 22);
+
+            jest.setSystemTime(expectedDate1);
+
+            expect(DateUtils.currentYear).toBe(2022);
+
+            jest.setSystemTime(expectedDate2);
+
+            expect(DateUtils.currentYear).toBe(2002);
+
+            jest.useRealTimers();
+        });
+    });
+
     describe('getValidDate', () => {
         it('should return a valid formatted date if the format is MMM DD, YYYY, H:mm', () => {
             const date = 'Jan 02, 2010, 22:21';

--- a/packages/react/src/utils/DateUtils.ts
+++ b/packages/react/src/utils/DateUtils.ts
@@ -19,9 +19,15 @@ export const LONG_DATE_FORMAT: string = SIMPLE_DATE_FORMAT + ', H:mm';
 export const DATES_SEPARATOR: string = '%';
 
 export class DateUtils {
-    static currentDate: Date = new Date();
-    static currentMonth: number = DateUtils.currentDate.getMonth();
-    static currentYear: number = DateUtils.currentDate.getFullYear();
+    static get currentDate(): Date {
+        return new Date();
+    }
+    static get currentMonth(): number {
+        return DateUtils.currentDate.getMonth();
+    }
+    static get currentYear(): number {
+        return DateUtils.currentDate.getFullYear();
+    }
 
     static getPreviousYears(numberOfYears: number): string[] {
         return _.range(DateUtils.currentYear - numberOfYears, DateUtils.currentYear).map(String);


### PR DESCRIPTION
### Proposed Changes

The DateUtils had an issue where the date was only created once. This could cause issue when the date changes or in unit tests when trying to mock a specific date

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
