### PR TITLE
feat: upgrade monorepo to strict type check

### DIFF
--- a/packages/components-props-analyzer/tsconfig.json
+++ b/packages/components-props-analyzer/tsconfig.json
@@ -1,3 +1,6 @@
 {
-    "extends": "../tsconfig-base.json"
+    "extends": "../tsconfig-base.json",
+    "compilerOptions": {
+        "strict": false
+    }
 }

--- a/packages/figma/src/Alert.figma.tsx
+++ b/packages/figma/src/Alert.figma.tsx
@@ -1,5 +1,6 @@
 import {Alert, Text} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
+import type {ReactElement} from 'react';
 
 figma.connect(
     Alert.Information,
@@ -9,11 +10,11 @@ figma.connect(
         props: {
             message: figma.textContent('Message'),
             withCloseButton: figma.boolean('Show CloseButton'),
-            title: figma.boolean('Show Title', {
+            title: figma.boolean<string, undefined>('Show Title', {
                 true: figma.textContent('Title'),
             }),
-            contentSwap: figma.boolean('Show ContentSwap', {
-                true: figma.instance('Instance'),
+            contentSwap: figma.boolean<ReactElement, undefined>('Show ContentSwap', {
+                true: figma.instance<ReactElement>('Instance'),
             }),
         },
         example: ({withCloseButton, title, contentSwap, message}) => (
@@ -33,11 +34,11 @@ figma.connect(
         props: {
             message: figma.textContent('Message'),
             withCloseButton: figma.boolean('Show CloseButton'),
-            title: figma.boolean('Show Title', {
+            title: figma.boolean<string, undefined>('Show Title', {
                 true: figma.textContent('Title'),
             }),
-            contentSwap: figma.boolean('Show ContentSwap', {
-                true: figma.instance('Instance'),
+            contentSwap: figma.boolean<ReactElement, undefined>('Show ContentSwap', {
+                true: figma.instance<ReactElement>('Instance'),
             }),
         },
         example: ({withCloseButton, title, contentSwap, message}) => (
@@ -57,11 +58,11 @@ figma.connect(
         props: {
             message: figma.textContent('Message'),
             withCloseButton: figma.boolean('Show CloseButton'),
-            title: figma.boolean('Show Title', {
+            title: figma.boolean<string, undefined>('Show Title', {
                 true: figma.textContent('Title'),
             }),
-            contentSwap: figma.boolean('Show ContentSwap', {
-                true: figma.instance('Instance'),
+            contentSwap: figma.boolean<ReactElement, undefined>('Show ContentSwap', {
+                true: figma.instance<ReactElement>('Instance'),
             }),
         },
         example: ({withCloseButton, title, contentSwap, message}) => (
@@ -81,11 +82,11 @@ figma.connect(
         props: {
             message: figma.textContent('Message'),
             withCloseButton: figma.boolean('Show CloseButton'),
-            title: figma.boolean('Show Title', {
+            title: figma.boolean<string, undefined>('Show Title', {
                 true: figma.textContent('Title'),
             }),
-            contentSwap: figma.boolean('Show ContentSwap', {
-                true: figma.instance('Instance'),
+            contentSwap: figma.boolean<ReactElement, undefined>('Show ContentSwap', {
+                true: figma.instance<ReactElement>('Instance'),
             }),
         },
         example: ({withCloseButton, title, contentSwap, message}) => (

--- a/packages/figma/src/Badge.figma.tsx
+++ b/packages/figma/src/Badge.figma.tsx
@@ -1,16 +1,17 @@
 import {Badge} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
+import type {ReactElement} from 'react';
 
 const badgeProps = {
     size: figma.enum('Size', {
         Small: 'small',
         Large: 'large',
     }),
-    leftSection: figma.boolean('LeftSection', {
-        true: figma.instance('Swap Left'),
+    leftSection: figma.boolean<ReactElement, undefined>('LeftSection', {
+        true: figma.instance<ReactElement>('Swap Left'),
     }),
-    rightSection: figma.boolean('RightSection', {
-        true: figma.instance('Swap Right'),
+    rightSection: figma.boolean<ReactElement, undefined>('RightSection', {
+        true: figma.instance<ReactElement>('Swap Right'),
     }),
     placeholder: figma.string('Placeholder'),
 };

--- a/packages/figma/src/Button.figma.tsx
+++ b/packages/figma/src/Button.figma.tsx
@@ -1,12 +1,13 @@
 import {Button} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
+import type {ReactElement} from 'react';
 
 const buttonProps = {
-    leftSection: figma.boolean('Left Section', {
-        true: figma.instance('Swap Left'),
+    leftSection: figma.boolean<ReactElement, undefined>('Left Section', {
+        true: figma.instance<ReactElement>('Swap Left'),
     }),
-    rightSection: figma.boolean('Right Section', {
-        true: figma.instance('Swap Right'),
+    rightSection: figma.boolean<ReactElement, undefined>('Right Section', {
+        true: figma.instance<ReactElement>('Swap Right'),
     }),
     placeholder: figma.string('Placeholder'),
     disabled: figma.enum('State', {

--- a/packages/figma/src/DatePickerInput.figma.tsx
+++ b/packages/figma/src/DatePickerInput.figma.tsx
@@ -1,6 +1,6 @@
 import {DatePickerInput} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
-import {ReactNode} from 'react';
+import type {ReactElement} from 'react';
 
 figma.connect(
     DatePickerInput,
@@ -27,8 +27,12 @@ figma.connect(
             }),
             inputProps: figma.nestedProps('.Input.Input', {
                 placeholder: figma.boolean('Placeholder', {true: figma.string('Text'), false: undefined}),
-                leftSection: figma.boolean<ReactNode, never>('Left Section', {true: figma.instance('Swap Left')}),
-                rightSection: figma.boolean<ReactNode, never>('Right Section', {true: figma.instance('Swap Right')}),
+                leftSection: figma.boolean<ReactElement, undefined>('Left Section', {
+                    true: figma.instance<ReactElement>('Swap Left'),
+                }),
+                rightSection: figma.boolean<ReactElement, undefined>('Right Section', {
+                    true: figma.instance<ReactElement>('Swap Right'),
+                }),
                 disabled: figma.enum('State', {Disabled: true}),
                 readOnly: figma.enum('State', {'Read-only': true}),
             }),

--- a/packages/figma/src/MonthPickerInput.figma.tsx
+++ b/packages/figma/src/MonthPickerInput.figma.tsx
@@ -1,6 +1,6 @@
 import {MonthPickerInput} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
-import {ReactNode} from 'react';
+import type {ReactElement} from 'react';
 
 figma.connect(
     MonthPickerInput,
@@ -27,8 +27,12 @@ figma.connect(
             }),
             inputProps: figma.nestedProps('.Input.Input', {
                 placeholder: figma.boolean('Placeholder', {true: figma.string('Text'), false: undefined}),
-                leftSection: figma.boolean<ReactNode, never>('Left Section', {true: figma.instance('Swap Left')}),
-                rightSection: figma.boolean<ReactNode, never>('Right Section', {true: figma.instance('Swap Right')}),
+                leftSection: figma.boolean<ReactElement, undefined>('Left Section', {
+                    true: figma.instance<ReactElement>('Swap Left'),
+                }),
+                rightSection: figma.boolean<ReactElement, undefined>('Right Section', {
+                    true: figma.instance<ReactElement>('Swap Right'),
+                }),
                 disabled: figma.enum('State', {Disabled: true}),
                 readOnly: figma.enum('State', {'Read-only': true}),
             }),

--- a/packages/figma/src/NavLink.figma.tsx
+++ b/packages/figma/src/NavLink.figma.tsx
@@ -1,5 +1,6 @@
 import {NavLink} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
+import type {ReactElement} from 'react';
 
 figma.connect(
     NavLink,
@@ -10,11 +11,11 @@ figma.connect(
             disabled: figma.enum('State', {
                 Disabled: true,
             }),
-            rightSection: figma.boolean<React.ReactNode, never>('Right Section', {
-                true: figma.instance('Swap Right'),
+            rightSection: figma.boolean<ReactElement, undefined>('Right Section', {
+                true: figma.instance<ReactElement>('Swap Right'),
             }),
-            leftSection: figma.boolean<React.ReactNode, never>('Left Section', {
-                true: figma.instance('Swap Left'),
+            leftSection: figma.boolean<ReactElement, undefined>('Left Section', {
+                true: figma.instance<ReactElement>('Swap Left'),
             }),
             active: figma.enum('State', {
                 Active: true,

--- a/packages/figma/src/NumberInput.figma.tsx
+++ b/packages/figma/src/NumberInput.figma.tsx
@@ -1,6 +1,6 @@
 import {NumberInput} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
-import {type ReactNode} from 'react';
+import type {ReactElement} from 'react';
 
 figma.connect(
     NumberInput,
@@ -27,7 +27,9 @@ figma.connect(
             }),
             inputProps: figma.nestedProps('.NumberInput.Input', {
                 placeholder: figma.boolean('Placeholder', {true: figma.textContent('0'), false: undefined}),
-                leftSection: figma.boolean<ReactNode, never>('Left Section', {true: figma.instance('Swap Left')}),
+                leftSection: figma.boolean<ReactElement, undefined>('Left Section', {
+                    true: figma.instance<ReactElement>('Swap Left'),
+                }),
                 disabled: figma.enum('State', {Disabled: true}),
                 readOnly: figma.enum('State', {'Read-only': true}),
             }),

--- a/packages/figma/src/PillsInput.figma.tsx
+++ b/packages/figma/src/PillsInput.figma.tsx
@@ -1,6 +1,6 @@
 import {Pill, PillsInput} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
-import {type ReactNode} from 'react';
+import type {ReactElement} from 'react';
 
 figma.connect(
     PillsInput,
@@ -27,8 +27,12 @@ figma.connect(
             }),
 
             inputProps: figma.nestedProps('.PillsInput.Input', {
-                leftSection: figma.boolean<ReactNode, never>('Left Section', {true: figma.instance('Swap Left')}),
-                rightSection: figma.boolean<ReactNode, never>('Right Section', {true: figma.instance('Swap Right')}),
+                leftSection: figma.boolean<ReactElement, undefined>('Left Section', {
+                    true: figma.instance<ReactElement>('Swap Left'),
+                }),
+                rightSection: figma.boolean<ReactElement, undefined>('Right Section', {
+                    true: figma.instance<ReactElement>('Swap Right'),
+                }),
                 disabled: figma.enum('State', {Disabled: true}),
                 readOnly: figma.enum('State', {'Read-only': true}),
             }),

--- a/packages/figma/src/TextInput.figma.tsx
+++ b/packages/figma/src/TextInput.figma.tsx
@@ -1,6 +1,6 @@
 import {TextInput} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
-import {type ReactNode} from 'react';
+import type {ReactElement} from 'react';
 
 figma.connect(
     TextInput,
@@ -27,8 +27,12 @@ figma.connect(
             }),
             inputProps: figma.nestedProps('.Input.Input', {
                 placeholder: figma.boolean('Placeholder', {true: figma.string('Text'), false: undefined}),
-                leftSection: figma.boolean<ReactNode, never>('Left Section', {true: figma.instance('Swap Left')}),
-                rightSection: figma.boolean<ReactNode, never>('Right Section', {true: figma.instance('Swap Right')}),
+                leftSection: figma.boolean<ReactElement, undefined>('Left Section', {
+                    true: figma.instance<ReactElement>('Swap Left'),
+                }),
+                rightSection: figma.boolean<ReactElement, undefined>('Right Section', {
+                    true: figma.instance<ReactElement>('Swap Right'),
+                }),
                 disabled: figma.enum('State', {Disabled: true}),
                 readOnly: figma.enum('State', {'Read-only': true}),
             }),

--- a/packages/figma/src/Textarea.figma.tsx
+++ b/packages/figma/src/Textarea.figma.tsx
@@ -1,6 +1,6 @@
 import {Textarea} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
-import {type ReactNode} from 'react';
+import type {ReactElement} from 'react';
 
 figma.connect(
     Textarea,
@@ -27,8 +27,12 @@ figma.connect(
             }),
             inputProps: figma.nestedProps('.Textarea.Input', {
                 placeholder: figma.boolean('Placeholder', {true: figma.textContent('Placeholder'), false: undefined}),
-                leftSection: figma.boolean<ReactNode, never>('Left Section', {true: figma.instance('Swap Left')}),
-                rightSection: figma.boolean<ReactNode, never>('Right Section', {true: figma.instance('Swap Right')}),
+                leftSection: figma.boolean<ReactElement, undefined>('Left Section', {
+                    true: figma.instance<ReactElement>('Swap Left'),
+                }),
+                rightSection: figma.boolean<ReactElement, undefined>('Right Section', {
+                    true: figma.instance<ReactElement>('Swap Right'),
+                }),
                 disabled: figma.enum('State', {Disabled: true}),
                 readOnly: figma.enum('State', {'Read-only': true}),
             }),

--- a/packages/figma/src/TimePicker.figma.tsx
+++ b/packages/figma/src/TimePicker.figma.tsx
@@ -1,6 +1,6 @@
 import {TimePicker} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
-import {type ReactNode} from 'react';
+import type {ReactElement} from 'react';
 
 figma.connect(
     TimePicker,
@@ -26,8 +26,12 @@ figma.connect(
                 }),
             }),
             inputProps: figma.nestedProps('.Input.Input', {
-                leftSection: figma.boolean<ReactNode, never>('Left Section', {true: figma.instance('Swap Left')}),
-                rightSection: figma.boolean<ReactNode, never>('Right Section', {true: figma.instance('Swap Right')}),
+                leftSection: figma.boolean<ReactElement, undefined>('Left Section', {
+                    true: figma.instance<ReactElement>('Swap Left'),
+                }),
+                rightSection: figma.boolean<ReactElement, undefined>('Right Section', {
+                    true: figma.instance<ReactElement>('Swap Right'),
+                }),
                 disabled: figma.enum('State', {Disabled: true}),
                 readOnly: figma.enum('State', {'Read-only': true}),
             }),

--- a/packages/figma/src/YearPickerInput.figma.tsx
+++ b/packages/figma/src/YearPickerInput.figma.tsx
@@ -1,6 +1,6 @@
 import {YearPickerInput} from '@coveord/plasma-mantine';
 import {figma} from '@figma/code-connect';
-import {ReactNode} from 'react';
+import type {ReactElement} from 'react';
 
 figma.connect(
     YearPickerInput,
@@ -27,8 +27,12 @@ figma.connect(
             }),
             inputProps: figma.nestedProps('.Input.Input', {
                 placeholder: figma.boolean('Placeholder', {true: figma.string('Text'), false: undefined}),
-                leftSection: figma.boolean<ReactNode, never>('Left Section', {true: figma.instance('Swap Left')}),
-                rightSection: figma.boolean<ReactNode, never>('Right Section', {true: figma.instance('Swap Right')}),
+                leftSection: figma.boolean<ReactElement, undefined>('Left Section', {
+                    true: figma.instance<ReactElement>('Swap Left'),
+                }),
+                rightSection: figma.boolean<ReactElement, undefined>('Right Section', {
+                    true: figma.instance<ReactElement>('Swap Right'),
+                }),
                 disabled: figma.enum('State', {Disabled: true}),
                 readOnly: figma.enum('State', {'Read-only': true}),
             }),

--- a/packages/mantine/src/components/BlankSlate/BlankSlate.tsx
+++ b/packages/mantine/src/components/BlankSlate/BlankSlate.tsx
@@ -11,7 +11,7 @@ interface BlankSlateProps {
 }
 
 export const BlankSlate: FunctionComponent<PropsWithChildren<BlankSlateProps>> = ({children, withBorder = true}) => (
-    <Paper shadow={withBorder && 'xs'} p="xl" withBorder={withBorder}>
+    <Paper shadow={withBorder ? 'xs' : undefined} p="xl" withBorder={withBorder}>
         <Stack align="center">{children}</Stack>
     </Paper>
 );

--- a/packages/mantine/src/components/Button/ButtonWithDisabledTooltip.tsx
+++ b/packages/mantine/src/components/Button/ButtonWithDisabledTooltip.tsx
@@ -27,7 +27,14 @@ const _ButtonWithDisabledTooltip = forwardRef<HTMLDivElement, ButtonWithDisabled
     ({disabledTooltip, disabled, children, disabledTooltipProps, fullWidth, ...others}, ref) =>
         disabledTooltip ? (
             <Tooltip label={disabledTooltip} disabled={!disabled} {...disabledTooltipProps}>
-                <Box ref={ref} style={{'&:hover': {cursor: 'not-allowed'}, width: fullWidth && '100%'}} {...others}>
+                <Box
+                    ref={ref}
+                    style={{
+                        '&:hover': {cursor: 'not-allowed'},
+                        width: fullWidth ? '100%' : undefined,
+                    }}
+                    {...others}
+                >
                     {children}
                 </Box>
             </Tooltip>

--- a/packages/mantine/src/components/ChildForm/ChildForm.tsx
+++ b/packages/mantine/src/components/ChildForm/ChildForm.tsx
@@ -34,7 +34,7 @@ type ChildFormFactory = Factory<{
     stylesNames: ChildFormStylesNames;
 }>;
 
-const defaultProps: Partial<ChildFormProps> = {};
+const defaultProps = {} satisfies Partial<ChildFormProps>;
 
 export const ChildForm = polymorphicFactory<ChildFormFactory>((props, ref) => {
     const {className, children, style, classNames, styles, unstyled, vars, title, description, ...others} = useProps(

--- a/packages/mantine/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/mantine/src/components/CodeEditor/CodeEditor.tsx
@@ -80,12 +80,14 @@ interface CodeEditorProps
     options?: Pick<monacoEditor.IStandaloneEditorConstructionOptions, 'tabSize'>;
 }
 
-const defaultProps: Partial<CodeEditorProps> = {
+const defaultProps = {
     language: 'plaintext',
     monacoLoader: 'local',
     defaultValue: '',
     minHeight: 300,
-};
+    justify: 'flex-start',
+    gap: 'sm',
+} satisfies Partial<CodeEditorProps>;
 
 export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
     const {
@@ -109,6 +111,8 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
         monacoLoader,
         options: {tabSize} = {tabSize: 2},
         editorHandle,
+        h,
+        mah,
         ...others
     } = useProps('CodeEditor', defaultProps, props);
     const [loaded, setLoaded] = useState(false);
@@ -119,7 +123,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
         finalValue: '',
     });
     const [parentHeight, ref] = useParentHeight();
-    const editorRef = useRef(null);
+    const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null);
 
     const loadLocalMonaco = async () => {
         const monacoInstance = await import('monaco-editor');
@@ -230,7 +234,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                     tabSize,
                 }}
                 value={_value}
-                onChange={handleChange}
+                onChange={(nextValue) => handleChange(nextValue ?? '')}
                 beforeMount={(monaco) => {
                     registerLanguages(monaco);
                     registerThemes(monaco);
@@ -260,7 +264,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
 
     const height = Math.max(Number.isNaN(parentHeight) ? 0 : parentHeight, minHeight);
     return (
-        <Stack justify="flex-start" gap="sm" h={height} mah={maxHeight} ref={ref} {...others}>
+        <Stack ref={ref} {...others} h={h ?? height} mah={mah ?? maxHeight}>
             <Group justify="space-between">
                 {_header}
                 {_buttons}

--- a/packages/mantine/src/components/Collection/Collection.tsx
+++ b/packages/mantine/src/components/Collection/Collection.tsx
@@ -187,7 +187,7 @@ export type CollectionFactory = Factory<{
     stylesNames: CollectionStylesNames;
 }>;
 
-const defaultProps: Partial<CollectionProps<unknown>> = {
+const defaultProps = {
     draggable: false,
     addLabel: 'Add item',
     addDisabledTooltip: 'There is already an empty item',
@@ -196,7 +196,7 @@ const defaultProps: Partial<CollectionProps<unknown>> = {
     gap: 'md',
     required: false,
     getItemId: ({id}: any) => id,
-};
+} satisfies Partial<CollectionProps<unknown>>;
 
 export const Collection = <T,>(props: CollectionProps<T> & {ref?: ForwardedRef<HTMLDivElement>}) => {
     const {
@@ -234,7 +234,7 @@ export const Collection = <T,>(props: CollectionProps<T> & {ref?: ForwardedRef<H
         styles,
         unstyled,
         ...others
-    } = useProps('Collection', defaultProps as CollectionProps<T>, props);
+    } = useProps('Collection', defaultProps, props);
 
     // Runtime validation: ensure columns and children are mutually exclusive
     if (columns && children) {
@@ -248,7 +248,7 @@ export const Collection = <T,>(props: CollectionProps<T> & {ref?: ForwardedRef<H
     const getStyles = useStyles<CollectionFactory>({
         name: 'Collection',
         classes,
-        props,
+        props: props as CollectionProps<unknown>,
         className,
         style,
         classNames,

--- a/packages/mantine/src/components/Collection/CollectionItem.tsx
+++ b/packages/mantine/src/components/Collection/CollectionItem.tsx
@@ -18,10 +18,10 @@ interface CollectionItemSharedProps extends GroupProps {
     removable?: boolean;
 }
 
-const defaultProps: Partial<CollectionItemSharedProps> = {
+const defaultProps = {
     removable: true,
     gap: 'sm',
-};
+} satisfies Partial<CollectionItemSharedProps>;
 
 const StaticCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSharedProps>> = (props) => {
     const {
@@ -33,18 +33,12 @@ const StaticCollectionItem: FunctionComponent<PropsWithChildren<CollectionItemSh
         // Style props
         style,
         className,
-        classNames,
-        styles,
         ...others
     } = useProps('CollectionItem', defaultProps, props);
     const ctx = useCollectionContext();
 
     return (
-        <Group
-            data-testid={`item-${id}`}
-            {...ctx.getStyles('item', {style, className, classNames, styles})}
-            {...others}
-        >
+        <Group data-testid={`item-${id}`} {...ctx.getStyles('item', {style, className})} {...others}>
             {children}
             <RemoveButton removable={removable} onRemove={onRemove} />
         </Group>
@@ -62,16 +56,10 @@ const DisabledCollectionItem: FunctionComponent<PropsWithChildren<CollectionItem
         // Style props
         style,
         className,
-        classNames,
-        styles,
         ...others
     } = useProps('CollectionItem', defaultProps, props);
     return (
-        <Group
-            data-testid={`item-${id}`}
-            {...ctx.getStyles('item', {style, className, classNames, styles})}
-            {...others}
-        >
+        <Group data-testid={`item-${id}`} {...ctx.getStyles('item', {style, className})} {...others}>
             {children}
         </Group>
     );
@@ -87,8 +75,6 @@ const DraggableCollectionItem: FunctionComponent<PropsWithChildren<CollectionIte
 
         // Style props
         className,
-        classNames,
-        styles,
         ...others
     } = useProps('CollectionItem', defaultProps, props);
 
@@ -108,8 +94,6 @@ const DraggableCollectionItem: FunctionComponent<PropsWithChildren<CollectionIte
                       }
                     : undefined,
                 className,
-                classNames,
-                styles,
             })}
             data-isdragging={isDragging}
             {...others}

--- a/packages/mantine/src/components/Collection/enhanceWithCollectionProps.ts
+++ b/packages/mantine/src/components/Collection/enhanceWithCollectionProps.ts
@@ -1,11 +1,16 @@
 import {UseFormInput, type FormArrayElement} from '@mantine/form';
 import {CollectionProps} from './Collection.js';
 
+type EnhanceGetInputPayload<
+    FormValues,
+    TransformValues extends (values: FormValues) => unknown = (values: FormValues) => FormValues,
+> = Parameters<NonNullable<UseFormInput<FormValues, TransformValues>['enhanceGetInputProps']>>[0];
+
 export const enhanceWithCollectionProps = <
     FormValues,
     TransformValues extends (values: FormValues) => unknown = (values: FormValues) => FormValues,
 >(
-    payload: Parameters<UseFormInput<FormValues, TransformValues>['enhanceGetInputProps']>[0],
+    payload: EnhanceGetInputPayload<FormValues, TransformValues>,
     field: (typeof payload)['field'],
     options?: {validateInputOnChange?: boolean},
 ): Pick<CollectionProps<unknown>, 'onReorderItem' | 'onInsertItem' | 'onRemoveItem'> => {
@@ -20,8 +25,12 @@ export const enhanceWithCollectionProps = <
                 payload.form.removeListItem(field, index);
                 validateInputOnChange && payload.form.validate();
             },
-            onInsertItem: (valueToInsert: FormArrayElement<FormValues, (typeof payload)['field']>, index: number) => {
-                payload.form.insertListItem(field, valueToInsert, index);
+            onInsertItem: (valueToInsert: unknown, index: number) => {
+                payload.form.insertListItem(
+                    field,
+                    valueToInsert as FormArrayElement<FormValues, (typeof payload)['field']>,
+                    index,
+                );
                 validateInputOnChange && payload.form.validate();
             },
         };

--- a/packages/mantine/src/components/Collection/layouts/horizontal-layout/HorizontalLayoutBody.tsx
+++ b/packages/mantine/src/components/Collection/layouts/horizontal-layout/HorizontalLayoutBody.tsx
@@ -1,12 +1,13 @@
 import {Box, Stack, useProps} from '@mantine/core';
 import {ForwardedRef, useMemo} from 'react';
+import {CollectionColumnDef} from '../../CollectionColumn.types.js';
 import {useCollectionContext} from '../../CollectionContext.js';
 import {getColumnSizeStyles} from '../shared/columnUtils.js';
 import {createItemRenderers, ItemContentRenderer, LayoutClasses, mapItemsToComponents} from '../shared/itemRenderer.js';
 import {LAYOUT_BODY_DEFAULT_PROPS, LayoutBodyProps} from '../shared/layoutConstants.js';
 import classes from './HorizontalLayout.module.css';
 
-const defaultProps: Partial<LayoutBodyProps> = LAYOUT_BODY_DEFAULT_PROPS;
+const defaultProps = LAYOUT_BODY_DEFAULT_PROPS satisfies Partial<LayoutBodyProps>;
 
 /**
  * Horizontal layout specific content renderer - renders cells in a row
@@ -30,20 +31,19 @@ const renderHorizontalContent: ItemContentRenderer<unknown> = (
     </>
 );
 
-// Create renderers once - they are stable component references
-const horizontalRenderers = createItemRenderers<unknown>();
-
 export const HorizontalLayoutBody = <T,>(props: LayoutBodyProps<T> & {ref?: ForwardedRef<HTMLDivElement>}) => {
     const collectionCtx = useCollectionContext();
     const {items, onRemove, removable, draggable, disabled, readOnly, getItemId, gap, ref, ...others} = useProps(
         'HorizontalLayoutBody',
-        defaultProps as LayoutBodyProps<T>,
+        defaultProps,
         props,
     );
+    const columns = (collectionCtx.columns ?? []) as Array<CollectionColumnDef<T>>;
+    const horizontalRenderers = useMemo(() => createItemRenderers<T>(), []);
 
     const config = useMemo(
         () => ({
-            renderContent: renderHorizontalContent,
+            renderContent: renderHorizontalContent as ItemContentRenderer<T>,
             containerSelector: 'row',
             inlineControls: true,
         }),
@@ -57,7 +57,7 @@ export const HorizontalLayoutBody = <T,>(props: LayoutBodyProps<T> & {ref?: Forw
         draggable,
         disabled,
         readOnly,
-        columns: collectionCtx.columns,
+        columns,
     });
 
     return (

--- a/packages/mantine/src/components/Collection/layouts/horizontal-layout/HorizontalLayoutHeader.tsx
+++ b/packages/mantine/src/components/Collection/layouts/horizontal-layout/HorizontalLayoutHeader.tsx
@@ -1,4 +1,5 @@
 import {Box, useProps} from '@mantine/core';
+import {clsx} from 'clsx';
 import {ForwardedRef} from 'react';
 import {useCollectionContext} from '../../CollectionContext.js';
 import {getColumnSizeStyles} from '../shared/columnUtils.js';
@@ -6,20 +7,21 @@ import {renderColumnHeader} from '../shared/headerUtils.js';
 import {LAYOUT_HEADER_DEFAULT_PROPS, LayoutHeaderProps} from '../shared/layoutConstants.js';
 import classes from './HorizontalLayout.module.css';
 
-const defaultProps: Partial<LayoutHeaderProps> = LAYOUT_HEADER_DEFAULT_PROPS;
+const defaultProps = LAYOUT_HEADER_DEFAULT_PROPS satisfies Partial<LayoutHeaderProps>;
 
 export const HorizontalLayoutHeader = (props: LayoutHeaderProps & {ref?: ForwardedRef<HTMLDivElement>}) => {
     const collectionCtx = useCollectionContext();
-    const {draggable, removable, style, ref, ...others} = useProps(
+    const {draggable, removable, style, className, ref, ...others} = useProps(
         'HorizontalLayoutHeader',
-        defaultProps as LayoutHeaderProps,
+        defaultProps,
         props,
     );
+    const columns = collectionCtx.columns ?? [];
 
     return (
-        <Box ref={ref} className={classes.headerRow} style={style} {...others}>
+        <Box ref={ref} className={clsx(classes.headerRow, className)} style={style} {...others}>
             {draggable && <div className={classes.dragHandleHeader} />}
-            {collectionCtx.columns.map((column, index) => {
+            {columns.map((column, index) => {
                 const columnId = column.id ?? `column-${index}`;
                 return (
                     <Box key={columnId} className={classes.headerCell} style={getColumnSizeStyles(column)}>

--- a/packages/mantine/src/components/Collection/layouts/shared/layoutConstants.ts
+++ b/packages/mantine/src/components/Collection/layouts/shared/layoutConstants.ts
@@ -19,10 +19,10 @@ export interface LayoutHeaderProps extends BoxProps {
 /**
  * Common default props shared across all layout header components.
  */
-export const LAYOUT_HEADER_DEFAULT_PROPS: Partial<LayoutHeaderProps> = {
+export const LAYOUT_HEADER_DEFAULT_PROPS = {
     draggable: false,
     removable: true,
-};
+} satisfies Partial<LayoutHeaderProps>;
 
 /**
  * Common props shared across all layout body components.
@@ -42,10 +42,10 @@ export interface LayoutBodyProps<T = unknown> extends BoxProps {
  * Common default props shared across all layout body components.
  * This ensures consistent defaults and reduces duplication.
  */
-export const LAYOUT_BODY_DEFAULT_PROPS: Partial<LayoutBodyProps> = {
+export const LAYOUT_BODY_DEFAULT_PROPS = {
     removable: true,
     draggable: false,
     disabled: false,
     readOnly: false,
     gap: 'md' as MantineSpacing,
-} as const;
+} as const satisfies Partial<LayoutBodyProps>;

--- a/packages/mantine/src/components/Collection/layouts/vertical-layout/VerticalLayoutBody.tsx
+++ b/packages/mantine/src/components/Collection/layouts/vertical-layout/VerticalLayoutBody.tsx
@@ -15,7 +15,7 @@ import {LAYOUT_BODY_DEFAULT_PROPS, LayoutBodyProps} from '../shared/layoutConsta
 import {RemoveButton} from '../shared/RemoveButton.js';
 import classes from './VerticalLayout.module.css';
 
-const defaultProps: Partial<LayoutBodyProps<unknown>> = LAYOUT_BODY_DEFAULT_PROPS;
+const defaultProps = LAYOUT_BODY_DEFAULT_PROPS satisfies Partial<LayoutBodyProps<unknown>>;
 
 /**
  * Renders the stack of fields (columns) for a vertical layout item
@@ -81,16 +81,15 @@ const renderVerticalDraggableContent: DraggableContentRenderer<any> = (
     </Group>
 );
 
-// Create renderers once - they are stable component references
-const verticalRenderers = createItemRenderers<any>();
-
 export const VerticalLayoutBody = <T,>(props: LayoutBodyProps<T> & {ref?: ForwardedRef<HTMLDivElement>}) => {
     const collectionCtx = useCollectionContext();
     const {items, onRemove, removable, draggable, disabled, readOnly, getItemId, gap, ref, ...others} = useProps(
         'VerticalLayoutBody',
-        defaultProps as LayoutBodyProps<T>,
+        defaultProps,
         props,
     );
+    const columns = (collectionCtx.columns ?? []) as Array<CollectionColumnDef<T>>;
+    const verticalRenderers = useMemo(() => createItemRenderers<T>(), []);
 
     const config = useMemo(
         () => ({
@@ -109,7 +108,7 @@ export const VerticalLayoutBody = <T,>(props: LayoutBodyProps<T> & {ref?: Forwar
         draggable,
         disabled,
         readOnly,
-        columns: collectionCtx.columns,
+        columns,
     });
 
     return (

--- a/packages/mantine/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/mantine/src/components/DateRangePicker/DateRangePicker.tsx
@@ -10,7 +10,7 @@ import {
     useProps,
     useStyles,
 } from '@mantine/core';
-import {DatesRangeValue, DateStringValue} from '@mantine/dates';
+import {DatesRangeValue} from '@mantine/dates';
 import {useUncontrolled} from '@mantine/hooks';
 import dayjs from 'dayjs';
 import {useUrlSyncedState, UseUrlSyncedStateOptions} from '../../hooks/use-url-synced-state';
@@ -91,10 +91,10 @@ export type DateRangePickerFactory = Factory<{
     stylesNames: DateRangePickerStylesNames;
 }>;
 
-const defaultProps: Partial<DateRangePickerProps> = {
+const defaultProps = {
     placeholder: 'Select date range',
     formatter: (time) => dayjs(time).format('MMM D, YYYY'),
-};
+} satisfies Partial<DateRangePickerProps>;
 
 export const DateRangePicker = factory<DateRangePickerFactory>((props: DateRangePickerProps, ref) => {
     const {
@@ -121,7 +121,7 @@ export const DateRangePicker = factory<DateRangePickerFactory>((props: DateRange
         vars,
         unstyled,
         ...others
-    } = useProps('PlasmaDateRangePicker', defaultProps as Partial<DateRangePickerProps>, props);
+    } = useProps('PlasmaDateRangePicker', defaultProps, props);
 
     const getStyles = useStyles<DateRangePickerFactory>({
         name: 'DateRangePicker',
@@ -168,8 +168,8 @@ export const DateRangePicker = factory<DateRangePickerFactory>((props: DateRange
     };
 
     const _value = value ?? dateRange;
-    const formattedRange = `${formatter(_value[0])} - ${formatter(_value[1])}`;
-    const dateRangeInitialized = _value.every((date: DateStringValue) => typeof date === 'string' && date !== '');
+    const dateRangeInitialized = _value.every((date): date is string => typeof date === 'string' && date !== '');
+    const formattedRange = dateRangeInitialized ? `${formatter(_value[0])} - ${formatter(_value[1])}` : placeholder;
 
     return (
         <Popover opened={_opened} onChange={setOpened}>
@@ -183,7 +183,7 @@ export const DateRangePicker = factory<DateRangePickerFactory>((props: DateRange
                     {...getStyles('input', {className, style, ...stylesApiProps})}
                     {...others}
                 >
-                    {dateRangeInitialized ? formattedRange : placeholder}
+                    {formattedRange}
                 </InputBase>
             </Popover.Target>
             <Popover.Dropdown p={0}>

--- a/packages/mantine/src/components/DateRangePicker/DateRangePickerInlineCalendar.tsx
+++ b/packages/mantine/src/components/DateRangePicker/DateRangePickerInlineCalendar.tsx
@@ -7,8 +7,10 @@ import {Button} from '../Button/Button.js';
 import DateRangeClasses from './DateRange.module.css';
 import {DateRangePickerPreset, DateRangePickerPresetSelect} from './DateRangePickerPresetSelect.js';
 import {EditableDateRangePicker, EditableDateRangePickerProps} from './EditableDateRangePicker.js';
-export interface DateRangePickerInlineCalendarProps
-    extends Pick<EditableDateRangePickerProps, 'startProps' | 'endProps'> {
+export interface DateRangePickerInlineCalendarProps extends Pick<
+    EditableDateRangePickerProps,
+    'startProps' | 'endProps'
+> {
     /**
      * Initial selected range
      */
@@ -84,7 +86,7 @@ export const DateRangePickerInlineCalendar = ({
     const onCalendarApply = () => {
         // In case the user only clicked the start date, but not the end date,
         // assume a single day was meant to be selected.
-        if (!form.values.dates[1]) {
+        if (!form.values.dates[1] && form.values.dates[0]) {
             form.values.dates[1] = endOfDay(form.values.dates[0]);
         }
         onApply(form.values.dates);

--- a/packages/mantine/src/components/DateRangePicker/DateRangePickerPopoverCalendar.tsx
+++ b/packages/mantine/src/components/DateRangePicker/DateRangePickerPopoverCalendar.tsx
@@ -46,25 +46,25 @@ export const DateRangePickerPopoverCalendar = ({
     const [opened, setOpened] = useState(false);
     const ref = useClickOutside(() => setOpened(false));
 
-    const [_value, handleChange] = useUncontrolled<DatesRangeValue<DateStringValue> | null>({
+    const [_value, handleChange] = useUncontrolled<DatesRangeValue<DateStringValue | null>>({
         value,
         defaultValue,
         onChange,
         finalValue: [null, null],
     });
 
-    const onCalendarChange = (dates: DatesRangeValue<DateStringValue | null>) => {
-        if (dates[0] !== null) {
-            dates[0] = dayjs(dates[0]).toISOString();
-        }
-        if (dates[1] !== null) {
-            dates[1] = dayjs(dates[1]).toISOString();
-        }
-        handleChange?.(dates);
-        if (dates[1] !== null) {
+    const onCalendarChange = (dates: DatesRangeValue<Date | string | null>) => {
+        const normalized: DatesRangeValue<DateStringValue | null> = [
+            dates[0] ? dayjs(dates[0]).toISOString() : null,
+            dates[1] ? dayjs(dates[1]).toISOString() : null,
+        ];
+
+        handleChange(normalized);
+        if (normalized[1] !== null) {
             setOpened(false);
         }
     };
+    const calendarValue = _value.map((date) => (date ? new Date(date) : null)) as DatesRangeValue<Date>;
 
     return (
         <>
@@ -95,7 +95,7 @@ export const DateRangePickerPopoverCalendar = ({
                         columnsToScroll={1}
                         firstDayOfWeek={0}
                         allowSingleDateInRange
-                        value={_value}
+                        value={calendarValue}
                         onChange={onCalendarChange}
                         {...rangeCalendarProps}
                     />

--- a/packages/mantine/src/components/DateRangePicker/DateRangePickerPresetSelect.tsx
+++ b/packages/mantine/src/components/DateRangePicker/DateRangePickerPresetSelect.tsx
@@ -10,8 +10,8 @@ export interface DateRangePickerPreset {
 
 interface DateRangePickerPresetsSelectProps {
     presets: Record<string, DateRangePickerPreset>;
-    value: DatesRangeValue<DateStringValue>;
-    onChange?(value: DatesRangeValue): void;
+    value: DatesRangeValue<DateStringValue | null>;
+    onChange?(value: DatesRangeValue<DateStringValue | null>): void;
     selectProps?: Partial<Omit<SelectProps, 'data' | 'value' | 'onChange'>>;
 }
 
@@ -45,8 +45,11 @@ export const DateRangePickerPresetSelect = ({
         }
     }, [value]);
 
-    const onChangePreset = (presetId: keyof typeof presets) => {
-        const range = presets[presetId].range as any;
+    const onChangePreset = (presetId: string | null) => {
+        if (!presetId) {
+            return;
+        }
+        const range = presets[presetId].range as DatesRangeValue<DateStringValue | null>;
         onChange?.(range);
     };
 

--- a/packages/mantine/src/components/DateRangePicker/EditableDateRangePicker.tsx
+++ b/packages/mantine/src/components/DateRangePicker/EditableDateRangePicker.tsx
@@ -1,18 +1,19 @@
-import {DateInput, DatePickerProps, DateStringValue, type DatesRangeValue} from '@mantine/dates';
+import {DateInput, DateStringValue, type DatesRangeValue} from '@mantine/dates';
 import dayjs from 'dayjs';
+import {ComponentProps} from 'react';
 
 export interface EditableDateRangePickerProps {
     value: DatesRangeValue<DateStringValue | null>;
-    onChange?(value: DatesRangeValue<DateStringValue> | null): void;
+    onChange?(value: DatesRangeValue<DateStringValue | null>): void;
     onFocus?: () => void;
     /**
      * Props for the start input
      */
-    startProps?: Omit<Partial<DatePickerProps>, 'value' | 'onChange' | 'onFocus'>;
+    startProps?: Omit<Partial<ComponentProps<typeof DateInput>>, 'value' | 'onChange' | 'onFocus'>;
     /**
      * Props for the end input
      */
-    endProps?: Omit<Partial<DatePickerProps>, 'value' | 'onChange' | 'onFocus'>;
+    endProps?: Omit<Partial<ComponentProps<typeof DateInput>>, 'value' | 'onChange' | 'onFocus'>;
 }
 
 export const EditableDateRangePicker = ({
@@ -23,10 +24,10 @@ export const EditableDateRangePicker = ({
     endProps = {},
 }: EditableDateRangePickerProps) => {
     const onChangeStart = (date: DateStringValue | null) => {
-        onChange?.([dayjs(date).startOf('day').toISOString(), value?.[1]]);
+        onChange?.([date ? dayjs(date).startOf('day').toISOString() : null, value?.[1] ?? null]);
     };
     const onChangeEnd = (date: DateStringValue | null) => {
-        onChange?.([value?.[0], dayjs(date).endOf('day').toISOString()]);
+        onChange?.([value?.[0] ?? null, date ? dayjs(date).endOf('day').toISOString() : null]);
     };
 
     return (

--- a/packages/mantine/src/components/DateTimeRangePicker/EditableDateTimeRangePicker.tsx
+++ b/packages/mantine/src/components/DateTimeRangePicker/EditableDateTimeRangePicker.tsx
@@ -1,5 +1,6 @@
-import {DatePickerProps, DatesRangeValue, DateStringValue, DateTimePicker} from '@mantine/dates';
+import {DatesRangeValue, DateStringValue, DateTimePicker} from '@mantine/dates';
 import dayjs from 'dayjs';
+import {ComponentProps} from 'react';
 
 export interface EditableDateTimeRangePickerProps {
     value: DatesRangeValue<DateStringValue | null>;
@@ -15,11 +16,11 @@ export interface EditableDateTimeRangePickerProps {
     /**
      * Props for the start input
      */
-    startProps?: Omit<Partial<DatePickerProps>, 'value' | 'onChange' | 'onFocus'>;
+    startProps?: Omit<Partial<ComponentProps<typeof DateTimePicker>>, 'value' | 'onChange' | 'onFocus'>;
     /**
      * Props for the end input
      */
-    endProps?: Omit<Partial<DatePickerProps>, 'value' | 'onChange' | 'onFocus'>;
+    endProps?: Omit<Partial<ComponentProps<typeof DateTimePicker>>, 'value' | 'onChange' | 'onFocus'>;
 }
 
 export const EditableDateTimeRangePicker = ({
@@ -30,11 +31,15 @@ export const EditableDateTimeRangePicker = ({
     startProps = {},
     endProps = {},
 }: EditableDateTimeRangePickerProps) => {
-    const onStartDateChange = (startDate: string) => {
+    const onStartDateChange = (startDate: string | null) => {
+        if (startDate === null) {
+            onChange?.([null, value?.[1] ?? null]);
+            return;
+        }
         if (value?.[1] && dayjs(startDate) > dayjs(value[1])) {
             onChange?.([startDate, null]);
         } else {
-            onChange?.([startDate, value?.[1]]);
+            onChange?.([startDate, value?.[1] ?? null]);
         }
     };
 
@@ -56,9 +61,9 @@ export const EditableDateTimeRangePicker = ({
             <DateTimePicker
                 clearable={false}
                 label="End"
-                value={value?.[1]}
-                minDate={value?.[0]}
-                onChange={(endDate) => onChange?.([value?.[0], endDate])}
+                value={value?.[1] ?? undefined}
+                minDate={value?.[0] ?? undefined}
+                onChange={(endDate) => onChange?.([value?.[0] ?? null, endDate])}
                 valueFormat={dateFormat}
                 w={150}
                 styles={{...endProps.styles}}

--- a/packages/mantine/src/components/EllipsisText/EllipsisText.tsx
+++ b/packages/mantine/src/components/EllipsisText/EllipsisText.tsx
@@ -30,9 +30,9 @@ type EllipsisTextFactory = Factory<{
     stylesNames: EllipsisTextStylesNames;
 }>;
 
-const defaultProps: Partial<EllipsisTextProps> = {
+const defaultProps = {
     tooltipProps: {},
-};
+} satisfies Partial<EllipsisTextProps>;
 
 export const EllipsisText = polymorphicFactory<EllipsisTextFactory>((props, ref) => {
     const {className, children, style, classNames, styles, unstyled, variant, lineClamp, tooltipProps, ...others} =

--- a/packages/mantine/src/components/Facet/Facet.tsx
+++ b/packages/mantine/src/components/Facet/Facet.tsx
@@ -150,7 +150,7 @@ export type FacetFactory = Factory<{
     stylesNames: FacetStylesNames;
 }>;
 
-const defaultProps: Partial<FacetProps> = {
+const defaultProps = {
     searchPlaceholder: 'Search',
     nothingFound: 'No matching items',
     placeholder: 'No items',
@@ -158,7 +158,7 @@ const defaultProps: Partial<FacetProps> = {
     limit: Infinity,
     itemComponent: DefaultFacetItem,
     listComponent: FacetScrollArea,
-};
+} satisfies Partial<FacetProps>;
 
 export const Facet: FunctionComponent<FacetProps> = factory<FacetFactory>((_props, ref) => {
     const props = useProps('Facet', defaultProps, _props);
@@ -212,7 +212,7 @@ export const Facet: FunctionComponent<FacetProps> = factory<FacetFactory>((_prop
     const handleValueSelect = (val: string) =>
         handleSelection(_selection.includes(val) ? _selection.filter((v) => v !== val) : [..._selection, val]);
 
-    let groupName: string = null;
+    let groupName: string | null = null;
 
     useEffect(() => {
         combobox.openDropdown();

--- a/packages/mantine/src/components/Header/Header.tsx
+++ b/packages/mantine/src/components/Header/Header.tsx
@@ -85,11 +85,11 @@ export type HeaderFactory = Factory<{
     };
 }>;
 
-const defaultProps: Partial<HeaderProps> = {
+const defaultProps = {
     variant: 'primary',
     justify: 'space-between',
     wrap: 'nowrap',
-};
+} satisfies Partial<HeaderProps>;
 
 const getSpacing = (variant: HeaderVariant) => (variant === 'secondary' ? 'xxs' : 'xs');
 

--- a/packages/mantine/src/components/Header/HeaderDocAnchor/HeaderDocAnchor.tsx
+++ b/packages/mantine/src/components/Header/HeaderDocAnchor/HeaderDocAnchor.tsx
@@ -41,14 +41,14 @@ export type HeaderDocAnchorFactory = Factory<{
     compound: true;
 }>;
 
-const defaultProps: Partial<HeaderDocAnchorProps> = {
+const defaultProps = {
     position: 'right',
     children: <InfoToken.Question />,
-};
+} satisfies Partial<HeaderDocAnchorProps>;
 
 export const HeaderDocAnchor = factory<HeaderDocAnchorFactory>((_props, ref) => {
     const props = useProps('PlasmaHeaderActions', defaultProps, _props);
-    const {className, classNames, styles, style, children, label, position, vars, ...others} = props;
+    const {className, classNames, styles, style, children, label, position, vars, inline = true, ...others} = props;
 
     const ctx = useHeaderContext();
 
@@ -61,7 +61,7 @@ export const HeaderDocAnchor = factory<HeaderDocAnchorFactory>((_props, ref) => 
         >
             <Anchor
                 ref={ref}
-                inline
+                inline={inline}
                 target="_blank"
                 {...ctx.getStyles('docAnchor', {classNames, styles, props, style, className})}
                 {...others}

--- a/packages/mantine/src/components/Header/HeaderRight/HeaderRight.tsx
+++ b/packages/mantine/src/components/Header/HeaderRight/HeaderRight.tsx
@@ -18,9 +18,9 @@ export type HeaderRightFactory = Factory<{
     compound: true;
 }>;
 
-const defaultProps: Partial<HeaderRightProps> = {
+const defaultProps = {
     gap: 'xs',
-};
+} satisfies Partial<HeaderRightProps>;
 
 export const HeaderRight = factory<HeaderRightFactory>((_props, ref) => {
     const props = useProps('HeaderRight', defaultProps, _props);

--- a/packages/mantine/src/components/InfoToken/InfoToken.tsx
+++ b/packages/mantine/src/components/InfoToken/InfoToken.tsx
@@ -64,7 +64,7 @@ export type InfoTokenProps = Omit<InfoTokenInternalProps, 'type'>;
 type InfoTokenCompoundComponent = (<C = 'div'>(props: PolymorphicComponentProps<C, InfoTokenProps>) => ReactElement) &
     Omit<FunctionComponent<PolymorphicComponentProps<any, InfoTokenProps>>, never>;
 
-const defaultProps: Partial<InfoTokenInternalProps> = {variant: 'outline', type: 'information', size: 'xs'};
+const defaultProps = {variant: 'outline', type: 'information', size: 'xs'} satisfies Partial<InfoTokenInternalProps>;
 
 const colorResolver = (type: InfoTokenType): string => {
     switch (type) {
@@ -132,8 +132,9 @@ const iconResolver = (type: InfoTokenType): TablerIcon => {
 };
 
 const varsResolver = createVarsResolver<InfoTokenFactory>((_theme, {type}) => {
-    const color = colorResolver(type);
-    const bgColor = bgColorResolver(type);
+    const resolvedType = type ?? defaultProps.type;
+    const color = colorResolver(resolvedType);
+    const bgColor = bgColorResolver(resolvedType);
     return {
         root: {
             '--it-color': color,

--- a/packages/mantine/src/components/InlineConfirm/InlineConfirm.tsx
+++ b/packages/mantine/src/components/InlineConfirm/InlineConfirm.tsx
@@ -31,7 +31,7 @@ export type InlineConfirmFactory = Factory<{
     };
 }>;
 
-const defaultProps: Partial<InlineConfirmProps> = {};
+const defaultProps = {} satisfies Partial<InlineConfirmProps>;
 
 export const InlineConfirm = ((_props) => {
     const {children} = useProps('InlineConfirm', defaultProps, _props);

--- a/packages/mantine/src/components/InlineConfirm/InlineConfirmContext.ts
+++ b/packages/mantine/src/components/InlineConfirm/InlineConfirmContext.ts
@@ -1,8 +1,8 @@
 import {createSafeContext} from '@mantine/core';
 
 type InlineConfirmContextType = {
-    confirmingId: string;
-    setConfirmingId: (id: string) => void;
+    confirmingId: string | null;
+    setConfirmingId: (id: string | null) => void;
     clearConfirm: () => void;
 };
 

--- a/packages/mantine/src/components/InlineConfirm/InlineConfirmPrompt.tsx
+++ b/packages/mantine/src/components/InlineConfirm/InlineConfirmPrompt.tsx
@@ -40,13 +40,13 @@ export type InlineConfirmPromptFactory = Factory<{
     ref: HTMLDivElement;
 }>;
 
-const defaultProps: Partial<InlineConfirmPromptProps> = {
+const defaultProps = {
     label: 'Are you sure?',
     confirm: <Button.DestructivePrimary>Delete</Button.DestructivePrimary>,
     cancel: <Button.Tertiary>Cancel</Button.Tertiary>,
     gap: 'xs',
     wrap: 'nowrap',
-};
+} satisfies Partial<InlineConfirmPromptProps>;
 
 export const InlineConfirmPrompt = factory<InlineConfirmPromptFactory>((props, ref) => {
     const {inlineConfirmId, label, confirm, cancel, onConfirm, onCancel, ...others} = useProps(

--- a/packages/mantine/src/components/LastUpdated/LastUpdated.tsx
+++ b/packages/mantine/src/components/LastUpdated/LastUpdated.tsx
@@ -30,18 +30,17 @@ export type LastUpdatedFactory = Factory<{
     stylesNames: LastUpdatedStylesNames;
 }>;
 
-const defaultProps: Partial<LastUpdatedProps> = {
+const defaultProps = {
     label: 'Last update:',
     formatter: (time) => dayjs(time).format('h:mm:ss A'),
-};
+} satisfies Partial<LastUpdatedProps>;
 
 export const LastUpdated = factory<LastUpdatedFactory>((props: LastUpdatedProps, ref: ForwardedRef<HTMLDivElement>) => {
     const {formatter, label, time, classNames, className, styles, style, vars, unstyled, ...others} = useProps(
         'PlasmaLastUpdated',
-        defaultProps as Partial<LastUpdatedProps>,
+        defaultProps,
         props,
     );
-
     const resolvedTime = time ?? dayjs().valueOf();
 
     const getStyles = useStyles<LastUpdatedFactory>({
@@ -58,12 +57,7 @@ export const LastUpdated = factory<LastUpdatedFactory>((props: LastUpdatedProps,
     const stylesApiProps = {classNames, styles};
 
     return (
-        <Group
-            justify={props.justify}
-            ref={ref}
-            {...getStyles('root', {className, style, ...stylesApiProps})}
-            {...others}
-        >
+        <Group ref={ref} {...getStyles('root', {className, style, ...stylesApiProps})} {...others}>
             <Text size="xs" {...getStyles('label', {className, style, ...stylesApiProps})}>
                 {label}
                 <span role="timer">{formatter(resolvedTime)}</span>

--- a/packages/mantine/src/components/Prompt/Prompt.tsx
+++ b/packages/mantine/src/components/Prompt/Prompt.tsx
@@ -110,7 +110,7 @@ const _Prompt = factory<PromptFactory>((_props, ref) => {
     const IconComponent = PromptVariantIconsMapping[variant];
 
     return (
-        <PromptContextProvider value={{variant: variant, getStyles}}>
+        <PromptContextProvider value={{variant, getStyles}}>
             <Modal.Root ref={ref} variant="prompt" {...others} {...getStyles('root')}>
                 <Modal.Overlay {...getStyles('overlay', stylesApiProps)} />
                 <Modal.Content {...getStyles('content', stylesApiProps)}>

--- a/packages/mantine/src/components/Prompt/Prompt.tsx
+++ b/packages/mantine/src/components/Prompt/Prompt.tsx
@@ -14,6 +14,7 @@ import {
     ComponentType,
     forwardRef,
     ForwardRefExoticComponent,
+    isValidElement,
     ReactElement,
     ReactNode,
     RefAttributes,
@@ -60,10 +61,11 @@ const PromptVariantIconsMapping: Record<PromptVariant, typeof InfoToken.Informat
     information: InfoToken.Information,
 };
 
-const defaultProps: Partial<PromptInternalProps> = {
+const defaultProps = {
     variant: 'information',
     centered: true,
-};
+    size: 'sm',
+} satisfies Partial<PromptInternalProps>;
 
 const _Prompt = factory<PromptFactory>((_props, ref) => {
     const props = useProps('Prompt', defaultProps, _props);
@@ -94,17 +96,22 @@ const _Prompt = factory<PromptFactory>((_props, ref) => {
     const stylesApiProps = {classNames, styles};
 
     const footers: ReactElement[] = [];
-    const otherChildren: ReactElement[] = [];
+    const otherChildren: ReactNode[] = [];
 
-    Children.forEach(children, (child: ReactElement) => {
-        (child.type === PromptFooter ? footers : otherChildren).push(child);
+    Children.forEach(children, (child) => {
+        if (isValidElement(child) && child.type === PromptFooter) {
+            footers.push(child);
+            return;
+        }
+
+        otherChildren.push(child);
     });
 
     const IconComponent = PromptVariantIconsMapping[variant];
 
     return (
-        <PromptContextProvider value={{variant, getStyles}}>
-            <Modal.Root ref={ref} variant="prompt" size="sm" {...others} {...getStyles('root')}>
+        <PromptContextProvider value={{variant: variant, getStyles}}>
+            <Modal.Root ref={ref} variant="prompt" {...others} {...getStyles('root')}>
                 <Modal.Overlay {...getStyles('overlay', stylesApiProps)} />
                 <Modal.Content {...getStyles('content', stylesApiProps)}>
                     <Modal.Header {...getStyles('header', stylesApiProps)}>

--- a/packages/mantine/src/components/Prompt/PromptCancelButton.tsx
+++ b/packages/mantine/src/components/Prompt/PromptCancelButton.tsx
@@ -16,7 +16,7 @@ export type PromptCancelButtonFactory = Factory<{
     compound: true;
 }>;
 
-const defaultProps: Partial<PromptCancelButtonProps> = {};
+const defaultProps = {} satisfies Partial<PromptCancelButtonProps>;
 
 export const PromptCancelButton = factory<PromptCancelButtonFactory>((_props, ref) => {
     const {getStyles} = usePromptContext();

--- a/packages/mantine/src/components/Prompt/PromptConfirmButton.tsx
+++ b/packages/mantine/src/components/Prompt/PromptConfirmButton.tsx
@@ -30,7 +30,7 @@ const COMPONENT_BY_VARIANT: Record<
     critical: Button.DestructivePrimary,
 };
 
-const defaultProps: Partial<PromptConfirmButtonProps> = {};
+const defaultProps = {} satisfies Partial<PromptConfirmButtonProps>;
 
 export const PromptConfirmButton = factory<PromptConfirmButtonFactory>((_props, ref) => {
     const {variant, getStyles} = usePromptContext();

--- a/packages/mantine/src/components/RadioCard/RadioCard.tsx
+++ b/packages/mantine/src/components/RadioCard/RadioCard.tsx
@@ -44,11 +44,22 @@ export type RadioCardProps = MantineRadioCardProps &
         disabledTooltip?: string;
     };
 
-const defaultProps: Partial<RadioCardProps> = {};
+const defaultProps = {} satisfies Partial<RadioCardProps>;
 
 export const RadioCard = factory<RadioCardFactory>((_props, ref) => {
-    const {classNames, styles, style, className, vars, disabled, label, description, disabledTooltip, ...others} =
-        useProps('RadioCard', defaultProps, _props);
+    const {
+        classNames,
+        styles,
+        style,
+        className,
+        vars,
+        disabled,
+        label,
+        description,
+        disabledTooltip,
+        readOnly,
+        ...others
+    } = useProps('RadioCard', defaultProps, _props);
     const getStyles = useStyles<RadioCardFactory>({
         name: 'RadioCard',
         classes,
@@ -65,9 +76,9 @@ export const RadioCard = factory<RadioCardFactory>((_props, ref) => {
             <Radio.Card
                 ref={ref}
                 disabled={disabled}
-                readOnly={_props.readOnly}
                 {...getStyles('card', {className, style, classNames, styles})}
                 {...others}
+                aria-readonly={readOnly}
             >
                 <Group {...getStyles('container', {classNames, styles})}>
                     <Radio.Indicator size="xs" disabled={disabled} {...getStyles('indicator', {classNames, styles})} />

--- a/packages/mantine/src/components/StatusToken/StatusToken.tsx
+++ b/packages/mantine/src/components/StatusToken/StatusToken.tsx
@@ -13,10 +13,10 @@ import {
 } from '@mantine/core';
 
 import Circle from './icons/circle.svg?raw';
+import Info from './icons/info.svg?raw';
 import Ring from './icons/ring.svg?raw';
 import Square from './icons/square.svg?raw';
 import Triangle from './icons/triangle.svg?raw';
-import Info from './icons/info.svg?raw';
 import classes from './StatusToken.module.css';
 
 export type StatusTokenFactory = Factory<{
@@ -49,7 +49,7 @@ export interface StatusTokenProps extends BoxProps, StylesApiProps<StatusTokenFa
     variant?: StatusTokenVariant;
 }
 
-const defaultProps: Partial<StatusTokenProps> = {size: 'lg', variant: 'info'};
+const defaultProps = {size: 'lg', variant: 'info'} satisfies Partial<StatusTokenProps>;
 
 const resolveThemeColorFromVariant = (variant: StatusTokenVariant, theme: MantineTheme): string => {
     switch (variant) {
@@ -93,11 +93,13 @@ const resolveIconSrcFromVariant = (variant: StatusTokenVariant): string => {
 };
 
 const varsResolver = createVarsResolver<StatusTokenFactory>((theme, {variant, size}) => {
-    const color = resolveThemeColorFromVariant(variant, theme);
+    const resolvedVariant = variant ?? defaultProps.variant;
+    const resolvedSize = size ?? defaultProps.size;
+    const color = resolveThemeColorFromVariant(resolvedVariant, theme);
     return {
         root: {
             '--status-token-color': color,
-            '--status-token-size': getSize(resolveSize(size), 'status-token-size'),
+            '--status-token-size': getSize(resolveSize(resolvedSize), 'status-token-size'),
         },
     };
 });
@@ -115,7 +117,7 @@ const statusTokenLabels: Record<StatusTokenVariant, string> = {
 
 export const StatusToken: ReturnType<typeof polymorphicFactory<StatusTokenFactory>> =
     polymorphicFactory<StatusTokenFactory>((props, ref) => {
-        const {variant, vars, size, className, style, unstyled, styles, classNames, ...others} = useProps(
+        const {variant, vars, className, style, unstyled, styles, classNames, ...others} = useProps(
             'StatusToken',
             defaultProps,
             props,

--- a/packages/mantine/src/components/StickyFooter/StickyFooter.tsx
+++ b/packages/mantine/src/components/StickyFooter/StickyFooter.tsx
@@ -32,10 +32,10 @@ export type StickyFooterFactory = Factory<{
     stylesNames: StickyFooterStylesNames;
 }>;
 
-const defaultProps: Partial<StickyFooterProps> = {
+const defaultProps = {
     gap: 'xs',
     justify: 'flex-end',
-};
+} satisfies Partial<StickyFooterProps>;
 
 export const StickyFooter = factory<StickyFooterFactory>((props, ref) => {
     const {borderTop, justify, gap, children, className, classNames, style, styles, unstyled, vars, ...others} =

--- a/packages/mantine/src/components/Table/Table.tsx
+++ b/packages/mantine/src/components/Table/Table.tsx
@@ -242,10 +242,10 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
             <TableProvider<T>
                 value={{
                     getStyles,
-                    getRowActions: getRowActions,
+                    getRowActions,
                     store,
                     table,
-                    layouts: layouts,
+                    layouts,
                     containerRef,
                 }}
             >

--- a/packages/mantine/src/components/Table/Table.tsx
+++ b/packages/mantine/src/components/Table/Table.tsx
@@ -77,14 +77,14 @@ export type PlasmaTableFactory = Factory<{
     };
 }>;
 
-const defaultProps: Partial<TableProps<unknown>> = {
+const defaultProps = {
     layouts: [TableLayouts.Rows as TableLayout],
     layoutProps: {},
     loading: false,
     additionalRootNodes: [],
     options: {},
     getRowActions: () => [],
-};
+} satisfies Partial<TableProps<unknown>>;
 
 export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElement>}) => {
     const {
@@ -110,7 +110,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
         styles,
         unstyled,
         ...others
-    } = useProps('PlasmaTable', defaultProps as TableProps<T>, props);
+    } = useProps('PlasmaTable', defaultProps, props);
 
     const getStyles = useStyles<PlasmaTableFactory>({
         name: 'PlasmaTable',
@@ -145,7 +145,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
         onColumnVisibilityChange: store.setColumnVisibility,
         columns: store.multiRowSelectionEnabled ? [TableSelectableColumn as ColumnDef<T>].concat(columns) : columns,
         getCoreRowModel: getCoreRowModel(),
-        manualPagination: options?.getPaginationRowModel === undefined,
+        manualPagination: options.getPaginationRowModel === undefined,
         enableMultiRowSelection: !!store.multiRowSelectionEnabled,
         getRowId,
         getRowCanExpand: (row: Row<T>) => !!getRowExpandedContent?.(row.original, row.index, row),
@@ -155,7 +155,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
             minSize: defaultColumnSizing.minSize,
             maxSize: defaultColumnSizing.maxSize,
         },
-        rowCount: options?.getFilteredRowModel ? undefined : store.state.totalEntries,
+        rowCount: options.getFilteredRowModel ? undefined : (store.state.totalEntries ?? undefined),
         ...options,
     });
 
@@ -232,12 +232,23 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
     }
 
     const Layout =
-        store.state.layout === null ? layouts[0] : layouts.find(({displayName}) => displayName === store.state.layout);
+        store.state.layout === null
+            ? layouts[0]
+            : (layouts.find(({displayName}) => displayName === store.state.layout) ?? layouts[0]);
     const hasRows = table.getRowModel().rows.length > 0;
 
     return (
         <Box ref={mergedRef} {...others} {...getStyles('root')}>
-            <TableProvider<T> value={{getStyles, getRowActions, store, table, layouts, containerRef}}>
+            <TableProvider<T>
+                value={{
+                    getStyles,
+                    getRowActions: getRowActions,
+                    store,
+                    table,
+                    layouts: layouts,
+                    containerRef,
+                }}
+            >
                 <Layout>
                     {store.isVacant && !store.isFiltered ? (
                         noData

--- a/packages/mantine/src/components/Table/layouts/row-layout/RowLayout.tsx
+++ b/packages/mantine/src/components/Table/layouts/row-layout/RowLayout.tsx
@@ -19,7 +19,7 @@ export type RowLayoutFactory = Factory<{
     stylesNames: RowLayoutStylesNames;
     staticComponents: TableLayout;
 }>;
-const defaultProps: Partial<RowLayoutProps> = {};
+const defaultProps = {} satisfies Partial<RowLayoutProps>;
 
 export const RowLayout = ((props: RowLayoutProps) => {
     const {children, styles, classNames, unstyled} = useProps('PlasmaRowLayout', defaultProps, props);

--- a/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutBody.tsx
+++ b/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutBody.tsx
@@ -13,9 +13,7 @@ import {useRowLayout} from './RowLayoutContext.js';
 export type RowLayoutBodyStylesNames = 'row' | 'cell' | 'collapsibleRow' | 'collapsibleWrapper';
 
 export interface RowLayoutBodyProps<T>
-    extends BoxProps,
-        TableLayoutProps<T>,
-        CompoundStylesApiProps<RowLayoutBodyFactory> {}
+    extends BoxProps, TableLayoutProps<T>, CompoundStylesApiProps<RowLayoutBodyFactory> {}
 
 export type RowLayoutBodyFactory = Factory<{
     props: RowLayoutBodyProps<unknown>;
@@ -24,7 +22,7 @@ export type RowLayoutBodyFactory = Factory<{
     compound: true;
 }>;
 
-const defaultProps: Partial<RowLayoutBodyProps<unknown>> = {};
+const defaultProps = {} satisfies Partial<RowLayoutBodyProps<unknown>>;
 
 export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: ForwardedRef<HTMLTableRowElement>}) => {
     const ctx = useRowLayout();
@@ -38,11 +36,11 @@ export const RowLayoutBody = <T,>(props: RowLayoutBodyProps<T> & {ref?: Forwarde
         style,
         getRowAttributes,
         ...others
-    } = useProps('RowLayoutBody', defaultProps as RowLayoutBodyProps<T>, props);
+    } = useProps('RowLayoutBody', defaultProps, props);
     const {table, store} = useTableContext<T>();
     const toggleCollapsible = (el: HTMLTableRowElement) => {
         const cell = el.children[el.children.length - 1] as HTMLTableCellElement;
-        cell.querySelector('button').click();
+        cell.querySelector('button')?.click();
     };
 
     const rows = table.getRowModel()?.rows.map((row) => {

--- a/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutHeader.tsx
+++ b/packages/mantine/src/components/Table/layouts/row-layout/RowLayoutHeader.tsx
@@ -10,9 +10,7 @@ import {useRowLayout} from './RowLayoutContext.js';
 export type RowLayoutHeaderStyleNames = 'headerRow';
 
 export interface RowLayoutHeaderProps<T>
-    extends BoxProps,
-        TableLayoutProps<T>,
-        CompoundStylesApiProps<RowLayoutBodyFactory> {}
+    extends BoxProps, TableLayoutProps<T>, CompoundStylesApiProps<RowLayoutBodyFactory> {}
 
 type RowLayoutHeaderFactory = Factory<{
     props: RowLayoutHeaderProps<unknown>;
@@ -21,7 +19,7 @@ type RowLayoutHeaderFactory = Factory<{
     compound: true;
 }>;
 
-const defaultProps: Partial<RowLayoutHeaderProps<unknown>> = {};
+const defaultProps = {} satisfies Partial<RowLayoutHeaderProps<unknown>>;
 
 export const RowLayoutHeader = <T,>(props: RowLayoutHeaderProps<T> & {ref?: ForwardedRef<HTMLTableRowElement>}) => {
     const ctx = useRowLayout();
@@ -36,7 +34,7 @@ export const RowLayoutHeader = <T,>(props: RowLayoutHeaderProps<T> & {ref?: Forw
         classNames,
         styles,
         ...others
-    } = useProps('RowLayoutHeader', defaultProps as RowLayoutHeaderProps<T>, props);
+    } = useProps('RowLayoutHeader', defaultProps, props);
     const {table, store} = useTableContext<T>();
 
     const headers = table.getHeaderGroups().map((headerGroup) => (

--- a/packages/mantine/src/components/Table/table-actions/TableActionItem.tsx
+++ b/packages/mantine/src/components/Table/table-actions/TableActionItem.tsx
@@ -8,7 +8,8 @@ import {Menu, type MenuItemProps} from '../../Menu/Menu.js';
 export type TableActionItemStylesNames = 'actionItemRoot';
 
 export interface TableActionItemProps
-    extends Omit<ButtonProps, 'classNames' | 'styles' | 'vars' | 'variant' | 'leftSection' | 'rightSection'>,
+    extends
+        Omit<ButtonProps, 'classNames' | 'styles' | 'vars' | 'variant' | 'leftSection' | 'rightSection'>,
         Omit<MenuItemProps, 'classNames' | 'styles' | 'vars' | 'variant' | 'leftSection' | 'disabled'>,
         CompoundStylesApiProps<TableActionItemFactory> {
     /**
@@ -29,7 +30,7 @@ type TableActionItemFactory = PolymorphicFactory<{
     compound: true;
 }>;
 
-const defaultProps: Partial<TableActionItemProps> = {};
+const defaultProps = {} satisfies Partial<TableActionItemProps>;
 
 export const TableActionItem = polymorphicFactory<TableActionItemFactory>(
     (props: TableActionItemProps & {component?: any}, ref) => {

--- a/packages/mantine/src/components/Table/table-actions/TableActionsList.tsx
+++ b/packages/mantine/src/components/Table/table-actions/TableActionsList.tsx
@@ -28,7 +28,8 @@ export type TableActionsListStylesNames =
     | 'actionsGroupItems';
 
 export interface TableActionsListProps
-    extends Omit<MenuProps, 'classNames' | 'styles' | 'vars' | 'variant'>,
+    extends
+        Omit<MenuProps, 'classNames' | 'styles' | 'vars' | 'variant'>,
         CompoundStylesApiProps<TableActionsListFactory> {
     actions: TableAction[];
     /**
@@ -52,11 +53,11 @@ type TableActionsListFactory = Factory<{
     variant: 'split' | 'combined';
 }>;
 
-const defaultProps: Partial<TableActionsListProps> = {
+const defaultProps = {
     label: 'More',
     primaryGroupLabel: '',
     icon: <MoreSize16Px height={16} />,
-};
+} satisfies Partial<TableActionsListProps>;
 
 interface ActionsDict {
     $$primary: TableAction[];
@@ -80,6 +81,9 @@ export const TableActionsList = (props: TableActionsListProps) => {
         styles,
         vars: _vars,
         variant,
+        withinPortal,
+        opened: controlledOpened,
+        onChange: onMenuChange,
         ...others
     } = useProps('PlasmaTableActionsListColumn', defaultProps, props);
     const [opened, setOpened] = useState(false);
@@ -93,6 +97,7 @@ export const TableActionsList = (props: TableActionsListProps) => {
         if (!newOpened) {
             setOpened(false);
         }
+        onMenuChange?.(newOpened);
     };
 
     const actionsGroups: ActionsDict = actions.reduce<ActionsDict>(
@@ -129,7 +134,7 @@ export const TableActionsList = (props: TableActionsListProps) => {
                 <TableActionProvider value={{primary: true}}>{primaryActions}</TableActionProvider>
                 {secondaryActionGroups.length > 0 ? (
                     <TableActionProvider value={{primary: false}}>
-                        <Menu withinPortal={false} {...others} keepMounted>
+                        <Menu withinPortal={withinPortal ?? false} {...others} keepMounted>
                             <Menu.Target>
                                 <Button.Quaternary
                                     {...getStyles('actionsTarget', {styles, classNames})}
@@ -155,7 +160,7 @@ export const TableActionsList = (props: TableActionsListProps) => {
         <InlineConfirm>
             {confirmPrompts}
             <TableActionProvider value={{primary: false}}>
-                <Menu opened={opened} onChange={onChange} {...others} keepMounted>
+                <Menu opened={controlledOpened ?? opened} onChange={onChange} {...others} keepMounted>
                     <Menu.Target>
                         <Tooltip label={label} {...getStyles('actionsTooltip', {styles, classNames})}>
                             <ActionIcon.Quaternary
@@ -184,12 +189,12 @@ export const TableActionsList = (props: TableActionsListProps) => {
 };
 
 interface ActionsGroupsMenuItemsProps {
-    styles: Partial<Record<TableActionsListStylesNames, CSSProperties>>;
-    classNames: Partial<Record<TableActionsListStylesNames, string>>;
+    styles?: Partial<Record<TableActionsListStylesNames, CSSProperties>>;
+    classNames?: Partial<Record<TableActionsListStylesNames, string>>;
     actionGroups: ActionGroup[];
 }
 
-const ActionsGroupsMenuItems = ({styles, classNames, actionGroups}: ActionsGroupsMenuItemsProps) => {
+const ActionsGroupsMenuItems = ({styles = {}, classNames = {}, actionGroups}: ActionsGroupsMenuItemsProps) => {
     const {getStyles} = useTableContext();
     return actionGroups.map(({name, actions}, index) => (
         <Box key={name} {...getStyles('actionsGroup', {styles, classNames})}>

--- a/packages/mantine/src/components/Table/table-actions/TableHeaderActions.tsx
+++ b/packages/mantine/src/components/Table/table-actions/TableHeaderActions.tsx
@@ -1,5 +1,5 @@
 import {Factory, factory, Grid, GridColProps, Group, useProps} from '@mantine/core';
-import {ReactElement, useMemo} from 'react';
+import {useMemo} from 'react';
 
 import {TableComponentsOrder} from '../Table.js';
 import {useTableContext} from '../TableContext.js';
@@ -16,43 +16,41 @@ type TableHeaderActionsFactory = Factory<{
     compound: true;
 }>;
 
-const defaultProps: Partial<TableHeaderActionsProps> = {};
+const defaultProps = {} satisfies Partial<TableHeaderActionsProps>;
 
-export const TableHeaderActions = factory<TableHeaderActionsFactory>(
-    (props: TableHeaderActionsProps, ref): ReactElement => {
-        const {store, getStyles, getRowActions} = useTableContext();
-        const {style, className, classNames, styles, ...others} = useProps(
-            'PlasmaTableHeaderActions',
-            defaultProps,
-            props,
-        );
+export const TableHeaderActions = factory<TableHeaderActionsFactory>((props: TableHeaderActionsProps, ref) => {
+    const {store, getStyles, getRowActions} = useTableContext();
+    const {style, className, classNames, styles, span, order, ...others} = useProps(
+        'PlasmaTableHeaderActions',
+        defaultProps,
+        props,
+    );
 
-        const actions = useMemo(() => {
-            const selectedRows = store.getSelectedRows();
-            if (selectedRows.length === 0) {
-                return [];
-            }
-            return getRowActions(selectedRows);
-        }, [store.state.rowSelection]);
-
-        if (actions.length === 0) {
-            return null;
+    const actions = useMemo(() => {
+        const selectedRows = store.getSelectedRows();
+        if (selectedRows.length === 0) {
+            return [];
         }
+        return getRowActions(selectedRows);
+    }, [store.state.rowSelection]);
 
-        const stylesApiProps = {classNames, styles};
+    if (actions.length === 0) {
+        return null;
+    }
 
-        return (
-            <Grid.Col
-                span="content"
-                order={TableComponentsOrder.Actions}
-                ref={ref}
-                {...getStyles('headerActionsRoot', {className, style, ...stylesApiProps})}
-                {...others}
-            >
-                <Group gap="xs" {...getStyles('headerActionsGroup', stylesApiProps)}>
-                    <TableActionsList actions={actions} variant="split" />
-                </Group>
-            </Grid.Col>
-        );
-    },
-);
+    const stylesApiProps = {classNames, styles};
+
+    return (
+        <Grid.Col
+            span={span ?? 'content'}
+            order={order ?? TableComponentsOrder.Actions}
+            ref={ref}
+            {...getStyles('headerActionsRoot', {className, style, ...stylesApiProps})}
+            {...others}
+        >
+            <Group gap="xs" {...getStyles('headerActionsGroup', stylesApiProps)}>
+                <TableActionsList actions={actions} variant="split" />
+            </Group>
+        </Grid.Col>
+    );
+});

--- a/packages/mantine/src/components/Table/table-column/TableActionsColumn.tsx
+++ b/packages/mantine/src/components/Table/table-column/TableActionsColumn.tsx
@@ -48,16 +48,16 @@ interface TableActionsColumnProps extends Omit<TableActionsListProps, 'actions'>
     info: CellContext<unknown, unknown>;
 }
 
-const defaultProps: Partial<TableActionsColumnProps> = {
+const defaultProps = {
     label: 'Actions',
     icon: <MoreSize16Px height={16} />,
-};
+} satisfies Partial<TableActionsColumnProps>;
 
 const ActionsMenu: FunctionComponent<TableActionsColumnProps> = (props) => {
     const {getRowActions} = useTableContext();
 
-    const {info, ...others} = useProps('PlasmaTableActionsColumn', defaultProps, props);
+    const {info, variant, ...others} = useProps('PlasmaTableActionsColumn', defaultProps, props);
 
     const actionsElements = getRowActions([info.row.original]);
-    return <TableActionsList actions={actionsElements} variant="combined" {...others} />;
+    return <TableActionsList actions={actionsElements} variant={variant ?? 'combined'} {...others} />;
 };

--- a/packages/mantine/src/components/Table/table-column/TableCollapsibleColumn.tsx
+++ b/packages/mantine/src/components/Table/table-column/TableCollapsibleColumn.tsx
@@ -57,21 +57,31 @@ type TableCollapsibleColumnFactory = Factory<{
     compound: true;
 }>;
 
-const defaultProps: Partial<CollapsibleIconProps> = {
+const defaultProps = {
     iconExpanded: <IconChevronUp aria-label="Collapse" size={16} />,
     iconCollapsed: <IconChevronDown aria-label="Expand" size={16} />,
-};
+} satisfies Partial<CollapsibleIconProps>;
 
 const CollapsibleIcon = factory<TableCollapsibleColumnFactory>((props, ref) => {
     const {getStyles} = useTableContext();
-    const {info, onToggle, iconExpanded, iconCollapsed, classNames, className, style, styles, ...others} = useProps(
-        'PlasmaTableCollapsibleColumn',
-        defaultProps,
-        props,
-    );
+    const {
+        info,
+        onToggle,
+        iconExpanded,
+        iconCollapsed,
+        classNames,
+        className,
+        style,
+        styles,
+        onClick: onActionClick,
+        color,
+        radius,
+        ...others
+    } = useProps('PlasmaTableCollapsibleColumn', defaultProps, props);
     const handler = info.row.getToggleExpandedHandler();
     const onClick = (e: ReactMouseEvent<HTMLButtonElement>) => {
         e.stopPropagation();
+        onActionClick?.(e);
         onToggle?.(e);
         handler();
     };
@@ -79,8 +89,8 @@ const CollapsibleIcon = factory<TableCollapsibleColumnFactory>((props, ref) => {
         <ActionIcon.Quaternary
             ref={ref}
             onClick={onClick}
-            color="gray"
-            radius="sm"
+            color={color ?? 'gray'}
+            radius={radius ?? 'sm'}
             {...getStyles('collapsibleIcon', {className, classNames, styles, style})}
             {...others}
         >

--- a/packages/mantine/src/components/Table/table-date-range-picker/TableDateRangePicker.tsx
+++ b/packages/mantine/src/components/Table/table-date-range-picker/TableDateRangePicker.tsx
@@ -33,9 +33,9 @@ export type TableDateRangePickerFactory = Factory<{
     compound: true;
 }>;
 
-const defaultProps: Partial<TableDateRangePickerProps> = {
+const defaultProps = {
     presets: {},
-};
+} satisfies Partial<TableDateRangePickerProps>;
 
 export const TableDateRangePicker = factory<TableDateRangePickerFactory>((props, ref) => {
     const {store, getStyles} = useTableContext();

--- a/packages/mantine/src/components/Table/table-filter/TableFilter.tsx
+++ b/packages/mantine/src/components/Table/table-filter/TableFilter.tsx
@@ -25,9 +25,9 @@ export type TableFilterFactory = Factory<{
     compound: true;
 }>;
 
-const defaultProps: Partial<TableFilterProps> = {
+const defaultProps = {
     placeholder: 'Search by any field',
-};
+} satisfies Partial<TableFilterProps>;
 
 export const TableFilter = factory<TableFilterFactory>((props, ref) => {
     const {store, getStyles} = useTableContext();

--- a/packages/mantine/src/components/Table/table-header/TableHeader.tsx
+++ b/packages/mantine/src/components/Table/table-header/TableHeader.tsx
@@ -37,12 +37,12 @@ export type TableHeaderFactory = Factory<{
     compound: true;
 }>;
 
-const defaultProps: Partial<TableHeaderProps> = {
+const defaultProps = {
     unselectAllLabel: 'Unselect all',
     selectedCountLabel: (count) => `${count} selected`,
     showActions: true,
     borderTop: true,
-};
+} satisfies Partial<TableHeaderProps>;
 
 export const TableHeader = factory<TableHeaderFactory>((props, ref) => {
     const {store, getStyles} = useTableContext();

--- a/packages/mantine/src/components/Table/table-header/Th.tsx
+++ b/packages/mantine/src/components/Table/table-header/Th.tsx
@@ -33,15 +33,15 @@ export type TableThFactory = Factory<{
     compound: true;
 }>;
 
-const defaultProps: Partial<ThProps> = {
+const defaultProps = {
     sortingIcons: SortingIcons,
-};
+} satisfies Partial<ThProps>;
 
 export const Th = <T,>(props: ThProps<T> & {ref?: ForwardedRef<HTMLTableCellElement>}) => {
     const {getStyles} = useTableContext();
     const {header, sortingIcons, classNames, className, styles, style, vars, ...others} = useProps(
         'PlasmaTableTh',
-        defaultProps as Partial<ThProps<T>>,
+        defaultProps,
         props,
     );
 

--- a/packages/mantine/src/components/Table/table-pagination/TablePagination.tsx
+++ b/packages/mantine/src/components/Table/table-pagination/TablePagination.tsx
@@ -11,7 +11,7 @@ export const TablePagination: FunctionComponent<TablePaginationProps> = ({onPage
     const updatePage = (newPage: number) => {
         onPageChange?.(newPage - 1);
         store.setPagination((prev) => ({...prev, pageIndex: newPage - 1}));
-        containerRef.current.scrollIntoView({behavior: 'smooth'});
+        containerRef.current?.scrollIntoView({behavior: 'smooth'});
     };
 
     const total = table.getPageCount();

--- a/packages/mantine/src/components/Table/table-predicate/TablePredicate.tsx
+++ b/packages/mantine/src/components/Table/table-predicate/TablePredicate.tsx
@@ -45,15 +45,15 @@ export type TablePredicateFactory = Factory<{
     compound: true;
 }>;
 
-const defaultProps: Partial<TablePredicateProps> = {};
+const defaultProps = {} satisfies Partial<TablePredicateProps>;
 
 export const TablePredicate: FunctionComponent<TablePredicateProps> = factory<TablePredicateFactory>((props, ref) => {
     const {store, getStyles} = useTableContext();
     const {id, data, label, classNames, className, styles, style, renderOption, comboboxProps, vars, ...others} =
         useProps('PlasmaTablePredicate', defaultProps, props);
 
-    const handleChange = (newValue: string) => {
-        store.setPredicates((prev) => ({...prev, [id]: newValue}));
+    const handleChange = (newValue: string | null) => {
+        store.setPredicates((prev) => ({...prev, [id]: newValue ?? ''}));
         store.setPagination((prev) => ({...prev, pageIndex: 0}));
     };
 

--- a/packages/mantine/src/components/Table/use-table.ts
+++ b/packages/mantine/src/components/Table/use-table.ts
@@ -237,14 +237,18 @@ const PAGINATION_SERIALIZATION = serialization<'pagination'>({
         ['page', (pageIndex + 1).toString()],
         ['pageSize', pageSize.toString()],
     ],
-    deserializer: (params, initialState) =>
-        defaultsDeep(
+    deserializer: (params, initialState) => {
+        const page = params.get('page');
+        const pageSize = params.get('pageSize');
+
+        return defaultsDeep(
             {
-                pageIndex: params.get('page') ? Math.max(1, parseInt(params.get('page'), 10)) - 1 : undefined,
-                pageSize: params.get('pageSize') ? parseInt(params.get('pageSize'), 10) : undefined,
+                pageIndex: page ? Math.max(1, parseInt(page, 10)) - 1 : undefined,
+                pageSize: pageSize ? parseInt(pageSize, 10) : undefined,
             },
             initialState,
-        ),
+        );
+    },
 });
 
 const SORTING_SERIALIZATION = serialization<'sorting'>({
@@ -487,8 +491,8 @@ export const useTable = <TData>(userOptions: UseTableOptions<TData> = {}): Table
         clearRowSelection,
         getSelectedRows,
         getSelectedRow,
-        rowSelectionEnabled: options.enableRowSelection,
-        rowSelectionForced: options.forceSelection,
-        multiRowSelectionEnabled: options.enableMultiRowSelection,
+        rowSelectionEnabled: !!options.enableRowSelection,
+        rowSelectionForced: !!options.forceSelection,
+        multiRowSelectionEnabled: !!options.enableMultiRowSelection,
     };
 };

--- a/packages/mantine/src/hooks/use-url-synced-state.ts
+++ b/packages/mantine/src/hooks/use-url-synced-state.ts
@@ -23,7 +23,8 @@ const slice = Function.prototype.call.bind(Array.prototype.slice) as <T>(
  * @param href The url to extract the parts from.
  * @returns The separate parts, all are an empty string if not present.
  */
-const extractParts = (href: string) => slice(/^([^?#]*)(\?[^#]*|)(#[^?]*|)(\?.*|)$/.exec(href ?? ''), 1, 5) as UrlParts;
+const extractParts = (href: string) =>
+    slice(/^([^?#]*)(\?[^#]*|)(#[^?]*|)(\?.*|)$/.exec(href ?? '') ?? ['', '', '', '', ''], 1, 5) as UrlParts;
 
 /**
  * The index of the search parameter to use, e.g. hashSearch for hash routes (hash starts with '#/').
@@ -107,7 +108,7 @@ export const useUrlSyncedState = <T>(options: UseUrlSyncedStateOptions<T>) => {
     });
     // Capture the initial state as a map (first render only!), to compare values and see if they should be set to the params.
     const initialStateSerialized = useMemo(() => {
-        const stateMap = new Map<string, string>();
+        const stateMap = new Map<string, string | null | undefined>();
         let initialize: URLSearchParams | null = null;
         let needsApply = false;
         for (const [key, value, alwaysEmit] of options.serializer(getInitialState(options))) {
@@ -120,7 +121,7 @@ export const useUrlSyncedState = <T>(options: UseUrlSyncedStateOptions<T>) => {
                 }
             }
         }
-        if (needsApply) {
+        if (needsApply && initialize) {
             applySearchParams(initialize);
         }
         return stateMap;

--- a/packages/mantine/src/theme/Plasmantine.tsx
+++ b/packages/mantine/src/theme/Plasmantine.tsx
@@ -6,13 +6,15 @@ import {mergeCSSVariablesResolvers} from './mergeCSSVariablesResolvers.js';
 import {plasmaCSSVariablesResolver} from './plasmaCSSVariablesResolver.js';
 import {plasmaTheme} from './Theme.js';
 
+const emptyTheme = {};
+
 export const Plasmantine: FunctionComponent<MantineProviderProps> = ({
     children,
     theme: externalTheme,
     cssVariablesResolver: externalCSSVariablesResolver,
     ...others
 }) => {
-    const theme = mergeThemeOverrides(plasmaTheme, externalTheme);
+    const theme = mergeThemeOverrides(plasmaTheme, externalTheme ?? emptyTheme);
     const cssVariablesResolver = mergeCSSVariablesResolvers(plasmaCSSVariablesResolver, externalCSSVariablesResolver);
 
     return (

--- a/packages/mantine/src/theme/mergeCSSVariablesResolvers.ts
+++ b/packages/mantine/src/theme/mergeCSSVariablesResolvers.ts
@@ -1,10 +1,12 @@
 import {CSSVariablesResolver, deepMerge} from '@mantine/core';
 
 export const mergeCSSVariablesResolvers =
-    (...resolvers: CSSVariablesResolver[]): CSSVariablesResolver =>
+    (...resolvers: Array<CSSVariablesResolver | undefined>): CSSVariablesResolver =>
     (theme) =>
-        resolvers.filter(Boolean).reduce((acc, resolver) => deepMerge(acc, resolver(theme)), {
-            variables: {},
-            dark: {},
-            light: {},
-        });
+        resolvers
+            .filter((resolver): resolver is CSSVariablesResolver => Boolean(resolver))
+            .reduce((acc, resolver) => deepMerge(acc, resolver(theme)), {
+                variables: {},
+                dark: {},
+                light: {},
+            });

--- a/packages/react-icons/src/vite-plugin/index.ts
+++ b/packages/react-icons/src/vite-plugin/index.ts
@@ -9,7 +9,7 @@ const plasmaIconsMockPlugin = () =>
     ({
         name: 'coveord/plasma-react-icons/mock',
         enforce: 'pre',
-        transform: (code: string, id: string): TransformResult => {
+        transform: (code: string, id: string): TransformResult | null => {
             // Only transform relevant files (e.g., .ts, .tsx, .js, .jsx) that import from @coveord/plasma-react-icons and aren't in node_modules
             if (
                 !code.includes('@coveord/plasma-react-icons') ||

--- a/packages/storybook/src/Args.ts
+++ b/packages/storybook/src/Args.ts
@@ -97,7 +97,7 @@ const placeholder: Arg<string> = {
     initialValue: 'Placeholder',
 };
 
-const clearable: Arg<boolean> = {
+const clearable: Arg<boolean | undefined> = {
     type: {
         control: 'boolean',
         description: 'Display clear button when value is present',

--- a/packages/storybook/src/call-to-action/ActionIcon.stories.tsx
+++ b/packages/storybook/src/call-to-action/ActionIcon.stories.tsx
@@ -3,10 +3,14 @@ import {ActionIcon} from '@coveord/plasma-mantine/components/ActionIcon';
 import {IconBell} from '@coveord/plasma-react-icons';
 import type {Meta, StoryObj} from '@storybook/react-vite';
 
-const meta: Meta<typeof ActionIcon> = {
+interface ActionIconStoryArgs {
+    size: 'sm' | 'md';
+    variant: keyof typeof ActionIcon;
+}
+
+const meta: Meta<ActionIconStoryArgs> = {
     title: '@components/call-to-action/ActionIcon',
     id: 'ActionIcon',
-    component: ActionIcon,
     parameters: {
         layout: 'centered',
     },
@@ -38,15 +42,15 @@ const meta: Meta<typeof ActionIcon> = {
     },
 };
 export default meta;
-type Story = StoryObj<typeof ActionIcon>;
+type Story = StoryObj<ActionIconStoryArgs>;
 
 export const Demo: Story = {
-    render: (props: {size: 'sm' | 'md'; variant: string}) => {
-        const ActionIconComponent = ActionIcon[props.variant as keyof typeof ActionIcon] as React.ComponentType<any>;
+    render: (args) => {
+        const ActionIconComponent = ActionIcon[args.variant as keyof typeof ActionIcon] as React.ComponentType<any>;
         const Icon = () => <IconBell size={16} />;
         const onClick = () => showNotification({message: 'ActionIcon clicked', autoClose: false});
         return (
-            <ActionIconComponent onClick={onClick} size={props.size}>
+            <ActionIconComponent onClick={onClick} size={args.size}>
                 <Icon />
             </ActionIconComponent>
         );

--- a/packages/storybook/src/call-to-action/CloseButton.stories.tsx
+++ b/packages/storybook/src/call-to-action/CloseButton.stories.tsx
@@ -1,10 +1,13 @@
 import {CloseButton} from '@coveord/plasma-mantine/components/CloseButton';
 import type {Meta, StoryObj} from '@storybook/react-vite';
 
-const meta: Meta<typeof CloseButton> = {
+interface CloseButtonStoryArgs {
+    size: 'sm' | 'md';
+}
+
+const meta: Meta<CloseButtonStoryArgs> = {
     title: '@components/call-to-action/CloseButton',
     id: 'CloseButton',
-    component: CloseButton,
     parameters: {
         layout: 'centered',
     },
@@ -20,8 +23,8 @@ const meta: Meta<typeof CloseButton> = {
     },
 };
 export default meta;
-type Story = StoryObj<typeof CloseButton>;
+type Story = StoryObj<CloseButtonStoryArgs>;
 
 export const Demo: Story = {
-    render: (props: {size: 'sm' | 'md'}) => <CloseButton size={props.size} />,
+    render: (args) => <CloseButton size={args.size} />,
 };

--- a/packages/storybook/src/data-display/Table.stories.tsx
+++ b/packages/storybook/src/data-display/Table.stories.tsx
@@ -149,7 +149,7 @@ const TableCards = <TData,>(props: TableLayoutProps<TData>) => {
 };
 
 const CardLayout: TableLayout = ({children}) => <>{children}</>;
-CardLayout.Header = () => null;
+CardLayout.Header = () => <></>;
 CardLayout.displayName = 'Cards';
 CardLayout.Body = TableCards;
 CardLayout.Icon = IconLayoutGrid;

--- a/packages/storybook/src/feedback/Progress.stories.tsx
+++ b/packages/storybook/src/feedback/Progress.stories.tsx
@@ -40,7 +40,11 @@ const colorMapping = {
 } as const;
 
 export const Demo: Story = {
-    render: (props: {value: number; variant?: 'info' | 'success' | 'caution' | 'error'}) => (
-        <Progress value={props.value} w={300} color={colorMapping[props.variant ?? 'info']} />
+    render: (args) => (
+        <Progress
+            value={args.value}
+            w={300}
+            color={colorMapping[(args.variant ?? 'info') as keyof typeof colorMapping]}
+        />
     ),
 };

--- a/packages/storybook/src/layout/ChildForm.stories.tsx
+++ b/packages/storybook/src/layout/ChildForm.stories.tsx
@@ -2,7 +2,7 @@ import {ChildForm, type ChildFormProps} from '@coveord/plasma-mantine/components
 import type {Meta, StoryObj} from '@storybook/react-vite';
 import {FunctionComponent, ReactNode} from 'react';
 
-const meta: Meta<typeof ChildForm> = {
+const meta: Meta<ChildFormProps> = {
     title: '@components/layout/ChildForm',
     id: 'ChildForm',
     component: ChildForm,
@@ -18,7 +18,7 @@ const meta: Meta<typeof ChildForm> = {
     },
 };
 export default meta;
-type Story = StoryObj<typeof ChildForm>;
+type Story = StoryObj<ChildFormProps>;
 
 const Inside = () => (
     <div
@@ -40,10 +40,10 @@ const Text: FunctionComponent<{children: ReactNode}> = ({children}) => <div styl
 Text.displayName = 'Text';
 
 export const Demo: Story = {
-    render: (props: ChildFormProps) => (
+    render: (args) => (
         <>
             <Text>Above</Text>
-            <ChildForm {...props}>
+            <ChildForm {...args}>
                 <Inside />
             </ChildForm>
             <Text>Below</Text>

--- a/packages/storybook/src/layout/Header.stories.tsx
+++ b/packages/storybook/src/layout/Header.stories.tsx
@@ -8,7 +8,7 @@ interface HeaderStoryProps {
     withActions: boolean;
 }
 
-const meta: Meta<typeof Header> = {
+const meta: Meta<HeaderProps & HeaderStoryProps> = {
     title: '@components/layout/Header',
     id: 'Header',
     component: Header,
@@ -29,21 +29,21 @@ const meta: Meta<typeof Header> = {
     },
 };
 export default meta;
-type Story = StoryObj<typeof Header>;
+type Story = StoryObj<HeaderProps & HeaderStoryProps>;
 
 export const Demo: Story = {
-    render: (props: HeaderProps & HeaderStoryProps) => (
-        <Header description={props.description} borderBottom={props.borderBottom} variant={props.variant}>
-            {props.breadcrumbs?.length > 0 && (
+    render: (args) => (
+        <Header description={args.description} borderBottom={args.borderBottom} variant={args.variant}>
+            {args.breadcrumbs?.length > 0 && (
                 <Header.Breadcrumbs>
-                    {props.breadcrumbs.map((breadcrumb) => (
+                    {args.breadcrumbs.map((breadcrumb) => (
                         <Header.BreadcrumbAnchor key={breadcrumb}>{breadcrumb}</Header.BreadcrumbAnchor>
                     ))}
                 </Header.Breadcrumbs>
             )}
-            {props.title}
-            {props.docAnchor && <Header.DocAnchor label={props.docAnchor} href="https://about:blank" />}
-            {props.withActions && (
+            {args.title}
+            {args.docAnchor && <Header.DocAnchor label={args.docAnchor} href="https://about:blank" />}
+            {args.withActions && (
                 <Header.Right>
                     <Button.Primary>Primary</Button.Primary>
                     <Button.Secondary>Secondary</Button.Secondary>

--- a/packages/tsconfig-base.json
+++ b/packages/tsconfig-base.json
@@ -31,7 +31,8 @@
         "emitDecoratorMetadata": true,
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
-        "importHelpers": true
+        "importHelpers": true,
+        "strict": true
     },
     "exclude": ["${configDir}/dist", "${configDir}/node_modules"]
 }


### PR DESCRIPTION
### Proposed Changes

This PR enables TypeScript `strict` mode in the shared monorepo base config and fixes the resulting type errors in packages that inherit from it.

- Shared config
  - Add `"strict": true` to `packages/tsconfig-base.json`.
  - Keep `packages/components-props-analyzer` opted out for now.
- `packages/figma`
  - Add explicit generics for `figma.boolean(...)` / `figma.instance(...)` so optional text and instance swaps resolve correctly under strict mode.
- `packages/mantine`
  - Fix strict-mode issues around nullability, default props, optional callbacks/refs, and helper/store typing.
  - Clean up `defaultProps` declarations by switching them to `satisfies Partial<...>` and removing the old cast-based pattern.
  - Make a few behaviors explicit where strict mode surfaced ambiguity, mainly in `CodeEditor`, date-range pickers, `LastUpdated`, and `Table*`.
- `packages/storybook` and build helpers
  - Tighten story arg and plugin return types where previous inference was too loose for strict mode.

### Potential Breaking Changes

No intentional breaking changes.

The only expected behavior changes are low-risk null/undefined handling fixes made explicit during the strict-mode migration.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [x] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
