### PR TITLE
feat(storybook): remove arg types from docs page

### DIFF
--- a/packages/storybook/.storybook/decorators/useColorScheme.tsx
+++ b/packages/storybook/.storybook/decorators/useColorScheme.tsx
@@ -5,8 +5,8 @@ import {useEffect} from 'react';
 export const useColorScheme: Decorator = (Story, context) => {
     const {setColorScheme} = useMantineColorScheme();
     useEffect(() => {
-        setColorScheme(context.globals.colorScheme);
-    }, [context.globals.colorScheme]);
+        setColorScheme(context.globals.backgrounds.value);
+    }, [context.globals.backgrounds.value]);
 
     return <Story />;
 };

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -1,5 +1,5 @@
 import {createTheme, Plasmantine} from '@coveord/plasma-mantine';
-import {ArgTypes, Description, Stories, Subtitle, Title} from '@storybook/addon-docs/blocks';
+import {Stories, Title} from '@storybook/addon-docs/blocks';
 import type {Preview} from '@storybook/react-vite';
 import {useColorScheme} from './decorators/useColorScheme.js';
 
@@ -24,30 +24,22 @@ const preview: Preview = {
                 dynamicTitle: true,
             },
         },
-        colorScheme: {
-            description: "Color scheme applied to Mantine's theme",
-            toolbar: {
-                title: 'Color Scheme',
-                items: [
-                    {value: 'light', title: 'Light', icon: 'sun'},
-                    {value: 'dark', title: 'Dark', icon: 'moon'},
-                ],
-                dynamicTitle: true,
-            },
-        },
     },
     initialGlobals: {
         primaryColor: 'teal',
-        colorScheme: 'light',
+        backgrounds: {value: 'light'},
     },
     parameters: {
+        backgrounds: {
+            options: {
+                dark: {name: 'Dark', value: 'var(--mantine-color-body)'},
+                light: {name: 'Light', value: 'var(--mantine-color-body)'},
+            },
+        },
         docs: {
             page: () => (
                 <>
                     <Title />
-                    <Subtitle />
-                    <Description />
-                    <ArgTypes />
                     <Stories title="Examples" />
                 </>
             ),


### PR DESCRIPTION
### Proposed Changes

Two main changes:
- removed the ArgTypes table from the Docs page (this gone 👇)
  <img width="1057" height="340" alt="image" src="https://github.com/user-attachments/assets/8fb2c61a-0880-483e-ac07-e394fa772f18" />
- Changed the color scheme switching logic to reuse storybook's "backgrounds" concept:
  Before
  <img width="1132" height="508" alt="image" src="https://github.com/user-attachments/assets/cc5d8948-79d3-47ee-9758-6052a62d46c7" />
  After
  <img width="1125" height="482" alt="image" src="https://github.com/user-attachments/assets/82dec67d-bfed-4eff-9f14-5b37921b2ae7" />




### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
