### PR TITLE
fix(table): hide column headers when NoData is shown

### DIFF
--- a/packages/mantine/src/components/Table/Table.tsx
+++ b/packages/mantine/src/components/Table/Table.tsx
@@ -252,12 +252,14 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
                                             </th>
                                         </tr>
                                     ) : null}
-                                    <Layout.Header
-                                        getRowExpandedContent={getRowExpandedContent}
-                                        getRowAttributes={getRowAttributes}
-                                        loading={loading}
-                                        {...layoutProps}
-                                    />
+                                    {hasRows || loading ? (
+                                        <Layout.Header
+                                            getRowExpandedContent={getRowExpandedContent}
+                                            getRowAttributes={getRowAttributes}
+                                            loading={loading}
+                                            {...layoutProps}
+                                        />
+                                    ) : null}
                                 </thead>
                                 <tbody {...getStyles('body')}>
                                     {hasRows ? (

--- a/packages/mantine/src/components/Table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/Table.spec.tsx
@@ -92,6 +92,23 @@ describe('Table', () => {
             expect(screen.getByRole('table')).not.toHaveAttribute('data-loading');
         });
 
+        it('keeps column headers visible when loading with no rows', () => {
+            const Fixture = () => {
+                const store = useTable<RowData>({initialState: {globalFilter: 'something'}});
+                return (
+                    <Table store={store} loading data={[]} columns={columns}>
+                        <Table.NoData>
+                            <EmptyState isFiltered={store.isFiltered} />
+                        </Table.NoData>
+                    </Table>
+                );
+            };
+            render(<Fixture />);
+
+            expect(screen.getByRole('columnheader', {name: /firstName/i})).toBeVisible();
+            expect(screen.getByRole('columnheader', {name: /lastName/i})).toBeVisible();
+        });
+
         it('shows a loading animation over the no data children (filtered)', () => {
             const Fixture = () => {
                 const store = useTable<RowData>({initialState: {globalFilter: 'something'}});

--- a/packages/mantine/src/components/Table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/Table.spec.tsx
@@ -39,6 +39,25 @@ describe('Table', () => {
             expect(screen.getByTestId('empty-state')).toBeVisible();
         });
 
+        it('hides column headers when filtered, not loading, and showing no data', () => {
+            const Fixture = () => {
+                const store = useTable<RowData>({initialState: {globalFilter: 'something'}});
+                return (
+                    <Table store={store} data={[]} columns={columns}>
+                        <Table.Header data-testid="table-header">header</Table.Header>
+                        <Table.NoData>
+                            <EmptyState isFiltered={store.isFiltered} />
+                        </Table.NoData>
+                    </Table>
+                );
+            };
+            render(<Fixture />);
+
+            expect(screen.queryByRole('columnheader', {name: /firstName/i})).not.toBeInTheDocument();
+            expect(screen.queryByRole('columnheader', {name: /lastName/i})).not.toBeInTheDocument();
+            expect(screen.getByTestId('filtered-empty-state')).toBeVisible();
+        });
+
         it('does not hide the footer and header if the table is filtered', () => {
             const Fixture = () => {
                 const store = useTable<RowData>({initialState: {globalFilter: 'something'}});


### PR DESCRIPTION
## Summary

Hides the `Layout.Header` (column headers row) when `Table.NoData` is displayed in the filtered-but-empty state and the table is not loading.

## Changes

- **Table.tsx**: Conditionally render `<Layout.Header>` only when `hasRows || loading` is true
- **Table.spec.tsx**: Added test verifying column headers are hidden in the filtered empty state

## Behavior

| State | Column Headers |
|-------|---------------|
| Has rows | Visible |
| Loading, no rows | Visible (preserves table structure during load) |
| Not loading, no rows, filtered (NoData shown) | **Hidden** |
| Vacant + unfiltered | Hidden (entire table replaced by NoData) |

Resolves [ADUI-10831](https://coveord.atlassian.net/browse/ADUI-10831)


Before

<img width="954" height="267" alt="image" src="https://github.com/user-attachments/assets/0a49d767-5e55-4445-a1d4-b2e4be549492" />

After

<img width="960" height="274" alt="image" src="https://github.com/user-attachments/assets/047b3ad6-594c-43d4-852a-8a55ed57362c" />


[ADUI-10831]: https://coveord.atlassian.net/browse/ADUI-10831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ