### PR TITLE
fix(table-url-state): fix number filter parsing

### DIFF
--- a/packages/react/src/components/table-hoc/TableWithUrlState.tsx
+++ b/packages/react/src/components/table-hoc/TableWithUrlState.tsx
@@ -139,7 +139,7 @@ const updateTableStateFromUrl =
         }
 
         if (urlParams.hasOwnProperty(Params.filter)) {
-            dispatch(filterThrough(tableId, urlParams[Params.filter]));
+            dispatch(filterThrough(tableId, urlParams[Params.filter] == null ? '' : String(urlParams[Params.filter])));
         }
 
         if (urlParams.hasOwnProperty(Params.sortKey) && urlParams.hasOwnProperty(Params.sortOrder)) {

--- a/packages/react/src/components/table-hoc/tests/TableWithUrlState.spec.tsx
+++ b/packages/react/src/components/table-hoc/tests/TableWithUrlState.spec.tsx
@@ -188,6 +188,33 @@ describe('Table HOC', () => {
 
                 expect(store.getActions()).toContainEqual(filterThrough('🎠', '💧'));
             });
+
+            it('should coerce a numeric "q" param to a string before dispatching the filter action', () => {
+                jest.spyOn(UrlUtils, 'getSearchParams').mockReturnValue({q: 123});
+                table = shallowWithStore(<TableWithUrlState id="🎠" />, store)
+                    .dive()
+                    .dive();
+
+                expect(store.getActions()).toContainEqual(filterThrough('🎠', '123'));
+            });
+
+            it('should dispatch an empty filter value when the "q" param is null', () => {
+                jest.spyOn(UrlUtils, 'getSearchParams').mockReturnValue({q: null});
+                table = shallowWithStore(<TableWithUrlState id="🎠" />, store)
+                    .dive()
+                    .dive();
+
+                expect(store.getActions()).toContainEqual(filterThrough('🎠', ''));
+            });
+
+            it('should dispatch an empty filter value when the "q" param is undefined', () => {
+                jest.spyOn(UrlUtils, 'getSearchParams').mockReturnValue({q: undefined});
+                table = shallowWithStore(<TableWithUrlState id="🎠" />, store)
+                    .dive()
+                    .dive();
+
+                expect(store.getActions()).toContainEqual(filterThrough('🎠', ''));
+            });
         });
 
         describe('when the table has a date picker', () => {


### PR DESCRIPTION
### Proposed Changes

https://coveord.atlassian.net/browse/PSE-1329

- The `TableWithUrlState` is using `UrlUtils.getSearchParams()` to initialize the state from the parameters in the URL: [here](https://github.com/coveo/plasma/pull/4467/changes#diff-3a99f3d9f283e6f10333064ed36a01ffe367e2dd8a064d85b581a6fac97bed5cR110).
- This utility is using a third party library which is parsing the number values as numbers: [here](https://github.com/coveo/plasma/blob/v53/packages/react/src/utils/UrlUtils.ts#L23). I assume this is because some values in the URL params are actually numbers like the page size or page number.

This can cause issues for example when a table has a global filter and someone enters a string containing numbers. The page is refreshed, the filter will be parsed as a number and will cause some crashes, for example trying to call `trimStart` on a number [here](https://github.com/coveo/plasma/blob/v53/packages/react/src/components/filterBox/FilterBoxSelectors.ts#L13).


🎬 Example:

https://github.com/user-attachments/assets/c093781d-df61-42e0-8e48-9f07da7a1ded

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
