### PR TITLE
feat: component Skeleton connection and storybook

### DIFF
--- a/packages/figma/src/Skeleton.figma.tsx
+++ b/packages/figma/src/Skeleton.figma.tsx
@@ -1,0 +1,29 @@
+import {Skeleton} from '@coveord/plasma-mantine';
+import {figma} from '@figma/code-connect';
+
+const props = {
+    variant: figma.enum('Variant', {
+        Default: 'default',
+        Circle: 'circle',
+        Content: 'content',
+    }),
+};
+
+figma.connect(
+    Skeleton,
+    'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-3.0---Components?node-id=2640-127&m=dev',
+    {
+        props,
+        example: () => <Skeleton height={16} width={320} />,
+    },
+);
+
+figma.connect(
+    Skeleton,
+    'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-3.0---Components?node-id=2640-127&m=dev',
+    {
+        props,
+        variant: {Variant: 'Circle'},
+        example: () => <Skeleton circle height={16} />,
+    },
+);

--- a/packages/mantine/src/components/Skeleton/Skeleton.ts
+++ b/packages/mantine/src/components/Skeleton/Skeleton.ts
@@ -1,1 +1,5 @@
+import {Skeleton} from '@mantine/core';
+
+Skeleton.displayName = 'Skeleton';
+
 export {Skeleton, type SkeletonFactory, type SkeletonProps} from '@mantine/core';

--- a/packages/storybook/src/feedback/Skeleton.stories.tsx
+++ b/packages/storybook/src/feedback/Skeleton.stories.tsx
@@ -1,0 +1,60 @@
+import {Skeleton} from '@coveord/plasma-mantine/components/Skeleton';
+import type {Meta, StoryObj} from '@storybook/react-vite';
+
+const meta: Meta<typeof Skeleton> = {
+    title: '@components/feedback/Skeleton',
+    component: Skeleton,
+    parameters: {
+        layout: 'centered',
+    },
+    args: {
+        height: 16,
+        width: 320,
+    },
+    argTypes: {
+        height: {
+            control: 'number',
+            description: 'Height of the skeleton',
+            table: {
+                type: {summary: 'number | string'},
+            },
+        },
+        width: {
+            control: 'number',
+            description: 'Width of the skeleton',
+            table: {
+                type: {summary: 'number | string'},
+            },
+        },
+        circle: {
+            control: 'boolean',
+            description: 'If true, border-radius will be set to 50%',
+            table: {
+                defaultValue: {summary: 'false'},
+                type: {summary: 'boolean'},
+            },
+        },
+        animate: {
+            control: 'boolean',
+            description: 'Determines whether skeleton should be animated',
+            table: {
+                defaultValue: {summary: 'true'},
+                type: {summary: 'boolean'},
+            },
+        },
+        visible: {
+            control: 'boolean',
+            description: 'Determines whether skeleton is visible',
+            table: {
+                defaultValue: {summary: 'true'},
+                type: {summary: 'boolean'},
+            },
+        },
+    },
+};
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+export const Demo: Story = {
+    render: (props: any) => <Skeleton {...props} />,
+};


### PR DESCRIPTION
### Proposed Changes

This pull request introduces the new `Skeleton` component from Mantine into our Plasma design system and adds related documentation and integration for Figma and Storybook. The main changes include creating the component entry point, connecting it to Figma for design handoff, and providing a Storybook story for usage documentation and testing.

Component integration and exports:

* Added a new entry point for the `Skeleton` component in `packages/mantine/src/components/Skeleton/Skeleton.ts`, setting its `displayName` and re-exporting it for use in the Plasma library.

Figma integration:

* Created a Figma connector in `packages/figma/src/Skeleton.figma.tsx` to link the `Skeleton` component with its design reference, including configurable props and example usages for both default and circle variants.

Storybook documentation:

* Added a new Storybook story in `packages/storybook/src/feedback/Skeleton.stories.tsx` that documents the `Skeleton` component, its props, and provides a demo for interactive usage and testing.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
