### PR TITLE
ci(cd): patch semantic-monorepo-tools to add --access public on publish

### DIFF
--- a/patches/@coveo__semantic-monorepo-tools@2.7.1.patch
+++ b/patches/@coveo__semantic-monorepo-tools@2.7.1.patch
@@ -9,6 +9,18 @@ index 2470346f66209b9b41ccafdab3e4c8a1d9201270..83ce095b3e5380f86d354c1e53f8ecbb
 -    await runOnChanged(`pnpm version ${newVersion} --no-git-tag-version`, since, forcePackages, excludePackages);
 +    await runOnChanged(`pnpm version ${newVersion} --no-git-tag-version --no-git-checks`, since, forcePackages, excludePackages);
  }
+diff --git a/dist/pnpm/doPnpmPublishVersions.js b/dist/pnpm/doPnpmPublishVersions.js
+index 107a330e8969397754d20be00bd34bc432240be0..b9e70b7fd1c30ab4967e1ec9bde552c7a6bde581 100644
+--- a/dist/pnpm/doPnpmPublishVersions.js
++++ b/dist/pnpm/doPnpmPublishVersions.js
+@@ -13,6 +13,6 @@ import pnpmLogger from "./utils/pnpmLogger.js";
+  */
+ export default async function (since, tag, branch, forcePackages = [], excludePackages = []) {
+     const filters = since ? `...[${since}]` : undefined;
+-    const pnpmArgs = ["--recursive"].concat(getOptionalFlagArgument("--filter", filters), ...getIncludeFilters(forcePackages), ...getExclusionFilters(excludePackages), "publish", getOptionalFlagArgument("--tag", tag), getOptionalFlagArgument("--publish-branch", branch));
++    const pnpmArgs = ["--recursive"].concat(getOptionalFlagArgument("--filter", filters), ...getIncludeFilters(forcePackages), ...getExclusionFilters(excludePackages), "publish", getOptionalFlagArgument("--tag", tag), getOptionalFlagArgument("--publish-branch", branch), "--access", "public", "--provenance");
+     await spawn("pnpm", pnpmArgs, pnpmLogger);
+ }
 diff --git a/src/pnpm/doPnpmBumpVersion.ts b/src/pnpm/doPnpmBumpVersion.ts
 index 7865dbff9de6bf2f2a5219e320249ff053a6233e..e6e5f7d9c30351c47d175e1f4c7b2f3cb8ed53e0 100644
 --- a/src/pnpm/doPnpmBumpVersion.ts
@@ -22,3 +34,16 @@ index 7865dbff9de6bf2f2a5219e320249ff053a6233e..e6e5f7d9c30351c47d175e1f4c7b2f3c
      since,
      forcePackages,
      excludePackages,
+diff --git a/src/pnpm/doPnpmPublishVersions.ts b/src/pnpm/doPnpmPublishVersions.ts
+index c9e671aa8dbf588a9e7e5cbe1ef3c9024cbfa0dc..7aa3b131f139418b43e6bd4f95b82f8c197b9a6e 100644
+--- a/src/pnpm/doPnpmPublishVersions.ts
++++ b/src/pnpm/doPnpmPublishVersions.ts
+@@ -28,6 +28,8 @@ export default async function (
+     "publish",
+     getOptionalFlagArgument("--tag", tag),
+     getOptionalFlagArgument("--publish-branch", branch),
++    "--access", "public",
++    "--provenance"
+   );
+   await spawn("pnpm", pnpmArgs, pnpmLogger);
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   nwsapi: 2.2.23
 
 patchedDependencies:
-  '@coveo/semantic-monorepo-tools@2.7.1': 6f04a4fce1efac7e2a5e7bc51e8e2f75cea0efa0e8cc97872be1b79d4fb2c498
+  '@coveo/semantic-monorepo-tools@2.7.1': 9ad8cdc7e13dfef2abe41d32e7fd891b27addc39fefed41ba5c4c2bd9646d2d4
 
 importers:
 
@@ -23,7 +23,7 @@ importers:
         version: 20.5.0
       '@coveo/semantic-monorepo-tools':
         specifier: 2.7.1
-        version: 2.7.1(patch_hash=6f04a4fce1efac7e2a5e7bc51e8e2f75cea0efa0e8cc97872be1b79d4fb2c498)
+        version: 2.7.1(patch_hash=9ad8cdc7e13dfef2abe41d32e7fd891b27addc39fefed41ba5c4c2bd9646d2d4)
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
@@ -7065,7 +7065,7 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
-  '@coveo/semantic-monorepo-tools@2.7.1(patch_hash=6f04a4fce1efac7e2a5e7bc51e8e2f75cea0efa0e8cc97872be1b79d4fb2c498)':
+  '@coveo/semantic-monorepo-tools@2.7.1(patch_hash=9ad8cdc7e13dfef2abe41d32e7fd891b27addc39fefed41ba5c4c2bd9646d2d4)':
     dependencies:
       conventional-changelog-writer: 7.0.1
       conventional-commits-parser: 5.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,12 +1,12 @@
 packages:
   - 'packages/*'
 allowBuilds:
+  '@coveo/semantic-monorepo-tools': false
   '@swc/core': false
   aws-sdk: false
   core-js-pure: false
   esbuild: false
   unrs-resolver: false
-  '@coveo/semantic-monorepo-tools': true
 minimumReleaseAge: 10080 # 7 days in minutes
 minimumReleaseAgeExclude:
   - '@mantine/*'


### PR DESCRIPTION
### Proposed Changes

Attempting to fix this error happening during publish in the CD workflow

<img width="993" height="258" alt="image" src="https://github.com/user-attachments/assets/a7ee632e-210a-4cef-9650-0b1ef2c84845" />

Solution:

<img width="695" height="325" alt="image" src="https://github.com/user-attachments/assets/a2151737-24f9-409e-8859-310e2af3eaf8" />


### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
