### PR TITLE
feat: component Card connection and storybook

### DIFF
--- a/packages/figma/src/Card.figma.tsx
+++ b/packages/figma/src/Card.figma.tsx
@@ -2,24 +2,43 @@ import {Card} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
 
 const cardsProps = {
-    type: figma.enum('Type', {'Table cards': 'Table cards', Container: 'Container', Table: 'Table', Action: 'Action'}),
-    state: figma.enum('State', {Default: 'Default', Hover: 'Hover', Selected: 'Selected'}),
+    state: figma.enum('State', {
+        Default: 'Default',
+        Hover: 'Hover',
+        Selected: 'Selected',
+        Disabled: 'Disabled',
+    }),
+    children: figma.instance('Content Swap'),
 };
 
 figma.connect(Card, 'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-3.0---Components?node-id=7-51677', {
     props: cardsProps,
-    variant: {Type: 'Table', State: 'Selected'},
-    example: (props) => <Card variant="hover" mod={{selected: true}} />,
+    variant: {State: 'Default'},
+    example: (props) => <Card>{props.children}</Card>,
 });
 
 figma.connect(Card, 'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-3.0---Components?node-id=7-51677', {
     props: cardsProps,
-    variant: {Type: 'Table', State: 'Hover'},
-    example: (props) => <Card variant="hover" mod={{selected: false}} />,
+    variant: {State: 'Selected'},
+    example: (props) => (
+        <Card variant="hover" mod={{selected: true}}>
+            {props.children}
+        </Card>
+    ),
 });
 
 figma.connect(Card, 'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-3.0---Components?node-id=7-51677', {
     props: cardsProps,
-    variant: {Type: 'Action'},
-    example: (props) => <Card />,
+    variant: {State: 'Hover'},
+    example: (props) => (
+        <Card variant="hover" mod={{selected: false}}>
+            {props.children}
+        </Card>
+    ),
+});
+
+figma.connect(Card, 'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-3.0---Components?node-id=7-51677', {
+    props: cardsProps,
+    variant: {State: 'Disabled'},
+    example: (props) => <Card mod={{disabled: true}}>{props.children}</Card>,
 });

--- a/packages/mantine/src/components/Card/Card.ts
+++ b/packages/mantine/src/components/Card/Card.ts
@@ -1,1 +1,5 @@
+import {Card} from '@mantine/core';
+
+Card.displayName = 'Card';
+
 export {Card, type CardFactory, type CardProps} from '@mantine/core';

--- a/packages/storybook/src/layout/Card.stories.tsx
+++ b/packages/storybook/src/layout/Card.stories.tsx
@@ -1,0 +1,75 @@
+import {Card} from '@coveord/plasma-mantine/components/Card';
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {useArgs} from 'storybook/preview-api';
+
+const meta: Meta<typeof Card> = {
+    title: '@components/layout/Card',
+    component: Card,
+    parameters: {
+        layout: 'centered',
+    },
+    args: {
+        variant: undefined,
+        disabled: false,
+        selected: false,
+    },
+    argTypes: {
+        variant: {
+            control: 'select',
+            options: [undefined, 'hover'],
+            table: {
+                defaultValue: {summary: 'Default'},
+            },
+        },
+        disabled: {
+            control: 'boolean',
+            if: {arg: 'variant', eq: 'hover'},
+            table: {
+                defaultValue: {summary: false},
+            },
+        },
+        selected: {
+            control: 'boolean',
+            if: {arg: 'variant', eq: 'hover'},
+            table: {
+                defaultValue: {summary: false},
+            },
+        },
+    },
+};
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+const PlaceholderContent = () => (
+    <div
+        style={{
+            height: 100,
+            width: 200,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: 'var(--mantine-color-blue-2)',
+        }}
+    >
+        Content
+    </div>
+);
+PlaceholderContent.displayName = 'PlaceholderContent';
+
+export const Demo: Story = {
+    render: (props: any) => {
+        const [{selected}, updateArgs] = useArgs();
+        const actionable = props.variant === 'hover';
+        const onClick = actionable
+            ? () => {
+                  updateArgs({selected: !selected});
+              }
+            : undefined;
+        const mods = actionable ? {disabled: props.disabled, selected} : undefined;
+        return (
+            <Card variant={props.variant} mod={mods} onClick={onClick}>
+                <PlaceholderContent />
+            </Card>
+        );
+    },
+};


### PR DESCRIPTION
### Proposed Changes

This pull request updates the Card component integration across Figma, Mantine, and Storybook packages to improve consistency, add new states, and enhance documentation and testing. The most important changes are:

**Card Component Enhancements and Integration:**

* Added a `Disabled` state and unified state management for the `Card` component in the Figma integration, updated example usage to support content swapping and improved variant handling.
* Created a new Storybook story for the `Card` component, showcasing its `variant`, `disabled`, and `selected` props, and providing interactive controls and a visual placeholder for content.

**Mantine Component Export Improvements:**

* Set the `displayName` for the `Card` component and ensured correct re-exporting of types and the component itself from `@mantine/core`.

Have a look at the Storybook!

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
