### PR TITLE
feat: component Textarea storybook

### DIFF
--- a/packages/figma/src/Textarea.figma.tsx
+++ b/packages/figma/src/Textarea.figma.tsx
@@ -7,14 +7,11 @@ figma.connect(
     'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasma-3.0---Components?node-id=2188-3792',
     {
         props: {
+            labelProps: figma.nestedProps('Input.Label', {
+                required: figma.boolean('Asterisk'),
+                label: figma.string('Label'),
+            }),
             wrapperProps: figma.nestedProps('Input.Wrapper', {
-                labelProps: figma.boolean('Label', {
-                    true: figma.nestedProps('Input.Label', {
-                        required: figma.boolean('Asterisk'),
-                        label: figma.string('Label'),
-                    }),
-                    false: {label: undefined, required: false},
-                }),
                 descriptionProps: figma.boolean('Description', {
                     true: figma.nestedProps('Input.Description', {
                         description: figma.string('Description'),
@@ -38,12 +35,12 @@ figma.connect(
         },
         example: (props) => (
             <Textarea
-                label={props.wrapperProps.labelProps.label}
+                label={props.labelProps.label}
                 description={props.wrapperProps.descriptionProps.description}
                 placeholder={props.inputProps.placeholder}
                 leftSection={props.inputProps.leftSection}
                 rightSection={props.inputProps.rightSection}
-                required={props.wrapperProps.labelProps.required}
+                required={props.labelProps.required}
                 disabled={props.inputProps.disabled}
                 readOnly={props.inputProps.readOnly}
                 error={props.wrapperProps.errorProps.error}

--- a/packages/storybook/src/form/Textarea.stories.tsx
+++ b/packages/storybook/src/form/Textarea.stories.tsx
@@ -1,0 +1,63 @@
+import {Textarea} from '@coveord/plasma-mantine/components/Textarea';
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {InputArgs, InputArgTypes, InputWrapperArgs, InputWrapperArgTypes} from './InputArgs.js';
+
+const meta: Meta<typeof Textarea> = {
+    title: '@components/form/Textarea',
+    component: Textarea,
+    parameters: {
+        layout: 'centered',
+    },
+    args: {
+        ...InputWrapperArgs,
+        ...InputArgs,
+    },
+    argTypes: {
+        ...InputWrapperArgTypes,
+        ...InputArgTypes,
+        rows: {
+            control: 'number',
+            description: 'Number of visible text lines',
+            table: {
+                type: {summary: 'number'},
+            },
+        },
+        autosize: {
+            control: 'boolean',
+            description: 'Autosize textarea to fit content',
+            table: {
+                defaultValue: {summary: 'false'},
+                type: {summary: 'boolean'},
+            },
+        },
+        minRows: {
+            control: 'number',
+            description: 'Minimum number of rows (when autosize is true)',
+            table: {
+                type: {summary: 'number'},
+            },
+        },
+        maxRows: {
+            control: 'number',
+            description: 'Maximum number of rows (when autosize is true)',
+            table: {
+                type: {summary: 'number'},
+            },
+        },
+        resize: {
+            control: 'select',
+            options: ['none', 'both', 'horizontal', 'vertical'],
+            description: 'CSS resize property',
+            table: {
+                defaultValue: {summary: "'both'"},
+                type: {summary: "'none' | 'both' | 'horizontal' | 'vertical'"},
+            },
+        },
+    },
+};
+export default meta;
+type Story = StoryObj<typeof Textarea>;
+
+export const Demo: Story = {
+    render: (props: any) => <Textarea {...props} />,
+};


### PR DESCRIPTION
### Proposed Changes

This pull request introduces a new `Textarea` component to the Plasma Mantine package and adds corresponding Storybook documentation for it. The changes ensure the component is properly exported and available for use, and provide a comprehensive Storybook setup with customizable controls for its props.

Component addition and export:

* Added and exported the `Textarea` component in `packages/mantine/src/components/Textarea/Textarea.ts`, ensuring it is available for import from the Plasma Mantine package.

Storybook documentation:

* Created a new Storybook story in `packages/storybook/src/form/Textarea.stories.tsx` for the `Textarea` component, including detailed controls and descriptions for its props such as `placeholder`, `disabled`, `rows`, `autosize`, `minRows`, `maxRows`, and `resize`, to facilitate interactive documentation and testing.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
