### PR TITLE
feat(mantine,RadioCard): update the RadioCard visually

### DIFF
--- a/packages/mantine/src/components/RadioCard/RadioCard.tsx
+++ b/packages/mantine/src/components/RadioCard/RadioCard.tsx
@@ -1,13 +1,11 @@
 import {
-    Box,
     Factory,
-    Group,
     RadioCardProps as MantineRadioCardProps,
     RadioCardStylesNames as MantineRadioCardStylesNames,
     Radio,
     RadioCardCssVariables,
+    Stack,
     StylesApiProps,
-    Title,
     Tooltip,
     factory,
     useProps,
@@ -15,6 +13,7 @@ import {
 } from '@mantine/core';
 import {ReactNode} from 'react';
 import classes from '../../styles/RadioCard.module.css';
+import {Input} from '../Input/Input';
 
 export type RadioCardStylesNames = MantineRadioCardStylesNames | 'container' | 'indicator' | 'title' | 'description';
 export type RadioCardFactory = Factory<{
@@ -47,8 +46,19 @@ export type RadioCardProps = MantineRadioCardProps &
 const defaultProps: Partial<RadioCardProps> = {};
 
 export const RadioCard = factory<RadioCardFactory>((_props, ref) => {
-    const {classNames, styles, style, className, vars, disabled, label, description, disabledTooltip, ...others} =
-        useProps('RadioCard', defaultProps, _props);
+    const {
+        children,
+        classNames,
+        styles,
+        style,
+        className,
+        vars,
+        disabled,
+        label,
+        description,
+        disabledTooltip,
+        ...others
+    } = useProps('RadioCard', defaultProps, _props);
     const getStyles = useStyles<RadioCardFactory>({
         name: 'RadioCard',
         classes,
@@ -69,13 +79,16 @@ export const RadioCard = factory<RadioCardFactory>((_props, ref) => {
                 {...getStyles('card', {className, style, classNames, styles})}
                 {...others}
             >
-                <Group {...getStyles('container', {classNames, styles})}>
-                    <Radio.Indicator size="xs" disabled={disabled} {...getStyles('indicator', {classNames, styles})} />
-                    <Title order={4} {...getStyles('title', {classNames, styles})}>
-                        {label}
-                    </Title>
-                </Group>
-                {description && <Box {...getStyles('description', {classNames, styles})}>{description}</Box>}
+                <Radio.Indicator disabled={disabled} {...getStyles('indicator', {classNames, styles})} />
+                <Stack {...getStyles('container', {classNames, styles})}>
+                    <Input.Label {...getStyles('title', {classNames, styles})}>{label}</Input.Label>
+                    {description && (
+                        <Input.Description {...getStyles('description', {classNames, styles})}>
+                            {description}
+                        </Input.Description>
+                    )}
+                    {children}
+                </Stack>
             </Radio.Card>
         </Tooltip>
     );

--- a/packages/mantine/src/styles/RadioCard.module.css
+++ b/packages/mantine/src/styles/RadioCard.module.css
@@ -5,24 +5,30 @@
 }
 
 .card {
-    display: inline-flex;
-    flex-direction: column;
+    --radio-card-outline-color: var(--mantine-color-default-border);
+
+    display: flex;
+    flex-flow: row nowrap;
     align-items: flex-start;
+    gap: var(--mantine-spacing-sm);
     padding: var(--mantine-spacing-sm);
     border-radius: var(--mantine-radius-lg);
+    border-color: var(--radio-card-outline-color);
+    transition: border-color 150ms ease;
 
     &[data-checked] {
-        border-color: var(--mantine-primary-color-filled);
+        --radio-card-outline-color: var(--mantine-primary-color-filled);
+    }
+
+    &[disabled],
+    &[readonly] {
+        --radio-card-outline-color: var(--mantine-color-default-border);
     }
 
     &[disabled] {
         cursor: not-allowed;
-        border-color: var(--mantine-color-default-border);
 
-        .title {
-            color: var(--mantine-color-disabled-color);
-        }
-
+        .title,
         .description {
             color: var(--mantine-color-disabled-color);
         }
@@ -30,44 +36,39 @@
 
     &[readonly] {
         pointer-events: none;
-        border-color: var(--mantine-color-default-border);
 
-        & .indicator {
-            border-color: var(--mantine-color-default-border);
+        .indicator[data-checked] {
+            background-color: var(--mantine-color-default);
+            color: var(--coveo-color-text-readonly);
 
-            &[data-checked] {
-                background-color: var(--coveo-color-bg-readonly);
-                color: var(--coveo-color-text-readonly);
-
-                & > svg {
-                    color: var(--coveo-color-text-readonly);
-                }
+            & > svg {
+                color: inherit;
             }
         }
     }
 }
 
 .container {
-    flex-wrap: nowrap;
-    gap: var(--mantine-spacing-sm);
-    align-items: baseline;
-    justify-content: flex-start;
-    width: 100%;
-    margin-bottom: var(--mantine-spacing-xs);
+    gap: var(--mantine-spacing-xs);
 }
 
 .title {
-    flex: 1;
-    word-break: break-word;
+    line-height: 20px;
 }
 
+.title,
 .description {
-    padding-left: var(--mantine-spacing-lg);
-    color: var(--mantine-color-dimmed);
-    font-weight: 400;
-    font-size: var(--mantine-font-size-xs);
+    flex: 1;
+    overflow-wrap: anywhere;
 }
 
 .indicator {
     cursor: pointer;
+    transition: border-color 150ms ease;
+
+    &,
+    &[data-disabled],
+    &[data-checked] {
+        border-color: var(--radio-card-outline-color);
+    }
 }

--- a/packages/storybook/src/form/string/RadioCard.stories.tsx
+++ b/packages/storybook/src/form/string/RadioCard.stories.tsx
@@ -1,4 +1,5 @@
 import {RadioCard} from '@coveord/plasma-mantine/components/RadioCard';
+import {Box} from '@coveord/plasma-mantine';
 import {Meta, StoryObj} from '@storybook/react-vite';
 import type {ComponentProps} from 'react';
 import {useArgs} from 'storybook/preview-api';
@@ -38,6 +39,10 @@ export const Demo: Story = {
         const [{checked}, updateArgs] = useArgs<RadioCardStoryArgs>();
         const onClick = () => updateArgs({checked: !checked});
 
-        return <RadioCard {...withLabelInfoProps(props)} onClick={onClick} />;
+        return (
+            <Box w={280}>
+                <RadioCard {...withLabelInfoProps(props)} onClick={onClick} />
+            </Box>
+        );
     },
 };


### PR DESCRIPTION
### Proposed Changes

|`master`|`DS-228-radio-card-visual-update`|figma|
|---|---|---|
|<img width="279" height="109" alt="image" src="https://github.com/user-attachments/assets/dd110bf9-b0d1-4b7b-9d95-d66017b4a76f" />|<img width="303" height="105" alt="image" src="https://github.com/user-attachments/assets/aa4abf36-f8f9-4bdc-8fc3-d7e59427f14b" />|<img width="347" height="104" alt="image" src="https://github.com/user-attachments/assets/670210e6-238a-4b08-8fdc-146bf4af5a9a" />|
|<img width="272" height="106" alt="image" src="https://github.com/user-attachments/assets/365b92b2-a9d8-4f2d-af24-5c8a01a19974" />|<img width="308" height="109" alt="image" src="https://github.com/user-attachments/assets/b2e9bde2-b1f2-474d-8543-5a9eba7e2d46" />|<img width="338" height="103" alt="image" src="https://github.com/user-attachments/assets/1ad5d994-a88a-485f-af33-621f412c5875" />|
|<img width="276" height="106" alt="image" src="https://github.com/user-attachments/assets/bd946375-d060-493a-a270-c585305121ad" />|<img width="299" height="104" alt="image" src="https://github.com/user-attachments/assets/96bc3a8d-a85c-416c-8308-2abc2eb3373b" />|<img width="339" height="100" alt="image" src="https://github.com/user-attachments/assets/7b72d3be-020c-4a55-a12b-dd08cc15c223" />|
|<img width="273" height="106" alt="image" src="https://github.com/user-attachments/assets/405291bd-6f35-476d-a12a-32144455a08d" />|<img width="305" height="103" alt="image" src="https://github.com/user-attachments/assets/7cec7057-7986-4a13-8f12-fa54d93c2ff1" />|<img width="337" height="96" alt="image" src="https://github.com/user-attachments/assets/5f8c7cd9-7443-4fa0-b551-62bc5ceb6f18" />|
|<img width="273" height="103" alt="image" src="https://github.com/user-attachments/assets/5cdd4f2a-dd2e-404d-818c-425daf40ebc5" />|<img width="302" height="105" alt="image" src="https://github.com/user-attachments/assets/9a2616d0-dfa6-4ef1-9dcf-ff901fbe0be2" />|<img width="402" height="113" alt="image" src="https://github.com/user-attachments/assets/7e813040-db65-4665-b2bd-c62f37b1211b" />|
|<img width="272" height="106" alt="image" src="https://github.com/user-attachments/assets/af05ffa6-0a7a-4562-bc13-09fc95ca6730" />|<img width="304" height="104" alt="image" src="https://github.com/user-attachments/assets/96841c0b-4479-44b6-880d-8c2d822ff56c" />|<img width="404" height="111" alt="image" src="https://github.com/user-attachments/assets/45d7bfed-92f3-42a6-8367-edb1eed03bcd" />|
|<img width="267" height="103" alt="image" src="https://github.com/user-attachments/assets/6a84a61a-a837-41c6-87c2-8e996919081d" />|<img width="306" height="104" alt="image" src="https://github.com/user-attachments/assets/e004a3de-a685-4c92-a024-6765256ada4d" />|<img width="340" height="91" alt="image" src="https://github.com/user-attachments/assets/f1b41d13-5d54-45f3-b69f-91bdff27306e" />|
|<img width="272" height="105" alt="image" src="https://github.com/user-attachments/assets/05084986-7903-47b8-bb48-b3e4c808e85e" />|<img width="301" height="100" alt="image" src="https://github.com/user-attachments/assets/4d0abe9d-b975-4b91-bd4f-b67645961f01" />|<img width="339" height="94" alt="image" src="https://github.com/user-attachments/assets/c6a90cab-7232-4636-9922-1595ac9664f1" />|










### Potential Breaking Changes

None, visual update only

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
