### PR TITLE
fix(mantine, badge): allow more props on the semantic badges

### DIFF
--- a/packages/mantine/src/components/badge/Badge.tsx
+++ b/packages/mantine/src/components/badge/Badge.tsx
@@ -11,7 +11,29 @@ import {
 } from '@mantine/core';
 import {forwardRef, ForwardRefExoticComponent, ReactElement, ReactNode, RefAttributes} from 'react';
 
-export interface SemanticBadgeProps {
+export interface SemanticBadgeProps
+    extends Pick<
+        BadgeProps,
+        | 'm'
+        | 'mt'
+        | 'mb'
+        | 'ml'
+        | 'mr'
+        | 'ms'
+        | 'me'
+        | 'mx'
+        | 'my'
+        | 'miw'
+        | 'maw'
+        | 'pos'
+        | 'top'
+        | 'left'
+        | 'right'
+        | 'bottom'
+        | 'inset'
+        | 'display'
+        | 'flex'
+    > {
     /**
      * The size of the badge.
      * @default 'small'


### PR DESCRIPTION
### Proposed Changes

The typing of the semantic badge is a bit restrictive at the moment. We cannot use Mantine BoxProps (m, ml, mr, etc). I changed the type to use BadgeProps and omitted a few things that we want to always keep the same

### Potential Breaking Changes

None, more props are available

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
