### PR TITLE
fix(mantine,button): button with disabled tooltip alignment glitch in Menu.

### DIFF
--- a/packages/mantine/src/components/button/ButtonWithDisabledTooltip.tsx
+++ b/packages/mantine/src/components/button/ButtonWithDisabledTooltip.tsx
@@ -27,12 +27,7 @@ const _ButtonWithDisabledTooltip = forwardRef<HTMLDivElement, ButtonWithDisabled
     ({disabledTooltip, disabled, children, disabledTooltipProps, fullWidth, ...others}, ref) =>
         disabledTooltip ? (
             <Tooltip label={disabledTooltip} disabled={!disabled} {...disabledTooltipProps}>
-                <Box
-                    ref={ref}
-                    style={{'&:hover': {cursor: 'not-allowed'}, width: fullWidth && '100%'}}
-                    display="inline-block"
-                    {...others}
-                >
+                <Box ref={ref} style={{'&:hover': {cursor: 'not-allowed'}, width: fullWidth && '100%'}} {...others}>
                     {children}
                 </Box>
             </Tooltip>

--- a/packages/mantine/src/components/collection/Collection.module.css
+++ b/packages/mantine/src/components/collection/Collection.module.css
@@ -21,3 +21,7 @@
 .dragHandle {
     cursor: move;
 }
+
+.addButtonContainer {
+    align-self: flex-start;
+}

--- a/packages/mantine/src/components/collection/Collection.tsx
+++ b/packages/mantine/src/components/collection/Collection.tsx
@@ -251,7 +251,7 @@ export const Collection = <T,>(props: CollectionProps<T> & {ref?: ForwardedRef<H
     const addAllowed = allowAdd?.(value) ?? true;
 
     const _addButton = canEdit ? (
-        <Box>
+        <Box className={classes.addButtonContainer}>
             <Button.Quaternary
                 leftSection={<IconPlus size={16} />}
                 onClick={() => onInsertItem(newItem, value?.length ?? 0)}

--- a/packages/website/src/examples/form/collection/Collection.demo.tsx
+++ b/packages/website/src/examples/form/collection/Collection.demo.tsx
@@ -21,7 +21,9 @@ const Demo = () => {
             draggable
             addLabel="Add task"
             description="These will have to be done by next week"
+            addDisabledTooltip="You have reached the maximum number of tasks"
             label="List of tasks"
+            allowAdd={(value) => value.length < 10}
             newItem={{name: '', done: false}}
             {...form.getInputProps('todoList')}
         >

--- a/packages/website/src/examples/layout/Table/Table.demo.tsx
+++ b/packages/website/src/examples/layout/Table/Table.demo.tsx
@@ -74,6 +74,7 @@ const Demo = () => {
                     component: (
                         <Table.ActionItem
                             onClick={() => alert(`Action 1 triggered for row: ${selected[0].id}`)}
+                            disabledTooltip="This action is disabled"
                             leftSection={<EditSize16Px height={16} />}
                             key="action-1"
                         >


### PR DESCRIPTION
### Proposed Changes

Following this [PR](https://github.com/coveo/plasma/pull/4144), some buttons in Menu components are appearing on the same line.

<img width="304" height="216" alt="Screenshot 2025-10-17 at 1 02 38 PM" src="https://github.com/user-attachments/assets/bb44b6a4-792c-4061-a8fb-e8e2abd25f3d" />


I removed the `inline-block` style from the component but made sure that the tooltip was still displayed correctly when used with the add button of a Collection.

<img width="207" height="273" alt="Screenshot 2025-10-17 at 1 00 28 PM" src="https://github.com/user-attachments/assets/bf5acd8f-4cba-4acb-b633-e7651a032f8c" />

<img width="659" height="153" alt="Screenshot 2025-10-17 at 1 00 17 PM" src="https://github.com/user-attachments/assets/b99fe265-acf5-41c3-9c6e-ea4357ce18d0" />


I updated the Collection and Table demos so we can validate the [fix](https://plasma.coveo.com/feature/PSE-527-fix-button-align/layout/Table). 🧪 

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
