### PR TITLE
fix(facet): fix alignement of remove button when title wraps

### DIFF
--- a/packages/mantine/src/components/Facet/Facet.module.css
+++ b/packages/mantine/src/components/Facet/Facet.module.css
@@ -71,6 +71,7 @@
 .facetRemoveButton {
     flex-shrink: 0;
     margin-left: auto;
+    align-self: flex-start;
 }
 
 .facetSearch {


### PR DESCRIPTION
### Proposed Changes

Fix the alignement of the remove button in the `Facet` component when there's a long title that wraps multiple lines. 

📷 Before

<img width="327" height="459" alt="Screenshot 2026-05-21 at 9 16 15 AM" src="https://github.com/user-attachments/assets/93d99ed3-49df-4069-93dc-cb29a623fc3a" />

📷 After

<img width="391" height="475" alt="Screenshot 2026-05-21 at 9 15 18 AM" src="https://github.com/user-attachments/assets/e2bd722b-0444-4d37-8257-33365c947214" />


[Demo link](https://plasma.coveo.com/feature/PSE-1357-fix-facet-remove/?path=/story/facet--demo&args=removable:!true). 🧪 

### Potential Breaking Changes

None.

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
