### PR TITLE
refactor(ci): centralize base URL computation into a shared composite action

### DIFF
--- a/.github/actions/compute-base-url/action.yml
+++ b/.github/actions/compute-base-url/action.yml
@@ -1,0 +1,26 @@
+name: Compute Base URL
+description: >
+    Computes the public base URL for the current branch deployment.
+    Returns https://plasma.coveo.com for master, https://plasma.coveo.com/feature/{branch} for all other branches.
+    Slashes in branch names are replaced with dashes.
+inputs:
+    branch:
+        description: Branch name
+        required: true
+outputs:
+    base-url:
+        description: Full public base URL without trailing slash (e.g. https://plasma.coveo.com/feature/my-branch)
+        value: ${{ steps.compute.outputs.base-url }}
+runs:
+    using: composite
+    steps:
+        - id: compute
+          shell: bash
+          run: |
+              BRANCH="${{ inputs.branch }}"
+              if [ "$BRANCH" = "master" ]; then
+                echo "base-url=https://plasma.coveo.com" >> $GITHUB_OUTPUT
+              else
+                CLEAN_BRANCH="${BRANCH//\//-}"
+                echo "base-url=https://plasma.coveo.com/feature/${CLEAN_BRANCH}" >> $GITHUB_OUTPUT
+              fi

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -14,6 +14,11 @@ outputs:
 runs:
     using: composite
     steps:
+        - name: Compute base URL
+          id: base-url
+          uses: ./.github/actions/compute-base-url
+          with:
+              branch: ${{ github.head_ref || github.ref_name }}
         - name: Configure AWS Credentials
           uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
           with:
@@ -23,6 +28,6 @@ runs:
           id: s3-push
           shell: bash
           env:
-              BRANCH: ${{ github.head_ref || github.ref_name }}
               BUCKET: ${{ inputs.AWS_BUCKET }}
-          run: bash ./.github/actions/deploy/deploy.sh "$BRANCH" "$BUCKET"
+              PLASMA_BASE_URL: ${{ steps.base-url.outputs.base-url }}
+          run: bash ./.github/actions/deploy/deploy.sh "$BUCKET"

--- a/.github/actions/deploy/deploy.sh
+++ b/.github/actions/deploy/deploy.sh
@@ -2,28 +2,16 @@
 
 set -e
 
-BRANCH="$1"
-BUCKET="$2"
+BUCKET="$1"
 DESTINATION=react-vapor
-ORIGIN="https://plasma.coveo.com"
-STORYBOOK_PATHNAME="/"
-OLD_WEBSITE_PATHNAME="/old/"
-DEMO_PATHNAME="/feature/"
+URL_PATH="${PLASMA_BASE_URL#https://plasma.coveo.com}" # strips the origin, leaving "" for master or "/feature/my-branch" for PRs
 
-if [ "$BRANCH" = "master" ]
-then
-    echo "Deploying Storybook"
-    aws s3 cp ./packages/storybook/storybook-static s3://${BUCKET}/${DESTINATION}${STORYBOOK_PATHNAME} --recursive
-    echo "Storybook successfully deployed to ${ORIGIN}${STORYBOOK_PATHNAME}"
-    echo "Deploying old Plasma website"
-    aws s3 cp ./packages/website/dist s3://${BUCKET}/${DESTINATION}${OLD_WEBSITE_PATHNAME} --recursive
-    echo "Old Plasma website successfully deployed to ${ORIGIN}${OLD_WEBSITE_PATHNAME}"
-else
-    CLEAN_BRANCH_NAME=${BRANCH//\//-} # replaces all / by -
-    echo "demo-output-path=${ORIGIN}${DEMO_PATHNAME}${CLEAN_BRANCH_NAME}" >> $GITHUB_OUTPUT
-    echo "Uploading storybook files of ${BRANCH} to ${BUCKET}/${DESTINATION}${DEMO_PATHNAME}${CLEAN_BRANCH_NAME}${STORYBOOK_PATHNAME}."
-    aws s3 cp ./packages/storybook/storybook-static s3://${BUCKET}/${DESTINATION}${DEMO_PATHNAME}${CLEAN_BRANCH_NAME}${STORYBOOK_PATHNAME} --recursive
-    echo "Uploading plasma-website files of ${BRANCH} to ${BUCKET}/${DESTINATION}${DEMO_PATHNAME}${CLEAN_BRANCH_NAME}${OLD_WEBSITE_PATHNAME}."
-    aws s3 cp ./packages/website/dist s3://${BUCKET}/${DESTINATION}${DEMO_PATHNAME}${CLEAN_BRANCH_NAME}${OLD_WEBSITE_PATHNAME} --recursive
-    echo "Branch ${BRANCH} successfully deployed to ${ORIGIN}${DEMO_PATHNAME}${CLEAN_BRANCH_NAME}${STORYBOOK_PATHNAME} and ${ORIGIN}${DEMO_PATHNAME}${CLEAN_BRANCH_NAME}${OLD_WEBSITE_PATHNAME}"
-fi
+echo "demo-output-path=${PLASMA_BASE_URL}" >> $GITHUB_OUTPUT
+
+echo "Deploying Storybook to ${PLASMA_BASE_URL}/"
+aws s3 cp ./packages/storybook/storybook-static s3://${BUCKET}/${DESTINATION}${URL_PATH}/ --recursive
+
+echo "Deploying old Plasma website to ${PLASMA_BASE_URL}/old/"
+aws s3 cp ./packages/website/dist s3://${BUCKET}/${DESTINATION}${URL_PATH}/old/ --recursive
+
+echo "Successfully deployed to ${PLASMA_BASE_URL}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,8 +39,15 @@ jobs:
               uses: ./.github/actions/lint
               with:
                   WORKFLOW: 'cd'
+            - name: Compute base URL
+              id: base-url
+              uses: ./.github/actions/compute-base-url
+              with:
+                  branch: ${{ github.ref_name }}
             - name: Build
               uses: ./.github/actions/build
+              env:
+                  PLASMA_BASE_URL: ${{ steps.base-url.outputs.base-url }}
             - name: Test
               uses: ./.github/actions/test
             - name: Publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,14 @@ jobs:
               with:
                   fetch-depth: 0
             - uses: ./.github/actions/setup
+            - name: Compute base URL
+              id: base-url
+              uses: ./.github/actions/compute-base-url
+              with:
+                  branch: ${{ github.head_ref || github.ref_name }}
             - uses: ./.github/actions/build
+              env:
+                  PLASMA_BASE_URL: ${{ steps.base-url.outputs.base-url }}
             - uses: ./.github/actions/deploy
               id: deploy-demo
               with:

--- a/packages/website/build/getBasePath.ts
+++ b/packages/website/build/getBasePath.ts
@@ -1,9 +1,10 @@
-const isCI = !!process.env.JENKINS_HOME || process.env.CI === 'true';
-const branchName = process.env.BRANCH_NAME || process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME;
+const baseUrl = process.env.PLASMA_BASE_URL;
 
 let basePath = '/';
-if (isCI) {
-    basePath = branchName === 'master' ? '/old/' : `/feature/${branchName.replaceAll('/', '-')}/old/`;
+if (baseUrl) {
+    const {pathname} = new URL(baseUrl);
+    const prefix = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+    basePath = `${prefix}/old/`;
 }
 
 export default basePath;

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,7 @@
             "dependsOn": ["^build"],
             "outputs": ["dist/**", "storybook-static/**"],
             "outputLogs": "new-only",
-            "env": ["CI", "BRANCH_NAME", "GITHUB_HEAD_REF", "GITHUB_REF_NAME"]
+            "env": ["CI", "PLASMA_BASE_URL"]
         },
         "test": {
             "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

Introduces a single source of truth for the branch → public URL mapping, replacing ad-hoc string manipulation scattered across shell scripts, TypeScript build code, and GitHub Actions workflows.

### Proposed Changes

- **Add `.github/actions/compute-base-url`** — a new composite action that maps `master` → `https://plasma.coveo.com` and any other branch → `https://plasma.coveo.com/feature/<branch>` (slashes replaced with dashes). This is the single place the URL logic lives.
- **Simplify `deploy.sh`** — remove the hardcoded `ORIGIN` constant and branch-conditional logic; derive the S3 destination path directly from the `PLASMA_BASE_URL` env var injected by the action.
- **Simplify `packages/website/build/getBasePath.ts`** — replace the multi-variable CI/branch detection with a single `PLASMA_BASE_URL` read and a standard `URL` parse.
- **Update `ci.yml` and `cd.yml`** — both workflows now call `compute-base-url` before the build step and expose `PLASMA_BASE_URL` as an env var to the build action.

### Potential Breaking Changes

None — the public URLs produced are identical to before. The deploy output (S3 paths and demo links) is unchanged; only the code path that computes them has been consolidated.

### Acceptance Criteria

- [x] CI and CD workflows pass end-to-end with the refactored deploy logic
- [x] PR demo links resolve to the correct `/feature/<branch>` URL
- [x] Master deployments continue to land at `https://plasma.coveo.com`
- [ ] The proposed changes are covered by unit tests
- [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)