### PR TITLE
fix(mantine,button): button with disabled tooltip now has display inline-block

### DIFF
--- a/packages/mantine/src/components/button/ButtonWithDisabledTooltip.tsx
+++ b/packages/mantine/src/components/button/ButtonWithDisabledTooltip.tsx
@@ -27,7 +27,12 @@ const _ButtonWithDisabledTooltip = forwardRef<HTMLDivElement, ButtonWithDisabled
     ({disabledTooltip, disabled, children, disabledTooltipProps, fullWidth, ...others}, ref) =>
         disabledTooltip ? (
             <Tooltip label={disabledTooltip} disabled={!disabled} {...disabledTooltipProps}>
-                <Box ref={ref} style={{'&:hover': {cursor: 'not-allowed'}, width: fullWidth && '100%'}} {...others}>
+                <Box
+                    ref={ref}
+                    style={{'&:hover': {cursor: 'not-allowed'}, width: fullWidth && '100%'}}
+                    display="inline-block"
+                    {...others}
+                >
                     {children}
                 </Box>
             </Tooltip>

--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -252,14 +252,16 @@ export const Collection = <T,>(props: CollectionProps<T> & {ref?: ForwardedRef<H
     const addAllowed = allowAdd?.(value) ?? true;
 
     const _addButton = canEdit ? (
-        <Button.Quaternary
-            leftSection={<IconPlus size={16} />}
-            onClick={() => onInsertItem(newItem, value?.length ?? 0)}
-            disabled={!addAllowed}
-            disabledTooltip={addDisabledTooltip}
-        >
-            {addLabel}
-        </Button.Quaternary>
+        <Box>
+            <Button.Quaternary
+                leftSection={<IconPlus size={16} />}
+                onClick={() => onInsertItem(newItem, value?.length ?? 0)}
+                disabled={!addAllowed}
+                disabledTooltip={addDisabledTooltip}
+            >
+                {addLabel}
+            </Button.Quaternary>
+        </Box>
     ) : null;
 
     const getIndex = (id: string) => standardizedItems.findIndex((item) => item.id === id);


### PR DESCRIPTION
### Proposed Changes

Before

<img width="656" height="372" alt="image" src="https://github.com/user-attachments/assets/e7a7dff2-6fcb-476d-a05f-d0def5158db9" />



After

<img width="669" height="382" alt="image" src="https://github.com/user-attachments/assets/81b5daf9-1070-433f-9507-6bde37634ec6" />


<!-- Explain what are your changes. -->

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
