### PR TITLE
DS-292 override Mantine combobox chevron

### DIFF
--- a/packages/mantine/src/components/Combobox/PlasmaComboboxChevron.module.css
+++ b/packages/mantine/src/components/Combobox/PlasmaComboboxChevron.module.css
@@ -1,5 +1,7 @@
 .root {
     display: block;
     transform: rotate(0deg);
-    transition: transform 150ms ease;
+    transition-property: transform;
+    transition-timing-function: var(--coveo-transition-function);
+    transition-duration: var(--coveo-transition-duration);
 }

--- a/packages/mantine/src/components/Combobox/PlasmaComboboxChevron.module.css
+++ b/packages/mantine/src/components/Combobox/PlasmaComboboxChevron.module.css
@@ -1,0 +1,5 @@
+.root {
+    display: block;
+    transform: rotate(0deg);
+    transition: transform 150ms ease;
+}

--- a/packages/mantine/src/components/Combobox/PlasmaComboboxChevron.tsx
+++ b/packages/mantine/src/components/Combobox/PlasmaComboboxChevron.tsx
@@ -1,0 +1,30 @@
+import {IconChevronDown} from '@coveord/plasma-react-icons';
+import clsx from 'clsx';
+import {ComponentPropsWithoutRef, forwardRef} from 'react';
+import classes from './PlasmaComboboxChevron.module.css';
+
+type PlasmaComboboxChevronProps = ComponentPropsWithoutRef<'svg'> & {
+    children?: never;
+    /* Mantine's ComboboxChevron renders an svg by default and forwards these svg props
+     * to the override component. We declare them here so we can strip them before
+     * rendering IconChevronDown, which should keep Tabler's own svg attributes.
+     */
+    fill?: string;
+    viewBox?: string;
+    xmlns?: string;
+};
+
+export const PlasmaComboboxChevron = forwardRef<SVGSVGElement, PlasmaComboboxChevronProps>(
+    ({children: _children, className, fill: _fill, viewBox: _viewBox, xmlns: _xmlns, ...props}, ref) => (
+        <IconChevronDown
+            {...props}
+            ref={ref}
+            className={clsx(classes.root, className)}
+            data-plasma-combobox-chevron
+            size={16}
+            aria-hidden="true"
+        />
+    ),
+);
+
+PlasmaComboboxChevron.displayName = 'PlasmaComboboxChevron';

--- a/packages/mantine/src/components/ReadOnly/ReadOnlyInputStyles.ts
+++ b/packages/mantine/src/components/ReadOnly/ReadOnlyInputStyles.ts
@@ -13,7 +13,4 @@ export const readOnlyInputStyles = (theme: MantineTheme) => ({
     input: {
         cursor: 'text',
     },
-    section: {
-        color: theme.colors.gray[7],
-    },
 });

--- a/packages/mantine/src/components/ReadOnly/ReadOnlyInputStyles.ts
+++ b/packages/mantine/src/components/ReadOnly/ReadOnlyInputStyles.ts
@@ -13,4 +13,7 @@ export const readOnlyInputStyles = (theme: MantineTheme) => ({
     input: {
         cursor: 'text',
     },
+    section: {
+        color: theme.colors.gray[7],
+    },
 });

--- a/packages/mantine/src/components/Select/Select.tsx
+++ b/packages/mantine/src/components/Select/Select.tsx
@@ -5,7 +5,7 @@ const ReadOnlySelect = MantineSelect.withProps({styles: readOnlyInputStyles});
 
 export const Select = factory<SelectFactory>((props, ref) => {
     if (props.readOnly && !props.disabled) {
-        return <ReadOnlySelect ref={ref} {...props} />;
+        return <ReadOnlySelect ref={ref} data-readonly {...props} />;
     }
     return <MantineSelect ref={ref} {...props} />;
 });

--- a/packages/mantine/src/components/Table/Table.module.css
+++ b/packages/mantine/src/components/Table/Table.module.css
@@ -12,7 +12,9 @@
 .header {
     position: sticky;
     top: 0;
-    transition: box-shadow 150ms ease;
+    transition-property: box-shadow;
+    transition-timing-function: var(--coveo-transition-function);
+    transition-duration: var(--coveo-transition-duration);
     z-index: 1;
 
     &::after {

--- a/packages/mantine/src/styles/Card.module.css
+++ b/packages/mantine/src/styles/Card.module.css
@@ -1,5 +1,7 @@
 .root {
-    transition: box-shadow 150ms ease-in-out;
+    transition-property: box-shadow;
+    transition-timing-function: var(--coveo-transition-function);
+    transition-duration: var(--coveo-transition-duration);
 
     &:not([data-with-border]) {
         border: 1px solid transparent;

--- a/packages/mantine/src/styles/Input.module.css
+++ b/packages/mantine/src/styles/Input.module.css
@@ -14,7 +14,8 @@
 
     &[data-disabled] {
         > .section {
-            > svg {
+            > svg,
+            > [data-combined-clear-section] > svg {
                 color: var(--input-disabled-color);
             }
         }
@@ -22,7 +23,8 @@
 
     &[data-error] {
         > .section {
-            > svg {
+            > svg,
+            > [data-combined-clear-section] > svg {
                 color: var(--mantine-color-error);
             }
         }
@@ -33,10 +35,15 @@
     @mixin dark {
         --input-bg: var(--mantine-color-default);
     }
+
+    &[data-expanded]:not([data-readonly]) ~ .section [data-plasma-combobox-chevron] {
+        transform: rotate(180deg);
+    }
 }
 
 .section {
-    > svg {
+    > svg,
+    > [data-combined-clear-section] > svg {
         color: var(--mantine-color-dimmed);
     }
 }

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -23,6 +23,7 @@ import {
     CloseButton,
     ColorSwatch,
     Combobox,
+    ComboboxChevron,
     ComboboxSearch,
     createTheme,
     deepMerge,
@@ -70,6 +71,7 @@ import {Accordion} from '../components/Accordion/Accordion.js';
 import {CheckboxIcon} from '../components/CheckboxIcon/CheckboxIcon.js';
 import {CircleLoader} from '../components/CircleLoader/CircleLoader.js';
 import {InfoToken} from '../components/InfoToken/InfoToken.js';
+import {PlasmaComboboxChevron} from '../components/Combobox/PlasmaComboboxChevron.js';
 import AccordionClasses from '../styles/Accordion.module.css';
 import ActionIconClasses from '../styles/ActionIcon.module.css';
 import AlertClasses from '../styles/Alert.module.css';
@@ -282,6 +284,11 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
             classNames: ComboboxClasses,
             defaultProps: {
                 middlewares: {inline: true},
+            },
+        }),
+        ComboboxChevron: ComboboxChevron.extend({
+            defaultProps: {
+                component: PlasmaComboboxChevron,
             },
         }),
         ComboboxSearch: ComboboxSearch.extend({

--- a/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
+++ b/packages/mantine/src/theme/plasmaCSSVariablesResolver.ts
@@ -18,6 +18,8 @@ export const plasmaCSSVariablesResolver: CSSVariablesResolver = (theme) => {
             '--coveo-fw-light': '300',
             '--coveo-fw-normal': '400',
             '--coveo-fw-bold': '500',
+            '--coveo-transition-duration': '150ms',
+            '--coveo-transition-function': 'ease-in-out',
         },
         dark: {
             // custom colors

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -1,8 +1,8 @@
 import './styles/reset.css';
 
-import '@mantine/core/styles.css';
-import '@mantine/dates/styles.css';
-import '@mantine/notifications/styles.css';
+import '@mantine/core/styles.layer.css';
+import '@mantine/dates/styles.layer.css';
+import '@mantine/notifications/styles.layer.css';
 
 import type {Preview} from '@storybook/react-vite';
 import {useColorScheme} from './decorators/useColorScheme.js';

--- a/packages/storybook/.storybook/styles/reset.css
+++ b/packages/storybook/.storybook/styles/reset.css
@@ -1,130 +1,134 @@
-/* http://meyerweb.com/eric/tools/css/reset/ 
-   v2.0 | 20110126
-   License: none (public domain)
-*/
+@layer reset, mantine;
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-    margin: 0;
-    padding: 0;
-    border: 0;
-    font-size: 100%;
-    font: inherit;
-    vertical-align: baseline;
-}
+@layer reset {
+    /* http://meyerweb.com/eric/tools/css/reset/ 
+       v2.0 | 20110126
+       License: none (public domain)
+    */
 
-/* HTML5 display-role reset for older browsers */
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-    display: block;
-}
+    html,
+    body,
+    div,
+    span,
+    applet,
+    object,
+    iframe,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p,
+    blockquote,
+    pre,
+    a,
+    abbr,
+    acronym,
+    address,
+    big,
+    cite,
+    code,
+    del,
+    dfn,
+    em,
+    img,
+    ins,
+    kbd,
+    q,
+    s,
+    samp,
+    small,
+    strike,
+    strong,
+    sub,
+    sup,
+    tt,
+    var,
+    b,
+    u,
+    i,
+    center,
+    dl,
+    dt,
+    dd,
+    ol,
+    ul,
+    li,
+    fieldset,
+    form,
+    label,
+    legend,
+    table,
+    caption,
+    tbody,
+    tfoot,
+    thead,
+    tr,
+    th,
+    td,
+    article,
+    aside,
+    canvas,
+    details,
+    embed,
+    figure,
+    figcaption,
+    footer,
+    header,
+    hgroup,
+    menu,
+    nav,
+    output,
+    ruby,
+    section,
+    summary,
+    time,
+    mark,
+    audio,
+    video {
+        margin: 0;
+        padding: 0;
+        border: 0;
+        font-size: 100%;
+        font: inherit;
+        vertical-align: baseline;
+    }
 
-body {
-    line-height: 1;
-}
+    /* HTML5 display-role reset for older browsers */
+    article,
+    aside,
+    details,
+    figcaption,
+    figure,
+    footer,
+    header,
+    hgroup,
+    menu,
+    nav,
+    section {
+        display: block;
+    }
 
-ol,
-ul {
-    list-style: none;
-}
+    body {
+        line-height: 1;
+    }
 
-blockquote,
-q {
-    quotes: none;
-}
+    ol,
+    ul {
+        list-style: none;
+    }
 
-blockquote::before,
-blockquote::after,
-q::before,
-q::after {
-    content: '';
-    content: none;
+    blockquote,
+    q {
+        quotes: none;
+    }
+
+    blockquote::before,
+    blockquote::after,
+    q::before,
+    q::after {
+        content: '';
+        content: none;
+    }
 }

--- a/packages/storybook/src/types/css.d.ts
+++ b/packages/storybook/src/types/css.d.ts
@@ -2,3 +2,5 @@ declare module '*.module.css' {
     const classes: Record<string, string>;
     export default classes;
 }
+
+declare module '*.css';


### PR DESCRIPTION
## What changed
- override Mantine's default `ComboboxChevron` globally with a custom `PlasmaComboboxChevron`
- render the Plasma `IconChevronDown` instead of Mantine's built-in chevron
- rotate the chevron when combobox-backed inputs are expanded
- keep read-only `Select` from rotating by tagging the read-only path with `data-readonly`
- preserve right-section color behavior for default, disabled, error, and read-only states, including Mantine's combined clear-section wrapper

## Why it changed
Mantine's default combobox chevron does not match the Plasma iconography we want across `Select`-style controls. 

## Preview


https://github.com/user-attachments/assets/44503ab4-1375-49b5-b646-f5ec028909fb

