### PR TITLE
fix(mantine): add missing jsdoc on table components

### DIFF
--- a/packages/mantine/src/components/Table/Table.tsx
+++ b/packages/mantine/src/components/Table/Table.tsx
@@ -298,7 +298,7 @@ export const TableComponentsOrder = {
 };
 
 /**
- * Generic column to use when your table needs an accordion (collapsible rows, but only one open at the time)
+ * Generic column to use when your table needs an accordion (collapsible rows, but only one open at a time).
  */
 Table.AccordionColumn = TableAccordionColumn;
 /**
@@ -314,7 +314,7 @@ Table.ActionItem = TableActionItem;
  */
 Table.CollapsibleColumn = TableCollapsibleColumn;
 /**
- * A date range picker integrated with the table store, resets pagination on change.
+ * A date range picker integrated with the table store that resets pagination on change.
  */
 Table.DateRangePicker = TableDateRangePicker;
 /**
@@ -355,7 +355,7 @@ Table.Pagination = TablePagination;
  */
 Table.PerPage = TablePerPage;
 /**
- * A dropdown that filters table data by a predefined set of values, resets pagination on change.
+ * A dropdown that filters table data by a predefined set of values and resets pagination on change.
  */
 Table.Predicate = TablePredicate;
 

--- a/packages/mantine/src/components/Table/Table.tsx
+++ b/packages/mantine/src/components/Table/Table.tsx
@@ -297,20 +297,66 @@ export const TableComponentsOrder = {
     LayoutControl: 1,
 };
 
+/**
+ * Generic column to use when your table needs an accordion (collapsible rows, but only one open at the time)
+ */
 Table.AccordionColumn = TableAccordionColumn;
+/**
+ * Generic column to use when your table needs actions on rows
+ */
 Table.ActionsColumn = TableActionsColumn;
+/**
+ * An action to display when a row is selected in the table. Can be displayed as a primary action or menu item.
+ */
 Table.ActionItem = TableActionItem;
+/**
+ * Generic column to use when your table needs collapsible rows
+ */
 Table.CollapsibleColumn = TableCollapsibleColumn;
+/**
+ * A date range picker integrated with the table store, resets pagination on change.
+ */
 Table.DateRangePicker = TableDateRangePicker;
+/**
+ * A search input that filters table rows by matching against any field.
+ * The filter value is debounced and resets pagination to the first page on change.
+ */
 Table.Filter = TableFilter;
+/**
+ * Container for elements displayed below the table body, typically pagination and per-page controls.
+ */
 Table.Footer = TableFooter;
+/**
+ * Container for elements displayed above the table body such as filters, predicates, and actions.
+ */
 Table.Header = TableHeader;
+/**
+ * Displays the time of the last data update, automatically refreshing when table data changes.
+ */
 Table.LastUpdated = TableLastUpdated;
+/**
+ * Available table layout configurations (e.g., Rows, Cards).
+ */
 Table.Layouts = TableLayouts;
+/**
+ * Skeleton overlay displayed while the table data is loading.
+ */
 Table.Loading = TableLoading;
+/**
+ * Container displayed when the table has no data to show.
+ */
 Table.NoData = TableNoData;
+/**
+ * Page navigation control that syncs with the table store and scrolls to the table on page change.
+ */
 Table.Pagination = TablePagination;
+/**
+ * Control allowing users to choose how many results are displayed per page.
+ */
 Table.PerPage = TablePerPage;
+/**
+ * A dropdown that filters table data by a predefined set of values, resets pagination on change.
+ */
 Table.Predicate = TablePredicate;
 
 Table.extend = identity as CustomComponentThemeExtend<PlasmaTableFactory>;


### PR DESCRIPTION
### Proposed Changes

Added a bit of doc on the Table components to guide developers in their usage

### Potential Breaking Changes

None

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
