### PR TITLE
feat(CopyToClipboard): deprecate 'withLabel' prop and update story

### DIFF
--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -9,9 +9,7 @@ export interface CopyToClipboardProps extends ActionIconProps {
      */
     value: string;
     /**
-     *
-     * @deprecated Place the CopyToClipboard component inside the rightSection of input components instead
-     *
+     * @deprecated Place the CopyToClipboard component inside the `rightSection` of input components instead.
      * Whether to display the string to be copied alongside the button.
      *
      * @default false

--- a/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/packages/mantine/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -9,6 +9,9 @@ export interface CopyToClipboardProps extends ActionIconProps {
      */
     value: string;
     /**
+     *
+     * @deprecated Place the CopyToClipboard component inside the rightSection of input components instead
+     *
      * Whether to display the string to be copied alongside the button.
      *
      * @default false

--- a/packages/storybook/src/call-to-action/CopyToClipboard.stories.tsx
+++ b/packages/storybook/src/call-to-action/CopyToClipboard.stories.tsx
@@ -14,20 +14,21 @@ const meta: Meta<typeof CopyToClipboard> = {
             description: 'The value to be copied to clipboard',
             table: {type: {summary: 'string'}},
         },
-        withLabel: {
-            control: 'boolean',
-            description: 'Whether to show the "Copy to clipboard" label',
-            table: {defaultValue: {summary: 'false'}, type: {summary: 'boolean'}},
+        size: {
+            control: 'select',
+            options: ['md', 'lg'],
         },
     },
     args: {
+        size: 'md',
         value: 'Copy me!',
-        withLabel: false,
+        tooltipLabelCopy: 'Copy to clipboard',
+        tooltipLabelCopied: 'Copied',
     },
 };
 export default meta;
-type Story = StoryObj<typeof CopyToClipboard>;
+type Story = StoryObj<typeof meta>;
 
 export const Demo: Story = {
-    render: ({value, withLabel}) => <CopyToClipboard value={value} withLabel={withLabel} />,
+    render: (args) => <CopyToClipboard {...args} />,
 };


### PR DESCRIPTION
### Proposed Changes

- Deprecated the `withLabel` prop on `CopyToClipboard` — consumers should now place the component inside the `rightSection` of input components instead.
- Updated the Storybook story to reflect the deprecation: removed the `withLabel` control, added a `size` control (`md` / `lg`), and spread all args directly into the component for a cleaner render function.
- Set sensible story defaults: `size: 'md'`, `tooltipLabelCopy`, and `tooltipLabelCopied`.

### Potential Breaking Changes

- `withLabel` is now marked `@deprecated`. It still works but users should migrate to placing `CopyToClipboard` in the `rightSection` of input components. No runtime behaviour changed in this PR.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified (`@deprecated` JSDoc tag added)
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)