### PR TITLE
fix(mantine, breadcrumbs): update size of component

### DIFF
--- a/packages/figma/src/Header.figma.tsx
+++ b/packages/figma/src/Header.figma.tsx
@@ -18,7 +18,7 @@ figma.connect(Header, 'https://www.figma.com/design/FIkUthFdwxiJKSBE06qjY0/Plasm
     example: (props) => (
         <Header description={props.description} borderBottom>
             <Header.Breadcrumbs>
-                <Header.BreadcrumbAnchor>Parent</Header.BreadcrumbAnchor>
+                <Header.BreadcrumbAnchor single>Parent</Header.BreadcrumbAnchor>
             </Header.Breadcrumbs>
             {props.title}
             <Header.DocAnchor label="Documentation Link" href="" />

--- a/packages/mantine/src/components/Header/HeaderBreadcrumbs/HeaderBreadcrumbAnchor.tsx
+++ b/packages/mantine/src/components/Header/HeaderBreadcrumbs/HeaderBreadcrumbAnchor.tsx
@@ -32,7 +32,7 @@ export const HeaderBreadcrumbAnchor = polymorphicFactory<HeaderBreadcrumbAnchorF
             align="center"
             {...ctx.getStyles('breadcrumbAnchorSingleGroup', {className, classNames, styles, style, props})}
         >
-            <IconChevronLeft aria-label="arrow pointing back" size={16} />
+            <IconChevronLeft aria-label="arrow pointing back" size={20} />
             {children}
         </Flex>
     ) : (

--- a/packages/mantine/src/styles/Breadcrumbs.module.css
+++ b/packages/mantine/src/styles/Breadcrumbs.module.css
@@ -1,8 +1,8 @@
 .root {
-    font-size: var(--mantine-font-size-xs);
+    font-size: var(--mantine-font-size-sm);
     font-weight: var(--coveo-fw-bold);
 }
 
 .breadcrumb {
-    line-height: 14px;
+    line-height: 16px;
 }

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -218,7 +218,7 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
         Breadcrumbs: Breadcrumbs.extend({
             classNames: BreadcrumbsClasses,
             defaultProps: {
-                separator: <IconSlash size={16} color="var(--mantine-color-dimmed)" />,
+                separator: <IconSlash size={20} color="var(--mantine-color-dimmed)" />,
                 separatorMargin: 'xxs',
             },
         }),

--- a/packages/storybook/src/layout/Header.stories.tsx
+++ b/packages/storybook/src/layout/Header.stories.tsx
@@ -37,7 +37,9 @@ export const Demo: Story = {
             {props.breadcrumbs?.length > 0 && (
                 <Header.Breadcrumbs>
                     {props.breadcrumbs.map((breadcrumb) => (
-                        <Header.BreadcrumbAnchor key={breadcrumb}>{breadcrumb}</Header.BreadcrumbAnchor>
+                        <Header.BreadcrumbAnchor single={props.breadcrumbs.length === 1} key={breadcrumb}>
+                            {breadcrumb}
+                        </Header.BreadcrumbAnchor>
                     ))}
                 </Header.Breadcrumbs>
             )}


### PR DESCRIPTION
### Proposed Changes

Updated the style of the breadcrumb component:
- Changed font-size to 14px
- Updated line-height to 16px
- Changed icon size (both the back arrow and separator) to 20px

Updated the Figma and CodeConnect examples

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
