### PR TITLE
fix(prompt): add back ref prop to PromptCompoundComponent

### DIFF
--- a/packages/mantine/src/components/LastUpdated/LastUpdated.tsx
+++ b/packages/mantine/src/components/LastUpdated/LastUpdated.tsx
@@ -1,6 +1,6 @@
 import {BoxProps, factory, Factory, Group, GroupProps, StylesApiProps, Text, useProps, useStyles} from '@mantine/core';
 import dayjs from 'dayjs';
-import React from 'react';
+import {ForwardedRef} from 'react';
 
 export type LastUpdatedStylesNames = 'root' | 'label';
 
@@ -35,43 +35,41 @@ const defaultProps: Partial<LastUpdatedProps> = {
     formatter: (time) => dayjs(time).format('h:mm:ss A'),
 };
 
-export const LastUpdated = factory<LastUpdatedFactory>(
-    (props: LastUpdatedProps, ref: React.ForwardedRef<HTMLDivElement>) => {
-        const {formatter, label, time, classNames, className, styles, style, vars, unstyled, ...others} = useProps(
-            'PlasmaLastUpdated',
-            defaultProps as Partial<LastUpdatedProps>,
-            props,
-        );
+export const LastUpdated = factory<LastUpdatedFactory>((props: LastUpdatedProps, ref: ForwardedRef<HTMLDivElement>) => {
+    const {formatter, label, time, classNames, className, styles, style, vars, unstyled, ...others} = useProps(
+        'PlasmaLastUpdated',
+        defaultProps as Partial<LastUpdatedProps>,
+        props,
+    );
 
-        const resolvedTime = time ?? dayjs().valueOf();
+    const resolvedTime = time ?? dayjs().valueOf();
 
-        const getStyles = useStyles<LastUpdatedFactory>({
-            name: 'LastUpdated',
-            classes: {},
-            props,
-            className,
-            style,
-            classNames,
-            styles,
-            unstyled,
-            vars,
-        });
-        const stylesApiProps = {classNames, styles};
+    const getStyles = useStyles<LastUpdatedFactory>({
+        name: 'LastUpdated',
+        classes: {},
+        props,
+        className,
+        style,
+        classNames,
+        styles,
+        unstyled,
+        vars,
+    });
+    const stylesApiProps = {classNames, styles};
 
-        return (
-            <Group
-                justify={props.justify}
-                ref={ref}
-                {...getStyles('root', {className, style, ...stylesApiProps})}
-                {...others}
-            >
-                <Text size="xs" {...getStyles('label', {className, style, ...stylesApiProps})}>
-                    {label}
-                    <span role="timer">{formatter(resolvedTime)}</span>
-                </Text>
-            </Group>
-        );
-    },
-);
+    return (
+        <Group
+            justify={props.justify}
+            ref={ref}
+            {...getStyles('root', {className, style, ...stylesApiProps})}
+            {...others}
+        >
+            <Text size="xs" {...getStyles('label', {className, style, ...stylesApiProps})}>
+                {label}
+                <span role="timer">{formatter(resolvedTime)}</span>
+            </Text>
+        </Group>
+    );
+});
 
 LastUpdated.displayName = 'LastUpdated';

--- a/packages/mantine/src/components/Prompt/Prompt.tsx
+++ b/packages/mantine/src/components/Prompt/Prompt.tsx
@@ -8,7 +8,16 @@ import {
     useProps,
     useStyles,
 } from '@mantine/core';
-import {Children, ComponentProps, ComponentType, forwardRef, FunctionComponent, ReactElement, ReactNode} from 'react';
+import {
+    Children,
+    ComponentProps,
+    ComponentType,
+    forwardRef,
+    ForwardRefExoticComponent,
+    ReactElement,
+    ReactNode,
+    RefAttributes,
+} from 'react';
 import {InfoToken} from '../InfoToken/InfoToken.js';
 import {Modal} from '../Modal/Modal.js';
 import {PromptContextProvider} from './Prompt.context.js';
@@ -123,12 +132,12 @@ const _Prompt = factory<PromptFactory>((_props, ref) => {
 });
 _Prompt.displayName = 'Prompt';
 
-type PromptCompoundComponent = ((props: PromptProps) => ReactElement) & Omit<FunctionComponent<PromptProps>, never>;
+type PromptCompoundComponent = ForwardRefExoticComponent<PromptProps & RefAttributes<HTMLDivElement>>;
 
 const PromptFooter: ComponentType<ComponentProps<typeof Modal.Footer>> = (props) => <Modal.Footer {...props} />;
 PromptFooter.displayName = 'Prompt.Footer';
 
-const createPromptCompound = (variant: PromptVariant, displayName: string): PromptCompoundComponent => {
+const createPromptCompound = (variant: PromptVariant, displayName: string) => {
     const Component = forwardRef<HTMLDivElement, PromptProps>((props, ref) => (
         <_Prompt ref={ref} {...props} variant={variant} />
     ));


### PR DESCRIPTION
### Proposed Changes

Fixing this type error:

<img width="876" height="174" alt="image" src="https://github.com/user-attachments/assets/daddf8d8-a93e-4ec5-bf08-d6d303287dd9" />

The latest breaking changed made to Prompt were missing the ref prop on the compound components.


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
