### PR TITLE
feat(infotoken): +xl size

### DIFF
--- a/packages/mantine/src/components/InfoToken/InfoToken.tsx
+++ b/packages/mantine/src/components/InfoToken/InfoToken.tsx
@@ -33,7 +33,7 @@ export type InfoTokenFactory = Factory<{
 export type InfoTokenComponentStylesNames = 'root';
 export type InfoTokenType = 'information' | 'advice' | 'warning' | 'error' | 'question' | 'success';
 export type InfoTokenVariant = 'outline' | 'light';
-export type InfoTokenSizes = 'xs' | 'sm' | 'md' | 'lg';
+export type InfoTokenSizes = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export type InfoTokenCssVariables = {
     root: '--it-color' | '--it-bg';
 };
@@ -103,14 +103,16 @@ const bgColorResolver = (type: InfoTokenType): string => {
 const sizeResolver = (size: InfoTokenSizes): number => {
     switch (size) {
         case 'sm':
-            return 20;
+            return 16;
         case 'md':
-            return 24;
+            return 20;
         case 'lg':
+            return 24;
+        case 'xl':
             return 32;
         case 'xs':
         default:
-            return 16;
+            return 12;
     }
 };
 

--- a/packages/storybook/src/feedback/InfoToken.stories.tsx
+++ b/packages/storybook/src/feedback/InfoToken.stories.tsx
@@ -36,10 +36,10 @@ const meta: Meta<InfoTokenStoryArgs> = {
         },
         size: {
             control: 'select',
-            options: ['xs', 'sm', 'md', 'lg'],
+            options: ['xs', 'sm', 'md', 'lg', 'xl'],
             table: {
                 defaultValue: {summary: 'xs'},
-                type: {summary: 'sm | lg'},
+                type: {summary: 'sm | xl'},
             },
         },
     },


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->

This PR adds back the `xl` size of the `InfoToken` component and makes some changes of values for each sizes. It adjusted the storybook demo too

Before:

- xs : 16px
- sm: 20px
- md: 24px
- lg: 32px

<img width="611" height="224" alt="image" src="https://github.com/user-attachments/assets/6a487e51-0136-4bfe-afb0-c6b72bbf30df" />


After:

- xs: 12px
- sm: 16px
- md: 20px
- lg: 24px
- xl: 32px

<img width="885" height="264" alt="image" src="https://github.com/user-attachments/assets/d877f507-6fba-45eb-9f6c-5edae352c5e6" />


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
