### PR TITLE
chore(deps): update coveo/semantic-monorepo-tools

### DIFF
--- a/.github/actions/lint/lintChangedFiles.mjs
+++ b/.github/actions/lint/lintChangedFiles.mjs
@@ -4,7 +4,7 @@ import {ESLint} from 'eslint';
 const changedFiles = process.argv.slice(2);
 const changedFilesWithoutDuplicates = [...new Set(changedFiles)];
 
-const ALLOWED_EXTENSIONS = ['js', 'ts', 'jsx', 'tsx'];
+const ALLOWED_EXTENSIONS = ['js', '.mjs', 'ts', '.mts', 'jsx', 'tsx'];
 
 (async function main() {
     const eslint = new ESLint();
@@ -19,19 +19,21 @@ const ALLOWED_EXTENSIONS = ['js', 'ts', 'jsx', 'tsx'];
 
     console.log('\x1b[32mFiltered list of files that will be linted', filteredArray);
 
-    const results = await eslint.lintFiles(filteredArray);
+    if (filteredArray.length > 0) {
+        const results = await eslint.lintFiles(filteredArray);
 
-    const formatter = await eslint.loadFormatter('stylish');
-    const resultText = formatter.format(results);
+        const formatter = await eslint.loadFormatter('stylish');
+        const resultText = formatter.format(results);
 
-    console.log('\x1b[32mLint results:', resultText || '\x1b[32mNo error or warning were found');
+        console.log('\x1b[32mLint results:', resultText || '\x1b[32mNo error or warning were found');
 
-    // Force exit 1 if error are found to make GitHub runner fail the step
-    results.some((result) => {
-        if (result.errorCount > 0) {
-            process.exit(1);
-        }
-    });
+        // Force exit 1 if error are found to make GitHub runner fail the step
+        results.some((result) => {
+            if (result.errorCount > 0) {
+                process.exit(1);
+            }
+        });
+    }
 })().catch((error) => {
     process.exitCode = 1;
     console.error(error);

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "@commitlint/cli": "20.5.2",
         "@commitlint/config-conventional": "20.5.0",
-        "@coveo/semantic-monorepo-tools": "2.7.1",
+        "@coveo/semantic-monorepo-tools": "github:coveo/semantic-monorepo-tools#main",
         "@types/node": "24.12.2",
         "@vitest/eslint-plugin": "1.6.16",
         "aws-sdk": "2.1693.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: 20.5.0
         version: 20.5.0
       '@coveo/semantic-monorepo-tools':
-        specifier: 2.7.1
-        version: 2.7.1
+        specifier: github:coveo/semantic-monorepo-tools#main
+        version: https://codeload.github.com/coveo/semantic-monorepo-tools/tar.gz/8905e268e4da91a687c1bd5de8aa0c07cb352646
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
@@ -957,8 +957,9 @@ packages:
       conventional-commits-parser:
         optional: true
 
-  '@coveo/semantic-monorepo-tools@2.7.1':
-    resolution: {integrity: sha512-yPUdpPgoZWxX/lyhQWaskwGXS4ZFLsOK4QVUyD+1BtOk/827vqw93Q7UD4aumuYMVKTDnGjjHOEmHl07nzUvYw==}
+  '@coveo/semantic-monorepo-tools@https://codeload.github.com/coveo/semantic-monorepo-tools/tar.gz/8905e268e4da91a687c1bd5de8aa0c07cb352646':
+    resolution: {gitHosted: true, integrity: sha512-5NRjUbwOKBM3M68nUbLr7nKdeVhln96BA+uxJ3vjSyQquJhkGMSZkS5EKKeXRYBPbdUsLlWlx2mYdz3LRSraWw==, tarball: https://codeload.github.com/coveo/semantic-monorepo-tools/tar.gz/8905e268e4da91a687c1bd5de8aa0c07cb352646}
+    version: 2.7.1
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7062,7 +7063,7 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
-  '@coveo/semantic-monorepo-tools@2.7.1':
+  '@coveo/semantic-monorepo-tools@https://codeload.github.com/coveo/semantic-monorepo-tools/tar.gz/8905e268e4da91a687c1bd5de8aa0c07cb352646':
     dependencies:
       conventional-changelog-writer: 7.0.1
       conventional-commits-parser: 5.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ allowBuilds:
   core-js-pure: false
   esbuild: false
   unrs-resolver: false
+  '@coveo/semantic-monorepo-tools': true
 minimumReleaseAge: 10080 # 7 days in minutes
 minimumReleaseAgeExclude:
   - '@mantine/*'


### PR DESCRIPTION
### Proposed Changes

Updating `coveo/semantic-monorepo-tools` to the latest version to pick-up this fix: https://github.com/coveo/semantic-monorepo-tools/pull/339

Since the CD of coveo/semantic-monorepo-tools is broken I went with a temporary workaround of installing from the git main branch directly.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
