### PR TITLE
feat(mantine,theme): change text selection color

### DIFF
--- a/packages/mantine/src/styles/global.css
+++ b/packages/mantine/src/styles/global.css
@@ -1,0 +1,14 @@
+body {
+    font-weight: 400;
+    font-size: var(--mantine-font-size-sm);
+
+    &::selection {
+        color: var(--mantine-color-white);
+        background-color: var(--mantine-primary-color-filled);
+    }
+}
+
+b,
+strong {
+    font-weight: 500;
+}

--- a/packages/mantine/src/theme/Plasmantine.tsx
+++ b/packages/mantine/src/theme/Plasmantine.tsx
@@ -4,6 +4,7 @@ import {FunctionComponent} from 'react';
 import {plasmaCSSVariablesResolver} from './plasmaCSSVariablesResolver';
 import {plasmaTheme} from './Theme';
 import {mergeCSSVariablesResolvers} from './mergeCSSVariablesResolvers';
+import '../styles/global.css';
 
 export const Plasmantine: FunctionComponent<MantineProviderProps> = ({
     children,


### PR DESCRIPTION
### Proposed Changes

Adding a global.css file that gets imported with the Plasmantine provider. In this file, I added a change to the text selection color. This change has been validated with the design team.

Before
<img width="695" alt="image" src="https://github.com/user-attachments/assets/d9504d79-ccb7-442c-ab6b-3088d2e2f173" />

After


https://github.com/user-attachments/assets/d087b171-0afd-43e7-9f10-6d98ce59f8dc



### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
