### PR TITLE
feat(header): header actions gap from 16 to 8 px

### DIFF
--- a/packages/mantine/src/components/Header/HeaderRight/HeaderRight.tsx
+++ b/packages/mantine/src/components/Header/HeaderRight/HeaderRight.tsx
@@ -19,7 +19,7 @@ export type HeaderRightFactory = Factory<{
 }>;
 
 const defaultProps: Partial<HeaderRightProps> = {
-    gap: 'sm',
+    gap: 'xs',
 };
 
 export const HeaderRight = factory<HeaderRightFactory>((_props, ref) => {


### PR DESCRIPTION
### Proposed Changes

Changed the `gap` between `Header Actions` from `16px -> 8px`

Before:

<img width="681" height="154" alt="image" src="https://github.com/user-attachments/assets/a04745b2-afae-4da6-bcaf-5454060439d0" />

After

<img width="690" height="152" alt="image" src="https://github.com/user-attachments/assets/c4c1901d-c6f5-42fd-97f2-94fe7eab2f6a" />

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
