### PR TITLE
feat(figma): connect Tooltip and InfoToken

### DIFF
--- a/packages/figma/src/Card.figma.tsx
+++ b/packages/figma/src/Card.figma.tsx
@@ -2,8 +2,13 @@ import {Card} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
 
 const cardsProps = {
-    state: figma.enum('State', {Default: 'Default', Hover: 'Hover', Selected: 'Selected'}),
-    children: figma.instance('Modal.ContentSwap'),
+    state: figma.enum('State', {
+        Default: 'Default',
+        Hover: 'Hover',
+        Selected: 'Selected',
+        Disabled: 'Disabled',
+    }),
+    children: figma.instance('Content Swap'),
 };
 
 figma.connect(Card, 'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-3.0---Components?node-id=7-51677', {
@@ -15,11 +20,25 @@ figma.connect(Card, 'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-
 figma.connect(Card, 'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-3.0---Components?node-id=7-51677', {
     props: cardsProps,
     variant: {State: 'Selected'},
-    example: () => <Card variant="hover" mod={{selected: true}} />,
+    example: (props) => (
+        <Card variant="hover" mod={{selected: true}}>
+            {props.children}
+        </Card>
+    ),
 });
 
 figma.connect(Card, 'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-3.0---Components?node-id=7-51677', {
     props: cardsProps,
     variant: {State: 'Hover'},
-    example: () => <Card variant="hover" mod={{selected: false}} />,
+    example: (props) => (
+        <Card variant="hover" mod={{selected: false}}>
+            {props.children}
+        </Card>
+    ),
+});
+
+figma.connect(Card, 'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-3.0---Components?node-id=7-51677', {
+    props: cardsProps,
+    variant: {State: 'Disabled'},
+    example: (props) => <Card mod={{disabled: true}}>{props.children}</Card>,
 });

--- a/packages/figma/src/InfoToken.figma.tsx
+++ b/packages/figma/src/InfoToken.figma.tsx
@@ -11,7 +11,7 @@ figma.connect(
                 Warning: 'warning',
                 Error: 'error',
                 Advice: 'advice',
-                Question: 'advice',
+                Question: 'question',
             }),
             size: figma.enum('Size', {sm: 'xs', lg: 'md'}),
         },

--- a/packages/figma/src/Tooltip.figma.tsx
+++ b/packages/figma/src/Tooltip.figma.tsx
@@ -7,12 +7,13 @@ figma.connect(
     {
         props: {
             label: figma.string('Tooltip'),
-            position: figma.enum('Tip position', {
-                Top: 'top',
-                Bottom: 'bottom',
+            position: figma.enum('Arrow Position', {
+                Top: 'bottom',
+                Bottom: 'top',
                 Left: 'right',
                 Right: 'left',
             }),
+            withArrow: figma.boolean('With Arrow'),
         },
         example: (props) => <Tooltip {...props} />,
     },


### PR DESCRIPTION
### Proposed Changes

This pull request updates Figma integration files for Plasma components by adding new component connections and simplifying the configuration of existing ones. The main focus is on improving how components are connected and previewed in Figma, as well as introducing new Plasma components for design-system documentation.

**New component integrations:**

- Added Figma connection for the `InfoToken` component, supporting variants like Information, Warning, Error, Advice, and Question, and allowing size selection.
- Added Figma connection for the `Tooltip` component, supporting customizable label and tip position properties.

**Enhancements to existing component integration:**

- Simplified the `Card` component Figma integration by:
  - Removing the `type` property and using only `state` and `children` props.
  - Updating example usages to better reflect different card states.
  - Adjusting variant configurations to focus on card state rather than type.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
