### PR TITLE
feat(mantine,breadcrum): update header breadcrumb implementation

### DIFF
--- a/packages/mantine/src/components/header/Header.tsx
+++ b/packages/mantine/src/components/header/Header.tsx
@@ -17,6 +17,11 @@ import classes from './Header.module.css';
 import {HeaderRight, HeaderRightStyleNames} from './HeaderRight/HeaderRight';
 import {HeaderBreadcrumbs, HeaderBreadcrumbsStyleNames} from './HeaderBreadcrumbs/HeaderBreadcrumbs';
 import {HeaderDocAnchor, HeaderDocAnchorStyleNames} from './HeaderDocAnchor/HeaderDocAnchor';
+import {
+    HeaderBreadcrumbAnchor,
+    type HeaderBreadcrumbAnchorStyleNames,
+} from './HeaderBreadcrumbs/HeaderBreadcrumbAnchor';
+import {HeaderBreadcrumbText, HeaderBreadcrumbTextStyleNames} from './HeaderBreadcrumbs/HeaderBreadcrumbText';
 
 export type {HeaderRightProps} from './HeaderRight/HeaderRight';
 export type {HeaderBreadcrumbsProps} from './HeaderBreadcrumbs/HeaderBreadcrumbs';
@@ -30,6 +35,9 @@ export type HeaderStyleNames =
     | 'divider'
     | 'body'
     | HeaderDocAnchorStyleNames
+    | HeaderBreadcrumbsStyleNames
+    | HeaderBreadcrumbAnchorStyleNames
+    | HeaderBreadcrumbTextStyleNames
     | HeaderBreadcrumbsStyleNames
     | HeaderRightStyleNames;
 
@@ -70,6 +78,8 @@ export type HeaderFactory = Factory<{
     stylesNames: HeaderStyleNames;
     staticComponents: {
         Breadcrumbs: typeof HeaderBreadcrumbs;
+        BreadcrumbAnchor: typeof HeaderBreadcrumbAnchor;
+        BreadcrumbText: typeof HeaderBreadcrumbText;
         Right: typeof HeaderRight;
         DocAnchor: typeof HeaderDocAnchor;
         /**
@@ -149,6 +159,8 @@ export const Header = factory<HeaderFactory>((_props, ref) => {
 });
 
 Header.Breadcrumbs = HeaderBreadcrumbs;
+Header.BreadcrumbAnchor = HeaderBreadcrumbAnchor;
+Header.BreadcrumbText = HeaderBreadcrumbText;
 Header.Right = HeaderRight;
 Header.DocAnchor = HeaderDocAnchor;
 /**

--- a/packages/mantine/src/components/header/HeaderBreadcrumbs/HeaderBreadcrumbAnchor.tsx
+++ b/packages/mantine/src/components/header/HeaderBreadcrumbs/HeaderBreadcrumbAnchor.tsx
@@ -1,0 +1,28 @@
+import {Anchor, type AnchorProps, type PolymorphicFactory, polymorphicFactory} from '@mantine/core';
+import {useHeaderContext} from '../Header.context';
+
+export type HeaderBreadcrumbAnchorStyleNames = 'breadcrumbAnchor';
+
+export type HeaderBreadcrumbAnchorFactory = PolymorphicFactory<{
+    props: AnchorProps;
+    ref: HTMLAnchorElement;
+    stylesNames: HeaderBreadcrumbAnchorStyleNames;
+    compound: true;
+    defaultComponent: 'a';
+    defaultRef: HTMLAnchorElement;
+}>;
+
+export const HeaderBreadcrumbAnchor = polymorphicFactory<HeaderBreadcrumbAnchorFactory>((props, ref) => {
+    const {className, classNames, styles, style, ...others} = props;
+    const ctx = useHeaderContext();
+
+    return (
+        <Anchor
+            ref={ref}
+            inherit
+            {...ctx.getStyles('breadcrumbAnchor', {className, classNames, styles, style, props})}
+            {...others}
+        />
+    );
+});
+HeaderBreadcrumbAnchor.displayName = '@coveo/plasma-mantine/HeaderBreadcrumbAnchor';

--- a/packages/mantine/src/components/header/HeaderBreadcrumbs/HeaderBreadcrumbText.tsx
+++ b/packages/mantine/src/components/header/HeaderBreadcrumbs/HeaderBreadcrumbText.tsx
@@ -1,0 +1,28 @@
+import {type PolymorphicFactory, polymorphicFactory, Text, type TextProps} from '@mantine/core';
+import {useHeaderContext} from '../Header.context';
+
+export type HeaderBreadcrumbTextStyleNames = 'breadcrumbText';
+
+export type HeaderBreadcrumbTextFactory = PolymorphicFactory<{
+    props: TextProps;
+    ref: HTMLParagraphElement;
+    stylesNames: HeaderBreadcrumbTextStyleNames;
+    compound: true;
+    defaultComponent: 'p';
+    defaultRef: HTMLParagraphElement;
+}>;
+
+export const HeaderBreadcrumbText = polymorphicFactory<HeaderBreadcrumbTextFactory>((props, ref) => {
+    const {className, classNames, styles, style, ...others} = props;
+    const ctx = useHeaderContext();
+
+    return (
+        <Text
+            ref={ref}
+            inherit
+            {...ctx.getStyles('breadcrumbText', {className, classNames, styles, style, props})}
+            {...others}
+        />
+    );
+});
+HeaderBreadcrumbText.displayName = '@coveo/plasma-mantine/HeaderBreadcrumbText';

--- a/packages/mantine/src/styles/Breadcrumbs.module.css
+++ b/packages/mantine/src/styles/Breadcrumbs.module.css
@@ -1,9 +1,11 @@
 .root {
     font-size: var(--mantine-font-size-xs);
-    font-weight: var(--mantine-heading-font-weight);
+    font-weight: var(--coveo-fw-bold);
 }
 
 .breadcrumb {
+    line-height: 14px;
+
     &:not(a) {
         color: var(--coveo-color-title);
     }

--- a/packages/website/src/examples/layout/Header/Header.demo.tsx
+++ b/packages/website/src/examples/layout/Header/Header.demo.tsx
@@ -1,11 +1,11 @@
-import {Anchor, Button, Header, Text} from '@coveord/plasma-mantine';
+import {Button, Header} from '@coveord/plasma-mantine';
 
 const Demo = () => (
     <Header description="The header description" borderBottom>
         <Header.Breadcrumbs>
-            <Anchor>Back</Anchor>
-            <Anchor>Two</Anchor>
-            <Text>This</Text>
+            <Header.BreadcrumbAnchor>Grand Parent</Header.BreadcrumbAnchor>
+            <Header.BreadcrumbAnchor>Parent</Header.BreadcrumbAnchor>
+            <Header.BreadcrumbText>Current</Header.BreadcrumbText>
         </Header.Breadcrumbs>
         Title
         <Header.DocAnchor href="https://about:blank" label="Tooltip text" />


### PR DESCRIPTION
### Proposed Changes

Updating the style of the Breadcrumb component (used within headers) according to designs. I also created 2 new compound components: HeaderBreadcrumbAnchor and HeaderBreadcrumbText. These components make sure the proper font style is applied to breadcrumb items.

Before

<img width="631" height="206" alt="image" src="https://github.com/user-attachments/assets/c087acee-7110-4121-9f98-026012dbd55a" />


After

<img width="627" height="210" alt="image" src="https://github.com/user-attachments/assets/67a80dd5-eabd-4098-b8e5-fef253a56774" />

Designs

<img width="361" height="419" alt="image" src="https://github.com/user-attachments/assets/49cef64a-ecb5-4c04-80bd-69395665becf" />



### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
