### PR TITLE
fix(datetimepicker): the preselect presets in the datetimepicker component in plasma is not working

### DIFF
--- a/packages/mantine/src/components/date-range-picker/DateRangePickerPresetSelect.tsx
+++ b/packages/mantine/src/components/date-range-picker/DateRangePickerPresetSelect.tsx
@@ -25,7 +25,9 @@ export const DateRangePickerPresetSelect = ({
     const getSelectedPreset = () => {
         if (value[0] !== null && value[1] !== null && dayjs(value[0]).unix() !== dayjs(value[1]).unix()) {
             const selected = Object.entries(presets).find(
-                ([, {range}]) => dayjs(range[0]).isSame(value[0]) && dayjs(value[1]).isSame(value[1]),
+                ([, {range}]) =>
+                    dayjs(range[0]).isSame(dayjs(value[0]).toISOString()) &&
+                    dayjs(range[1]).isSame(dayjs(value[1]).toISOString()),
             );
             if (selected) {
                 return selected[0];

--- a/packages/website/src/examples/date-range/date-time-picker/DateTimeRangePicker.demo.tsx
+++ b/packages/website/src/examples/date-range/date-time-picker/DateTimeRangePicker.demo.tsx
@@ -6,15 +6,21 @@ const Demo = () => (
         presets={{
             lastHour: {
                 label: 'Last hour',
-                range: [dayjs().startOf('hour').toISOString(), dayjs().endOf('hour').toISOString()],
+                range: [
+                    dayjs().startOf('hour').toISOString(),
+                    dayjs().endOf('hour').second(0).millisecond(0).toISOString(),
+                ],
             },
             year2k: {
                 label: 'Year 2000',
-                range: [new Date(2000, 0, 1, 0, 0, 0).toISOString(), new Date(2000, 11, 31, 23, 59, 59).toISOString()],
+                range: [new Date(2000, 0, 1, 0, 0, 0).toISOString(), new Date(2000, 11, 31, 23, 59, 0).toISOString()],
             },
             currentMonth: {
                 label: 'Month',
-                range: [dayjs().startOf('month').toISOString(), dayjs().endOf('month').toISOString()],
+                range: [
+                    dayjs().startOf('month').toISOString(),
+                    dayjs().endOf('month').second(0).millisecond(0).toISOString(),
+                ],
             },
         }}
     />


### PR DESCRIPTION

### Proposed Changes

The issue : https://github.com/coveo-platform/admin-ui/pull/15392#pullrequestreview-2982981904

If in the presets there is for example "Last month" and when manually selecting in the input start and end the value of last month it must preselect last month in the preset dropdown, now it is corrected

<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
