### PR TITLE
feat(mantine,codeeditor): update style

### DIFF
--- a/packages/mantine/src/components/code-editor/CodeEditor.module.css
+++ b/packages/mantine/src/components/code-editor/CodeEditor.module.css
@@ -1,31 +1,35 @@
-.editor {
-    border: 1px solid var(--mantine-color-default-border);
-    border-radius: var(--mantine-radius-default);
+.root {
+    --ce-bg: var(--mantine-color-gray-0);
+    --ce-border-color: var(--mantine-color-default-border);
+
+    border: 1px solid var(--ce-border-color);
+    border-radius: var(--mantine-radius-lg);
     z-index: 1;
     height: 100%;
+    background-color: var(--ce-bg);
 
     @mixin light {
-        background-color: var(--mantine-color-gray-0);
+        --ce-bg: var(--mantine-color-gray-0);
     }
 
     @mixin dark {
-        background-color: var(--mantine-color-black);
+        --ce-bg: var(--mantine-color-black);
     }
 }
 
 .error {
-    border-color: var(--mantine-color-error);
+    --ce-border-color: var(--mantine-color-error);
 }
 
 .disabled {
     @mixin light {
-        border: 1px solid var(--mantine-color-gray-1);
-        background-color: var(--mantine-color-gray-1);
+        --ce-bg: var(--mantine-color-gray-1);
+        --ce-border-color: var(--mantine-color-gray-1);
 
         :global {
             .monaco-editor {
-                --vscode-editor-background: var(--mantine-color-gray-1);
-                --vscode-editorGutter-background: var(--mantine-color-gray-1);
+                --vscode-editor-background: var(--ce-bg);
+                --vscode-editorGutter-background: var(--ce-bg);
             }
         }
     }

--- a/packages/mantine/src/components/code-editor/CodeEditor.tsx
+++ b/packages/mantine/src/components/code-editor/CodeEditor.tsx
@@ -211,7 +211,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
             p="md"
             pl="xs"
             className={cx(
-                CodeEditorClasses.editor,
+                CodeEditorClasses.root,
                 {[CodeEditorClasses.error]: hasError},
                 {[CodeEditorClasses.disabled]: disabled},
             )}


### PR DESCRIPTION
### Proposed Changes

Updating the style of the CodeEditor according to what is suggested by UX and what is feasible. Left a few comments in Figma about stuff I couldn't change.


Before
<img width="631" height="475" alt="image" src="https://github.com/user-attachments/assets/5c5adad5-ba58-4db9-af12-065d43ea23cd" />
<img width="635" height="497" alt="image" src="https://github.com/user-attachments/assets/3604094f-8d4c-4dab-ba10-3d76a19fd8c6" />


After (pretty much only the border radius changed, the rest I could not do)
<img width="632" height="474" alt="image" src="https://github.com/user-attachments/assets/adcfc234-6449-4df8-8385-ff011ec9a333" />
<img width="634" height="486" alt="image" src="https://github.com/user-attachments/assets/ff70faec-50a0-4671-a581-4a257eea5fda" />



### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
