### PR TITLE
fix(react-icons): query icons with numbers in their name

### DIFF
--- a/packages/react-icons/src/testing-library/index.spec.tsx
+++ b/packages/react-icons/src/testing-library/index.spec.tsx
@@ -21,6 +21,9 @@ import {SearchSize24Px} from '../generated/search/index.js';
 import {AddSize16Px} from '../generated/add/index.js';
 import {DeleteSize24Px} from '../generated/delete/index.js';
 
+// Import Tabler icon for testing
+import {IconNumber123} from '../TablerIcons';
+
 describe('Plasma Icon Testing Utilities', () => {
     describe('queryByIconName', () => {
         test('finds search icon by accessible name', () => {
@@ -34,6 +37,13 @@ describe('Plasma Icon Testing Utilities', () => {
             const {container} = render(<SearchSize24Px aria-label="my-awesome-search-icon" />);
 
             const result = queryByIconName(container, 'my-awesome-search-icon');
+            expect(result).toBeInTheDocument();
+        });
+
+        test('finds icons with numbers in their name', () => {
+            const {container} = render(<IconNumber123 />);
+
+            const result = queryByIconName(container, 'iconNumber123');
             expect(result).toBeInTheDocument();
         });
 

--- a/packages/react-icons/src/testing-library/index.ts
+++ b/packages/react-icons/src/testing-library/index.ts
@@ -9,6 +9,7 @@ import {buildQueries, GetErrorFunction} from '@testing-library/dom';
 const slugify = (text: string) =>
     text
         .replace(/([a-z])([A-Z])/g, '$1-$2')
+        .replace(/([a-z])([0-9])/g, '$1-$2')
         .replace(/\s+/g, '-')
         .toLowerCase();
 


### PR DESCRIPTION
### Proposed Changes

This pull request improves the icon testing utilities in the `react-icons` package by enhancing support for icons with numbers in their names and updating related tests. The main changes include updating the `slugify` function to handle numbers in icon names and adding tests for number-containing icon names.

Before

```tsx
render(<IconNumber123 />);
expect(screen.getIconByName('iconNumber123')).toBeVisible(); // 💥
```

After

```tsx
render(<IconNumber123 />);
expect(screen.getIconByName('iconNumber123')).toBeVisible(); // ✅
```

<img width="756" height="367" alt="image" src="https://github.com/user-attachments/assets/3cbfd121-ca9f-4574-9b1f-2b0741a89d6b" />


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
