### PR TITLE
fix(inputlabelinfo): make pointer-event auto

### DIFF
--- a/packages/mantine/src/components/Input/InputLabelInfo.module.css
+++ b/packages/mantine/src/components/Input/InputLabelInfo.module.css
@@ -2,4 +2,5 @@
     position: relative; /* Required to make it work within a Switch label */
     margin-left: var(--mantine-spacing-xxs);
     vertical-align: text-bottom;
+    pointer-events: auto;
 }

--- a/packages/mantine/src/components/Input/InputLabelInfo.tsx
+++ b/packages/mantine/src/components/Input/InputLabelInfo.tsx
@@ -1,5 +1,5 @@
 import {factory, StylesApiProps, Tooltip, useProps, useStyles, type Factory, type TooltipProps} from '@mantine/core';
-import {type ReactNode} from 'react';
+import {type MouseEvent, type ReactNode} from 'react';
 import {InfoToken} from '../InfoToken/InfoToken.js';
 import classes from './InputLabelInfo.module.css';
 
@@ -37,7 +37,12 @@ export const InputLabelInfo = factory<InputLabelInfoFactory>((_props, ref) => {
     });
     return (
         <Tooltip label={children} {...others}>
-            <InfoToken.Information component="span" {...getStyles('labelInfo', {className, style})} ref={ref} />
+            <InfoToken.Information
+                component="span"
+                {...getStyles('labelInfo', {className, style})}
+                ref={ref}
+                onClick={(e: MouseEvent) => e.preventDefault()}
+            />
         </Tooltip>
     );
 });


### PR DESCRIPTION
### Proposed Changes

<!-- Explain what are your changes. -->

The InputLabelInfo component was not displaying the tooltip if the input was in read-only. By explicitly set `pointer-event: auto`, it overrides the `pointer-events: none` coming from the read only parent state

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
