### PR TITLE
fix(react-icons): mock and vite plugin

### DIFF
--- a/packages/react-icons/src/mock/MockUtils.spec.ts
+++ b/packages/react-icons/src/mock/MockUtils.spec.ts
@@ -1,0 +1,43 @@
+import {MockUtils} from './MockUtils';
+
+describe('MockUtils', () => {
+    describe('formatLabel', () => {
+        it('transforms icon name to camelCase label', () => {
+            expect(MockUtils.formatLabel('ArrowUpSize16Px')).toBe('arrowUp');
+        });
+
+        it('handles single word names', () => {
+            expect(MockUtils.formatLabel('HomeSize24Px')).toBe('home');
+        });
+
+        it('handles multi-word names', () => {
+            expect(MockUtils.formatLabel('ChevronDownSize32Px')).toBe('chevronDown');
+        });
+
+        it('returns original name if pattern does not match', () => {
+            expect(MockUtils.formatLabel('InvalidName')).toBe('invalidName');
+        });
+    });
+
+    describe('formatToTablerClassName', () => {
+        it('does not transform names that do not start with Icon', () => {
+            expect(MockUtils.formatToTablerClassName('ArrowUpSize16Px')).toBe('ArrowUpSize16Px');
+        });
+
+        it('handles single word names', () => {
+            expect(MockUtils.formatToTablerClassName('IconHome')).toBe('tabler-icon tabler-icon-home');
+        });
+
+        it('handles multi-word names', () => {
+            expect(MockUtils.formatToTablerClassName('IconChevronDown')).toBe('tabler-icon tabler-icon-chevron-down');
+        });
+
+        it('handles names with numbers', () => {
+            expect(MockUtils.formatToTablerClassName('Icon24')).toBe('tabler-icon tabler-icon-24');
+        });
+
+        it('handles consecutive uppercase letters', () => {
+            expect(MockUtils.formatToTablerClassName('IconHTTPS')).toBe('tabler-icon tabler-icon-https');
+        });
+    });
+});

--- a/packages/react-icons/src/mock/MockUtils.ts
+++ b/packages/react-icons/src/mock/MockUtils.ts
@@ -1,0 +1,23 @@
+/**
+ * Transforms ArrowUpSize16Px into arrowUp
+ */
+const formatLabel = (name: string) => {
+    const label = name.replace(/(.+)Size\d+Px/, '$1');
+    return label.charAt(0).toLowerCase() + label.slice(1);
+};
+
+const transformToKebabCase = (name: string) =>
+    name.charAt(0).toLowerCase() +
+    name
+        .slice(1)
+        .replace(/([a-z])([A-Z])/g, '$1-$2') // Add hyphen between camelCase
+        .replace(/([a-zA-Z])(\d+)/g, '$1-$2') // Add hyphen before numbers
+        .toLowerCase();
+
+const formatToTablerClassName = (name: string) =>
+    name.startsWith('Icon') ? `tabler-icon tabler-${transformToKebabCase(name)}` : name;
+
+export const MockUtils = {
+    formatLabel,
+    formatToTablerClassName,
+};

--- a/packages/react-icons/src/mock/index.spec.tsx
+++ b/packages/react-icons/src/mock/index.spec.tsx
@@ -1,0 +1,78 @@
+import {render, screen} from '@testing-library/react';
+import {extendScreen} from '../testing-library';
+import MockedIcons from './index';
+
+const extendedScreen = extendScreen(screen);
+
+describe('Mocked Icons Proxy', () => {
+    describe('Plasma icons', () => {
+        it('renders a regular icon with correct aria-label', () => {
+            render(<MockedIcons.ArrowUpSize16Px />);
+            const svg = screen.getByRole('img', {name: 'arrowUp'});
+
+            expect(svg).toBeInTheDocument();
+            expect(svg).toHaveAttribute('role', 'img');
+            expect(svg).toHaveAttribute('aria-label', 'arrowUp');
+        });
+
+        it('handles size props correctly', () => {
+            render(<MockedIcons.ArrowUpSize16Px height="24" width="32" />);
+            const svg = screen.getByRole('img', {name: 'arrowUp'});
+
+            expect(svg).toHaveAttribute('width', '32');
+            expect(svg).toHaveAttribute('height', '24');
+        });
+
+        it('defaults to 1em when no size is provided', () => {
+            render(<MockedIcons.ArrowUpSize16Px />);
+            const svg = screen.getByRole('img', {name: 'arrowUp'});
+
+            expect(svg).toHaveAttribute('width', '1em');
+            expect(svg).toHaveAttribute('height', '1em');
+        });
+
+        it('uses height for width when only height is provided', () => {
+            render(<MockedIcons.ArrowDownSize16Px height="24" />);
+            const svg = screen.getByRole('img', {name: 'arrowDown'});
+
+            expect(svg).toHaveAttribute('width', '24');
+            expect(svg).toHaveAttribute('height', '24');
+        });
+    });
+
+    describe('Tabler icons', () => {
+        it('renders a Tabler icon with correct className', () => {
+            render(<MockedIcons.IconChevronDown />);
+            const svg = extendedScreen.getByIconName('iconChevronDown');
+
+            expect(svg).toBeInTheDocument();
+            expect(svg).toHaveClass('tabler-icon tabler-icon-chevron-down');
+        });
+
+        it('handles size props correctly', () => {
+            render(<MockedIcons.IconChevronDown height="24" width="32" />);
+            const svg = extendedScreen.getByIconName('iconChevronDown');
+
+            expect(svg).toHaveAttribute('width', '32');
+            expect(svg).toHaveAttribute('height', '24');
+        });
+
+        it('defaults to 1em when no size is provided', () => {
+            render(<MockedIcons.IconChevronDown />);
+            const svg = extendedScreen.getByIconName('iconChevronDown');
+
+            expect(svg).toHaveAttribute('width', '1em');
+            expect(svg).toHaveAttribute('height', '1em');
+        });
+    });
+
+    describe('Display names', () => {
+        it('sets displayName for regular icons', () => {
+            expect(MockedIcons.ArrowUpSize16Px.displayName).toBe('ArrowUpSize16Px');
+        });
+
+        it('sets displayName for Tabler icons', () => {
+            expect(MockedIcons.IconChevronDown.displayName).toBe('IconChevronDown');
+        });
+    });
+});

--- a/packages/react-icons/src/mock/index.tsx
+++ b/packages/react-icons/src/mock/index.tsx
@@ -1,4 +1,5 @@
 import {forwardRef, type SVGProps} from 'react';
+import {MockUtils} from './MockUtils';
 
 /**
  * You can use the following mock in jest to avoid loading the actual icons during tests, it can slow down your tests if you don't.
@@ -6,21 +7,29 @@ import {forwardRef, type SVGProps} from 'react';
  * '^@coveord/plasma-react-icons$': '<rootDir>/node_modules/@coveord/plasma-react-icons/mock',
  */
 
-/**
- * Transforms ArrowUpSize16Px into arrowUp
- */
-const formatLabel = (name: string) => {
-    const label = name.replace(/(.+)Size\d+Px/, '$1');
-    return label.charAt(0).toLowerCase() + label.slice(1);
-};
-
 const handler = {
     get: (obj: any, prop: string) => {
+        if (prop.startsWith('Icon')) {
+            const TablerIconMock = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>(
+                ({height, width, ...others}, ref) => (
+                    <svg
+                        ref={ref}
+                        width={width || height || '1em'}
+                        height={height || width || '1em'}
+                        className={MockUtils.formatToTablerClassName(prop)}
+                        {...others}
+                    />
+                ),
+            );
+            TablerIconMock.displayName = prop;
+            return TablerIconMock;
+        }
+
         const IconMock = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>(({height, width, ...others}, ref) => (
             <svg
                 ref={ref}
                 role="img"
-                aria-label={formatLabel(prop)}
+                aria-label={MockUtils.formatLabel(prop)}
                 width={width || height || '1em'}
                 height={height || width || '1em'}
                 {...others}

--- a/packages/react-icons/src/vite-plugin/index.spec.ts
+++ b/packages/react-icons/src/vite-plugin/index.spec.ts
@@ -1,0 +1,176 @@
+import {describe, expect, it} from 'vitest';
+import plasmaIconsMockPlugin from './index';
+
+describe('plasmaIconsMockPlugin', () => {
+    const plugin = plasmaIconsMockPlugin();
+
+    describe('transform function', () => {
+        it('returns null for files without @coveord/plasma-react-icons import', () => {
+            const code = `import React from 'react';`;
+            const result = plugin.transform?.(code, '/test/file.tsx');
+
+            expect(result).toBeNull();
+        });
+
+        it('returns null for files in node_modules', () => {
+            const code = `import { ArrowUpSize16Px } from '@coveord/plasma-react-icons';`;
+            const result = plugin.transform?.(code, '/node_modules/some-package/index.js');
+
+            expect(result).toBeNull();
+        });
+
+        it('returns null for non-JavaScript/TypeScript files', () => {
+            const code = `import { ArrowUpSize16Px } from '@coveord/plasma-react-icons';`;
+            const result = plugin.transform?.(code, '/test/file.css');
+
+            expect(result).toBeNull();
+        });
+
+        it('transforms named imports to default import with property access', () => {
+            const code = `import { ArrowUpSize16Px } from '@coveord/plasma-react-icons';`;
+            const result = plugin.transform?.(code, '/test/file.tsx');
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toMatchInlineSnapshot(`
+              "import __plasmaIconsMock from '@coveord/plasma-react-icons/mock';
+              const ArrowUpSize16Px = __plasmaIconsMock.ArrowUpSize16Px;
+              "
+            `);
+        });
+
+        it('transforms multiple named imports', () => {
+            const code = `import { ArrowUpSize16Px, IconChevronDown, HomeSize24Px } from '@coveord/plasma-react-icons';`;
+            const result = plugin.transform?.(code, '/test/file.tsx');
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toMatchInlineSnapshot(`
+              "import __plasmaIconsMock from '@coveord/plasma-react-icons/mock';
+              const ArrowUpSize16Px = __plasmaIconsMock.ArrowUpSize16Px;
+              const IconChevronDown = __plasmaIconsMock.IconChevronDown;
+              const HomeSize24Px = __plasmaIconsMock.HomeSize24Px;
+              "
+            `);
+        });
+
+        it('handles multi-line named imports', () => {
+            const code = `import {
+                ArrowUpSize16Px,
+                IconChevronDown,
+                HomeSize24Px
+            } from '@coveord/plasma-react-icons';`;
+            const result = plugin.transform?.(code, '/test/file.tsx');
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toMatchInlineSnapshot(`
+              "import __plasmaIconsMock from '@coveord/plasma-react-icons/mock';
+              const ArrowUpSize16Px = __plasmaIconsMock.ArrowUpSize16Px;
+              const IconChevronDown = __plasmaIconsMock.IconChevronDown;
+              const HomeSize24Px = __plasmaIconsMock.HomeSize24Px;
+              "
+            `);
+        });
+
+        it('preserves the rest of the code', () => {
+            const code = `import { ArrowUpSize16Px } from '@coveord/plasma-react-icons';
+
+const MyComponent = () => {
+    return <ArrowUpSize16Px />;
+};`;
+            const result = plugin.transform?.(code, '/test/file.tsx');
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toMatchInlineSnapshot(`
+              "import __plasmaIconsMock from '@coveord/plasma-react-icons/mock';
+              const ArrowUpSize16Px = __plasmaIconsMock.ArrowUpSize16Px;
+
+
+              const MyComponent = () => {
+                  return <ArrowUpSize16Px />;
+              };"
+            `);
+        });
+
+        it('ignores type-only imports', () => {
+            const code = `import type { SomeType } from '@coveord/plasma-react-icons';`;
+            const result = plugin.transform?.(code, '/test/file.tsx');
+
+            expect(result).toBeNull();
+        });
+
+        it('handles mixed type and value imports', () => {
+            const code = `import { ArrowUpSize16Px, type IconProps } from '@coveord/plasma-react-icons';`;
+            const result = plugin.transform?.(code, '/test/file.tsx');
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toMatchInlineSnapshot(`
+              "import __plasmaIconsMock from '@coveord/plasma-react-icons/mock';
+              const ArrowUpSize16Px = __plasmaIconsMock.ArrowUpSize16Px;
+              "
+            `);
+        });
+
+        it('handles multiple import statements', () => {
+            const code = `import { ArrowUpSize16Px } from '@coveord/plasma-react-icons';
+import { IconChevronDown } from '@coveord/plasma-react-icons';`;
+            const result = plugin.transform?.(code, '/test/file.tsx');
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toMatchInlineSnapshot(`
+              "import __plasmaIconsMock from '@coveord/plasma-react-icons/mock';
+              const ArrowUpSize16Px = __plasmaIconsMock.ArrowUpSize16Px;
+              const IconChevronDown = __plasmaIconsMock.IconChevronDown;
+
+              "
+            `);
+        });
+
+        it('works with .ts files', () => {
+            const code = `import { ArrowUpSize16Px } from '@coveord/plasma-react-icons';`;
+            const result = plugin.transform?.(code, '/test/file.ts');
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toMatchInlineSnapshot(`
+              "import __plasmaIconsMock from '@coveord/plasma-react-icons/mock';
+              const ArrowUpSize16Px = __plasmaIconsMock.ArrowUpSize16Px;
+              "
+            `);
+        });
+
+        it('handles imports with single quotes', () => {
+            const code = `import { ArrowUpSize16Px } from '@coveord/plasma-react-icons';`;
+            const result = plugin.transform?.(code, '/test/file.tsx');
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toMatchInlineSnapshot(`
+              "import __plasmaIconsMock from '@coveord/plasma-react-icons/mock';
+              const ArrowUpSize16Px = __plasmaIconsMock.ArrowUpSize16Px;
+              "
+            `);
+        });
+
+        it('handles imports with double quotes', () => {
+            const code = `import { ArrowUpSize16Px } from "@coveord/plasma-react-icons";`;
+            const result = plugin.transform?.(code, '/test/file.tsx');
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toMatchInlineSnapshot(`
+              "import __plasmaIconsMock from '@coveord/plasma-react-icons/mock';
+              const ArrowUpSize16Px = __plasmaIconsMock.ArrowUpSize16Px;
+              "
+            `);
+        });
+
+        it('handles whitespace variations in imports', () => {
+            const code = `import { ArrowUpSize16Px, IconChevronDown } from '@coveord/plasma-react-icons';`;
+            const result = plugin.transform?.(code, '/test/file.tsx');
+
+            expect(result).not.toBeNull();
+            expect(result?.code).toMatchInlineSnapshot(`
+              "import __plasmaIconsMock from '@coveord/plasma-react-icons/mock';
+              const ArrowUpSize16Px = __plasmaIconsMock.ArrowUpSize16Px;
+              const IconChevronDown = __plasmaIconsMock.IconChevronDown;
+              "
+            `);
+        });
+    });
+});

--- a/packages/react-icons/src/vite-plugin/index.ts
+++ b/packages/react-icons/src/vite-plugin/index.ts
@@ -10,16 +10,22 @@ const plasmaIconsMockPlugin = () =>
         name: 'coveord/plasma-react-icons/mock',
         enforce: 'pre',
         transform: (code: string, id: string) => {
-            // Only transform relevant files (e.g., .ts, .tsx, .js, .jsx) that import from @coveord/plasma-react-icons
-            if (!code.includes('@coveord/plasma-react-icons') || !/\.(ts|tsx|js|jsx)$/.test(id)) {
+            // Only transform relevant files (e.g., .ts, .tsx, .js, .jsx) that import from @coveord/plasma-react-icons and aren't in node_modules
+            if (
+                !code.includes('@coveord/plasma-react-icons') ||
+                id.includes('/node_modules/') ||
+                !/\.(ts|tsx|js|jsx)$/.test(id)
+            ) {
                 return null;
             }
 
             // Transform named imports to default import + destructuring
-            // e.g., import { IconA, IconB } from '@coveord/plasma-react-icons'
-            // becomes: import __plasmaIcons from '@coveord/plasma-react-icons/mock'; const IconA = __plasmaIcons.IconA; const IconB = __plasmaIcons.IconB;
-            // Only match value imports, not type-only imports
-            const namedImportRegex = /import\s+(?!type\b)\{([^}]+)}\s+from\s+['"]@coveord\/plasma-react-icons['"]/g;
+            // e.g., import { ArrowUpSize16Px, IconHome } from '@coveord/plasma-react-icons'
+            // becomes:
+            // import __plasmaIcons from '@coveord/plasma-react-icons/mock';
+            // const ArrowUpSize16Px = __plasmaIcons.ArrowUpSize16Px;
+            // const IconHome = __plasmaIcons.IconHome;
+            const namedImportRegex = /import\s+(?!type\b)\{([^}]+)}\s+from\s+['"]@coveord\/plasma-react-icons['"];?/g;
 
             let transformedCode = code;
             const imports: string[] = [];
@@ -35,6 +41,7 @@ const plasmaIconsMockPlugin = () =>
                 const importedNames = match[1]
                     .split(',')
                     .map((name) => name.trim())
+                    .filter((name) => !name.startsWith('type ')) // avoid type-only imports
                     .filter((name) => name);
 
                 imports.push(...importedNames);


### PR DESCRIPTION
### Proposed Changes

This pull request introduces comprehensive improvements to the mocking and testing infrastructure for Plasma React Icons. The main changes include enhanced utilities for icon name formatting, improved mock rendering logic for icons (including Tabler icons), and robust test coverage for both the mock utilities and the Vite plugin that rewrites icon imports for testing. These updates ensure more accurate and maintainable icon mocks, better accessibility labeling, and seamless integration with the test environment.

### Icon Mocking and Rendering Enhancements
* Refactored the icon mock handler in `index.tsx` to use the new `MockUtils` for consistent label and class name formatting, and added specialized handling for Tabler icons with correct class names and display names.
* Added the `MockUtils` utility in `MockUtils.ts` for transforming icon names to camelCase labels and Tabler-compatible class names.

### Test Coverage Improvements
* Added a full test suite for `MockUtils` in `MockUtils.spec.ts`, verifying label and class name transformations for various icon name patterns.
* Added a comprehensive test suite for the icon mocks in `index.spec.tsx`, covering Plasma and Tabler icons, accessibility attributes, sizing props, and display names.

### Vite Plugin Improvements
* Enhanced the Vite plugin in `index.ts` to ignore files in `node_modules`, handle only relevant file extensions, and improve named import matching and rewriting logic. [[1]](diffhunk://#diff-17d7206a729879aa529f7a0881ca000bf9ed53f2d5a5e9f6af3dfcd902b89ceaL13-R28) [[2]](diffhunk://#diff-17d7206a729879aa529f7a0881ca000bf9ed53f2d5a5e9f6af3dfcd902b89ceaR44)
* Added a complete test suite for the Vite plugin in `index.spec.ts`, covering various import scenarios, edge cases, and ensuring correct transformation of Plasma icon imports for testing.

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
