### PR TITLE
fix(mantine): only apply inline middlewares in test environment

### DIFF
--- a/packages/mantine/src/__tests__/Utils.tsx
+++ b/packages/mantine/src/__tests__/Utils.tsx
@@ -2,27 +2,11 @@ import {render, RenderOptions, RenderResult} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {FunctionComponent, PropsWithChildren, ReactElement} from 'react';
 
-import {Combobox, createTheme, Popover} from '@mantine/core';
 import {Plasmantine} from '../theme/Plasmantine.js';
-
-const testTheme = createTheme({
-    components: {
-        Popover: Popover.extend({
-            defaultProps: {
-                middlewares: {inline: true},
-            },
-        }),
-        Combobox: Combobox.extend({
-            defaultProps: {
-                middlewares: {inline: true},
-            },
-        }),
-    },
-});
 
 const customRender = (ui: ReactElement, options?: Omit<RenderOptions, 'queries'>): RenderResult => {
     const TestWrapper: FunctionComponent<PropsWithChildren> = ({children}) => (
-        <Plasmantine withCssVariables={false} theme={testTheme}>
+        <Plasmantine withCssVariables={false} env="test">
             {children}
         </Plasmantine>
     );

--- a/packages/mantine/src/components/DateRangePicker/__tests__/DateRangePicker.spec.tsx
+++ b/packages/mantine/src/components/DateRangePicker/__tests__/DateRangePicker.spec.tsx
@@ -70,7 +70,7 @@ describe('DateRangePicker', () => {
 
         expect(onChange).toHaveBeenCalledTimes(1);
         expect(onChange).toHaveBeenCalledWith(['2022-01-02T00:00:00.000Z', '2022-01-08T23:59:59.999Z']);
-        expect(screen.queryByRole('dialog')).not.toBeVisible();
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
     it('closes popover when Cancel is clicked', async () => {
@@ -81,7 +81,7 @@ describe('DateRangePicker', () => {
         await screen.findByRole('dialog');
         await user.click(screen.getByRole('button', {name: 'Cancel'}));
 
-        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeVisible());
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
     });
 
     it('calls onCancel when Cancel button is clicked', async () => {

--- a/packages/mantine/src/components/DateRangePicker/__tests__/DateRangePickerPopoverCalendar.spec.tsx
+++ b/packages/mantine/src/components/DateRangePicker/__tests__/DateRangePickerPopoverCalendar.spec.tsx
@@ -55,8 +55,8 @@ describe('DateRangePickerPopoverCalendar', () => {
         await user.click(screen.getByRole('button', {name: '14 February 2022'}));
 
         // hides the calendar when the second date is clicked
-        await waitFor(() => expect(screen.queryByRole('button', {name: '8 January 2022'})).not.toBeVisible());
-        expect(screen.queryByRole('button', {name: '8 February 2022'})).not.toBeVisible();
+        await waitFor(() => expect(screen.queryByRole('button', {name: '8 January 2022'})).not.toBeInTheDocument());
+        expect(screen.queryByRole('button', {name: '8 February 2022'})).not.toBeInTheDocument();
 
         expect(screen.getByTestId('json')).toHaveTextContent('["2022-01-08T00:00:00.000Z","2022-02-14T00:00:00.000Z"]');
 

--- a/packages/mantine/src/theme/Plasmantine.tsx
+++ b/packages/mantine/src/theme/Plasmantine.tsx
@@ -1,22 +1,40 @@
 import '../styles/global.css';
 
-import {MantineProvider, MantineProviderProps, mergeThemeOverrides} from '@mantine/core';
+import {
+    Combobox,
+    createTheme,
+    MantineProvider,
+    MantineProviderProps,
+    mergeThemeOverrides,
+    Popover,
+} from '@mantine/core';
 import {FunctionComponent} from 'react';
 import {mergeCSSVariablesResolvers} from './mergeCSSVariablesResolvers.js';
 import {plasmaCSSVariablesResolver} from './plasmaCSSVariablesResolver.js';
 import {plasmaTheme} from './Theme.js';
 
+const testThemeOverride = createTheme({
+    components: {
+        Combobox: Combobox.extend({defaultProps: {middlewares: {inline: true}}}),
+        Popover: Popover.extend({defaultProps: {middlewares: {inline: true}}}),
+    },
+});
+
 export const Plasmantine: FunctionComponent<MantineProviderProps> = ({
     children,
     theme: externalTheme,
     cssVariablesResolver: externalCSSVariablesResolver,
+    env,
     ...others
 }) => {
-    const theme = mergeThemeOverrides(plasmaTheme, externalTheme);
+    const theme =
+        env === 'test'
+            ? mergeThemeOverrides(plasmaTheme, testThemeOverride, externalTheme)
+            : mergeThemeOverrides(plasmaTheme, externalTheme);
     const cssVariablesResolver = mergeCSSVariablesResolvers(plasmaCSSVariablesResolver, externalCSSVariablesResolver);
 
     return (
-        <MantineProvider theme={theme} cssVariablesResolver={cssVariablesResolver} {...others}>
+        <MantineProvider theme={theme} cssVariablesResolver={cssVariablesResolver} env={env} {...others}>
             {children}
         </MantineProvider>
     );

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -284,9 +284,6 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
         }),
         Combobox: Combobox.extend({
             classNames: ComboboxClasses,
-            defaultProps: {
-                middlewares: {inline: true},
-            },
         }),
         ComboboxChevron: ComboboxChevron.extend({
             defaultProps: {
@@ -443,7 +440,6 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
         Popover: Popover.extend({
             classNames: PopoverClasses,
             defaultProps: {
-                middlewares: {inline: true},
                 position: 'bottom-start',
             },
         }),

--- a/packages/mantine/src/theme/__tests__/Plasmantine.spec.tsx
+++ b/packages/mantine/src/theme/__tests__/Plasmantine.spec.tsx
@@ -1,0 +1,48 @@
+import {MantineThemeOverride, useMantineTheme} from '@mantine/core';
+import {render} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+
+import {plasmaTheme} from '../Theme.js';
+import {Plasmantine} from '../Plasmantine.js';
+
+describe('Plasmantine', () => {
+    it('does not include inline middlewares in the base theme', () => {
+        const components = (plasmaTheme as MantineThemeOverride).components;
+        expect(components?.Combobox?.defaultProps?.middlewares).toBeUndefined();
+        expect(components?.Popover?.defaultProps?.middlewares).toBeUndefined();
+    });
+
+    it('injects inline middlewares when env="test"', () => {
+        let theme: ReturnType<typeof useMantineTheme> | undefined;
+        const Spy = () => {
+            theme = useMantineTheme();
+            return null;
+        };
+
+        render(
+            <Plasmantine withCssVariables={false} env="test">
+                <Spy />
+            </Plasmantine>,
+        );
+
+        expect(theme!.components?.Combobox?.defaultProps?.middlewares).toEqual({inline: true});
+        expect(theme!.components?.Popover?.defaultProps?.middlewares).toEqual({inline: true});
+    });
+
+    it('does not inject inline middlewares without env="test"', () => {
+        let theme: ReturnType<typeof useMantineTheme> | undefined;
+        const Spy = () => {
+            theme = useMantineTheme();
+            return null;
+        };
+
+        render(
+            <Plasmantine withCssVariables={false}>
+                <Spy />
+            </Plasmantine>,
+        );
+
+        expect(theme!.components?.Combobox?.defaultProps?.middlewares).toBeUndefined();
+        expect(theme!.components?.Popover?.defaultProps?.middlewares).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

Remove `middlewares: {inline: true}` from Combobox and Popover defaultProps in the base plasma theme. This fixes NaN warnings at runtime when these components are inside a hidden `Tabs.Panel` (see [mantine#8084](https://github.com/mantinedev/mantine/issues/8084)).

Instead, `Plasmantine` now automatically injects the inline middlewares only when `env="test"` is passed, keeping JSDOM tests working without polluting the production theme.

## Changes

- **Theme.tsx**: Removed `middlewares: {inline: true}` from Combobox and Popover defaultProps
- **Plasmantine.tsx**: Detects `env === "test"` and merges inline middlewares into the theme
- **Utils.tsx**: Simplified test wrapper to use `<Plasmantine env="test">` instead of manual testTheme
- **Plasmantine.spec.tsx** (new): Verifies middlewares are absent in production and present in test env
- **DateRangePicker tests**: Fixed assertions using `.not.toBeVisible()` on unmounted elements

## Testing

- All 50 test files pass (386 tests)
- New regression test confirms production theme has no middlewares

MHUB-2938