### PR TITLE
feat(react-icons, mock): update mock to also mock in node_modules

### DIFF
--- a/packages/react-icons/src/vite-plugin/index.spec.ts
+++ b/packages/react-icons/src/vite-plugin/index.spec.ts
@@ -12,11 +12,26 @@ describe('plasmaIconsMockPlugin', () => {
             expect(result).toBeNull();
         });
 
-        it('returns null for files in node_modules', () => {
+        it('returns null for files in node_modules when includeDependencies is disabled', () => {
+            const code = `import { ArrowUpSize16Px } from '@coveord/plasma-react-icons';`;
+            const result = plasmaIconsMockPlugin({includeDependencies: false}).transform?.(
+                code,
+                '/node_modules/some-package/index.js',
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('transforms files in node_modules when includeDependencies is enabled (default behaviour)', () => {
             const code = `import { ArrowUpSize16Px } from '@coveord/plasma-react-icons';`;
             const result = plugin.transform?.(code, '/node_modules/some-package/index.js');
 
-            expect(result).toBeNull();
+            expect(result).not.toBeNull();
+            expect(result?.code).toMatchInlineSnapshot(`
+              "import __plasmaIconsMock from '@coveord/plasma-react-icons/mock';
+              const ArrowUpSize16Px = __plasmaIconsMock.ArrowUpSize16Px;
+              "
+            `);
         });
 
         it('returns null for non-JavaScript/TypeScript files', () => {

--- a/packages/react-icons/src/vite-plugin/index.ts
+++ b/packages/react-icons/src/vite-plugin/index.ts
@@ -1,20 +1,30 @@
 import type {Plugin, TransformResult} from 'vite';
 
+export interface PlasmaIconsMockPluginOptions {
+    /**
+     * Should the plugin transform import in dependencies (node_modules) as well.
+     * This is useful if you want to mock icons in a dependency that imports @coveord/plasma-react-icons.
+     *
+     * @default true
+     */
+    includeDependencies?: boolean;
+}
+
 /**
  * Vitest plugin to mock @coveord/plasma-react-icons with the mock version.
  * The mock uses a Proxy that dynamically generates icon components based on the property name.
  * This plugin transforms named imports into property access on the default import.
  */
-const plasmaIconsMockPlugin = () =>
+const plasmaIconsMockPlugin = ({includeDependencies = true}: PlasmaIconsMockPluginOptions = {}) =>
     ({
         name: 'coveord/plasma-react-icons/mock',
         enforce: 'pre',
         transform: (code: string, id: string): TransformResult => {
-            // Only transform relevant files (e.g., .ts, .tsx, .js, .jsx) that import from @coveord/plasma-react-icons and aren't in node_modules
+            // Only transform relevant files (e.g., .ts, .tsx, .js, .jsx) that import from @coveord/plasma-react-icons
             if (
                 !code.includes('@coveord/plasma-react-icons') ||
-                id.includes('/node_modules/') ||
-                !/\.(ts|tsx|js|jsx)$/.test(id)
+                (!includeDependencies && id.includes('/node_modules/')) ||
+                !/\.[cm]?[jt]sx?$/.test(id)
             ) {
                 return null;
             }


### PR DESCRIPTION
### Proposed Changes

Update the behaviour of the plasma-react-icons mock to also update import inside of node_modules. On big projects where dependencies also use plasma-react-icons this can save multiple seconds per test run

There is a new parameter `includeDependencies` that can be set to `false` to keep the old behaviour

### Potential Breaking Changes

Now the icons are also mocked in dependencies by default

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
