### PR TITLE
fix(mantine): disable menu item links properly

### DIFF
--- a/packages/mantine/src/components/menu/Menu.tsx
+++ b/packages/mantine/src/components/menu/Menu.tsx
@@ -14,7 +14,13 @@ const _MenuItem = forwardRef<HTMLButtonElement, MenuItemProps>(
             disabledTooltip={disabledTooltip}
             disabledTooltipProps={disabledTooltipProps}
         >
-            <MantineMenu.Item ref={ref} disabled={disabled} {...others} />
+            <MantineMenu.Item
+                ref={ref}
+                disabled={disabled}
+                data-disabled={disabled}
+                {...others}
+                {...(disabled && (others as any).href ? {href: undefined} : {})}
+            />
         </ButtonWithDisabledTooltip>
     ),
 );

--- a/packages/mantine/src/components/menu/__tests__/Menu.spec.tsx
+++ b/packages/mantine/src/components/menu/__tests__/Menu.spec.tsx
@@ -1,0 +1,18 @@
+import {render, screen} from '../../../__tests__/Utils';
+import {Menu} from '../Menu';
+
+describe('Menu', () => {
+    it('prevents navigating to the specified link when disabled', async () => {
+        render(
+            <Menu opened>
+                <Menu.Item component="a" href="https://coveo.com" disabled>
+                    Disabled Item
+                </Menu.Item>
+            </Menu>,
+        );
+        const disabledItem = screen.getByRole('menuitem', {name: 'Disabled Item'});
+        expect(disabledItem).toBeInTheDocument();
+        expect(disabledItem).toHaveAttribute('data-disabled', 'true');
+        expect(disabledItem).not.toHaveAttribute('href');
+    });
+});


### PR DESCRIPTION
### Proposed Changes

This would still open Coveo's website even if the item is disabled (and appears disabled)

```tsx
<Menu>
    <Menu.Item component="a" href="https://coveo.com" disabled>
        Disabled Item
    </Menu.Item>
</Menu>
```

Now the same code will not open the href when the disabled item is triggered. Since anchors cannot be disabled in html, my solution is to completely remove the href if the item has that prop.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
