### PR TITLE
fix(mantine): prevent undefined data passed down to react-table

### DIFF
--- a/packages/mantine/src/components/table/Table.tsx
+++ b/packages/mantine/src/components/table/Table.tsx
@@ -133,7 +133,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
     const noData = convertedChildren.find((child) => child.type === TableNoData);
 
     const table = useReactTable({
-        data,
+        data: data || [],
         state: {
             globalFilter: store.state.globalFilter,
             sorting: store.state.sorting,


### PR DESCRIPTION
### Proposed Changes

This pull request includes a minor fix to the `Table` component to ensure it works correctly when no data is provided.

* The `data` prop passed to `useReactTable` is now defaulted to an empty array if undefined, preventing potential runtime errors when `data` is not supplied.

The issue can be reproduced with a table that uses `react-query` without `keePreviousData` and that has pagination. Basically when you select a row, then switch to another page, while the query fetches the second page the data becomes undefined and the error shows up. For a reason unclear to me you have to first select a row before changing page, if you don't the error doesn't happen.

Before

https://github.com/user-attachments/assets/c474ef46-8771-4990-b618-b495551822d4

After

https://github.com/user-attachments/assets/41b7448e-4592-4802-8ac7-35fba1ab2bf5






### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
