### PR TITLE
feat(ActionIcon): update styles to match figma

### DIFF
--- a/packages/mantine/src/components/InfoToken/InfoToken.module.css
+++ b/packages/mantine/src/components/InfoToken/InfoToken.module.css
@@ -6,7 +6,7 @@
 
     &[data-variant='light'] {
         background-color: var(--it-bg);
-        border-radius: var(--mantine-spacing-xxs);
+        border-radius: var(--mantine-radius-sm);
         padding: var(--mantine-spacing-xs);
 
         &[data-size='xs'] {

--- a/packages/mantine/src/styles/ActionIcon.module.css
+++ b/packages/mantine/src/styles/ActionIcon.module.css
@@ -1,5 +1,28 @@
 .root {
+    --ai-size-sm: 16px;
+    --ai-size-md: 24px;
     --ai-size-lg: 36px;
+    --ai-icon-size: 20px;
+
+    svg {
+        width: var(--ai-icon-size);
+        height: var(--ai-icon-size);
+    }
+
+    &[data-size='sm'] {
+        --ai-radius: var(--mantine-radius-sm);
+        --ai-icon-size: 12px;
+    }
+
+    &[data-size='md'] {
+        --ai-radius: var(--mantine-radius-sm);
+        --ai-icon-size: 16px;
+    }
+
+    &[data-size='lg'] {
+        --ai-radius: var(--mantine-radius-md);
+        --ai-icon-size: 20px;
+    }
 
     &[data-variant='subtle'] {
         &:where(:disabled:not([data-loading]), [data-disabled]:not([data-loading])) {

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -187,7 +187,7 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
         }),
         ActionIcon: ActionIcon.extend({
             defaultProps: {
-                size: 'lg',
+                size: 'md',
             },
             classNames: ActionIconClasses,
         }),

--- a/packages/storybook/src/call-to-action/ActionIcon.stories.tsx
+++ b/packages/storybook/src/call-to-action/ActionIcon.stories.tsx
@@ -1,9 +1,14 @@
-import {showNotification} from '@coveord/plasma-mantine';
-import {ActionIcon} from '@coveord/plasma-mantine/components/ActionIcon';
-import {IconBell} from '@coveord/plasma-react-icons';
+import {ActionIcon, type ActionIconProps} from '@coveord/plasma-mantine/components/ActionIcon';
+import {IconX} from '@coveord/plasma-react-icons';
 import type {Meta, StoryObj} from '@storybook/react-vite';
 
-const meta: Meta<typeof ActionIcon> = {
+type ActionIconVariants = keyof typeof ActionIcon;
+
+type ActionIconStoryArgs = ActionIconProps & {
+    variant: ActionIconVariants;
+};
+
+const meta: Meta<ActionIconStoryArgs> = {
     title: '@components/call-to-action/ActionIcon',
     id: 'ActionIcon',
     component: ActionIcon,
@@ -22,14 +27,14 @@ const meta: Meta<typeof ActionIcon> = {
                 'DestructiveSecondary',
                 'DestructiveTertiary',
                 'DestructiveQuaternary',
-            ],
+            ] as ActionIconVariants[],
             description: 'ActionIcon variant',
         },
         size: {
             control: 'select',
-            options: ['sm', 'md'],
+            options: ['sm', 'md', 'lg'],
             description: 'Size of the ActionIcon',
-            table: {defaultValue: {summary: 'md'}, type: {summary: 'sm | md'}},
+            table: {defaultValue: {summary: 'md'}, type: {summary: 'sm | md | lg'}},
         },
     },
     args: {
@@ -38,16 +43,14 @@ const meta: Meta<typeof ActionIcon> = {
     },
 };
 export default meta;
-type Story = StoryObj<typeof ActionIcon>;
+type Story = StoryObj<typeof meta>;
 
 export const Demo: Story = {
-    render: (props: {size: 'sm' | 'md'; variant: string}) => {
-        const ActionIconComponent = ActionIcon[props.variant as keyof typeof ActionIcon] as React.ComponentType<any>;
-        const Icon = () => <IconBell size={16} />;
-        const onClick = () => showNotification({message: 'ActionIcon clicked', autoClose: false});
+    render: (props) => {
+        const ActionIconComponent = ActionIcon[props.variant];
         return (
-            <ActionIconComponent onClick={onClick} size={props.size}>
-                <Icon />
+            <ActionIconComponent size={props.size}>
+                <IconX />
             </ActionIconComponent>
         );
     },


### PR DESCRIPTION
### Proposed Changes

Updates the `ActionIcon` component sizes and styles to match the Figma design spec.

**Size changes:**
- Three supported sizes: `sm`, `md`, and `lg` (previously only `sm` and `md`)
- Default size changed from `lg` to `md`
- Component dimensions: `sm` = 16px, `md` = 24px, `lg` = 36px

**Icon size auto-sizing:**
- The icon inside `ActionIcon` is now automatically sized based on the `size` prop — `sm` renders a 12px icon, `md` a 16px icon, `lg` a 20px icon
- You no longer need to manually pass a `size` prop to the `Icon` component rendered inside `ActionIcon` children

**Border radius:**
- `sm` and `md` use `radius-sm` (`4px`)
- `lg` uses `radius-md` (`8px`)

**Other:**
- Minor fix in `InfoToken`: border-radius on the `light` variant now correctly uses `--mantine-radius-sm` instead of `--mantine-spacing-xxs`
- Storybook updated to reflect the new sizes and cleaned up the `Demo` story

### Potential Breaking Changes

- **Default size changed**: `ActionIcon` now defaults to `md` instead of `lg`. Usages that relied on the implicit `lg` default will render smaller unless an explicit `size="lg"` is added.
- **Icon size is now controlled**: Explicitly passing a `size` prop on the child `Icon` component will be overridden by the CSS set by `ActionIcon`. Remove any manual `size` props from icons rendered inside `ActionIcon`.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
