### PR TITLE
fix(llms): enforce ASCII-only output in dist files

### DIFF
--- a/.github/actions/deploy/deploy.sh
+++ b/.github/actions/deploy/deploy.sh
@@ -12,9 +12,7 @@ echo "Copying LLM files into Storybook output"
 cp -r ./packages/llms/dist/. ./packages/storybook/storybook-static/
 
 echo "Deploying Storybook to ${PLASMA_BASE_URL}/"
-aws s3 cp ./packages/storybook/storybook-static s3://${BUCKET}/${DESTINATION}${URL_PATH}/ --recursive --exclude "*.txt" --exclude "*.md"
-aws s3 cp ./packages/storybook/storybook-static s3://${BUCKET}/${DESTINATION}${URL_PATH}/ --recursive --exclude "*" --include "*.txt" --content-type "text/plain; charset=utf-8"
-aws s3 cp ./packages/storybook/storybook-static s3://${BUCKET}/${DESTINATION}${URL_PATH}/ --recursive --exclude "*" --include "*.md" --content-type "text/markdown; charset=utf-8"
+aws s3 cp ./packages/storybook/storybook-static s3://${BUCKET}/${DESTINATION}${URL_PATH}/ --recursive
 
 echo "Deploying old Plasma website to ${PLASMA_BASE_URL}/old/"
 aws s3 cp ./packages/website/dist s3://${BUCKET}/${DESTINATION}${URL_PATH}/old/ --recursive

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -252,11 +252,12 @@ pnpm add -Dw <package-name>
 
 ## LLM Component Documentation
 
-Component specs for AI consumption live in `packages/llms/src/components/` — one markdown file per component with frontmatter, props tables, and usage examples.
+Component specs for AI consumption live in `packages/llms/src/components/` -- one markdown file per component with frontmatter, props tables, and usage examples.
 
 - When looking up how a Plasma component works, read the relevant spec file in `packages/llms/src/components/`.
 - When creating or updating a component spec, use the `plasma-component-docs` skill.
 - Always import from `@coveord/plasma-mantine`, even when consulting Mantine docs as reference.
+- All spec files MUST use only ASCII characters. The build enforces this constraint.
 
 ## Additional Resources
 

--- a/.github/skills/plasma-component-docs/SKILL.md
+++ b/.github/skills/plasma-component-docs/SKILL.md
@@ -23,21 +23,22 @@ Use `grep`/`glob` to locate files when the exact path is unknown.
 
 From the component source, identify:
 
-- **Plasma-specific props** — props defined in the Plasma wrapper (not inherited from Mantine). Include prop name, type, required flag, default, and JSDoc description.
-- **Sub-components** — static properties assigned to the component (e.g. `Button.Primary`, `Table.Header`).
-- **Extends** — if the component extends a Mantine base, note it in the Props section header (see format).
+- **Plasma-specific props** -- props defined in the Plasma wrapper (not inherited from Mantine). Include prop name, type, required flag, default, and JSDoc description.
+- **Sub-components** -- static properties assigned to the component (e.g. `Button.Primary`, `Table.Header`).
+- **Extends** -- if the component extends a Mantine base, note it in the Props section header (see format).
 
 From stories, extract:
 
-- **Usage examples** — the most common real-world snippet(s); see [references/format.md](references/format.md) for the Usage section rules.
+- **Usage examples** -- the most common real-world snippet(s); see [references/format.md](references/format.md) for the Usage section rules.
 
 ### 3. Write the spec
 
 Follow the format in [references/format.md](references/format.md) exactly. Key rules:
 
 - YAML frontmatter `description` must be one sentence (used in `llms.txt` index).
-- Omit the Props table entirely if no Plasma-specific props exist — use the `_No additional props_` shorthand instead.
-- End every file with `[Full Plasma documentation]({{BASE_URL}})`. Use the literal placeholder `{{BASE_URL}}` — it is substituted at build time.
+- Omit the Props table entirely if no Plasma-specific props exist -- use the `_No additional props_` shorthand instead.
+- End every file with `[Full Plasma documentation]({{BASE_URL}})`. Use the literal placeholder `{{BASE_URL}}` -- it is substituted at build time.
+- **ASCII only** -- all source `.md` files MUST contain only ASCII characters (U+0000-U+007F). The build will fail if non-ASCII characters are detected in dist output. Use `|` (pipe) as metadata separator and `--` as em-dash replacement.
 
 ### 4. Regenerate dist outputs
 

--- a/.github/skills/plasma-component-docs/references/format.md
+++ b/.github/skills/plasma-component-docs/references/format.md
@@ -39,9 +39,9 @@ description: One-sentence description used in llms.txt index.  <- REQUIRED
 
 ## Usage
 
-`tsx
+~~~tsx
 [most common use case -- copy-pasteable snippet, including imports]
-`
+~~~
 
 ---
 

--- a/.github/skills/plasma-component-docs/references/format.md
+++ b/.github/skills/plasma-component-docs/references/format.md
@@ -14,12 +14,12 @@ Component specs MUST use RFC 2119 keywords (always uppercased) to express requir
 
 **Critical rule:** only use these keywords when the subject is **the developer using the component**. Never use them to describe what the component or library does internally.
 
-- ✓ "MAY be provided to explain why the item is disabled." (user's choice)
-- ✓ "Async handlers MAY be provided; the button shows a loading state while the promise resolves." (user's choice + plain fact)
-- ✗ "The button MUST show a loading state…" → write: "shows a loading state…"
-- ✗ "The card MUST render this content as its label." → write: "Rendered as the primary label."
+- [ok] "MAY be provided to explain why the item is disabled." (user's choice)
+- [ok] "Async handlers MAY be provided; the button shows a loading state while the promise resolves." (user's choice + plain fact)
+- [error] "The button MUST show a loading state..." -> write: "shows a loading state..."
+- [error] "The card MUST render this content as its label." -> write: "Rendered as the primary label."
 
-Avoid vague imperatives like "always", "never", "prefer", or "avoid" in user-facing rules — replace them with the appropriate RFC 2119 keyword.
+Avoid vague imperatives like "always", "never", "prefer", or "avoid" in user-facing rules -- replace them with the appropriate RFC 2119 keyword.
 
 ---
 
@@ -27,21 +27,21 @@ Every file in `packages/llms/src/components/` follows this structure:
 
 ```markdown
 ---
-name: ComponentName                ← REQUIRED
-description: One-sentence description used in llms.txt index.  ← REQUIRED
+name: ComponentName                <- REQUIRED
+description: One-sentence description used in llms.txt index.  <- REQUIRED
 ---
 
 ## Props
 
 [One of the two forms below]
 
-## Sub-components ← omit if none
+## Sub-components <- omit if none
 
 ## Usage
 
-​`tsx
-[most common use case — copy-pasteable snippet, including imports]
-​`
+`tsx
+[most common use case -- copy-pasteable snippet, including imports]
+`
 
 ---
 
@@ -52,29 +52,29 @@ description: One-sentence description used in llms.txt index.  ← REQUIRED
 
 ## Usage section
 
-MUST appear after all other sections (Props, Sub-components) and before the footer link. MUST show the most common real-world usage as a self-contained `tsx` snippet. SHOULD use Plasma sub-components where they exist. MAY include 2–3 examples for components with multiple important patterns (e.g. async click, disabled state). MUST NOT be exhaustive — the Props table covers the full API.
+MUST appear after all other sections (Props, Sub-components) and before the footer link. MUST show the most common real-world usage as a self-contained `tsx` snippet. SHOULD use Plasma sub-components where they exist. MAY include 2-3 examples for components with multiple important patterns (e.g. async click, disabled state). MUST NOT be exhaustive -- the Props table covers the full API.
 
 ````markdown
 ## Usage
 
-​```tsx
+```tsx
 import {Button} from '@coveord/plasma-mantine';
 
 <Button.Primary onClick={() => console.log('saved')}>Save</Button.Primary>
 
-// Async click — button shows a loading spinner automatically
+// Async click -- button shows a loading spinner automatically
 <Button.Primary onClick={async () => { await save(); }}>Save</Button.Primary>
 
 // Disabled with explanation
 <Button.Primary disabled disabledTooltip="Complete the form first">Submit</Button.Primary>
-​```
+```
 ````
 
 ---
 
-## Props section — two forms
+## Props section -- two forms
 
-**Form A — No Plasma-specific props:**
+**Form A -- No Plasma-specific props:**
 
 ```markdown
 ## Props
@@ -82,21 +82,21 @@ import {Button} from '@coveord/plasma-mantine';
 _No additional props beyond the Mantine base component._
 ```
 
-**Form B — With Plasma-specific props:**
+**Form B -- With Plasma-specific props:**
 
 ```markdown
 ## Props
 
 > Extends: `MantineBaseProps`, `OtherInterface`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`propName`** `string` · required · default: `undefined` — What it does.
-**`optionalProp`** `boolean` · optional · default: `false` — What it does.
+**`propName`** `string` | required | default: `undefined` -- What it does.
+**`optionalProp`** `boolean` | optional | default: `false` -- What it does.
 ```
 
 Rules:
 
-- Use `·` (U+00B7) as separator between metadata fields.
-- Use `—` (em dash with spaces) to separate metadata from the description.
+- Use `|` (pipe) as separator between metadata fields.
+- Use `--` (double dash) to separate metadata from the description.
 - Use `required` or `optional` explicitly for every prop.
 - `default:` is always shown; use `undefined` when there is no default (required props always get `undefined`).
 - Only list props defined in the Plasma wrapper; inherited Mantine props go in the `> Extends:` note.

--- a/packages/llms/src/build.ts
+++ b/packages/llms/src/build.ts
@@ -31,6 +31,32 @@ const write = (filePath: string, content: string) => {
     console.log(`  ✓  ${path.relative(distDir, filePath)} (${kb} KB)`);
 };
 
+const assertAsciiOnly = () => {
+    const NON_ASCII = /[^\x00-\x7F]/;
+    const files = fs.readdirSync(distDir, {recursive: true, encoding: 'utf-8'});
+    const violations: string[] = [];
+    for (const file of files) {
+        const filePath = path.join(distDir, file);
+        if (!fs.statSync(filePath).isFile()) {
+            continue;
+        }
+        const content = fs.readFileSync(filePath, 'utf-8');
+        const match = NON_ASCII.exec(content);
+        if (match) {
+            const line = content.slice(0, match.index).split('\n').length;
+            violations.push(
+                `  ${file}:${line} found U+${match[0].codePointAt(0)!.toString(16).padStart(4, '0').toUpperCase()}`,
+            );
+        }
+    }
+    if (violations.length > 0) {
+        console.error('\n\u274c Non-ASCII characters detected in dist output:\n');
+        violations.forEach((v) => console.error(v));
+        console.error('\nAll dist files must contain only ASCII characters.\n');
+        process.exit(1);
+    }
+};
+
 const main = () => {
     console.log('\n🚀 Generating Plasma LLM documentation…\n');
     console.log(`   Base URL: ${BASE_URL}\n`);
@@ -71,7 +97,9 @@ const main = () => {
     const skillTemplate = fs.readFileSync(path.resolve(currentDir, '../src/skill.md'), 'utf-8');
     write(path.join(distDir, 'plasma-skill.md'), skillTemplate.replaceAll('{{BASE_URL}}', BASE_URL));
 
-    console.log(`\n✅ Done! Generated docs for ${docs.length} components.\n`);
+    assertAsciiOnly();
+
+    console.log(`\n\u2705 Done! Generated docs for ${docs.length} components.\n`);
 };
 
 main();

--- a/packages/llms/src/components/ActionIcon.md
+++ b/packages/llms/src/components/ActionIcon.md
@@ -7,9 +7,9 @@ description: Icon-only button that can trigger actions and can show a disabled-s
 
 > Extends: `MantineActionIconProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`onClick`** `ClickHandler<HTMLButtonElement>` · optional · default: `undefined` — Handler executed on click. Supports standard, async, and parameterless handlers. Async handlers MAY be provided; the button shows a loading state while the promise resolves.
-**`disabledTooltip`** `string` · optional · default: `undefined` — Tooltip message displayed when `disabled` is `true`.
-**`disabledTooltipProps`** `Omit<TooltipProps, 'disabled' | 'label' | 'children'>` · optional · default: `undefined` — Additional tooltip props that MAY be set on the disabled button tooltip.
+**`onClick`** `ClickHandler<HTMLButtonElement>` | optional | default: `undefined` -- Handler executed on click. Supports standard, async, and parameterless handlers. Async handlers MAY be provided; the button shows a loading state while the promise resolves.
+**`disabledTooltip`** `string` | optional | default: `undefined` -- Tooltip message displayed when `disabled` is `true`.
+**`disabledTooltipProps`** `Omit<TooltipProps, 'disabled' | 'label' | 'children'>` | optional | default: `undefined` -- Additional tooltip props that MAY be set on the disabled button tooltip.
 
 ## Sub-components
 

--- a/packages/llms/src/components/Badge.md
+++ b/packages/llms/src/components/Badge.md
@@ -7,8 +7,8 @@ description: Status label that can display short text, counts, or metadata tags.
 
 > Extends: `BadgeProps` (sub-components use `SemanticBadgeProps`, a restricted subset). Only Plasma-specific props are listed below; inherited props MUST be referenced in Mantine documentation.
 
-**`size`** `'small' | 'large'` · optional · default: `'small'` — Controls the badge height and text size.
-**`on`** `'light' | 'dark'` · optional · default: current colour scheme — Forces the light or dark colour variant.
+**`size`** `'small' | 'large'` | optional | default: `'small'` -- Controls the badge height and text size.
+**`on`** `'light' | 'dark'` | optional | default: current colour scheme -- Forces the light or dark colour variant.
 
 ## Sub-components
 

--- a/packages/llms/src/components/BlankSlate.md
+++ b/packages/llms/src/components/BlankSlate.md
@@ -5,7 +5,7 @@ description: Empty state container for views with no content to display.
 
 ## Props
 
-**`withBorder`** `boolean` · optional · default: `true` — Renders a border when this prop is `true` and omits it when this prop is `false`.
+**`withBorder`** `boolean` | optional | default: `true` -- Renders a border when this prop is `true` and omits it when this prop is `false`.
 
 ## Usage
 

--- a/packages/llms/src/components/BrowserPreview.md
+++ b/packages/llms/src/components/BrowserPreview.md
@@ -7,8 +7,8 @@ description: Renders a simulated browser chrome frame around preview content.
 
 > Extends: `StackProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`headerTooltip`** `string` · optional · default: `undefined` — Text displayed in a tooltip in the header.
-**`title`** `string` · optional · default: `undefined` — Custom title displayed at the center of the header.
+**`headerTooltip`** `string` | optional | default: `undefined` -- Text displayed in a tooltip in the header.
+**`title`** `string` | optional | default: `undefined` -- Custom title displayed at the center of the header.
 
 ## Usage
 
@@ -40,7 +40,7 @@ export function Example() {
                         <Stack key={product.name} gap={0}>
                             <Text>{product.name}</Text>
                             <Text size="xs" c="dimmed">
-                                {product.department} • {product.price}
+                                {product.department} * {product.price}
                             </Text>
                         </Stack>
                     ))}

--- a/packages/llms/src/components/Button.md
+++ b/packages/llms/src/components/Button.md
@@ -7,11 +7,11 @@ description: Action button that triggers tasks and provides async loading and di
 
 > Extends: `ButtonProps`, `ButtonWithDisabledTooltipProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`onClick`** `ClickHandler<HTMLButtonElement>` · optional · default: `undefined` — Handler executed on click. Async handlers MAY be used; the button shows a loading state while the promise resolves.
-**`disabledTooltip`** `string` · optional · default: `undefined` — The tooltip message displayed when the button is disabled.
-**`disabled`** `boolean` · optional · default: `undefined` — Indicates whether the button underneath the tooltip is disabled.
-**`disabledTooltipProps`** `Omit<TooltipProps, 'disabled' | 'label' | 'children'>` · optional · default: `undefined` — Additional tooltip props MAY be set on the disabled button tooltip.
-**`fullWidth`** `boolean` · optional · default: `undefined` — When provided, sets the button width to 100% of the parent element.
+**`onClick`** `ClickHandler<HTMLButtonElement>` | optional | default: `undefined` -- Handler executed on click. Async handlers MAY be used; the button shows a loading state while the promise resolves.
+**`disabledTooltip`** `string` | optional | default: `undefined` -- The tooltip message displayed when the button is disabled.
+**`disabled`** `boolean` | optional | default: `undefined` -- Indicates whether the button underneath the tooltip is disabled.
+**`disabledTooltipProps`** `Omit<TooltipProps, 'disabled' | 'label' | 'children'>` | optional | default: `undefined` -- Additional tooltip props MAY be set on the disabled button tooltip.
+**`fullWidth`** `boolean` | optional | default: `undefined` -- When provided, sets the button width to 100% of the parent element.
 
 ## Sub-components
 

--- a/packages/llms/src/components/ChildForm.md
+++ b/packages/llms/src/components/ChildForm.md
@@ -7,8 +7,8 @@ description: Expandable nested sub-form within a parent form context.
 
 > Extends: `CollapseProps`, `StylesApiProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`title`** `string` · optional · default: `undefined` — MAY define the title of the child form.
-**`description`** `ReactNode` · optional · default: `undefined` — MAY define the description of the child form.
+**`title`** `string` | optional | default: `undefined` -- MAY define the title of the child form.
+**`description`** `ReactNode` | optional | default: `undefined` -- MAY define the description of the child form.
 
 ## Usage
 

--- a/packages/llms/src/components/CodeEditor.md
+++ b/packages/llms/src/components/CodeEditor.md
@@ -7,19 +7,19 @@ description: Monaco-based code editor that supports syntax highlighting, validat
 
 > Extends: `InputWrapperProps`, `StackProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`language`** `'plaintext' | 'json' | 'markdown' | 'python' | 'xml' | (string & unknown)` · optional · default: `plaintext` — Defines the language syntax of the editor.
-**`defaultValue`** `string` · optional · default: `''` — For uncontrolled input, this prop MAY provide the default value.
-**`value`** `string` · optional · default: `undefined` — For controlled input, this prop MUST provide the value.
-**`onChange`** `(value: string) => void` · optional · default: `undefined` — For controlled input, this callback receives the updated value.
-**`onSearch`** `() => void` · optional · default: `undefined` — If provided, this callback is called whenever the search icon is clicked.
-**`onCopy`** `() => void` · optional · default: `undefined` — If provided, this callback is called whenever the copy icon is clicked.
-**`onFocus`** `() => void` · optional · default: `undefined` — If provided, this callback is called whenever the code editor gets focus.
-**`editorHandle`** `React.MutableRefObject<monacoEditor.IStandaloneCodeEditor | null>` · optional · default: `undefined` — This ref MAY provide access to the editor's functionality.
-**`minHeight`** `number` · optional · default: `300` — The CodeEditor height, including label and description, is never smaller than this value. By default, the CodeEditor adjusts to fill its parent height. If the parent height is too short, the component uses this value as its minimum height.
-**`maxHeight`** `number` · optional · default: `undefined` — The CodeEditor height, including label and description, is never larger than this value. By default, the CodeEditor adjusts to fill its parent height. This prop can set the maximum height when the parent height would otherwise be too high.
-**`disabled`** `boolean` · optional · default: `undefined` — When set, the editor is read-only and uses disabled styling.
-**`monacoLoader`** `'cdn' | 'local'` · optional · default: `local` — Defines how the Monaco editor files are loaded. When `local` is used, the required [additional configuration](https://github.com/suren-atoyan/monaco-react#use-monaco-editor-as-an-npm-package) MUST be provided.
-**`options`** `Pick<monacoEditor.IStandaloneEditorConstructionOptions, 'tabSize'>` · optional · default: `undefined` — This prop MAY pass options to the Monaco editor. It currently supports only [`tabSize`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IStandaloneEditorConstructionOptions.html#tabSize).
+**`language`** `'plaintext' | 'json' | 'markdown' | 'python' | 'xml' | (string & unknown)` | optional | default: `plaintext` -- Defines the language syntax of the editor.
+**`defaultValue`** `string` | optional | default: `''` -- For uncontrolled input, this prop MAY provide the default value.
+**`value`** `string` | optional | default: `undefined` -- For controlled input, this prop MUST provide the value.
+**`onChange`** `(value: string) => void` | optional | default: `undefined` -- For controlled input, this callback receives the updated value.
+**`onSearch`** `() => void` | optional | default: `undefined` -- If provided, this callback is called whenever the search icon is clicked.
+**`onCopy`** `() => void` | optional | default: `undefined` -- If provided, this callback is called whenever the copy icon is clicked.
+**`onFocus`** `() => void` | optional | default: `undefined` -- If provided, this callback is called whenever the code editor gets focus.
+**`editorHandle`** `React.MutableRefObject<monacoEditor.IStandaloneCodeEditor | null>` | optional | default: `undefined` -- This ref MAY provide access to the editor's functionality.
+**`minHeight`** `number` | optional | default: `300` -- The CodeEditor height, including label and description, is never smaller than this value. By default, the CodeEditor adjusts to fill its parent height. If the parent height is too short, the component uses this value as its minimum height.
+**`maxHeight`** `number` | optional | default: `undefined` -- The CodeEditor height, including label and description, is never larger than this value. By default, the CodeEditor adjusts to fill its parent height. This prop can set the maximum height when the parent height would otherwise be too high.
+**`disabled`** `boolean` | optional | default: `undefined` -- When set, the editor is read-only and uses disabled styling.
+**`monacoLoader`** `'cdn' | 'local'` | optional | default: `local` -- Defines how the Monaco editor files are loaded. When `local` is used, the required [additional configuration](https://github.com/suren-atoyan/monaco-react#use-monaco-editor-as-an-npm-package) MUST be provided.
+**`options`** `Pick<monacoEditor.IStandaloneEditorConstructionOptions, 'tabSize'>` | optional | default: `undefined` -- This prop MAY pass options to the Monaco editor. It currently supports only [`tabSize`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IStandaloneEditorConstructionOptions.html#tabSize).
 
 ## Usage
 

--- a/packages/llms/src/components/Collection.md
+++ b/packages/llms/src/components/Collection.md
@@ -7,25 +7,25 @@ description: Dynamic list input that can render items with column-based layouts 
 
 > Extends: `__InputWrapperProps`, `BoxProps`, `StylesApiProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`columns`** `Array<CollectionColumnDef<T>>` · optional · default: `undefined` — MAY provide column definitions for the collection. This prop is REQUIRED when using the column-based pattern.
-**`layout`** `CollectionLayout` · optional · default: `CollectionLayouts.Horizontal` — MAY define the layout component to use for rendering. This prop MUST only be used with `columns`.
-**`children`** `(item: T, index: number) => ReactNode` · optional · default: `undefined` — MAY provide a render function called for each item passed in the `value` prop. `columns` and `layout` MUST NOT be used with this pattern.
-**`newItem`** `T | (() => T)` · required · default: `undefined` — REQUIRED. MUST define the default value each new item SHOULD have.
-**`value`** `T[]` · optional · default: `[]` — MAY provide the list of items to display inside the collection.
-**`getItemId`** `(originalItem: T, itemIndex: number) => string` · optional · default: `({id}) => id` — MAY define how each item is uniquely identified. It is RECOMMENDED that you specify this prop to an ID that makes sense. This method is REQUIRED when using this component with ReactHookForm.
-**`onFocus`** `() => void` · optional · default: `undefined` — Optional. Unused and has no effect.
-**`onChange`** `(value: T[]) => void` · optional · default: `undefined` — MAY be used to receive the whole list of items after the change whenever the value needs to be updated.
-**`onRemoveItem`** `(itemIndex: number) => void` · optional · default: `undefined` — MAY be used to receive the index of the item removed from the collection using the remove button.
-**`onReorderItem`** `(payload: {from: number; to: number}) => void` · optional · default: `undefined` — MAY be used to receive the origin and destination index whenever a collection item needs to be reordered.
-**`onInsertItem`** `(value: T, index: number) => void` · optional · default: `undefined` — MAY be used to receive the value of the item to insert and the index of the new item to insert when a new item needs to be added to the collection.
-**`draggable`** `boolean` · optional · default: `false` — MAY enable drag and drop behavior for the collection.
-**`disabled`** `boolean` · optional · default: `false` — Can disable the collection; in other words, it can put the collection in read-only mode.
-**`readOnly`** `boolean` · optional · default: `false` — MAY mark the collection as readOnly. If true, the collection prevents adding or removing items.
-**`allowAdd`** `boolean | ((values: T[]) => boolean)` · optional · default: `undefined` — MAY determine if the add item button SHOULD be enabled given the current items of the collection. The button remains enabled if this prop is undefined.
-**`addLabel`** `ReactNode` · optional · default: `"Add item"` — MAY define the label of the add item button.
-**`addDisabledTooltip`** `string` · optional · default: `'There is already an empty item'` — MAY define the tooltip text displayed when hovering over the disabled add item button.
-**`gap`** `MantineSpacing` · optional · default: `'md'` — MAY define the gap between the collection items.
-**`required`** `boolean` · optional · default: `false` — MAY mark the collection as required. When true, the collection hides the remove button if there is only one item.
+**`columns`** `Array<CollectionColumnDef<T>>` | optional | default: `undefined` -- MAY provide column definitions for the collection. This prop is REQUIRED when using the column-based pattern.
+**`layout`** `CollectionLayout` | optional | default: `CollectionLayouts.Horizontal` -- MAY define the layout component to use for rendering. This prop MUST only be used with `columns`.
+**`children`** `(item: T, index: number) => ReactNode` | optional | default: `undefined` -- MAY provide a render function called for each item passed in the `value` prop. `columns` and `layout` MUST NOT be used with this pattern.
+**`newItem`** `T | (() => T)` | required | default: `undefined` -- REQUIRED. MUST define the default value each new item SHOULD have.
+**`value`** `T[]` | optional | default: `[]` -- MAY provide the list of items to display inside the collection.
+**`getItemId`** `(originalItem: T, itemIndex: number) => string` | optional | default: `({id}) => id` -- MAY define how each item is uniquely identified. It is RECOMMENDED that you specify this prop to an ID that makes sense. This method is REQUIRED when using this component with ReactHookForm.
+**`onFocus`** `() => void` | optional | default: `undefined` -- Optional. Unused and has no effect.
+**`onChange`** `(value: T[]) => void` | optional | default: `undefined` -- MAY be used to receive the whole list of items after the change whenever the value needs to be updated.
+**`onRemoveItem`** `(itemIndex: number) => void` | optional | default: `undefined` -- MAY be used to receive the index of the item removed from the collection using the remove button.
+**`onReorderItem`** `(payload: {from: number; to: number}) => void` | optional | default: `undefined` -- MAY be used to receive the origin and destination index whenever a collection item needs to be reordered.
+**`onInsertItem`** `(value: T, index: number) => void` | optional | default: `undefined` -- MAY be used to receive the value of the item to insert and the index of the new item to insert when a new item needs to be added to the collection.
+**`draggable`** `boolean` | optional | default: `false` -- MAY enable drag and drop behavior for the collection.
+**`disabled`** `boolean` | optional | default: `false` -- Can disable the collection; in other words, it can put the collection in read-only mode.
+**`readOnly`** `boolean` | optional | default: `false` -- MAY mark the collection as readOnly. If true, the collection prevents adding or removing items.
+**`allowAdd`** `boolean | ((values: T[]) => boolean)` | optional | default: `undefined` -- MAY determine if the add item button SHOULD be enabled given the current items of the collection. The button remains enabled if this prop is undefined.
+**`addLabel`** `ReactNode` | optional | default: `"Add item"` -- MAY define the label of the add item button.
+**`addDisabledTooltip`** `string` | optional | default: `'There is already an empty item'` -- MAY define the tooltip text displayed when hovering over the disabled add item button.
+**`gap`** `MantineSpacing` | optional | default: `'md'` -- MAY define the gap between the collection items.
+**`required`** `boolean` | optional | default: `false` -- MAY mark the collection as required. When true, the collection hides the remove button if there is only one item.
 
 ## Sub-components
 

--- a/packages/llms/src/components/CopyToClipboard.md
+++ b/packages/llms/src/components/CopyToClipboard.md
@@ -7,12 +7,12 @@ description: Action icon that copies a string value to the clipboard and shows t
 
 > Extends: `ActionIconProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`value`** `string` · required · default: `undefined` — The value copied to the clipboard.
-**`withLabel`** `boolean` · optional · default: `false` — Deprecated. You SHOULD place the `CopyToClipboard` component inside the `rightSection` of input components instead. When used, this prop displays the string to be copied alongside the button.
-**`onCopy`** `MouseEventHandler<HTMLButtonElement>` · optional · default: `undefined` — If provided, this callback is called each time the value is copied to the clipboard.
-**`color`** `MantineColor | (string & {})` · optional · default: `gray` — The icon uses this color when idle.
-**`tooltipLabelCopy`** `string` · optional · default: `Copy to clipboard` — The tooltip displays this text when hovering over the button.
-**`tooltipLabelCopied`** `string` · optional · default: `Copied` — The tooltip displays this text when the value is copied to the clipboard.
+**`value`** `string` | required | default: `undefined` -- The value copied to the clipboard.
+**`withLabel`** `boolean` | optional | default: `false` -- Deprecated. You SHOULD place the `CopyToClipboard` component inside the `rightSection` of input components instead. When used, this prop displays the string to be copied alongside the button.
+**`onCopy`** `MouseEventHandler<HTMLButtonElement>` | optional | default: `undefined` -- If provided, this callback is called each time the value is copied to the clipboard.
+**`color`** `MantineColor | (string & {})` | optional | default: `gray` -- The icon uses this color when idle.
+**`tooltipLabelCopy`** `string` | optional | default: `Copy to clipboard` -- The tooltip displays this text when hovering over the button.
+**`tooltipLabelCopied`** `string` | optional | default: `Copied` -- The tooltip displays this text when the value is copied to the clipboard.
 
 ## Usage
 

--- a/packages/llms/src/components/EllipsisText.md
+++ b/packages/llms/src/components/EllipsisText.md
@@ -7,10 +7,10 @@ description: Text component that truncates overflowing content and can show the 
 
 > Extends: `BoxProps`, `StylesApiProps<EllipsisTextFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`children`** `ReactNode` · required · default: `undefined` — Consumers MUST provide the content rendered inside the truncated text, and that value can also be used as the tooltip label when overflow occurs.
-**`variant`** `TextProps['variant']` · optional · default: `undefined` — Consumers MAY use this text variant to align the truncated content with surrounding typography.
-**`lineClamp`** `TextProps['lineClamp']` · optional · default: `undefined` — Consumers MAY set this line clamp for multi-line truncation; when omitted, the component uses single-line ellipsis behavior.
-**`tooltipProps`** `Partial<Omit<TooltipProps, 'label' | 'opened' | 'children'>>` · optional · default: `{}` — Consumers MAY customize the internal Mantine `Tooltip`, but MUST NOT provide `label`, `opened`, or `children`.
+**`children`** `ReactNode` | required | default: `undefined` -- Consumers MUST provide the content rendered inside the truncated text, and that value can also be used as the tooltip label when overflow occurs.
+**`variant`** `TextProps['variant']` | optional | default: `undefined` -- Consumers MAY use this text variant to align the truncated content with surrounding typography.
+**`lineClamp`** `TextProps['lineClamp']` | optional | default: `undefined` -- Consumers MAY set this line clamp for multi-line truncation; when omitted, the component uses single-line ellipsis behavior.
+**`tooltipProps`** `Partial<Omit<TooltipProps, 'label' | 'opened' | 'children'>>` | optional | default: `{}` -- Consumers MAY customize the internal Mantine `Tooltip`, but MUST NOT provide `label`, `opened`, or `children`.
 
 ## Usage
 

--- a/packages/llms/src/components/Facet.md
+++ b/packages/llms/src/components/Facet.md
@@ -7,26 +7,26 @@ description: Facet renders a searchable list of selectable filter options with o
 
 > Extends: `BoxProps`, `StylesApiProps<FacetFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`data`** `FacetData` · required · default: `undefined` — The data to render in the component.
-**`onChange`** `(values: string[]) => void` · optional · default: `undefined` — Function called when an item is selected or unselected. `values` contains the selected items.
-**`onRemove`** `() => void` · optional · default: `undefined` — Called when the remove button is clicked. Only relevant when `removable` is `true`.
-**`removable`** `boolean` · optional · default: `false` — When `true`, displays a close button in the facet header to allow removal.
-**`initialSelection`** `string[]` · optional · default: `[]` — Initial items selection.
-**`selection`** `string[]` · optional · default: `[]` — Determined items selection.
-**`itemComponent`** `FacetItemComponent` · optional · default: `a checkbox with the label of the item` — Custom item component.
-**`itemCountFormatter`** `(value: number) => string` · optional · default: `(count) => count.toString()` — Function to format the facet item count. `count` is the facet item count.
-**`searchPlaceholder`** `string` · optional · default: `Search` — Search input placeholder.
-**`onSearch`** `(value: string) => void` · optional · default: `undefined` — Called when the search query changes. `value` MUST be the search query.
-**`filter`** `(query: string, item: FacetItem) => boolean` · optional · default: `function that compare the query with the label and value, case-insensitive` — Function to filter search results. `query` is the value of the search input. `item` is the current item.
-**`query`** `string` · optional · default: `undefined` — Value of the search input.
-**`nothingFound`** `ReactNode` · optional · default: `No matching items` — Nothing found message.
-**`placeholder`** `ReactNode` · optional · default: `No items` — Displayed when a list is empty and there is no search query.
-**`title`** `ReactNode` · optional · default: `undefined` — Facet title.
-**`height`** `number | 'auto'` · optional · default: `200` — Maximum height. This prop SHOULD only be used when there are more than 7 values.
-**`radius`** `number | string` · optional · default: `md` — Predefined border-radius value from `theme.radius` or number for border-radius in px.
-**`listComponent`** `FunctionComponent<any>` · optional · default: `FacetScrollArea` — Change list component. This prop MAY be used to add custom scrollbars.
-**`limit`** `number` · optional · default: `Infinity` — Limit amount of items showed at a time.
-**`hideSearch`** `boolean` · optional · default: `data.length <= 7` — This prop controls whether the search input is displayed.
+**`data`** `FacetData` | required | default: `undefined` -- The data to render in the component.
+**`onChange`** `(values: string[]) => void` | optional | default: `undefined` -- Function called when an item is selected or unselected. `values` contains the selected items.
+**`onRemove`** `() => void` | optional | default: `undefined` -- Called when the remove button is clicked. Only relevant when `removable` is `true`.
+**`removable`** `boolean` | optional | default: `false` -- When `true`, displays a close button in the facet header to allow removal.
+**`initialSelection`** `string[]` | optional | default: `[]` -- Initial items selection.
+**`selection`** `string[]` | optional | default: `[]` -- Determined items selection.
+**`itemComponent`** `FacetItemComponent` | optional | default: `a checkbox with the label of the item` -- Custom item component.
+**`itemCountFormatter`** `(value: number) => string` | optional | default: `(count) => count.toString()` -- Function to format the facet item count. `count` is the facet item count.
+**`searchPlaceholder`** `string` | optional | default: `Search` -- Search input placeholder.
+**`onSearch`** `(value: string) => void` | optional | default: `undefined` -- Called when the search query changes. `value` MUST be the search query.
+**`filter`** `(query: string, item: FacetItem) => boolean` | optional | default: `function that compare the query with the label and value, case-insensitive` -- Function to filter search results. `query` is the value of the search input. `item` is the current item.
+**`query`** `string` | optional | default: `undefined` -- Value of the search input.
+**`nothingFound`** `ReactNode` | optional | default: `No matching items` -- Nothing found message.
+**`placeholder`** `ReactNode` | optional | default: `No items` -- Displayed when a list is empty and there is no search query.
+**`title`** `ReactNode` | optional | default: `undefined` -- Facet title.
+**`height`** `number | 'auto'` | optional | default: `200` -- Maximum height. This prop SHOULD only be used when there are more than 7 values.
+**`radius`** `number | string` | optional | default: `md` -- Predefined border-radius value from `theme.radius` or number for border-radius in px.
+**`listComponent`** `FunctionComponent<any>` | optional | default: `FacetScrollArea` -- Change list component. This prop MAY be used to add custom scrollbars.
+**`limit`** `number` | optional | default: `Infinity` -- Limit amount of items showed at a time.
+**`hideSearch`** `boolean` | optional | default: `data.length <= 7` -- This prop controls whether the search input is displayed.
 
 ## Usage
 

--- a/packages/llms/src/components/Header.md
+++ b/packages/llms/src/components/Header.md
@@ -7,11 +7,11 @@ description: Page-level header with a title and optional breadcrumbs, actions, a
 
 > Extends: `GroupProps`, `StylesApiProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`description`** `ReactNode` · optional · default: `undefined` — Optional description text displayed inside the header underneath the title.
-**`borderBottom`** `boolean` · optional · default: `undefined` — Adds a bottom border to the header when set.
-**`variant`** `'primary' | 'secondary'` · optional · default: `'primary'` — You SHOULD use the `primary` variant for page headers and the `secondary` variant elsewhere.
-**`children`** `ReactNode` · required · default: `undefined` — The title of the header MUST be provided.
-**`titleComponent`** `ElementType` · optional · default: `Title` — The component used to render the title MAY be customized.
+**`description`** `ReactNode` | optional | default: `undefined` -- Optional description text displayed inside the header underneath the title.
+**`borderBottom`** `boolean` | optional | default: `undefined` -- Adds a bottom border to the header when set.
+**`variant`** `'primary' | 'secondary'` | optional | default: `'primary'` -- You SHOULD use the `primary` variant for page headers and the `secondary` variant elsewhere.
+**`children`** `ReactNode` | required | default: `undefined` -- The title of the header MUST be provided.
+**`titleComponent`** `ElementType` | optional | default: `Title` -- The component used to render the title MAY be customized.
 
 ## Sub-components
 

--- a/packages/llms/src/components/InfoToken.md
+++ b/packages/llms/src/components/InfoToken.md
@@ -7,8 +7,8 @@ description: Inline token for displaying semantic metadata with a predefined ico
 
 > Extends: `BoxProps`, `StylesApiProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`variant`** `InfoTokenVariant` · optional · default: `'outline'` — The variant of the token MAY be set to control its visual treatment.
-**`size`** `InfoTokenSizes` · optional · default: `'xs'` — The size of the info token MAY be set to control its rendered size.
+**`variant`** `InfoTokenVariant` | optional | default: `'outline'` -- The variant of the token MAY be set to control its visual treatment.
+**`size`** `InfoTokenSizes` | optional | default: `'xs'` -- The size of the info token MAY be set to control its rendered size.
 
 ## Sub-components
 

--- a/packages/llms/src/components/Input.md
+++ b/packages/llms/src/components/Input.md
@@ -24,7 +24,7 @@ Plasma provides pre-configured sub-components as convenience wrappers. You SHOUL
 
 > Extends: `Omit<TooltipProps, 'label' | 'classNames' | 'attributes' | 'styles' | 'vars'>`, `StylesApiProps<InputLabelInfoFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`children`** `ReactNode` · required · default: `undefined` — The tooltip content to display.
+**`children`** `ReactNode` | required | default: `undefined` -- The tooltip content to display.
 
 ## Usage
 

--- a/packages/llms/src/components/LastUpdated.md
+++ b/packages/llms/src/components/LastUpdated.md
@@ -7,9 +7,9 @@ description: Component that displays a human-readable last-updated timestamp wit
 
 > Extends: `BoxProps`, `Pick<GroupProps, 'justify'>`, `StylesApiProps<LastUpdatedFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`formatter`** `(time: dayjs.ConfigType) => string` · optional · default: `(time) => dayjs(time).format('h:mm:ss A')` — Optional formatter function to format the time value. Receives the `time` prop and MUST return a string.
-**`time`** `dayjs.ConfigType` · optional · default: `dayjs().valueOf()` — The unformatted time to display, parsed by dayjs when possible.
-**`label`** `string` · optional · default: `'Last update:'` — Label that SHOULD contextualize the time.
+**`formatter`** `(time: dayjs.ConfigType) => string` | optional | default: `(time) => dayjs(time).format('h:mm:ss A')` -- Optional formatter function to format the time value. Receives the `time` prop and MUST return a string.
+**`time`** `dayjs.ConfigType` | optional | default: `dayjs().valueOf()` -- The unformatted time to display, parsed by dayjs when possible.
+**`label`** `string` | optional | default: `'Last update:'` -- Label that SHOULD contextualize the time.
 
 ## Usage
 

--- a/packages/llms/src/components/Menu.md
+++ b/packages/llms/src/components/Menu.md
@@ -11,12 +11,12 @@ _No additional props beyond the Mantine base component._
 
 Plasma overrides `Menu.Item` transparently to add disabled tooltip support. All other sub-components are standard Mantine.
 
-- `Menu.Item` — extends Mantine's `Menu.Item` with `disabledTooltip` and `disabledTooltipProps`
+- `Menu.Item` -- extends Mantine's `Menu.Item` with `disabledTooltip` and `disabledTooltipProps`
 
 ### Menu.Item additional props
 
-**`disabledTooltip`** `string` · optional · default: `undefined` — Tooltip text MAY be provided to explain why a disabled item cannot be activated.
-**`disabledTooltipProps`** `TooltipProps` · optional · default: `undefined` — Additional tooltip configuration MAY be provided for the disabled-state tooltip and SHOULD complement Plasma-managed fields.
+**`disabledTooltip`** `string` | optional | default: `undefined` -- Tooltip text MAY be provided to explain why a disabled item cannot be activated.
+**`disabledTooltipProps`** `TooltipProps` | optional | default: `undefined` -- Additional tooltip configuration MAY be provided for the disabled-state tooltip and SHOULD complement Plasma-managed fields.
 
 ## Usage
 

--- a/packages/llms/src/components/Modal.md
+++ b/packages/llms/src/components/Modal.md
@@ -7,8 +7,8 @@ description: Overlay dialog that focuses user attention and can render a descrip
 
 > Extends: `MantineModalProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`description`** `HeaderProps['description']` · optional · default: `undefined` — Description of the modal, displayed below the title, MAY be provided.
-**`help`** `HeaderDocAnchorProps` · optional · default: `undefined` — Help link for the modal, displayed in the header, MAY be provided. It SHOULD provide a link to external documentation or help resources.
+**`description`** `HeaderProps['description']` | optional | default: `undefined` -- Description of the modal, displayed below the title, MAY be provided.
+**`help`** `HeaderDocAnchorProps` | optional | default: `undefined` -- Help link for the modal, displayed in the header, MAY be provided. It SHOULD provide a link to external documentation or help resources.
 
 ## Sub-components
 

--- a/packages/llms/src/components/PasswordInput.md
+++ b/packages/llms/src/components/PasswordInput.md
@@ -17,7 +17,7 @@ function Example() {
 }
 ```
 
-When `readOnly` is set (and `disabled` is not), Plasma applies a distinct read-only visual style — use this instead of `disabled` when the value is informational and not interactive.
+When `readOnly` is set (and `disabled` is not), Plasma applies a distinct read-only visual style -- use this instead of `disabled` when the value is informational and not interactive.
 
 ---
 

--- a/packages/llms/src/components/Prompt.md
+++ b/packages/llms/src/components/Prompt.md
@@ -7,8 +7,8 @@ description: Confirmation modal with semantic variants and optional footer actio
 
 > Extends: `Omit<ModalRootProps, 'classNames' | 'styles' | 'vars' | 'attributes' | 'variant'>`, `Omit<StylesApiProps<PromptFactory>, 'variant'>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`children`** `ReactNode` · required · default: `undefined` — Prompt body content MUST be provided. It MAY include `Prompt.Footer` for action buttons.
-**`title`** `ReactNode` · required · default: `undefined` — Prompt title content MUST be provided and is rendered in the header.
+**`children`** `ReactNode` | required | default: `undefined` -- Prompt body content MUST be provided. It MAY include `Prompt.Footer` for action buttons.
+**`title`** `ReactNode` | required | default: `undefined` -- Prompt title content MUST be provided and is rendered in the header.
 
 ## Sub-components
 

--- a/packages/llms/src/components/RadioCard.md
+++ b/packages/llms/src/components/RadioCard.md
@@ -7,10 +7,10 @@ description: Selectable card control that presents a radio option with a label a
 
 > Extends: `RadioCardProps`, `StylesApiProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`label`** `ReactNode` · required · default: `undefined` — Content rendered as the primary label next to the radio indicator.
-**`description`** `ReactNode` · optional · default: `undefined` — Content rendered below the label as supporting text.
-**`readOnly`** `boolean` · optional · default: `undefined` — When `true`, the card appears read-only and prevents users from changing its value through direct interaction.
-**`disabledTooltip`** `string` · optional · default: `undefined` — When the card is disabled, this message can be shown in a tooltip to explain why selection is unavailable.
+**`label`** `ReactNode` | required | default: `undefined` -- Content rendered as the primary label next to the radio indicator.
+**`description`** `ReactNode` | optional | default: `undefined` -- Content rendered below the label as supporting text.
+**`readOnly`** `boolean` | optional | default: `undefined` -- When `true`, the card appears read-only and prevents users from changing its value through direct interaction.
+**`disabledTooltip`** `string` | optional | default: `undefined` -- When the card is disabled, this message can be shown in a tooltip to explain why selection is unavailable.
 
 ## Usage
 

--- a/packages/llms/src/components/Select.md
+++ b/packages/llms/src/components/Select.md
@@ -32,7 +32,7 @@ function Example() {
 }
 ```
 
-When `readOnly` is set (and `disabled` is not), Plasma applies a distinct read-only visual style — use this instead of `disabled` when the value is informational and not interactive.
+When `readOnly` is set (and `disabled` is not), Plasma applies a distinct read-only visual style -- use this instead of `disabled` when the value is informational and not interactive.
 
 ---
 

--- a/packages/llms/src/components/StatusToken.md
+++ b/packages/llms/src/components/StatusToken.md
@@ -7,8 +7,8 @@ description: Status indicator with semantic color coding.
 
 > Extends: `BoxProps`, `StylesApiProps<StatusTokenFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`size`** `'sm' | 'lg'` · optional · default: `'lg'` — The size of the token MAY be set to control the rendered icon dimensions.
-**`variant`** `'info' | 'success' | 'caution' | 'error' | 'disabled' | 'waiting' | 'edited' | 'new'` · optional · default: `'info'` — The variant of the token MUST match the status semantics you need to communicate.
+**`size`** `'sm' | 'lg'` | optional | default: `'lg'` -- The size of the token MAY be set to control the rendered icon dimensions.
+**`variant`** `'info' | 'success' | 'caution' | 'error' | 'disabled' | 'waiting' | 'edited' | 'new'` | optional | default: `'info'` -- The variant of the token MUST match the status semantics you need to communicate.
 
 ## Usage
 

--- a/packages/llms/src/components/StickyFooter.md
+++ b/packages/llms/src/components/StickyFooter.md
@@ -7,9 +7,9 @@ description: Action footer that remains fixed to the bottom of the viewport.
 
 > Extends: `Omit<GroupProps, 'classNames' | 'styles' | 'vars' | 'variant'>`, `StylesApiProps<StickyFooterFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`borderTop`** `boolean` · optional · default: `undefined` — When `true`, a border is rendered on top of the footer.
-**`children`** `ReactNode` · optional · default: `undefined` — Footer children SHOULD usually be buttons.
-**`variant`** `'default' | 'modal-footer'` · optional · default: `undefined` — The `modal-footer` variant SHOULD be used when rendering the `StickyFooter` inside `Modal`. The `modal-footer` variant removes the modal's default padding so that the footer properly hugs the bottom of the modal. It also adds a border on top of the footer. Deprecated: You SHOULD use `Modal.Footer` from `@coveord/plasma-mantine/Modal` for modal footers. For other cases, the `default` variant SHOULD suffice.
+**`borderTop`** `boolean` | optional | default: `undefined` -- When `true`, a border is rendered on top of the footer.
+**`children`** `ReactNode` | optional | default: `undefined` -- Footer children SHOULD usually be buttons.
+**`variant`** `'default' | 'modal-footer'` | optional | default: `undefined` -- The `modal-footer` variant SHOULD be used when rendering the `StickyFooter` inside `Modal`. The `modal-footer` variant removes the modal's default padding so that the footer properly hugs the bottom of the modal. It also adds a border on top of the footer. Deprecated: You SHOULD use `Modal.Footer` from `@coveord/plasma-mantine/Modal` for modal footers. For other cases, the `default` variant SHOULD suffice.
 
 ## Usage
 

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -7,19 +7,19 @@ description: Table for displaying tabular data with optional filtering, paginati
 
 > Extends: `BoxProps & StylesApiProps<PlasmaTableFactory>`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.
 
-**`store`** `TableStore<TData>` · required · default: `undefined` — You MUST pass the table store returned by `useTable`.
-**`data`** `TData[] | null` · required · default: `undefined` — Data to display in the table. You MUST use `null` when the table is initially loading.
-**`getRowId`** `CoreOptions<TData>['getRowId']` · optional · default: `undefined` — Defines how each row is uniquely identified. You SHOULD specify this prop with an ID that makes sense.
-**`getRowAttributes`** `(datum: TData, index: number, row: Row<TData>) => Record<string, unknown>` · optional · default: `undefined` — HTML attributes MAY be defined for each row with this prop.
-**`getRowExpandedContent`** `(datum: TData, index: number, row: Row<TData>) => ReactNode` · optional · default: `undefined` — Function that generates the expandable content of a row. You MUST return `null` for rows that do not need to be expandable.
-**`getRowActions`** `(data: TData[]) => TableAction[]` · optional · default: `() => []` — Function that generates the actions for the selected rows. If the table does not support multi selection, you MUST access `data[0]`. You MUST return an empty array for rows that do not have actions.
-**`columns`** `Array<ColumnDef<TData>>` · required · default: `undefined` — Columns to display in the table. This prop MUST define the rendered columns.
-**`layouts`** `TableLayout[]` · optional · default: `[Table.Layouts.Rows]` — Available layouts. This prop MAY be used to expose layout switching.
-**`layoutProps`** `{onRowDoubleClick?: (selectedRow: TData, index: number, row: Row<TData>) => void} & Record<string, unknown>` · optional · default: `{}` — Props passed down to the active layout Header and Body components.
-**`loading`** `boolean` · optional · default: `false` — Whether the table is loading or not. This prop MAY be used to show loading states.
-**`children`** `ReactNode` · optional · default: `undefined` — Children to display in the table. They MUST be wrapped in either `Table.Header` or `Table.Footer`.
-**`additionalRootNodes`** `HTMLElement[]` · optional · default: `[]` — Nodes that are considered inside the table. Rows normally get unselected when clicking outside the table, but the component can have difficulty guessing what is inside or outside, for example when using modals. You MAY use this prop to force the table to consider some nodes to be inside the table.
-**`options`** `Omit<Partial<TableOptions<TData>>, 'initialState' | 'data' | 'columns' | 'manualPagination' | 'enableMultiRowSelection' | 'getRowId' | 'getRowCanExpand' | 'enableRowSelection' | 'onRowSelectionChange'>` · optional · default: `{}` — Additional options MAY be passed to the table with this prop.
+**`store`** `TableStore<TData>` | required | default: `undefined` -- You MUST pass the table store returned by `useTable`.
+**`data`** `TData[] | null` | required | default: `undefined` -- Data to display in the table. You MUST use `null` when the table is initially loading.
+**`getRowId`** `CoreOptions<TData>['getRowId']` | optional | default: `undefined` -- Defines how each row is uniquely identified. You SHOULD specify this prop with an ID that makes sense.
+**`getRowAttributes`** `(datum: TData, index: number, row: Row<TData>) => Record<string, unknown>` | optional | default: `undefined` -- HTML attributes MAY be defined for each row with this prop.
+**`getRowExpandedContent`** `(datum: TData, index: number, row: Row<TData>) => ReactNode` | optional | default: `undefined` -- Function that generates the expandable content of a row. You MUST return `null` for rows that do not need to be expandable.
+**`getRowActions`** `(data: TData[]) => TableAction[]` | optional | default: `() => []` -- Function that generates the actions for the selected rows. If the table does not support multi selection, you MUST access `data[0]`. You MUST return an empty array for rows that do not have actions.
+**`columns`** `Array<ColumnDef<TData>>` | required | default: `undefined` -- Columns to display in the table. This prop MUST define the rendered columns.
+**`layouts`** `TableLayout[]` | optional | default: `[Table.Layouts.Rows]` -- Available layouts. This prop MAY be used to expose layout switching.
+**`layoutProps`** `{onRowDoubleClick?: (selectedRow: TData, index: number, row: Row<TData>) => void} & Record<string, unknown>` | optional | default: `{}` -- Props passed down to the active layout Header and Body components.
+**`loading`** `boolean` | optional | default: `false` -- Whether the table is loading or not. This prop MAY be used to show loading states.
+**`children`** `ReactNode` | optional | default: `undefined` -- Children to display in the table. They MUST be wrapped in either `Table.Header` or `Table.Footer`.
+**`additionalRootNodes`** `HTMLElement[]` | optional | default: `[]` -- Nodes that are considered inside the table. Rows normally get unselected when clicking outside the table, but the component can have difficulty guessing what is inside or outside, for example when using modals. You MAY use this prop to force the table to consider some nodes to be inside the table.
+**`options`** `Omit<Partial<TableOptions<TData>>, 'initialState' | 'data' | 'columns' | 'manualPagination' | 'enableMultiRowSelection' | 'getRowId' | 'getRowCanExpand' | 'enableRowSelection' | 'onRowSelectionChange'>` | optional | default: `{}` -- Additional options MAY be passed to the table with this prop.
 
 ## Sub-components
 

--- a/packages/llms/src/llms-full-txt.md
+++ b/packages/llms/src/llms-full-txt.md
@@ -1,4 +1,4 @@
-# Plasma Design System — Full LLM Documentation
+# Plasma Design System -- Full LLM Documentation
 
 Plasma is Coveo's design system built on top of Mantine. It provides a curated set of React components, a custom Mantine theme, design tokens, and icons for use in Coveo Cloud products.
 

--- a/packages/llms/src/llms-full-txt.ts
+++ b/packages/llms/src/llms-full-txt.ts
@@ -6,9 +6,9 @@ import type {ComponentDoc} from './build.ts';
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const template = fs.readFileSync(path.resolve(currentDir, '../src/llms-full-txt.md'), 'utf-8');
 
-const BOUNDARY = `\n\n${'─'.repeat(80)}\n\n`;
+const BOUNDARY = `\n\n${'-'.repeat(80)}\n\n`;
 
-/** Generates llms-full.txt — a single file concatenating all component documentation. */
+/** Generates llms-full.txt -- a single file concatenating all component documentation. */
 export const generateLlmsFullTxt = (docs: ComponentDoc[]): string => {
     const componentDocs = docs
         .map((doc) => {

--- a/packages/llms/src/llms-txt.md
+++ b/packages/llms/src/llms-txt.md
@@ -1,4 +1,4 @@
-# Plasma Design System — LLM Documentation
+# Plasma Design System -- LLM Documentation
 
 Plasma is Coveo's design system built on top of Mantine. It provides a curated set of React components, a custom Mantine theme, design tokens, and icons for use in Coveo Cloud products.
 
@@ -15,7 +15,7 @@ For a single consolidated file with all component documentation, use:
 
 ## Optional
 
-Plasma re-exports ~90 Mantine components unchanged. For components not listed above, refer to Mantine's documentation — but always import from `@coveord/plasma-mantine`, not from `@mantine/*` packages.
+Plasma re-exports ~90 Mantine components unchanged. For components not listed above, refer to Mantine's documentation -- but always import from `@coveord/plasma-mantine`, not from `@mantine/*` packages.
 
 - [Mantine component index](https://mantine.dev/llms.txt): index of all Mantine components
 - [Mantine full documentation](https://mantine.dev/llms-full.txt): complete Mantine component docs (props, usage)

--- a/packages/llms/src/skill.md
+++ b/packages/llms/src/skill.md
@@ -1,6 +1,6 @@
 ---
 name: plasma
-description: Plasma design system setup, conventions, and component documentation for `@coveord/plasma-mantine` — Coveo's Mantine-based React component library. Use when building or modifying UI in a project that uses Plasma, looking up component props or usage patterns, setting up a new Plasma project, or any task involving `@coveord/plasma-mantine` components.
+description: Plasma design system setup, conventions, and component documentation for `@coveord/plasma-mantine` -- Coveo's Mantine-based React component library. Use when building or modifying UI in a project that uses Plasma, looking up component props or usage patterns, setting up a new Plasma project, or any task involving `@coveord/plasma-mantine` components.
 ---
 
 Plasma is Coveo's design system built on top of [Mantine](https://mantine.dev/). It provides React components, a custom theme, design tokens, and icons for Coveo Cloud products.
@@ -35,7 +35,7 @@ function App() {
 
 Plasma documents its wrapped components. Query Plasma first; fall back to Mantine for everything else.
 
-**Step 1 — Plasma (authoritative for Plasma-specific behaviour):**
+**Step 1 -- Plasma (authoritative for Plasma-specific behaviour):**
 
 Fetch the component index to see what Plasma documents:
 
@@ -55,7 +55,7 @@ Fetch full docs for all Plasma-wrapped components (props, sub-components, usage 
 {{BASE_URL}}/llms-full.txt
 ```
 
-**Step 2 — Mantine fallback (for re-exported components and inherited props):**
+**Step 2 -- Mantine fallback (for re-exported components and inherited props):**
 
 If a component isn't listed in the Plasma index, fetch Mantine's documentation:
 
@@ -68,9 +68,9 @@ https://mantine.dev/llms.txt
 **Always import from `@coveord/plasma-mantine`**, even when using Mantine docs as the API reference. `@coveord/plasma-mantine` re-exports all Mantine components with Coveo's theme and any Plasma overrides applied.
 
 ```tsx
-// ✓ Always — even for components only documented by Mantine
+// [ok] Always -- even for components only documented by Mantine
 import {TextInput, Select, Checkbox} from '@coveord/plasma-mantine';
 
-// ✗ Never
+// [error] Never
 import {TextInput} from '@mantine/core';
 ```


### PR DESCRIPTION
## Summary

Replace all non-ASCII characters in `packages/llms` source files with ASCII equivalents and add a build-time assertion that fails if any non-ASCII character makes it into `dist/`.

This removes the need for explicit `charset=utf-8` content-type headers when serving these files, unblocking hosting via Chromatic.

## Changes

- Replace `·` (middle dot) with `|`, `—` (em dash) with `--`, `─` (box drawing) with `-`, `✓`/`✗` with `[ok]`/`[error]` in all `.md` and `.ts` source files
- Add `assertAsciiOnly()` validation to the build script
- Simplify `deploy.sh` from 3 s3 cp calls to 1 (no more content-type overrides)
- Update `.github` skill docs and copilot instructions with new conventions

## Testing

- `pnpm build` in `packages/llms` passes with the ASCII assertion
- Verified `dist/` contains zero non-ASCII bytes

Resolves [ADUI-11480](https://coveord.atlassian.net/browse/ADUI-11480)

[ADUI-11480]: https://coveord.atlassian.net/browse/ADUI-11480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ