### PR TITLE
feat: component InfoToken connection and storybook

### DIFF
--- a/packages/figma/src/InfoToken.figma.tsx
+++ b/packages/figma/src/InfoToken.figma.tsx
@@ -1,0 +1,20 @@
+import {InfoToken} from '@coveord/plasma-mantine';
+import {figma} from '@figma/code-connect';
+
+figma.connect(
+    InfoToken,
+    'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-3.0---Components?node-id=7-50446',
+    {
+        props: {
+            variant: figma.enum('Variant', {
+                Information: 'information',
+                Warning: 'warning',
+                Error: 'error',
+                Advice: 'advice',
+                Question: 'question',
+            }),
+            size: figma.enum('Size', {sm: 'xs', lg: 'md'}),
+        },
+        example: (props) => <InfoToken {...props} />,
+    },
+);

--- a/packages/mantine/src/components/InfoToken/InfoToken.tsx
+++ b/packages/mantine/src/components/InfoToken/InfoToken.tsx
@@ -120,53 +120,56 @@ const varsResolver = createVarsResolver<InfoTokenFactory>((_theme, {variant}) =>
     };
 });
 
-export const InfoToken: ReturnType<typeof polymorphicFactory<InfoTokenFactory>> = polymorphicFactory<InfoTokenFactory>(
-    (_props, ref) => {
-        const props = useProps('InfoToken', defaultProps, _props);
-        const {variant, vars, className, style, unstyled, styles, classNames, size, ...others} = props;
-        const getStyles = useStyles<InfoTokenFactory>({
-            name: 'InfoToken',
-            classes,
-            className,
-            props,
-            style,
-            styles,
-            unstyled,
-            vars,
-            varsResolver,
-        });
-        const IconComponent = iconResolver(variant);
-        return (
-            <Box
-                ref={ref}
-                variant={variant}
-                role="img"
-                aria-label={variant}
-                size={size}
-                {...getStyles('root', {
-                    className,
-                    style,
-                    styles,
-                    classNames,
-                })}
-                {...others}
-            >
-                <IconComponent size={sizeResolver(size)} />
-            </Box>
-        );
-    },
-);
+export const InfoToken = polymorphicFactory<InfoTokenFactory>((_props, ref) => {
+    const props = useProps('InfoToken', defaultProps, _props);
+    const {variant, vars, className, style, unstyled, styles, classNames, size, ...others} = props;
+    const getStyles = useStyles<InfoTokenFactory>({
+        name: 'InfoToken',
+        classes,
+        className,
+        props,
+        style,
+        styles,
+        unstyled,
+        vars,
+        varsResolver,
+    });
+    const IconComponent = iconResolver(variant);
+    return (
+        <Box
+            ref={ref}
+            variant={variant}
+            role="img"
+            aria-label={variant}
+            size={size}
+            {...getStyles('root', {
+                className,
+                style,
+                styles,
+                classNames,
+            })}
+            {...others}
+        >
+            <IconComponent size={sizeResolver(size)} />
+        </Box>
+    );
+});
 
 const TokenInformation = InfoToken.withProps({
     variant: 'information',
 });
+(TokenInformation as typeof InfoToken).displayName = 'InfoToken.Information';
 const TokenInformationOutline = InfoToken.withProps({
     variant: 'information-outline',
 });
 const TokenAdvice = InfoToken.withProps({variant: 'advice'});
+(TokenAdvice as typeof InfoToken).displayName = 'InfoToken.Advice';
 const TokenWarning = InfoToken.withProps({variant: 'warning'});
+(TokenWarning as typeof InfoToken).displayName = 'InfoToken.Warning';
 const TokenError = InfoToken.withProps({variant: 'error'});
+(TokenError as typeof InfoToken).displayName = 'InfoToken.Error';
 const TokenQuestion = InfoToken.withProps({variant: 'question'});
+(TokenQuestion as typeof InfoToken).displayName = 'InfoToken.Question';
 
 InfoToken.Information = TokenInformation;
 InfoToken.InformationOutline = TokenInformationOutline;

--- a/packages/storybook/src/feedback/info-token/InfoToken.stories.tsx
+++ b/packages/storybook/src/feedback/info-token/InfoToken.stories.tsx
@@ -1,6 +1,5 @@
-import type {StoryObj, Meta} from '@storybook/react-vite';
 import {InfoToken} from '@coveord/plasma-mantine/components/InfoToken';
-import {Group, Stack} from '@coveord/plasma-mantine';
+import type {Meta, StoryObj} from '@storybook/react-vite';
 
 const meta: Meta<typeof InfoToken> = {
     title: '@components/feedback/InfoToken',
@@ -8,22 +7,34 @@ const meta: Meta<typeof InfoToken> = {
     parameters: {
         layout: 'centered',
     },
-    tags: ['autodocs'],
+    args: {
+        variant: 'Information',
+        size: 'xs',
+    },
+    argTypes: {
+        variant: {
+            control: 'select',
+            options: ['Information', 'Advice', 'Warning', 'Error', 'Question'],
+            table: {
+                defaultValue: {summary: 'Information'},
+            },
+        },
+        size: {
+            control: 'select',
+            options: ['xs', 'sm', 'md', 'lg', 'xl'],
+            table: {
+                defaultValue: {summary: 'xs'},
+                type: {summary: 'sm | lg'},
+            },
+        },
+    },
 };
 export default meta;
 type Story = StoryObj<typeof InfoToken>;
 
-export const Default: Story = {
-    render: () => (
-        <Stack gap="sm">
-            <Group>
-                <InfoToken.Information />
-                <InfoToken.InformationOutline />
-            </Group>
-            <InfoToken.Advice />
-            <InfoToken.Warning />
-            <InfoToken.Error />
-            <InfoToken.Question />
-        </Stack>
-    ),
+export const Demo: Story = {
+    render: ({variant, ...props}: any) => {
+        const Component = (InfoToken as any)[variant];
+        return <Component {...props} />;
+    },
 };


### PR DESCRIPTION
### Proposed Changes

This pull request improves the integration, usability, and documentation of the `InfoToken` component across Figma, Mantine, and Storybook. The main changes include adding Figma code connect integration, improving the Storybook story to support interactive controls, and enhancing the Mantine component's API and display names for better developer experience.

**Figma Integration:**

* Added a new file `InfoToken.figma.tsx` to connect the `InfoToken` component with Figma using the `@figma/code-connect` library, mapping its props and variants for design-system alignment.

**Mantine Component Enhancements:**

* Simplified the export of `InfoToken` by removing the explicit return type and assigning display names to each variant (`Information`, `Advice`, `Warning`, `Error`, `Question`) for improved debugging and documentation. [[1]](diffhunk://#diff-5687b877ea91092d7d3f7a1757bbdf991e0cdfc53ebd7abd78385cc9bd920e83L123-R123) [[2]](diffhunk://#diff-5687b877ea91092d7d3f7a1757bbdf991e0cdfc53ebd7abd78385cc9bd920e83L157-R172)

**Storybook Improvements:**

* Updated the Storybook story for `InfoToken` to provide interactive controls for `variant` and `size`, set default arguments, and replaced the static example with a dynamic demo that renders the selected variant, making the story more user-friendly and customizable.

Have a look at the storybook!

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
