### PR TITLE
fix(storybook): mdx demos need full import

### DIFF
--- a/packages/storybook/src/foundation/colors/Colors.mdx
+++ b/packages/storybook/src/foundation/colors/Colors.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/addon-docs/blocks';
-import { Overview } from './Colors.stories';
+import * as ColorStories from './Colors.stories';
 
-<Meta title="@foundation/Colors" />
+<Meta of={ColorStories} />
 
-<Story of={Overview} />
+<Story of={ColorStories.Overview} />

--- a/packages/storybook/src/foundation/iconography/Iconography.mdx
+++ b/packages/storybook/src/foundation/iconography/Iconography.mdx
@@ -1,6 +1,6 @@
 import {Meta, Story} from '@storybook/addon-docs/blocks';
-import {Overview} from './Iconography.stories';
+import * as IconographyStories from './Iconography.stories';
 
-<Meta title="@foundation/Iconography" />
+<Meta of={IconographyStories} />
 
-<Story of={Overview} />
+<Story of={IconographyStories.Overview} />

--- a/packages/storybook/src/foundation/radii/Radii.mdx
+++ b/packages/storybook/src/foundation/radii/Radii.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/addon-docs/blocks';
-import { Radii } from './Radii.stories';
+import * as RadiiStories from './Radii.stories';
 
-<Meta title="@foundation/Radii" />
+<Meta of={RadiiStories} />
 
-<Story of={Radii} />
+<Story of={RadiiStories.Radii} />

--- a/packages/storybook/src/foundation/shadows/Shadows.mdx
+++ b/packages/storybook/src/foundation/shadows/Shadows.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/addon-docs/blocks';
-import { Shadows } from './Shadows.stories';
+import * as ShadowStories from './Shadows.stories';
 
-<Meta title="@foundation/Shadows" />
+<Meta of={ShadowStories} />
 
-<Story of={Shadows} />
+<Story of={ShadowStories.Shadows} />

--- a/packages/storybook/src/foundation/spacings/Spacings.mdx
+++ b/packages/storybook/src/foundation/spacings/Spacings.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/addon-docs/blocks';
-import { Spacings } from './Spacings.stories';
+import * as SpacingStories from './Spacings.stories';
 
-<Meta title="@foundation/Spacings" />
+<Meta of={SpacingStories} />
 
-<Story of={Spacings} />
+<Story of={SpacingStories.Spacings} />

--- a/packages/storybook/src/foundation/typography/Typography.mdx
+++ b/packages/storybook/src/foundation/typography/Typography.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/addon-docs/blocks';
-import { Typography } from './Typography.stories';
+import * as TypographyStories from './Typography.stories';
 
-<Meta title="@foundation/Typography" />
+<Meta of={TypographyStories} />
 
-<Story of={Typography} />
+<Story of={TypographyStories.Typography} />

--- a/packages/storybook/src/foundation/variables/Variables.mdx
+++ b/packages/storybook/src/foundation/variables/Variables.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/addon-docs/blocks';
-import { Overview } from './Variables.stories';
+import * as VariableStories from './Variables.stories';
 
-<Meta title="@foundation/Variables" />
+<Meta of={VariableStories} />
 
-<Story of={Overview} />
+<Story of={VariableStories.Overview} />


### PR DESCRIPTION
### Proposed Changes

Problem: All 6 MDX files were using a destructured import (`import { Overview } from './Colors.stories')` and setting `<Meta title="@foundation/Colors" />` manually. In Storybook 10's production build, the `<Story of={...}>` block can't resolve the story's metadata (decorators, parameters, etc.) when it only receives a bare named export without the CSF module context.

Fix: Updated all MDX files to use the correct Storybook 7+ pattern:

1. `import * as Stories from './X.stories'` — namespace import so the full module context is available
2. `<Meta of={Stories} />` — attaches the MDX to the CSF module (title/tags/id are inherited from the story meta)
3. `<Story of={Stories.ExportName} />` — references the story via the module namespace

This likely worked locally in dev mode because Storybook's dev server keeps full module context through HMR, but the production build's static analysis and tree-shaking stripped the module context when using destructured imports.

Master: https://plasma.coveo.com/
Demo: https://plasma.coveo.com/feature/fix-ADUI-11460-master-demo/

### Potential Breaking Changes

None