### PR TITLE
feat(figma): code connect TextInput

### DIFF
--- a/packages/figma/src/TextInput.figma.tsx
+++ b/packages/figma/src/TextInput.figma.tsx
@@ -1,0 +1,46 @@
+import {TextInput} from '@coveord/plasma-mantine';
+import {figma} from '@figma/code-connect';
+import {ReactNode} from 'react';
+
+figma.connect(
+    TextInput,
+    'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-3.0---Components?node-id=7-50528&m=dev',
+    {
+        props: {
+            inputProps: figma.nestedProps('Input', {
+                placeholder: figma.boolean('Show Placeholder', {true: figma.string('Placeholder'), false: undefined}),
+                leftSection: figma.boolean<ReactNode, never>('Left Icon', {true: figma.instance('Swap Left')}),
+                rightSection: figma.boolean<ReactNode, never>('Right Icon', {true: figma.instance('Swap Right')}),
+                disabled: figma.enum('State', {Disabled: true}),
+                readOnly: figma.enum('State', {'Read-only': true}),
+            }),
+            labelProps: figma.boolean('Main Label', {
+                true: figma.nestedProps('Input.Label', {
+                    label: figma.boolean<ReactNode, never>('Show Label', {true: 'Label'}),
+                    description: figma.boolean<ReactNode, never>('Show Description', {true: 'Description'}),
+                    required: figma.boolean('Show Asterisk'),
+                }),
+                false: {label: undefined, description: undefined, required: false},
+            }),
+            errorProps: figma.boolean('Show Caption Error', {
+                true: figma.nestedProps('Input.Error', {
+                    error: figma.boolean<ReactNode, never>('Show Error', {true: 'Error'}),
+                }),
+                false: {error: undefined},
+            }),
+        },
+        example: ({inputProps, labelProps, errorProps}) => (
+            <TextInput
+                label={labelProps.label}
+                description={labelProps.description}
+                placeholder={inputProps.placeholder}
+                leftSection={inputProps.leftSection}
+                rightSection={inputProps.rightSection}
+                required={labelProps.required}
+                disabled={inputProps.disabled}
+                readOnly={inputProps.readOnly}
+                error={errorProps.error}
+            />
+        ),
+    },
+);


### PR DESCRIPTION
### Proposed Changes

This pull request adds Figma integration for the `TextInput` component in the Plasma design system, enabling interactive configuration of its props directly within Figma. The integration allows designers and developers to preview and adjust component states, labels, icons, and error messages from Figma's UI.

Figma integration for `TextInput`:

* Added `figma.connect` setup for the `TextInput` component, linking it to the relevant Figma design file and enabling live prop configuration for placeholder, icons, disabled/read-only states, labels, descriptions, required indicator, and error messages.
* Defined example usage to dynamically render the `TextInput` component based on selected Figma props, improving design-development collaboration and preview capabilities.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
