### PR TITLE
chore: add chromatic and deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,3 +56,7 @@ jobs:
                   AWS_ROLE: ${{ secrets.AWS_ROLE }}
                   AWS_REGION: ${{ secrets.AWS_REGION }}
                   AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+            - name: Deploy Storybook to Chromatic
+              env:
+                  CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+              run: pnpm --filter storybook run chromatic --storybookBuildDir storybook-static --ci --exit-zero-on-changes --auto-accept-changes --branchName=${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
                   egress-policy: audit
 
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  fetch-depth: 0
             - uses: ./.github/actions/setup
             - uses: ./.github/actions/build
             - uses: ./.github/actions/deploy
@@ -63,3 +65,7 @@ jobs:
               with:
                   message: 'Live demos of your latest successful build available here:\n- [:books: Storybook](${{ steps.deploy-demo.outputs.demo-output-path }}/)\n- [:globe_with_meridians: Plasma website (deprecated)](${{ steps.deploy-demo.outputs.demo-output-path }}/old/).'
                   avoidRepostsWith: Live demos of your latest successful build available here
+            - name: Deploy Storybook to Chromatic
+              env:
+                  CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+              run: pnpm --filter storybook run chromatic --storybookBuildDir storybook-static --ci

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -31,6 +31,7 @@ const preview: Preview = {
                 light: {name: 'Light', value: 'var(--mantine-color-body)'},
             },
         },
+        chromatic: {disableSnapshot: true},
         docs: {
             codePanel: true,
         },

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "scripts": {
         "build": "storybook build",
+        "chromatic": "chromatic --build-script-name build",
         "lint": "../../node_modules/.bin/eslint \"**/*.{ts,tsx}\"",
         "start": "storybook dev -p 6007"
     },
@@ -34,6 +35,7 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.1",
+        "chromatic": "16.1.0",
         "globals": "17.5.0",
         "postcss-preset-mantine": "1.18.0",
         "storybook": "10.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -478,6 +478,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 6.0.1
         version: 6.0.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.9))(yaml@2.8.3))
+      chromatic:
+        specifier: 16.1.0
+        version: 16.1.0
       globals:
         specifier: 17.5.0
         version: 17.5.0
@@ -3002,6 +3005,18 @@ packages:
 
   chroma-js@3.2.0:
     resolution: {integrity: sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==}
+
+  chromatic@16.1.0:
+    resolution: {integrity: sha512-7xyOUXe8jfY6c+g9S/U/cbvzVXMjdhh9cVZYvDp8dDGonjiKSbWO1dzWApdYHIiF2xj29pvWQB7N5LT6967IDw==}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
 
   cli-boxes@2.2.1:
     resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
@@ -8942,6 +8957,8 @@ snapshots:
       fsevents: 2.3.3
 
   chroma-js@3.2.0: {}
+
+  chromatic@16.1.0: {}
 
   cli-boxes@2.2.1: {}
 


### PR DESCRIPTION
### Proposed Changes

Add configuration for Chromatic
Chromatic will allow us to start doing visual regression testing once we’re there (and we have a license). It will also allow us to more easily document our components

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
