### PR TITLE
ci(cd): patch semantic-monorepo-tools to add --no-git-checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "@commitlint/cli": "20.5.2",
         "@commitlint/config-conventional": "20.5.0",
-        "@coveo/semantic-monorepo-tools": "github:coveo/semantic-monorepo-tools#main",
+        "@coveo/semantic-monorepo-tools": "2.7.1",
         "@types/node": "24.12.2",
         "@vitest/eslint-plugin": "1.6.16",
         "aws-sdk": "2.1693.0",

--- a/patches/@coveo__semantic-monorepo-tools@2.7.1.patch
+++ b/patches/@coveo__semantic-monorepo-tools@2.7.1.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/pnpm/doPnpmBumpVersion.js b/dist/pnpm/doPnpmBumpVersion.js
+index 2470346f66209b9b41ccafdab3e4c8a1d9201270..83ce095b3e5380f86d354c1e53f8ecbb33a1b325 100644
+--- a/dist/pnpm/doPnpmBumpVersion.js
++++ b/dist/pnpm/doPnpmBumpVersion.js
+@@ -7,5 +7,5 @@ import { runOnChanged } from "./utils/runOnChanged.js";
+  * @param excludePackages filter out the specified packages/directory from the output
+  */
+ export default async function (newVersion, since, forcePackages = [], excludePackages = []) {
+-    await runOnChanged(`pnpm version ${newVersion} --no-git-tag-version`, since, forcePackages, excludePackages);
++    await runOnChanged(`pnpm version ${newVersion} --no-git-tag-version --no-git-checks`, since, forcePackages, excludePackages);
+ }
+diff --git a/src/pnpm/doPnpmBumpVersion.ts b/src/pnpm/doPnpmBumpVersion.ts
+index 7865dbff9de6bf2f2a5219e320249ff053a6233e..e6e5f7d9c30351c47d175e1f4c7b2f3cb8ed53e0 100644
+--- a/src/pnpm/doPnpmBumpVersion.ts
++++ b/src/pnpm/doPnpmBumpVersion.ts
+@@ -14,7 +14,7 @@ export default async function (
+   excludePackages: string[] = [],
+ ) {
+   await runOnChanged(
+-    `pnpm version ${newVersion} --no-git-tag-version`,
++    `pnpm version ${newVersion} --no-git-tag-version --no-git-checks`,
+     since,
+     forcePackages,
+     excludePackages,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ overrides:
   '@babel/traverse': ^7.23.2
   nwsapi: 2.2.23
 
+patchedDependencies:
+  '@coveo/semantic-monorepo-tools@2.7.1': 6f04a4fce1efac7e2a5e7bc51e8e2f75cea0efa0e8cc97872be1b79d4fb2c498
+
 importers:
 
   .:
@@ -19,8 +22,8 @@ importers:
         specifier: 20.5.0
         version: 20.5.0
       '@coveo/semantic-monorepo-tools':
-        specifier: github:coveo/semantic-monorepo-tools#main
-        version: https://codeload.github.com/coveo/semantic-monorepo-tools/tar.gz/8905e268e4da91a687c1bd5de8aa0c07cb352646
+        specifier: 2.7.1
+        version: 2.7.1(patch_hash=6f04a4fce1efac7e2a5e7bc51e8e2f75cea0efa0e8cc97872be1b79d4fb2c498)
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
@@ -957,9 +960,8 @@ packages:
       conventional-commits-parser:
         optional: true
 
-  '@coveo/semantic-monorepo-tools@https://codeload.github.com/coveo/semantic-monorepo-tools/tar.gz/8905e268e4da91a687c1bd5de8aa0c07cb352646':
-    resolution: {gitHosted: true, integrity: sha512-5NRjUbwOKBM3M68nUbLr7nKdeVhln96BA+uxJ3vjSyQquJhkGMSZkS5EKKeXRYBPbdUsLlWlx2mYdz3LRSraWw==, tarball: https://codeload.github.com/coveo/semantic-monorepo-tools/tar.gz/8905e268e4da91a687c1bd5de8aa0c07cb352646}
-    version: 2.7.1
+  '@coveo/semantic-monorepo-tools@2.7.1':
+    resolution: {integrity: sha512-yPUdpPgoZWxX/lyhQWaskwGXS4ZFLsOK4QVUyD+1BtOk/827vqw93Q7UD4aumuYMVKTDnGjjHOEmHl07nzUvYw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7063,7 +7065,7 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
-  '@coveo/semantic-monorepo-tools@https://codeload.github.com/coveo/semantic-monorepo-tools/tar.gz/8905e268e4da91a687c1bd5de8aa0c07cb352646':
+  '@coveo/semantic-monorepo-tools@2.7.1(patch_hash=6f04a4fce1efac7e2a5e7bc51e8e2f75cea0efa0e8cc97872be1b79d4fb2c498)':
     dependencies:
       conventional-changelog-writer: 7.0.1
       conventional-commits-parser: 5.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,3 +29,5 @@ overrides:
 strictPeerDependencies: false
 saveExact: true
 autoInstallPeers: false
+patchedDependencies:
+  '@coveo/semantic-monorepo-tools@2.7.1': patches/@coveo__semantic-monorepo-tools@2.7.1.patch


### PR DESCRIPTION
### Proposed Changes

Replacing the github install of coveo/semantic-monorepo-tools by a pnpm patch 

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
