### PR TITLE
fix(modal): set body as the scroll container

### DIFF
--- a/packages/mantine/src/components/Modal/ModalFooter.module.css
+++ b/packages/mantine/src/components/Modal/ModalFooter.module.css
@@ -2,6 +2,7 @@
     .root {
         margin: calc(-1 * var(--mb-padding));
         margin-top: var(--mb-padding);
+        bottom: calc(-1 * var(--mb-padding));
     }
 }
 

--- a/packages/mantine/src/components/Prompt/Prompt.tsx
+++ b/packages/mantine/src/components/Prompt/Prompt.tsx
@@ -1,5 +1,4 @@
 import {
-    Box,
     factory,
     Factory,
     ModalRootProps,
@@ -114,9 +113,9 @@ const _Prompt = factory<PromptFactory>((_props, ref) => {
                         <Modal.CloseButton {...getStyles('close', stylesApiProps)} />
                     </Modal.Header>
                     <Modal.Body {...getStyles('body', stylesApiProps)}>
-                        <Box {...getStyles('inner', stylesApiProps)}>{otherChildren}</Box>
+                        {otherChildren}
+                        {footers}
                     </Modal.Body>
-                    {footers}
                 </Modal.Content>
             </Modal.Root>
         </PromptContextProvider>

--- a/packages/mantine/src/styles/Modal.module.css
+++ b/packages/mantine/src/styles/Modal.module.css
@@ -4,8 +4,21 @@
 
 .header {
     gap: var(--mantine-spacing-sm);
+    min-height: unset;
 }
 
 .close {
     align-self: flex-start;
+}
+
+.content {
+    overflow-y: initial;
+    display: flex;
+    flex-direction: column;
+}
+
+.body {
+    overflow-y: scroll;
+    border-end-start-radius: var(--modal-radius, var(--mantine-radius-default));
+    border-end-end-radius: var(--modal-radius, var(--mantine-radius-default));
 }

--- a/packages/storybook/src/layout/Modal.stories.tsx
+++ b/packages/storybook/src/layout/Modal.stories.tsx
@@ -1,7 +1,8 @@
-import {Button, Tabs} from '@coveord/plasma-mantine';
+import {Button, createColumnHelper, Table, Tabs, useTable} from '@coveord/plasma-mantine';
 import {Modal} from '@coveord/plasma-mantine/components/Modal';
+import {faker} from '@faker-js/faker';
 import type {Meta, StoryObj} from '@storybook/react-vite';
-import type {ComponentProps} from 'react';
+import {useMemo, type ComponentProps} from 'react';
 import {useArgs} from 'storybook/preview-api';
 
 type ModalStoryArgs = ComponentProps<typeof Modal> & {
@@ -82,6 +83,66 @@ export const ModalWithTabs: Story = {
                     <Tabs.Panel value="tab-2">Tab 2 content</Tabs.Panel>
                     <Tabs.Panel value="tab-3">Tab 3 content</Tabs.Panel>
                 </Tabs>
+                <Modal.Footer>
+                    <Button.Tertiary onClick={close}>Cancel</Button.Tertiary>
+                    <Button.Primary onClick={close}>Save</Button.Primary>
+                </Modal.Footer>
+            </Modal>
+        );
+    },
+};
+
+type Person = {
+    id: string;
+    firstName: string;
+    lastName: string;
+    age: number;
+};
+
+const columnHelper = createColumnHelper<Person>();
+const columns = [
+    columnHelper.accessor('firstName', {
+        header: 'First name',
+    }),
+    columnHelper.accessor('lastName', {
+        header: 'Last name',
+    }),
+    columnHelper.accessor('age', {
+        header: 'Age',
+    }),
+];
+const makeData = (len: number): Person[] =>
+    Array(len)
+        .fill(0)
+        .map(() => ({
+            id: faker.string.uuid(),
+            firstName: faker.person.firstName(),
+            lastName: faker.person.lastName(),
+            age: faker.number.int(40),
+        }));
+
+export const ModalWithTable: Story = {
+    render: (args) => {
+        const [{opened}, updateArgs] = useArgs<ModalStoryArgs>();
+        const close = () => updateArgs({opened: false});
+        const data = useMemo(() => makeData(20), []);
+
+        const table = useTable<Person>({
+            initialState: {
+                totalEntries: data.length,
+            },
+        });
+        return (
+            <Modal
+                size={args.size}
+                centered={args.centered}
+                opened={opened}
+                title={args.title}
+                description={args.description}
+                help={args.helpLabel || args.helpHref ? {href: args.helpHref, label: args.helpLabel} : undefined}
+                onClose={close}
+            >
+                <Table<Person> store={table} columns={columns} getRowId={({id}) => id.toString()} data={data} />
                 <Modal.Footer>
                     <Button.Tertiary onClick={close}>Cancel</Button.Tertiary>
                     <Button.Primary onClick={close}>Save</Button.Primary>


### PR DESCRIPTION
### Proposed Changes

Changed the modal style a bit so that the modal body (excludes the header) becomes the scroll container rather than the whole modal content (including the header). Since the modal header is always sticky, Mantine's default style of scrolling the whole modal content is problematic.

##### Before

https://github.com/user-attachments/assets/ebd50cc7-346d-4d7c-9fe7-376eb444a3a3

##### After

https://github.com/user-attachments/assets/43cc4bb2-45ca-4828-8a18-db699b55bfed

[Demo link](https://plasma.coveo.com/feature/ADUI-11393-fix-modal-body-scroll/?path=/story/modal--modal-with-table)

### Potential Breaking Changes

None expected, review modals implementation with custom style.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
