### PR TITLE
feat(facet): add removable option

### DIFF
--- a/packages/mantine/src/components/Facet/Facet.module.css
+++ b/packages/mantine/src/components/Facet/Facet.module.css
@@ -56,8 +56,20 @@
     flex: 1;
 }
 
+.facetTitleRow {
+    width: 100%;
+    min-width: 0;
+}
+
 .facetTitle {
+    flex: 1;
+    min-width: 0;
     margin-bottom: 0;
+}
+
+.facetRemoveButton {
+    flex-shrink: 0;
+    margin-left: auto;
 }
 
 .facetSearch {

--- a/packages/mantine/src/components/Facet/Facet.module.css
+++ b/packages/mantine/src/components/Facet/Facet.module.css
@@ -65,6 +65,7 @@
     flex: 1;
     min-width: 0;
     margin-bottom: 0;
+    overflow-wrap: anywhere;
 }
 
 .facetRemoveButton {

--- a/packages/mantine/src/components/Facet/Facet.tsx
+++ b/packages/mantine/src/components/Facet/Facet.tsx
@@ -1,4 +1,4 @@
-import {CrossSize16Px, FilterSize16Px} from '@coveord/plasma-react-icons';
+import {IconSearch, IconX} from '@coveord/plasma-react-icons';
 import {
     Box,
     BoxProps,
@@ -6,6 +6,7 @@ import {
     Divider,
     factory,
     Factory,
+    Group,
     StylesApiProps,
     Text,
     TextInput,
@@ -18,6 +19,7 @@ import {clsx} from 'clsx';
 import {FunctionComponent, ReactElement, ReactNode, useEffect} from 'react';
 import {groupOptions} from '../../utils/groupOptions.js';
 import {ActionIcon} from '../ActionIcon/ActionIcon.js';
+import {EllipsisText} from '../EllipsisText/EllipsisText.js';
 import {DefaultFacetItem} from './DefaultFacetItem.js';
 import classes from './Facet.module.css';
 import {FacetScrollArea} from './FacetScrollArea.js';
@@ -31,7 +33,9 @@ export type FacetStylesNames =
     | 'searchInput'
     | 'hiddenSearch'
     | 'facetBody'
+    | 'facetTitleRow'
     | 'facetTitle'
+    | 'facetRemoveButton'
     | 'facetSearch'
     | 'facetControl'
     | 'separator'
@@ -50,11 +54,21 @@ export interface FacetProps extends BoxProps, StylesApiProps<FacetFactory> {
      */
     onChange?: (values: string[]) => void;
     /**
+     * Function called when the remove icon is clicked.
+     */
+    onRemove?: () => void;
+    /**
      * Initial items selection
      *
      * @default []
      */
     initialSelection?: string[];
+    /**
+     * Determines if the facet is removable
+     *
+     * @default false
+     */
+    removable?: boolean;
     /**
      * Determined items selection
      *
@@ -158,6 +172,7 @@ const defaultProps: Partial<FacetProps> = {
     limit: Infinity,
     itemComponent: DefaultFacetItem,
     listComponent: FacetScrollArea,
+    removable: false,
 };
 
 export const Facet: FunctionComponent<FacetProps> = factory<FacetFactory>((_props, ref) => {
@@ -166,7 +181,9 @@ export const Facet: FunctionComponent<FacetProps> = factory<FacetFactory>((_prop
         className,
         data,
         onChange,
+        onRemove,
         initialSelection = [],
+        removable,
         selection,
         itemComponent: ItemComponent,
         listComponent: ListComponent,
@@ -260,7 +277,24 @@ export const Facet: FunctionComponent<FacetProps> = factory<FacetFactory>((_prop
             <Combobox store={combobox} onOptionSubmit={handleValueSelect}>
                 <Combobox.EventsTarget>
                     <Box className={classes.facetHeader}>
-                        {title ? <Title order={5}>{title}</Title> : null}
+                        <Group wrap="nowrap" justify="space-between" className={classes.facetTitleRow}>
+                            {title ? (
+                                <Title order={5} className={classes.facetTitle}>
+                                    <EllipsisText>{title}</EllipsisText>
+                                </Title>
+                            ) : null}
+                            {removable ? (
+                                <ActionIcon.Quaternary
+                                    size="xs"
+                                    color="gray"
+                                    onClick={() => onRemove?.()}
+                                    className={classes.facetRemoveButton}
+                                    aria-label="remove facet"
+                                >
+                                    <IconX height={16} />
+                                </ActionIcon.Quaternary>
+                            ) : null}
+                        </Group>
 
                         <TextInput
                             unstyled={unstyled}
@@ -282,10 +316,10 @@ export const Facet: FunctionComponent<FacetProps> = factory<FacetFactory>((_prop
                                             handleSearch('');
                                         }}
                                     >
-                                        <CrossSize16Px height={16} />
+                                        <IconX height={16} />
                                     </ActionIcon.Quaternary>
                                 ) : (
-                                    <FilterSize16Px height={16} />
+                                    <IconSearch height={16} />
                                 )
                             }
                         />

--- a/packages/mantine/src/components/Facet/Facet.tsx
+++ b/packages/mantine/src/components/Facet/Facet.tsx
@@ -19,7 +19,6 @@ import {useUncontrolled} from '@mantine/hooks';
 import {clsx} from 'clsx';
 import {FunctionComponent, ReactElement, ReactNode, useEffect} from 'react';
 import {groupOptions} from '../../utils/groupOptions.js';
-import {EllipsisText} from '../EllipsisText/EllipsisText.js';
 import {DefaultFacetItem} from './DefaultFacetItem.js';
 import classes from './Facet.module.css';
 import {FacetScrollArea} from './FacetScrollArea.js';
@@ -280,7 +279,7 @@ export const Facet: FunctionComponent<FacetProps> = factory<FacetFactory>((_prop
                         <Group wrap="nowrap" justify="space-between" className={classes.facetTitleRow}>
                             {title ? (
                                 <Title order={5} className={classes.facetTitle}>
-                                    <EllipsisText>{title}</EllipsisText>
+                                    {title}
                                 </Title>
                             ) : null}
                             {removable ? (

--- a/packages/mantine/src/components/Facet/Facet.tsx
+++ b/packages/mantine/src/components/Facet/Facet.tsx
@@ -284,7 +284,7 @@ export const Facet: FunctionComponent<FacetProps> = factory<FacetFactory>((_prop
                             ) : null}
                             {removable ? (
                                 <CloseButton
-                                    onClick={() => onRemove?.()}
+                                    onClick={onRemove}
                                     className={classes.facetRemoveButton}
                                     aria-label="remove facet"
                                 />

--- a/packages/mantine/src/components/Facet/Facet.tsx
+++ b/packages/mantine/src/components/Facet/Facet.tsx
@@ -1,7 +1,8 @@
-import {IconSearch, IconX} from '@coveord/plasma-react-icons';
+import {IconSearch} from '@coveord/plasma-react-icons';
 import {
     Box,
     BoxProps,
+    CloseButton,
     Combobox,
     Divider,
     factory,
@@ -18,7 +19,6 @@ import {useUncontrolled} from '@mantine/hooks';
 import {clsx} from 'clsx';
 import {FunctionComponent, ReactElement, ReactNode, useEffect} from 'react';
 import {groupOptions} from '../../utils/groupOptions.js';
-import {ActionIcon} from '../ActionIcon/ActionIcon.js';
 import {EllipsisText} from '../EllipsisText/EllipsisText.js';
 import {DefaultFacetItem} from './DefaultFacetItem.js';
 import classes from './Facet.module.css';
@@ -284,15 +284,11 @@ export const Facet: FunctionComponent<FacetProps> = factory<FacetFactory>((_prop
                                 </Title>
                             ) : null}
                             {removable ? (
-                                <ActionIcon.Quaternary
-                                    size="xs"
-                                    color="gray"
+                                <CloseButton
                                     onClick={() => onRemove?.()}
                                     className={classes.facetRemoveButton}
                                     aria-label="remove facet"
-                                >
-                                    <IconX height={16} />
-                                </ActionIcon.Quaternary>
+                                />
                             ) : null}
                         </Group>
 
@@ -309,15 +305,12 @@ export const Facet: FunctionComponent<FacetProps> = factory<FacetFactory>((_prop
                             className={clsx(classes.facetSearch, {[classes.hiddenSearch]: hideSearch})}
                             rightSection={
                                 search ? (
-                                    <ActionIcon.Quaternary
+                                    <CloseButton
                                         aria-label="clear search"
-                                        color="gray"
                                         onClick={() => {
                                             handleSearch('');
                                         }}
-                                    >
-                                        <IconX height={16} />
-                                    </ActionIcon.Quaternary>
+                                    />
                                 ) : (
                                     <IconSearch height={16} />
                                 )

--- a/packages/mantine/src/components/Facet/__tests__/Facet.component.spec.tsx
+++ b/packages/mantine/src/components/Facet/__tests__/Facet.component.spec.tsx
@@ -237,5 +237,25 @@ describe('Facet', () => {
             await user.click(screen.getByRole('button', {name: /clear search/i}));
             expect(onSearch).toHaveBeenCalledWith('');
         });
+
+        it('does not render the remove button by default', () => {
+            render(<Facet data={[]} title="My little title" />);
+            expect(screen.queryByRole('button', {name: /remove facet/i})).not.toBeInTheDocument();
+        });
+
+        it('renders the remove button when the removable prop is true', () => {
+            render(<Facet data={[]} title="My little title" removable />);
+            expect(screen.getByRole('button', {name: /remove facet/i})).toBeVisible();
+        });
+
+        it('calls onRemove when clicking the remove button', async () => {
+            const user = userEvent.setup();
+            const onRemove = vi.fn();
+            render(<Facet data={[]} title="My little title" onRemove={onRemove} removable />);
+
+            await user.click(screen.getByRole('button', {name: /remove facet/i}));
+
+            expect(onRemove).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/packages/storybook/src/form/array/Facet.stories.tsx
+++ b/packages/storybook/src/form/array/Facet.stories.tsx
@@ -1,4 +1,5 @@
 import {Facet} from '@coveord/plasma-mantine/components/Facet';
+import {Box} from '@mantine/core';
 import type {Meta, StoryObj} from '@storybook/react-vite';
 import type {ComponentProps} from 'react';
 import {Args} from '../../Args.js';
@@ -71,5 +72,9 @@ export const Demo: Story = {
             },
         },
     },
-    render: (props) => <Facet {...withTitleInfoProps(props)} />,
+    render: (props) => (
+        <Box w={280}>
+            <Facet {...withTitleInfoProps(props)} />
+        </Box>
+    ),
 };

--- a/packages/storybook/src/form/array/Facet.stories.tsx
+++ b/packages/storybook/src/form/array/Facet.stories.tsx
@@ -63,6 +63,13 @@ export const Demo: Story = {
                 defaultValue: {summary: 'data.length <= 7'},
             },
         },
+        removable: {
+            control: 'boolean',
+            description: 'Determines if the facet is removable',
+            table: {
+                defaultValue: {summary: 'false'},
+            },
+        },
     },
     render: (props) => <Facet {...withTitleInfoProps(props)} />,
 };


### PR DESCRIPTION
### Proposed Changes

[PSE-712](https://coveord.atlassian.net/browse/PSE-712)

Add remove support for the `Facet` component.

1. Added a `removable` prop that, when passed, will display an `X` icon next to the facet title. 
2. Added a `onRemove` prop which is a function that will be called when the remove icon is clicked.
3. Modified the Storybook demos to showcase it.
4. Updated the icons used in the component so we use `tabler` icons.

<img width="494" height="353" alt="Screenshot 2026-05-05 at 10 08 52 AM" src="https://github.com/user-attachments/assets/f74e2446-754d-463b-a767-de58f5b9b324" />


### Potential Breaking Changes

No breaking changes. This is a new prop that is yet to be used.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)


[PSE-712]: https://coveord.atlassian.net/browse/PSE-712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ