### PR TITLE
fix(styles): correct background color for radio card

### DIFF
--- a/packages/mantine/src/styles/RadioCard.module.css
+++ b/packages/mantine/src/styles/RadioCard.module.css
@@ -15,6 +15,7 @@
     border-radius: var(--mantine-radius-lg);
     border-color: var(--radio-card-outline-color);
     transition: border-color 150ms ease;
+    background-color: var(--mantine-color-body);
 
     &[data-checked] {
         --radio-card-outline-color: var(--mantine-primary-color-filled);
@@ -50,6 +51,7 @@
 
 .container {
     gap: var(--mantine-spacing-xs);
+    width: 100%;
 }
 
 .title {

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -27,8 +27,8 @@ const preview: Preview = {
     parameters: {
         backgrounds: {
             options: {
-                dark: {name: 'Dark', value: 'var(--mantine-color-body)'},
-                light: {name: 'Light', value: 'var(--mantine-color-body)'},
+                dark: {name: 'Dark', value: 'var(--coveo-app-background)'},
+                light: {name: 'Light', value: 'var(--coveo-app-background)'},
             },
         },
         chromatic: {disableSnapshot: true},


### PR DESCRIPTION
### Proposed Changes

RadioCard now has a background color instead of being transparent

|Before|After|
|---|---|
|<img width="411" height="167" alt="image" src="https://github.com/user-attachments/assets/4051603c-b4eb-4714-a135-994f674ee5c8" />|<img width="421" height="161" alt="image" src="https://github.com/user-attachments/assets/83fff361-4f50-4eeb-829f-2ed500829888" />|

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
