### PR TITLE
fix(mantine): prompt accessible name

### DIFF
--- a/packages/mantine/src/components/prompt/Prompt.tsx
+++ b/packages/mantine/src/components/prompt/Prompt.tsx
@@ -99,7 +99,14 @@ export const Prompt = factory<PromptFactory>((_props, ref) => {
         (child.type === Modal.Footer ? footers : otherChildren).push(child);
     });
 
-    const titleContent = typeof title === 'string' ? <Header variant="secondary">{title}</Header> : title;
+    const titleContent =
+        typeof title === 'string' ? (
+            <Header component={Modal.Title} variant="secondary">
+                {title}
+            </Header>
+        ) : (
+            title
+        );
 
     return (
         <PromptContextProvider value={{variant, getStyles}}>

--- a/packages/mantine/src/components/prompt/__tests__/Prompt.spec.tsx
+++ b/packages/mantine/src/components/prompt/__tests__/Prompt.spec.tsx
@@ -9,6 +9,7 @@ describe('Prompt', () => {
                 <Prompt.Footer>footer content</Prompt.Footer>
             </Prompt>,
         );
+        expect(screen.getByRole('dialog', {name: /title modal/i})).toBeInTheDocument();
         expect(screen.getByText(/content modal/i)).toBeInTheDocument();
         expect(screen.getByText(/footer content/i)).toBeInTheDocument();
         expect(screen.getByText(/title modal/i)).toBeInTheDocument();


### PR DESCRIPTION
### Proposed Changes

The last fix (https://github.com/coveo/plasma/pull/4044) for the prompt headings has removed the accessible name for prompts, leading to a lot of tests failing on the query `getByRole('dialog', {name: 'Prompt Title'})`.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
