### PR TITLE
feat(alert): +Success variant, +border

### DIFF
--- a/packages/mantine/src/components/Alert/Alert.tsx
+++ b/packages/mantine/src/components/Alert/Alert.tsx
@@ -22,6 +22,7 @@ type AlertOverloadFactory = Factory<{
         Advice: typeof AlertAdvice;
         Warning: typeof AlertWarning;
         Critical: typeof AlertCritical;
+        Success: typeof AlertSuccess;
     };
 }>;
 
@@ -30,45 +31,61 @@ Alert.displayName = 'Alert';
 
 const AlertInformation = Alert.withProps({
     color: 'gray',
-    icon: <InfoToken.Information />,
+    icon: <InfoToken.Information size="lg" />,
     vars: () => ({
         root: {
             '--alert-color': 'var(--mantine-color-text)',
             '--alert-bg': 'var(--mantine-color-gray-light)',
+            '--alert-bd': '2px solid var(--mantine-color-gray-light)',
         },
     }),
 });
 (AlertInformation as ComponentType).displayName = 'Alert.Information';
 
 const AlertAdvice = Alert.withProps({
-    icon: <InfoToken.Advice />,
+    icon: <InfoToken.Advice size="lg" />,
     vars: () => ({
         root: {
             '--alert-color': 'var(--mantine-primary-color-filled)',
             '--alert-bg': 'var(--mantine-primary-color-light)',
+            '--alert-bd': '2px solid var(--mantine-primary-color-light)',
         },
     }),
 });
 (AlertAdvice as ComponentType).displayName = 'Alert.Advice';
 
+const AlertSuccess = Alert.withProps({
+    icon: <InfoToken.Success size="lg" />,
+    vars: () => ({
+        root: {
+            '--alert-color': 'var(--mantine-color-green-filled)',
+            '--alert-bg': 'var(--mantine-color-green-light)',
+            '--alert-bd': '2px solid var(--mantine-color-green-light)',
+        },
+    }),
+});
+(AlertSuccess as ComponentType).displayName = 'Alert.Success';
+
 const AlertWarning = Alert.withProps({
     color: 'warning',
-    icon: <InfoToken.Warning />,
+    icon: <InfoToken.Warning size="lg" />,
     vars: () => ({
         root: {
             '--alert-color': 'var(--mantine-color-warning-filled)',
             '--alert-bg': 'var(--mantine-color-warning-light)',
+            '--alert-bd': '2px solid var(--mantine-color-warning-light)',
         },
     }),
 });
 (AlertWarning as ComponentType).displayName = 'Alert.Warning';
 
 const AlertCritical = Alert.withProps({
-    icon: <InfoToken.Error />,
+    icon: <InfoToken.Error size="lg" />,
     vars: () => ({
         root: {
             '--alert-color': 'var(--mantine-color-error)',
             '--alert-bg': 'var(--mantine-color-red-light)',
+            '--alert-bd': '2px solid var(--mantine-color-red-light)',
         },
     }),
 });
@@ -78,3 +95,4 @@ Alert.Information = AlertInformation;
 Alert.Advice = AlertAdvice;
 Alert.Warning = AlertWarning;
 Alert.Critical = AlertCritical;
+Alert.Success = AlertSuccess;

--- a/packages/mantine/src/components/Alert/Alert.tsx
+++ b/packages/mantine/src/components/Alert/Alert.tsx
@@ -71,9 +71,9 @@ const AlertWarning = Alert.withProps({
     icon: <InfoToken.Warning size="md" />,
     vars: () => ({
         root: {
-            '--alert-color': 'var(--mantine-color-warning-filled)',
-            '--alert-bg': 'var(--mantine-color-warning-light)',
-            '--alert-bd': '2px solid var(--mantine-color-warning-light)',
+            '--alert-color': 'var(--mantine-color-yellow-text)',
+            '--alert-bg': 'var(--mantine-color-yellow-light)',
+            '--alert-bd': '2px solid var(--mantine-color-yellow-light)',
         },
     }),
 });

--- a/packages/mantine/src/components/Alert/Alert.tsx
+++ b/packages/mantine/src/components/Alert/Alert.tsx
@@ -31,7 +31,7 @@ Alert.displayName = 'Alert';
 
 const AlertInformation = Alert.withProps({
     color: 'gray',
-    icon: <InfoToken.Information size="lg" />,
+    icon: <InfoToken.Information size="md" />,
     vars: () => ({
         root: {
             '--alert-color': 'var(--mantine-color-text)',
@@ -43,7 +43,7 @@ const AlertInformation = Alert.withProps({
 (AlertInformation as ComponentType).displayName = 'Alert.Information';
 
 const AlertAdvice = Alert.withProps({
-    icon: <InfoToken.Advice size="lg" />,
+    icon: <InfoToken.Advice size="md" />,
     vars: () => ({
         root: {
             '--alert-color': 'var(--mantine-primary-color-filled)',
@@ -55,7 +55,7 @@ const AlertAdvice = Alert.withProps({
 (AlertAdvice as ComponentType).displayName = 'Alert.Advice';
 
 const AlertSuccess = Alert.withProps({
-    icon: <InfoToken.Success size="lg" />,
+    icon: <InfoToken.Success size="md" />,
     vars: () => ({
         root: {
             '--alert-color': 'var(--mantine-color-green-filled)',
@@ -68,7 +68,7 @@ const AlertSuccess = Alert.withProps({
 
 const AlertWarning = Alert.withProps({
     color: 'warning',
-    icon: <InfoToken.Warning size="lg" />,
+    icon: <InfoToken.Warning size="md" />,
     vars: () => ({
         root: {
             '--alert-color': 'var(--mantine-color-warning-filled)',
@@ -80,7 +80,7 @@ const AlertWarning = Alert.withProps({
 (AlertWarning as ComponentType).displayName = 'Alert.Warning';
 
 const AlertCritical = Alert.withProps({
-    icon: <InfoToken.Error size="lg" />,
+    icon: <InfoToken.Error size="md" />,
     vars: () => ({
         root: {
             '--alert-color': 'var(--mantine-color-error)',

--- a/packages/mantine/src/styles/Alert.module.css
+++ b/packages/mantine/src/styles/Alert.module.css
@@ -2,9 +2,25 @@
     font-weight: var(--coveo-fw-bold);
 }
 
+.label {
+    color: var(--mantine-color-text);
+}
+
+.wrapper {
+    gap: var(--mantine-spacing-sm);
+}
+
+.icon {
+    margin-inline-end: 0;
+    margin-top: 0;
+    width: 24px;
+    height: 24px;
+}
+
+.body {
+    gap: var(--mantine-spacing-xxs);
+}
+
 .closeButton {
-    & svg {
-        width: 20px;
-        height: 20px;
-    }
+    color: var(--mantine-color-text);
 }

--- a/packages/mantine/src/styles/Alert.module.css
+++ b/packages/mantine/src/styles/Alert.module.css
@@ -2,10 +2,6 @@
     font-weight: var(--coveo-fw-bold);
 }
 
-.icon {
-    margin-inline-end: var(--mantine-spacing-sm);
-}
-
 .closeButton {
     & svg {
         width: 20px;

--- a/packages/mantine/src/styles/Alert.module.css
+++ b/packages/mantine/src/styles/Alert.module.css
@@ -13,8 +13,8 @@
 .icon {
     margin-inline-end: 0;
     margin-top: 0;
-    width: 24px;
-    height: 24px;
+    width: var(--mantine-spacing-md);
+    height: var(--mantine-spacing-md);
 }
 
 .body {

--- a/packages/storybook/src/feedback/Alert.stories.tsx
+++ b/packages/storybook/src/feedback/Alert.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Alert> = {
     argTypes: {
         variant: {
             control: 'select',
-            options: ['Advice', 'Critical', 'Information', 'Warning'],
+            options: ['Advice', 'Critical', 'Information', 'Warning', 'Success'],
             table: {
                 defaultValue: {summary: 'Alert.Information'},
             },


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->

This PR adds a new `Success` variant, changed the InfoToken size to `large` and adds a border to the `Alert`. Also minor fix to the margin of the icon so it's less _clustered_

New Success Variant:

<img width="925" height="183" alt="image" src="https://github.com/user-attachments/assets/f8122a20-1d92-4d10-b631-b4edee7f4b33" />

Before

<img width="705" height="144" alt="image" src="https://github.com/user-attachments/assets/385f5d6e-2e28-468d-b06f-f2b61b5b4176" />

After

<img width="734" height="182" alt="image" src="https://github.com/user-attachments/assets/b9bdd639-57c4-4459-a5b7-1169ea04421e" />

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
