### PR TITLE
feat(react-icons): add testing-library entrypoint

### DIFF
--- a/packages/react-icons/__tests__/Setup.ts
+++ b/packages/react-icons/__tests__/Setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -25,8 +25,11 @@
             "import": "./dist/esm/index.js"
         },
         "./mock": {
-            "require": "./dist/cjs/mock/index.js",
-            "import": "./dist/esm/mock/index.js"
+            "require": "./dist/cjs/mock/index.js"
+        },
+        "./testing-library": {
+            "require": "./dist/cjs/testing-library/index.js",
+            "import": "./dist/esm/testing-library/index.js"
         }
     },
     "main": "./dist/cjs/index.js",
@@ -40,7 +43,9 @@
         "clean": "rimraf dist",
         "generate": "node ./bin/index.js",
         "lintfix": "../../node_modules/.bin/prettier --write \"**/*.{scss,ts,tsx,js,jsx,json,md,yml,html}\" && ../../node_modules/.bin/eslint \"**/*.{ts,tsx}\" --fix",
-        "prepublishOnly": "publint"
+        "prepublishOnly": "publint",
+        "test": "pnpm generate && vitest run",
+        "test:watch": "vitest"
     },
     "dependencies": {
         "@swc/helpers": "0.5.17",
@@ -53,10 +58,14 @@
         "@svgr/plugin-jsx": "8.1.0",
         "@swc/cli": "0.7.8",
         "@swc/core": "1.13.5",
+        "@testing-library/dom": "10.4.1",
+        "@testing-library/jest-dom": "6.8.0",
+        "@testing-library/react": "16.3.0",
         "@types/react": "18.3.26",
         "@types/react-dom": "18.3.7",
         "fs-extra": "11.3.2",
         "glob": "11.0.3",
+        "jsdom": "25.0.1",
         "lodash.groupby": "4.6.0",
         "lodash.upperfirst": "4.3.1",
         "publint": "0.3.14",
@@ -64,7 +73,8 @@
         "react-dom": "18.3.1",
         "rimraf": "6.0.1",
         "tslib": "2.8.1",
-        "typescript": "5.9.3"
+        "typescript": "5.9.3",
+        "vitest": "3.2.4"
     },
     "peerDependencies": {
         "react": ">= 18.0",

--- a/packages/react-icons/src/testing-library/README.md
+++ b/packages/react-icons/src/testing-library/README.md
@@ -1,0 +1,108 @@
+# Testing Library for Plasma React Icons
+
+This package provides custom queries for finding Plasma icons in your tests, compatible with Testing Library patterns.
+
+## Installation
+
+The testing utilities are available as a separate entrypoint and use `@testing-library/dom` under the hood:
+
+```typescript
+import {getByIconName, queryByIconName, findByIconName} from '@coveord/plasma-react-icons/testing-library';
+```
+
+**Prerequisites:** This package requires `@testing-library/dom` to be installed in your project.
+
+## Setup
+
+### Option 1: Extend Screen Object (Recommended)
+
+Add this to a separate test utilities file (e.g., `test-utils.ts` or `testing-utils.ts`):
+
+```typescript
+import {screen as defaultScreen} from '@testing-library/react';
+import {extendScreen, IconQueries} from '@coveord/plasma-react-icons/testing-library';
+
+// Extend screen with icon queries with its type so that you have autocomplete in your IDE
+const screen: typeof defaultScreen & IconQueries = extendScreen(defaultScreen);
+
+// Export everything from testing library + our enhanced screen
+export * from '@testing-library/react';
+export {screen};
+
+// Then, in your test file
+import {render, screen} from './test-utils'; // or your utilities file path
+
+// Now screen.getByIconName, screen.queryByIconName, etc. are available
+```
+
+### Option 2: Import Individual Queries
+
+```typescript
+import {getByIconName, queryByIconName, findByIconName} from '@coveord/plasma-react-icons/testing-library';
+```
+
+## Usage
+
+### Basic Usage
+
+```jsx
+import {render} from '@testing-library/react';
+import {getByIconName} from '@coveord/plasma-react-icons/testing-library';
+import {AddSize16Px} from '@coveord/plasma-react-icons';
+
+test('should find icon by name', () => {
+    const {container} = render(<AddSize16Px />);
+
+    const icon = getByIconName(container, 'add');
+    expect(icon).toBeInTheDocument();
+});
+```
+
+### Using with Screen Object
+
+You can use the icon queries directly with the `screen` object:
+
+```jsx
+import {render, screen} from '@testing-library/react';
+import {extendScreen} from '@coveord/plasma-react-icons/testing-library';
+import {SearchSize24Px} from '@coveord/plasma-react-icons';
+
+// Extend the screen object once in your test setup
+extendScreen(screen);
+
+test('should find icon using screen', () => {
+    render(<SearchSize24Px />);
+    // Now you can use screen.getByIconName directly!
+    const icon = screen.getByIconName('search');
+    expect(icon).toBeInTheDocument();
+});
+```
+
+### Available Queries
+
+The testing library provides all standard Testing Library query variants:
+
+- `queryByIconName` - Returns the element or null if not found
+- `queryAllByIconName` - Returns an array of elements (empty if none found)
+- `getByIconName` - Returns the element or throws if not found/multiple found
+- `getAllByIconName` - Returns an array of elements or throws if none found
+- `findByIconName` - Async version of getByIconName
+- `findAllByIconName` - Async version of getAllByIconName
+
+### Icon Name Patterns
+
+The queries support two patterns:
+
+1. **Tabler Icons with "icon" prefix**: Uses CSS class selector
+
+    ```typescript
+    // For icons with names starting with "icon"
+    getByIconName(container, 'iconSearch'); // finds .tabler-icon-search
+    ```
+
+2. **Standard Icons**: Uses role="img" and accessible name
+
+    ```typescript
+    // For standard icons with aria-label or alt text
+    getByIconName(container, 'search'); // finds [role="img"][aria-label="search"]
+    ```

--- a/packages/react-icons/src/testing-library/index.spec.tsx
+++ b/packages/react-icons/src/testing-library/index.spec.tsx
@@ -1,0 +1,222 @@
+/* eslint-disable testing-library/prefer-presence-queries */
+/**
+ * Test suite for Plasma React Icons testing utilities
+ * Demonstrates usage of custom icon queries with Testing Library
+ */
+
+import {describe, test, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {
+    queryByIconName,
+    queryAllByIconName,
+    getByIconName,
+    getAllByIconName,
+    findByIconName,
+    findAllByIconName,
+    extendScreen,
+} from './index';
+
+// Import actual icons from the generated folder
+import {SearchSize24Px} from '../generated/search/index.js';
+import {AddSize16Px} from '../generated/add/index.js';
+import {DeleteSize24Px} from '../generated/delete/index.js';
+
+describe('Plasma Icon Testing Utilities', () => {
+    describe('queryByIconName', () => {
+        test('finds search icon by accessible name', () => {
+            const {container} = render(<SearchSize24Px />);
+
+            const result = queryByIconName(container, 'search');
+            expect(result).toBeInTheDocument();
+        });
+
+        test('returns null when icon not found', () => {
+            const {container} = render(<div>No icons here</div>);
+
+            const icon = queryByIconName(container, 'search');
+            expect(icon).toBeNull();
+        });
+
+        test('finds multiple different icon types', () => {
+            const {container} = render(
+                <div>
+                    <SearchSize24Px />
+                    <AddSize16Px />
+                    <DeleteSize24Px />
+                </div>,
+            );
+
+            expect(queryByIconName(container, 'search')).toBeInTheDocument();
+            expect(queryByIconName(container, 'add')).toBeInTheDocument();
+            expect(queryByIconName(container, 'delete')).toBeInTheDocument();
+        });
+    });
+
+    describe('queryAllByIconName', () => {
+        test('finds multiple icons with the same name', () => {
+            const {container} = render(
+                <div>
+                    <SearchSize24Px />
+                    <SearchSize24Px />
+                </div>,
+            );
+
+            const icons = queryAllByIconName(container, 'search');
+            expect(icons).toHaveLength(2);
+            icons.forEach((icon) => expect(icon).toBeInTheDocument());
+        });
+
+        test('returns empty array when no icons found', () => {
+            const {container} = render(<div>No icons here</div>);
+
+            const icons = queryAllByIconName(container, 'search');
+            expect(icons).toEqual([]);
+        });
+
+        test('finds and counts different icon types correctly', () => {
+            const {container} = render(
+                <div>
+                    <SearchSize24Px />
+                    <AddSize16Px />
+                    <DeleteSize24Px />
+                </div>,
+            );
+
+            expect(queryAllByIconName(container, 'search')).toHaveLength(1);
+            expect(queryAllByIconName(container, 'add')).toHaveLength(1);
+            expect(queryAllByIconName(container, 'delete')).toHaveLength(1);
+            expect(queryAllByIconName(container, 'missing')).toHaveLength(0);
+        });
+    });
+
+    describe('getByIconName', () => {
+        test('finds icon when present', () => {
+            const {container} = render(<SearchSize24Px />);
+
+            const result = getByIconName(container, 'search');
+            expect(result).toBeInTheDocument();
+        });
+
+        test('throws error when icon not found', () => {
+            const {container} = render(<div>No icons here</div>);
+
+            expect(() => getByIconName(container, 'search')).toThrow(
+                'Unable to find an element with icon name: search',
+            );
+        });
+    });
+
+    describe('getAllByIconName', () => {
+        test('finds multiple icons and returns all matches', () => {
+            const {container} = render(
+                <div>
+                    <SearchSize24Px />
+                    <AddSize16Px />
+                </div>,
+            );
+
+            const searchIcons = getAllByIconName(container, 'search');
+            expect(searchIcons).toHaveLength(1);
+            expect(searchIcons[0]).toBeInTheDocument();
+
+            const addIcons = getAllByIconName(container, 'add');
+            expect(addIcons).toHaveLength(1);
+            expect(addIcons[0]).toBeInTheDocument();
+        });
+
+        test('throws error when no icons found', () => {
+            const {container} = render(<div>No icons here</div>);
+
+            expect(() => getAllByIconName(container, 'search')).toThrow(
+                'Unable to find an element with icon name: search',
+            );
+        });
+    });
+
+    describe('findByIconName', () => {
+        test('finds icon asynchronously', async () => {
+            const {container} = render(<SearchSize24Px />);
+
+            const result = await findByIconName(container, 'search');
+            expect(result).toBeInTheDocument();
+        });
+
+        test('times out when icon not found', async () => {
+            const {container} = render(<div>No icons here</div>);
+
+            await expect(findByIconName(container, 'search')).rejects.toThrow(
+                'Unable to find an element with icon name: search',
+            );
+        });
+    });
+
+    describe('findAllByIconName', () => {
+        test('finds multiple icons asynchronously', async () => {
+            const {container} = render(
+                <div>
+                    <SearchSize24Px />
+                    <AddSize16Px />
+                </div>,
+            );
+
+            const icons = await findAllByIconName(container, 'search');
+            expect(icons).toHaveLength(1);
+            expect(icons[0]).toBeInTheDocument();
+        });
+    });
+
+    describe('Screen integration', () => {
+        test('extends screen object with all custom queries', () => {
+            const extendedScreen = extendScreen(screen);
+
+            // Verify that all custom queries are available on screen
+            expect(extendedScreen.getByIconName).toBeDefined();
+            expect(extendedScreen.getAllByIconName).toBeDefined();
+            expect(extendedScreen.queryByIconName).toBeDefined();
+            expect(extendedScreen.queryAllByIconName).toBeDefined();
+            expect(extendedScreen.findByIconName).toBeDefined();
+            expect(extendedScreen.findAllByIconName).toBeDefined();
+        });
+
+        test('works with actual icon components through screen', () => {
+            render(
+                <div>
+                    <SearchSize24Px />
+                    <AddSize16Px />
+                    <DeleteSize24Px />
+                </div>,
+            );
+            const extendedScreen = extendScreen(screen);
+
+            // Find icons by their accessible names using the screen object
+            const searchIcon = extendedScreen.queryByIconName('search');
+            expect(searchIcon).toBeInTheDocument();
+
+            const addIcon = extendedScreen.queryByIconName('add');
+            expect(addIcon).toBeInTheDocument();
+
+            const deleteIcon = extendedScreen.queryByIconName('delete');
+            expect(deleteIcon).toBeInTheDocument();
+        });
+    });
+
+    describe('Error handling', () => {
+        test('provides helpful error messages', () => {
+            const {container} = render(<div>No icons</div>);
+
+            expect(() => getByIconName(container, 'missing-icon')).toThrow(
+                'Unable to find an element with icon name: missing-icon',
+            );
+
+            expect(() => getAllByIconName(container, 'missing-icon')).toThrow(
+                'Unable to find an element with icon name: missing-icon',
+            );
+        });
+
+        test('handles empty strings gracefully', () => {
+            const {container} = render(<SearchSize24Px />);
+
+            expect(queryByIconName(container, '')).toBeNull();
+        });
+    });
+});

--- a/packages/react-icons/src/testing-library/index.ts
+++ b/packages/react-icons/src/testing-library/index.ts
@@ -1,0 +1,122 @@
+/**
+ * Custom queries for finding Plasma icons in tests
+ * Uses @testing-library/dom buildQueries for consistent behavior
+ */
+
+import {buildQueries, GetErrorFunction} from '@testing-library/dom';
+
+// Helper function to convert camelCase to kebab-case
+const slugify = (text: string) =>
+    text
+        .replace(/([a-z])([A-Z])/g, '$1-$2')
+        .replace(/\s+/g, '-')
+        .toLowerCase();
+
+// Error functions compatible with Testing Library
+const getMultipleError: GetErrorFunction = (c, iconName) => `Found multiple elements with icon name: ${iconName}`;
+
+const getMissingError: GetErrorFunction = (c, iconName) => `Unable to find an element with icon name: ${iconName}`;
+
+// Core query function that finds all matching elements
+const queryAllByIconName = (container: HTMLElement, iconName: string): HTMLElement[] => {
+    if (iconName.startsWith('icon')) {
+        // For Tabler icons with 'icon' prefix, use CSS class selector
+        const elements = container.querySelectorAll(`.tabler-${slugify(iconName)}`);
+        return Array.from(elements) as HTMLElement[];
+    } else {
+        // For other icons, look for elements with role="img" and matching accessible name
+        // This covers both img elements and SVG elements with role="img"
+        const roleElements = container.querySelectorAll('[role="img"]');
+        const matchingElements: HTMLElement[] = [];
+
+        roleElements.forEach((element) => {
+            const ariaLabel = element.getAttribute('aria-label');
+            const title = element.getAttribute('title');
+            if (ariaLabel === iconName || title === iconName) {
+                matchingElements.push(element as HTMLElement);
+            }
+        });
+
+        // Also check img elements for alt text
+        const imgElements = container.querySelectorAll('img');
+        imgElements.forEach((img) => {
+            const alt = img.getAttribute('alt');
+            const ariaLabel = img.getAttribute('aria-label');
+            if (alt === iconName || ariaLabel === iconName) {
+                matchingElements.push(img as HTMLElement);
+            }
+        });
+
+        return matchingElements;
+    }
+};
+
+// Use buildQueries to create all the standard Testing Library query variants
+const [queryByIconName, getAllByIconName, getByIconName, findAllByIconName, findByIconName] = buildQueries(
+    queryAllByIconName,
+    getMultipleError,
+    getMissingError,
+);
+
+// Export the queries
+export {queryByIconName, queryAllByIconName, getAllByIconName, getByIconName, findAllByIconName, findByIconName};
+
+// Type definitions for icon queries
+export interface IconQueries {
+    queryByIconName: (iconName: string) => HTMLElement | null;
+    queryAllByIconName: (iconName: string) => HTMLElement[];
+    getByIconName: (iconName: string) => HTMLElement;
+    getAllByIconName: (iconName: string) => HTMLElement[];
+    findByIconName: (iconName: string, options?: any) => Promise<HTMLElement>;
+    findAllByIconName: (iconName: string, options?: any) => Promise<HTMLElement[]>;
+}
+
+// Create screen-compatible queries that work with document.body as default container
+const screenQueries: IconQueries = {
+    queryByIconName: (iconName: string) => queryByIconName(document.body, iconName),
+    queryAllByIconName: (iconName: string) => queryAllByIconName(document.body, iconName),
+    getByIconName: (iconName: string) => getByIconName(document.body, iconName),
+    getAllByIconName: (iconName: string) => getAllByIconName(document.body, iconName),
+    findByIconName: (iconName: string, options?: any) => findByIconName(document.body, iconName, options),
+    findAllByIconName: (iconName: string, options?: any) => findAllByIconName(document.body, iconName, options),
+};
+
+// Export individual screen queries for convenience
+export const {
+    queryByIconName: screenQueryByIconName,
+    queryAllByIconName: screenQueryAllByIconName,
+    getByIconName: screenGetByIconName,
+    getAllByIconName: screenGetAllByIconName,
+    findByIconName: screenFindByIconName,
+    findAllByIconName: screenFindAllByIconName,
+} = screenQueries;
+
+/**
+ * Extends a Testing Library screen object with icon queries.
+ * This allows you to use icon queries directly on the screen object.
+ *
+ * @param testingLibraryScreen - The screen object from Testing Library (optional)
+ * @returns Extended screen object with icon queries
+ *
+ * @example
+ * import { render } from '@testing-library/react';
+ * import { extendScreen } from '@coveord/plasma-react-icons/testing-library';
+ *
+ * const screen = extendScreen();
+ * render(<MyComponent />);
+ * const icon = screen.getByIconName('add');
+ */
+export const extendScreen = <T extends Record<string, any> = Record<string, never>>(
+    testingLibraryScreen?: T,
+): T extends Record<string, never> ? IconQueries : T & IconQueries => {
+    // If no screen is provided, use our screen queries directly
+    if (!testingLibraryScreen) {
+        return screenQueries as T extends Record<string, never> ? IconQueries : T & IconQueries;
+    }
+
+    // Merge the provided screen with our icon queries
+    return {
+        ...testingLibraryScreen,
+        ...screenQueries,
+    } as T extends Record<string, never> ? IconQueries : T & IconQueries;
+};

--- a/packages/react-icons/tsconfig.json
+++ b/packages/react-icons/tsconfig.json
@@ -1,3 +1,6 @@
 {
-    "extends": "../tsconfig-base.json"
+    "extends": "../tsconfig-base.json",
+    "compilerOptions": {
+        "types": ["vitest/globals", "@testing-library/jest-dom"]
+    }
 }

--- a/packages/react-icons/vitest.config.ts
+++ b/packages/react-icons/vitest.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'jsdom',
+        setupFiles: ['./__tests__/Setup.ts'],
+        globals: true,
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,6 +341,15 @@ importers:
       '@swc/core':
         specifier: 1.13.5
         version: 1.13.5(@swc/helpers@0.5.17)
+      '@testing-library/dom':
+        specifier: 10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: 6.8.0
+        version: 6.8.0
+      '@testing-library/react':
+        specifier: 16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.26
         version: 18.3.26
@@ -353,6 +362,9 @@ importers:
       glob:
         specifier: 11.0.3
         version: 11.0.3
+      jsdom:
+        specifier: 25.0.1
+        version: 25.0.1
       lodash.groupby:
         specifier: 4.6.0
         version: 4.6.0
@@ -377,6 +389,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.8)(jiti@2.6.0)(jsdom@25.0.1)(sugarss@5.0.1(postcss@8.5.6))(yaml@2.8.1)
 
   packages/tokens:
     dependencies:
@@ -1859,6 +1874,10 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
+  '@testing-library/jest-dom@6.8.0':
+    resolution: {integrity: sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
@@ -2454,6 +2473,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
@@ -2706,6 +2728,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -2994,6 +3020,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -3512,6 +3542,10 @@ packages:
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
+
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -4082,6 +4116,15 @@ packages:
     resolution: {integrity: sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==}
     engines: {node: '>=12.0.0'}
 
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
     engines: {node: '>=18'}
@@ -4256,9 +4299,6 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
-
-  loupe@3.1.3:
-    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -4474,8 +4514,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.53.0:
     resolution: {integrity: sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mimic-fn@2.1.0:
@@ -5327,6 +5375,9 @@ packages:
     resolution: {integrity: sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
@@ -6322,7 +6373,7 @@ snapshots:
 
   '@babel/code-frame@7.26.2':
     dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -7508,13 +7559,22 @@ snapshots:
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.4
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
       picocolors: 1.1.1
       pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.8.0':
+    dependencies:
+      '@adobe/css-tools': 4.4.1
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
 
   '@testing-library/jest-dom@6.9.1':
     dependencies:
@@ -7527,7 +7587,7 @@ snapshots:
 
   '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.28.4
       '@testing-library/dom': 10.4.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -8172,6 +8232,8 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  asynckit@0.4.0: {}
+
   at-least-node@1.0.0: {}
 
   atomic-sleep@1.0.0: {}
@@ -8353,7 +8415,7 @@ snapshots:
       assertion-error: 2.0.1
       check-error: 2.1.1
       deep-eql: 5.0.2
-      loupe: 3.1.3
+      loupe: 3.2.1
       pathval: 2.0.0
 
   chalk@2.4.2:
@@ -8445,6 +8507,10 @@ snapshots:
   colord@2.9.3: {}
 
   colorette@2.0.20: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
 
@@ -8770,6 +8836,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -9404,6 +9472,14 @@ snapshots:
 
   form-data-encoder@2.1.4: {}
 
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   fraction.js@4.3.7: {}
 
   fs-extra@11.3.2:
@@ -10008,6 +10084,34 @@ snapshots:
 
   jsdoc-type-pratt-parser@4.1.0: {}
 
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.2.1
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.4
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.22
+      parse5: 7.2.1
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   jsdom@26.1.0:
     dependencies:
       cssstyle: 4.2.1
@@ -10194,8 +10298,6 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
-
-  loupe@3.1.3: {}
 
   loupe@3.2.1: {}
 
@@ -10600,7 +10702,13 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
   mime-db@1.53.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mimic-fn@2.1.0: {}
 
@@ -11472,6 +11580,8 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.50.1
       '@rollup/rollup-win32-x64-msvc': 4.50.1
       fsevents: 2.3.3
+
+  rrweb-cssom@0.7.1: {}
 
   rrweb-cssom@0.8.0: {}
 
@@ -12368,6 +12478,49 @@ snapshots:
       jiti: 2.6.0
       sugarss: 5.0.1(postcss@8.5.6)
       yaml: 2.8.1
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.8)(jiti@2.6.0)(jsdom@25.0.1)(sugarss@5.0.1(postcss@8.5.6))(yaml@2.8.1):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.3.6(@types/node@22.18.8)(jiti@2.6.0)(sugarss@5.0.1(postcss@8.5.6))(yaml@2.8.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      debug: 4.4.3(supports-color@5.5.0)
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.3.6(@types/node@22.18.8)(jiti@2.6.0)(sugarss@5.0.1(postcss@8.5.6))(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@22.18.8)(jiti@2.6.0)(sugarss@5.0.1(postcss@8.5.6))(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.18.8
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.8)(jiti@2.6.0)(jsdom@26.1.0)(sugarss@5.0.1(postcss@8.5.6))(yaml@2.8.1):
     dependencies:


### PR DESCRIPTION
### Proposed Changes

This pull request introduces a comprehensive Testing Library integration for Plasma React Icons, allowing users to easily query and assert icon components in their tests. It adds custom query functions, extends the Testing Library `screen` object, provides thorough documentation, and sets up a full testing environment using Vitest and jsdom. The package dependencies and configuration files are updated accordingly.

**Testing Library Integration and Utilities**

* Added a new `src/testing-library/index.ts` module that provides custom queries (`getByIconName`, `queryByIconName`, etc.) for Plasma icons, compatible with Testing Library patterns, and an `extendScreen` utility to augment the `screen` object.
* Created a comprehensive test suite in `src/testing-library/index.spec.tsx` to validate all custom queries and their integration with the Testing Library `screen` object.
* Added a detailed `src/testing-library/README.md` explaining installation, setup, usage, and supported query patterns for icon testing.

**Testing Environment Setup**

* Added Vitest configuration (`vitest.config.ts`), a global test setup file (`__tests__/Setup.ts`), and updated `tsconfig.json` to include Vitest and Testing Library types for a seamless testing experience. [[1]](diffhunk://#diff-e5a46c11fc8701b0cc39e0d64b9d660760ce98fdbf702ef7a8bc8116f3fc89ebR1-R9) [[2]](diffhunk://#diff-45640101770a59372354821f4d5105d797986ab0bc8d4f02d80414621b27d367R1) [[3]](diffhunk://#diff-5e03ef87e1a33a7843a4fd683303306984ae628b161513d2b1980e91447a4fc8L2-R5)
* Updated `package.json` scripts to support running and watching tests with Vitest, and added all necessary dependencies (`@testing-library/*`, `vitest`, `jsdom`, etc.). [[1]](diffhunk://#diff-0b58898192f3a93bd457e0d2b375c2332892ac70a93dafce4607816fec786d0fL43-R48) [[2]](diffhunk://#diff-0b58898192f3a93bd457e0d2b375c2332892ac70a93dafce4607816fec786d0fR61-R86)
* Updated `pnpm-lock.yaml` to reflect new dependencies and lockfile changes. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR344-R352) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR365-R367) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR392-R394)

**Package Entrypoints**

* Added a new `"./testing-library"` entrypoint in `package.json` to expose the custom queries for consumers.

These changes enable robust, accessible, and user-friendly testing of Plasma React Icons in consumer projects.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
