### PR TITLE
fix: rendering of badges with `circle` prop

### DIFF
--- a/packages/mantine/src/components/badge/Badge.tsx
+++ b/packages/mantine/src/components/badge/Badge.tsx
@@ -66,10 +66,8 @@ const enhanceBadge = (
             <Component
                 ref={ref}
                 {...props}
-                py={2}
-                px={12}
+                {...(!props.circle ? {py: 2, px: 12, h: props.size === 'large' ? 22 : 20} : {})}
                 size={props.size === 'large' ? 'lg' : 'md'}
-                h={props.size === 'large' ? 22 : 20}
             />
         );
     });

--- a/packages/website/src/examples/feedback/badge/Badge.demo.tsx
+++ b/packages/website/src/examples/feedback/badge/Badge.demo.tsx
@@ -1,4 +1,5 @@
 import {Badge, Center, Code, Grid} from '@coveord/plasma-mantine';
+import {IconCheck} from '@coveord/plasma-react-icons';
 import {FunctionComponent, ReactNode} from 'react';
 
 const Demo = () => (
@@ -82,6 +83,24 @@ const Demo = () => (
             <Badge.Disabled on="dark" size="large">
                 Disabled
             </Badge.Disabled>
+        </Cell>
+        <Cell>
+            <Badge.Primary circle>1</Badge.Primary>
+        </Cell>
+        <Cell>
+            <Badge.Primary circle size="large">
+                <IconCheck width={14} />
+            </Badge.Primary>
+        </Cell>
+        <Cell dark>
+            <Badge.Primary circle on="dark">
+                1
+            </Badge.Primary>
+        </Cell>
+        <Cell dark>
+            <Badge.Primary circle on="dark" size="large">
+                <IconCheck width={14} />
+            </Badge.Primary>
         </Cell>
     </Grid>
 );


### PR DESCRIPTION
### Proposed Changes

After the Commerce Health dashboards were refactored to use the "semantic badges", I realized that when we used them with the `circle` prop the rendering was broken.

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [X] The proposed changes are covered by unit tests
-   [X] The potential breaking changes are clearly identified
-   [X] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
