### PR TITLE
feat(mantine, table): toolbar to display components above the Table

### DIFF
--- a/.changeset/gentle-otters-jump.md
+++ b/.changeset/gentle-otters-jump.md
@@ -1,0 +1,10 @@
+---
+'@coveord/plasma-mantine': minor
+'@coveord/plasma-llms': minor
+---
+
+Add `Table.Toolbar` sub-component for rendering filters outside the header grid
+
+`Table.Toolbar` is a new opt-in container that renders above the table. Place `Table.Filter`, `Table.Predicate`, or `Table.DateRangePicker` inside it to display them outside the `Table.Header`. Components inside the toolbar skip the `Grid.Col` wrapper and render as plain flex items instead.
+
+The toolbar accepts standard Box props and supports `renderRoot` and `className` for full customization. Existing tables are unaffected — the toolbar is entirely additive.

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -17,7 +17,7 @@ description: Table for displaying tabular data with optional filtering, paginati
 **`layouts`** `TableLayout[]` · optional · default: `[Table.Layouts.Rows]` — Available layouts. This prop MAY be used to expose layout switching.
 **`layoutProps`** `{onRowDoubleClick?: (selectedRow: TData, index: number, row: Row<TData>) => void} & Record<string, unknown>` · optional · default: `{}` — Props passed down to the active layout Header and Body components.
 **`loading`** `boolean` · optional · default: `false` — Whether the table is loading or not. This prop MAY be used to show loading states.
-**`children`** `ReactNode` · optional · default: `undefined` — Children to display in the table. They MUST be wrapped in either `Table.Header`, `Table.Toolbar`, or `Table.Footer`.
+**`children`** `ReactNode` · optional · default: `undefined` — Children can include sub-components like `Table.Toolbar`, `Table.Header`, `Table.Footer`, `Table.NoData`, and `Table.LastUpdated`. Filter controls (`Table.Filter`, `Table.Predicate`, `Table.DateRangePicker`) MUST be placed inside `Table.Header` or `Table.Toolbar`.
 **`additionalRootNodes`** `HTMLElement[]` · optional · default: `[]` — Nodes that are considered inside the table. Rows normally get unselected when clicking outside the table, but the component can have difficulty guessing what is inside or outside, for example when using modals. You MAY use this prop to force the table to consider some nodes to be inside the table.
 **`options`** `Omit<Partial<TableOptions<TData>>, 'initialState' | 'data' | 'columns' | 'manualPagination' | 'enableMultiRowSelection' | 'getRowId' | 'getRowCanExpand' | 'enableRowSelection' | 'onRowSelectionChange'>` · optional · default: `{}` — Additional options MAY be passed to the table with this prop.
 
@@ -44,7 +44,7 @@ Plasma provides pre-configured sub-components as convenience wrappers. You SHOUL
 
 ### Table.Toolbar
 
-Use `Table.Toolbar` to render `Table.Filter`, `Table.Predicate`, and `Table.DateRangePicker` outside of the `Table.Header` grid layout. The toolbar renders above the table layout. Components inside `Table.Toolbar` render as plain flex items. You MAY use `renderRoot` to customize the toolbar's root element (e.g., `renderRoot={(props) => <Group {...props} />}`).
+Use `Table.Toolbar` to render `Table.Filter`, `Table.Predicate`, and `Table.DateRangePicker` outside of the `Table.Header` grid layout. The toolbar renders above the table layout. Components inside `Table.Toolbar` are not wrapped in `Grid.Col` (unlike when placed in `Table.Header`). You MAY use `renderRoot` to provide a flex container (e.g., `renderRoot={(props) => <Group {...props} />}`) and/or customize styles via standard Box props.
 
 ```tsx
 <Table store={store} columns={columns} data={data}>

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -17,7 +17,7 @@ description: Table for displaying tabular data with optional filtering, paginati
 **`layouts`** `TableLayout[]` · optional · default: `[Table.Layouts.Rows]` — Available layouts. This prop MAY be used to expose layout switching.
 **`layoutProps`** `{onRowDoubleClick?: (selectedRow: TData, index: number, row: Row<TData>) => void} & Record<string, unknown>` · optional · default: `{}` — Props passed down to the active layout Header and Body components.
 **`loading`** `boolean` · optional · default: `false` — Whether the table is loading or not. This prop MAY be used to show loading states.
-**`children`** `ReactNode` · optional · default: `undefined` — Children to display in the table. They MUST be wrapped in either `Table.Header` or `Table.Footer`.
+**`children`** `ReactNode` · optional · default: `undefined` — Children to display in the table. They MUST be wrapped in either `Table.Header`, `Table.Toolbar`, or `Table.Footer`.
 **`additionalRootNodes`** `HTMLElement[]` · optional · default: `[]` — Nodes that are considered inside the table. Rows normally get unselected when clicking outside the table, but the component can have difficulty guessing what is inside or outside, for example when using modals. You MAY use this prop to force the table to consider some nodes to be inside the table.
 **`options`** `Omit<Partial<TableOptions<TData>>, 'initialState' | 'data' | 'columns' | 'manualPagination' | 'enableMultiRowSelection' | 'getRowId' | 'getRowCanExpand' | 'enableRowSelection' | 'onRowSelectionChange'>` · optional · default: `{}` — Additional options MAY be passed to the table with this prop.
 
@@ -40,6 +40,24 @@ Plasma provides pre-configured sub-components as convenience wrappers. You SHOUL
 - `Table.Pagination`
 - `Table.PerPage`
 - `Table.Predicate`
+- `Table.Toolbar`
+
+### Table.Toolbar
+
+Use `Table.Toolbar` to render `Table.Filter`, `Table.Predicate`, and `Table.DateRangePicker` outside of the `Table.Header` grid layout. The toolbar renders above the table layout. Components inside `Table.Toolbar` render as plain flex items. You MAY use `renderRoot` to customize the toolbar's root element (e.g., `renderRoot={(props) => <Group {...props} />}`).
+
+```tsx
+<Table store={store} columns={columns} data={data}>
+    <Table.Toolbar>
+        <Table.Filter />
+        <Table.Predicate id="status" data={[...]} label="Status" />
+        <Table.DateRangePicker />
+    </Table.Toolbar>
+    {/* Table.Header can still be used for layout controls and row selection actions */}
+</Table>
+```
+
+You SHOULD use `Table.Toolbar` when filter components need to be rendered outside the table header grid (e.g., in a custom layout above the table). You MUST still render `Table.Toolbar` inside the `<Table>` component because it requires `useTableContext`.
 
 ## Usage
 

--- a/packages/mantine/src/components/Table/Table.tsx
+++ b/packages/mantine/src/components/Table/Table.tsx
@@ -278,14 +278,14 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
                                                 </th>
                                             </tr>
                                         ) : null}
-                                    {hasRows || loading ? (
-                                        <Layout.Header
-                                            getRowExpandedContent={getRowExpandedContent}
-                                            getRowAttributes={getRowAttributes}
-                                            loading={loading}
-                                            {...layoutProps}
-                                        />
-                                    ) : null}
+                                        {hasRows || loading ? (
+                                            <Layout.Header
+                                                getRowExpandedContent={getRowExpandedContent}
+                                                getRowAttributes={getRowAttributes}
+                                                loading={loading}
+                                                {...layoutProps}
+                                            />
+                                        ) : null}
                                     </thead>
                                     <tbody {...getStyles('body')}>
                                         {hasRows ? (

--- a/packages/mantine/src/components/Table/Table.tsx
+++ b/packages/mantine/src/components/Table/Table.tsx
@@ -12,13 +12,11 @@ import {
 import isEqual from 'fast-deep-equal';
 import {Children, ForwardedRef, ReactElement, useEffect, useRef} from 'react';
 import {CustomComponentThemeExtend, identity} from '../../utils/createFactoryComponent.js';
-import classes from './Table.module.css';
-import {TableLayout, TableProps} from './Table.types.js';
-import {TableProvider} from './TableContext.js';
 import {TableLayouts} from './layouts/TableLayouts.js';
 import {TableActionItem, TableActionItemStylesNames} from './table-actions/TableActionItem.js';
 import {TableActionsListStylesNames} from './table-actions/TableActionsList.js';
 import {TableHeaderActionsStylesNames} from './table-actions/TableHeaderActions.js';
+import {TableCell} from './table-cell/TableCell.js';
 import {TableActionsColumn} from './table-column/TableActionsColumn.js';
 import {
     TableAccordionColumn,
@@ -37,7 +35,10 @@ import {TableNoData} from './table-no-data/TableNoData.js';
 import {TablePagination} from './table-pagination/TablePagination.js';
 import {TablePerPage} from './table-per-page/TablePerPage.js';
 import {TablePredicate, TablePredicateStylesNames} from './table-predicate/TablePredicate.js';
-import {TableCell} from './table-cell/TableCell.js';
+import {TableToolbar, TableToolbarStylesNames} from './table-toolbar/TableToolbar.js';
+import classes from './Table.module.css';
+import {TableLayout, TableProps} from './Table.types.js';
+import {TableProvider} from './TableContext.js';
 import {TableState} from './use-table.js';
 
 type TableStylesNames =
@@ -54,7 +55,8 @@ type TableStylesNames =
     | TableHeaderStylesNames
     | TableThStylesNames
     | TableLastUpdatedStylesNames
-    | TablePredicateStylesNames;
+    | TablePredicateStylesNames
+    | TableToolbarStylesNames;
 
 export type PlasmaTableFactory = Factory<{
     props: TableProps<unknown>;
@@ -77,6 +79,7 @@ export type PlasmaTableFactory = Factory<{
         Pagination: typeof TablePagination;
         PerPage: typeof TablePerPage;
         Predicate: typeof TablePredicate;
+        Toolbar: typeof TableToolbar;
     };
 }>;
 
@@ -129,6 +132,7 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
     const convertedChildren = Children.toArray(children) as ReactElement[];
     const header = convertedChildren.find((child) => child.type === TableHeader);
     const footer = convertedChildren.find((child) => child.type === TableFooter);
+    const toolbar = convertedChildren.find((child) => child.type === TableToolbar);
     const lastUpdated = convertedChildren.find((child) => child.type === TableLastUpdated);
     const noData = convertedChildren.find((child) => child.type === TableNoData);
 
@@ -258,20 +262,22 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
                     containerRef,
                 }}
             >
-                <Layout>
-                    {store.isVacant && !store.isFiltered ? (
-                        noData
-                    ) : (
-                        <>
-                            <Box component="table" {...getStyles('table')} mod={{loading}}>
-                                <thead {...getStyles('header')}>
-                                    {header ? (
-                                        <tr>
-                                            <th style={{padding: 0}} colSpan={table.getAllColumns().length}>
-                                                {header}
-                                            </th>
-                                        </tr>
-                                    ) : null}
+                <>
+                    {store.isVacant && !store.isFiltered ? null : toolbar}
+                    <Layout>
+                        {store.isVacant && !store.isFiltered ? (
+                            noData
+                        ) : (
+                            <>
+                                <Box component="table" {...getStyles('table')} mod={{loading}}>
+                                    <thead {...getStyles('header')}>
+                                        {header ? (
+                                            <tr>
+                                                <th style={{padding: 0}} colSpan={table.getAllColumns().length}>
+                                                    {header}
+                                                </th>
+                                            </tr>
+                                        ) : null}
                                     {hasRows || loading ? (
                                         <Layout.Header
                                             getRowExpandedContent={getRowExpandedContent}
@@ -280,31 +286,32 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
                                             {...layoutProps}
                                         />
                                     ) : null}
-                                </thead>
-                                <tbody {...getStyles('body')}>
-                                    {hasRows ? (
-                                        <Layout.Body
-                                            getRowExpandedContent={getRowExpandedContent}
-                                            getRowAttributes={getRowAttributes}
-                                            loading={loading}
-                                            {...layoutProps}
-                                        />
-                                    ) : (
-                                        <tr>
-                                            <td colSpan={table.getAllColumns().length}>
-                                                <TableLoading visible={loading || !store.isFiltered}>
-                                                    {noData}
-                                                </TableLoading>
-                                            </td>
-                                        </tr>
-                                    )}
-                                </tbody>
-                            </Box>
-                            {footer}
-                            {lastUpdated}
-                        </>
-                    )}
-                </Layout>
+                                    </thead>
+                                    <tbody {...getStyles('body')}>
+                                        {hasRows ? (
+                                            <Layout.Body
+                                                getRowExpandedContent={getRowExpandedContent}
+                                                getRowAttributes={getRowAttributes}
+                                                loading={loading}
+                                                {...layoutProps}
+                                            />
+                                        ) : (
+                                            <tr>
+                                                <td colSpan={table.getAllColumns().length}>
+                                                    <TableLoading visible={loading || !store.isFiltered}>
+                                                        {noData}
+                                                    </TableLoading>
+                                                </td>
+                                            </tr>
+                                        )}
+                                    </tbody>
+                                </Box>
+                                {footer}
+                                {lastUpdated}
+                            </>
+                        )}
+                    </Layout>
+                </>
             </TableProvider>
         </Box>
     );
@@ -384,5 +391,6 @@ Table.PerPage = TablePerPage;
  * A dropdown that filters table data by a predefined set of values and resets pagination on change.
  */
 Table.Predicate = TablePredicate;
+Table.Toolbar = TableToolbar;
 
 Table.extend = identity as CustomComponentThemeExtend<PlasmaTableFactory>;

--- a/packages/mantine/src/components/Table/TableContext.tsx
+++ b/packages/mantine/src/components/Table/TableContext.tsx
@@ -1,6 +1,6 @@
 import {createSafeContext, GetStylesApi} from '@mantine/core';
 import {Table} from '@tanstack/table-core';
-import {MutableRefObject, ReactElement} from 'react';
+import {MutableRefObject, ReactNode} from 'react';
 import {type PlasmaTableFactory} from './Table.js';
 import {TableAction, TableLayout} from './Table.types.js';
 import {TableStore} from './use-table.js';
@@ -16,9 +16,9 @@ export interface TableContextValue<TData = unknown> {
 
 export interface TableProviderProps<T> {
     value: TableContextValue<T>;
-    children: ReactElement;
+    children: ReactNode;
 }
 
 export const [TableProvider, useTableContext] = createSafeContext<TableContextValue>(
     'Table component was not found in the tree',
-) as unknown as [<TData>(props: TableProviderProps<TData>) => ReactElement, <TData>() => TableContextValue<TData>];
+) as unknown as [<TData>(props: TableProviderProps<TData>) => ReactNode, <TData>() => TableContextValue<TData>];

--- a/packages/mantine/src/components/Table/__tests__/Table.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/Table.spec.tsx
@@ -19,11 +19,12 @@ const EmptyState = (props: {isFiltered: boolean}) =>
 
 describe('Table', () => {
     describe('when it is vacant', () => {
-        it('hides the footer and header if the table is not filtered', () => {
+        it('hides the toolbar, footer, and header if the table is not filtered', () => {
             const Fixture = () => {
                 const store = useTable<RowData>({initialState: {totalEntries: 0}});
                 return (
                     <Table data={[]} store={store} columns={columns}>
+                        <Table.Toolbar data-testid="table-toolbar">toolbar</Table.Toolbar>
                         <Table.Header data-testid="table-header">header</Table.Header>
                         <Table.Footer data-testid="table-footer">footer</Table.Footer>
                         <Table.NoData>
@@ -34,6 +35,7 @@ describe('Table', () => {
             };
             render(<Fixture />);
 
+            expect(screen.queryByTestId('table-toolbar')).not.toBeInTheDocument();
             expect(screen.queryByTestId('table-header')).not.toBeInTheDocument();
             expect(screen.queryByTestId('table-footer')).not.toBeInTheDocument();
             expect(screen.getByTestId('empty-state')).toBeVisible();
@@ -58,11 +60,12 @@ describe('Table', () => {
             expect(screen.getByTestId('filtered-empty-state')).toBeVisible();
         });
 
-        it('does not hide the footer and header if the table is filtered', () => {
+        it('does not hide the toolbar, footer, and header if the table is filtered', () => {
             const Fixture = () => {
                 const store = useTable<RowData>({initialState: {globalFilter: 'something'}});
                 return (
                     <Table store={store} data={[]} columns={columns}>
+                        <Table.Toolbar data-testid="table-toolbar">toolbar</Table.Toolbar>
                         <Table.Header data-testid="table-header">header</Table.Header>
                         <Table.Footer data-testid="table-footer">footer</Table.Footer>
                         <Table.NoData>
@@ -73,6 +76,7 @@ describe('Table', () => {
             };
             render(<Fixture />);
 
+            expect(screen.getByTestId('table-toolbar')).toBeVisible();
             expect(screen.getByTestId('table-header')).toBeVisible();
             expect(screen.getByTestId('table-footer')).toBeVisible();
             expect(screen.getByTestId('filtered-empty-state')).toBeVisible();

--- a/packages/mantine/src/components/Table/__tests__/TableToolbar.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/TableToolbar.spec.tsx
@@ -1,0 +1,139 @@
+import {ColumnDef, createColumnHelper} from '@tanstack/table-core';
+import {act, render, screen, userEvent} from '@test-utils';
+
+import dayjs from 'dayjs';
+import {Table} from '../Table.js';
+import {useTable} from '../use-table.js';
+
+type RowData = {name: string};
+
+const columnHelper = createColumnHelper<RowData>();
+const columns: Array<ColumnDef<RowData>> = [columnHelper.accessor('name', {enableSorting: false})];
+
+describe('Table.Toolbar', () => {
+    it('renders Table.Filter without Grid.Col', () => {
+        const Fixture = () => {
+            const store = useTable<RowData>();
+            return (
+                <Table store={store} data={[{name: 'fruit'}]} columns={columns}>
+                    <Table.Toolbar>
+                        <Table.Filter placeholder="Search toolbar" />
+                    </Table.Toolbar>
+                </Table>
+            );
+        };
+
+        // When rendering a Grid.Col outside a Grid Mantine throws an error
+        expect(() => render(<Fixture />)).not.toThrow();
+
+        expect(screen.getByPlaceholderText('Search toolbar')).toBeVisible();
+    });
+
+    it('renders Table.Predicate without Grid.Col', () => {
+        const Fixture = () => {
+            const store = useTable<RowData>({initialState: {predicates: {rank: 'ALL'}}});
+            return (
+                <Table store={store} data={[{name: 'fruit'}]} columns={columns}>
+                    <Table.Toolbar>
+                        <Table.Predicate
+                            id="rank"
+                            label="Rank"
+                            data={[
+                                {value: 'ALL', label: 'All'},
+                                {value: 'first', label: 'First'},
+                            ]}
+                        />
+                    </Table.Toolbar>
+                </Table>
+            );
+        };
+        // When rendering a Grid.Col outside a Grid Mantine throws an error
+        expect(() => render(<Fixture />)).not.toThrow();
+
+        expect(screen.getByRole('textbox', {name: 'Rank'})).toBeVisible();
+    });
+
+    it('renders Table.DateRangePicker without Grid.Col', () => {
+        const Fixture = () => {
+            const store = useTable<RowData>({
+                initialState: {dateRange: [dayjs('2022-01-01').toISOString(), dayjs('2022-01-07').toISOString()]},
+            });
+            return (
+                <Table store={store} data={[{name: 'fruit'}]} columns={columns}>
+                    <Table.Toolbar>
+                        <Table.DateRangePicker />
+                    </Table.Toolbar>
+                </Table>
+            );
+        };
+
+        // When rendering a Grid.Col outside a Grid Mantine throws an error
+        expect(() => render(<Fixture />)).not.toThrow();
+
+        expect(screen.getByRole('button', {name: /jan 1, 2022 - jan 7, 2022/i})).toBeVisible();
+    });
+
+    it('updates the table state when rendering the Filter in the Toolbar', async () => {
+        vi.useFakeTimers();
+        const user = userEvent.setup({advanceTimers: vi.advanceTimersByTime});
+        const Fixture = () => {
+            const store = useTable<RowData>({initialState: {pagination: {pageIndex: 1}, totalEntries: 52}});
+            return (
+                <Table store={store} data={[{name: 'fruit'}, {name: 'vegetable'}]} columns={columns}>
+                    <Table.Toolbar>
+                        <Table.Filter />
+                    </Table.Toolbar>
+                    <Table.Footer>
+                        <Table.Pagination />
+                    </Table.Footer>
+                </Table>
+            );
+        };
+        render(<Fixture />);
+
+        expect(screen.getByRole('button', {name: '2', current: 'page'})).toBeVisible();
+
+        await user.type(screen.getByRole('textbox'), 'veg');
+        act(() => {
+            vi.advanceTimersByTime(300);
+        });
+
+        expect(screen.getByRole('button', {name: '1', current: 'page'})).toBeVisible();
+        vi.useRealTimers();
+    });
+
+    it('updates the table state when rendering the Predicate in the Toolbar', async () => {
+        if (!HTMLElement.prototype.scrollIntoView) {
+            HTMLElement.prototype.scrollIntoView = () => {
+                vi.fn();
+            };
+        }
+        const user = userEvent.setup();
+        const Fixture = () => {
+            const store = useTable<RowData>({initialState: {pagination: {pageIndex: 1}, totalEntries: 52}});
+            return (
+                <Table store={store} data={[{name: 'fruit'}, {name: 'vegetable'}]} columns={columns}>
+                    <Table.Toolbar>
+                        <Table.Predicate
+                            id="rank"
+                            label="Rank"
+                            data={[
+                                {value: 'first', label: 'First'},
+                                {value: 'second', label: 'Second'},
+                            ]}
+                        />
+                    </Table.Toolbar>
+                    <Table.Footer>
+                        <Table.Pagination />
+                    </Table.Footer>
+                </Table>
+            );
+        };
+        render(<Fixture />);
+
+        expect(screen.getByRole('button', {name: '2', current: 'page'})).toBeVisible();
+        await user.click(screen.getByRole('textbox', {name: 'Rank'}));
+        await user.click(screen.getByRole('option', {name: 'First'}));
+        expect(screen.getByRole('button', {name: '1', current: 'page'})).toBeVisible();
+    });
+});

--- a/packages/mantine/src/components/Table/__tests__/TableToolbar.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/TableToolbar.spec.tsx
@@ -50,7 +50,7 @@ describe('Table.Toolbar', () => {
         // When rendering a Grid.Col outside a Grid Mantine throws an error
         expect(() => render(<Fixture />)).not.toThrow();
 
-        expect(screen.getByRole('textbox', {name: 'Rank'})).toBeVisible();
+        expect(screen.getByRole('combobox', {name: 'Rank'})).toBeVisible();
     });
 
     it('renders Table.DateRangePicker without Grid.Col', () => {
@@ -91,7 +91,7 @@ describe('Table.Toolbar', () => {
         };
         render(<Fixture />);
 
-        expect(screen.getByRole('button', {name: '2', current: 'page'})).toBeVisible();
+        expect(screen.getByRole('button', {name: '2'})).toBeVisible();
 
         await user.type(screen.getByRole('textbox'), 'veg');
         act(() => {
@@ -131,8 +131,8 @@ describe('Table.Toolbar', () => {
         };
         render(<Fixture />);
 
-        expect(screen.getByRole('button', {name: '2', current: 'page'})).toBeVisible();
-        await user.click(screen.getByRole('textbox', {name: 'Rank'}));
+        expect(screen.getByRole('button', {name: '2'})).toBeVisible();
+        await user.click(screen.getByRole('combobox', {name: 'Rank'}));
         await user.click(screen.getByRole('option', {name: 'First'}));
         expect(screen.getByRole('button', {name: '1', current: 'page'})).toBeVisible();
     });

--- a/packages/mantine/src/components/Table/table-date-range-picker/TableDateRangePicker.tsx
+++ b/packages/mantine/src/components/Table/table-date-range-picker/TableDateRangePicker.tsx
@@ -1,9 +1,10 @@
-import {BoxProps, CompoundStylesApiProps, Factory, factory, Grid, useProps} from '@mantine/core';
+import {Box, BoxProps, CompoundStylesApiProps, Factory, factory, Grid, useProps} from '@mantine/core';
 import {type DatesRangeValue, type DateStringValue} from '@mantine/dates';
 import {DateRangePicker, type DateRangePickerProps} from '../../DateRangePicker/DateRangePicker.js';
 import {DateRangePickerPreset} from '../../DateRangePicker/DateRangePickerPresetSelect.js';
 import {TableComponentsOrder} from '../Table.js';
 import {useTableContext} from '../TableContext.js';
+import {useIsInToolbar} from '../table-toolbar/TableToolbarContext.js';
 
 export type TableDateRangePickerStylesNames = 'dateRangeRoot';
 
@@ -60,6 +61,28 @@ export const TableDateRangePicker = factory<TableDateRangePickerFactory>((props)
     };
 
     const stylesApiProps = {classNames, styles};
+    const isInToolbar = useIsInToolbar();
+
+    const content = (
+        <DateRangePicker
+            value={store.state.dateRange}
+            onChange={onChange}
+            presets={presets}
+            rangeCalendarProps={rangeCalendarProps}
+            startProps={startProps}
+            endProps={endProps}
+            placeholder={placeholder}
+            miw={220}
+        />
+    );
+
+    if (isInToolbar) {
+        return (
+            <Box ref={ref} {...getStyles('dateRangeRoot', {className, style, ...stylesApiProps})} {...others}>
+                {content}
+            </Box>
+        );
+    }
 
     return (
         <Grid.Col
@@ -69,16 +92,7 @@ export const TableDateRangePicker = factory<TableDateRangePickerFactory>((props)
             {...getStyles('dateRangeRoot', {className, style, ...stylesApiProps})}
             {...others}
         >
-            <DateRangePicker
-                value={store.state.dateRange}
-                onChange={onChange}
-                presets={presets}
-                rangeCalendarProps={rangeCalendarProps}
-                startProps={startProps}
-                endProps={endProps}
-                placeholder={placeholder}
-                miw={220}
-            />
+            {content}
         </Grid.Col>
     );
 });

--- a/packages/mantine/src/components/Table/table-filter/TableFilter.tsx
+++ b/packages/mantine/src/components/Table/table-filter/TableFilter.tsx
@@ -1,11 +1,12 @@
 import {IconSearch, IconX} from '@coveord/plasma-react-icons';
-import {BoxProps, CompoundStylesApiProps, Factory, factory, Grid, TextInput, useProps} from '@mantine/core';
+import {Box, BoxProps, CompoundStylesApiProps, Factory, factory, Grid, TextInput, useProps} from '@mantine/core';
 import {useDebouncedValue, useDidUpdate} from '@mantine/hooks';
 import {ChangeEventHandler, MouseEventHandler, useEffect, useState} from 'react';
 
 import {ActionIcon} from '../../ActionIcon/ActionIcon.js';
 import {TableComponentsOrder} from '../Table.js';
 import {useTableContext} from '../TableContext.js';
+import {useIsInToolbar} from '../table-toolbar/TableToolbarContext.js';
 
 export type TableFilterStylesNames = 'filterRoot' | 'filterWrapper' | 'filterEmpty';
 
@@ -60,6 +61,34 @@ export const TableFilter = factory<TableFilterFactory>((props) => {
     }, [store.state.globalFilter]);
 
     const stylesApiProps = {classNames, styles};
+    const isInToolbar = useIsInToolbar();
+
+    const content = (
+        <TextInput
+            {...getStyles('filterWrapper', stylesApiProps)}
+            placeholder={placeholder}
+            autoComplete="off"
+            rightSection={
+                filter ? (
+                    <ActionIcon.Quaternary onClick={handleClear}>
+                        <IconX aria-label="clear" size={16} />
+                    </ActionIcon.Quaternary>
+                ) : (
+                    <IconSearch size={16} {...getStyles('filterEmpty', stylesApiProps)} />
+                )
+            }
+            value={filter}
+            onChange={handleChange}
+        />
+    );
+
+    if (isInToolbar) {
+        return (
+            <Box ref={ref} {...getStyles('filterRoot', {className, style, ...stylesApiProps})} {...others}>
+                {content}
+            </Box>
+        );
+    }
 
     return (
         <Grid.Col
@@ -69,22 +98,7 @@ export const TableFilter = factory<TableFilterFactory>((props) => {
             {...getStyles('filterRoot', {className, style, ...stylesApiProps})}
             {...others}
         >
-            <TextInput
-                {...getStyles('filterWrapper', stylesApiProps)}
-                placeholder={placeholder}
-                autoComplete="off"
-                rightSection={
-                    filter ? (
-                        <ActionIcon.Quaternary onClick={handleClear}>
-                            <IconX aria-label="clear" size={16} />
-                        </ActionIcon.Quaternary>
-                    ) : (
-                        <IconSearch size={16} {...getStyles('filterEmpty', stylesApiProps)} />
-                    )
-                }
-                value={filter}
-                onChange={handleChange}
-            />
+            {content}
         </Grid.Col>
     );
 });

--- a/packages/mantine/src/components/Table/table-predicate/TablePredicate.tsx
+++ b/packages/mantine/src/components/Table/table-predicate/TablePredicate.tsx
@@ -1,4 +1,5 @@
 import {
+    Box,
     BoxProps,
     ComboboxData,
     CompoundStylesApiProps,
@@ -15,6 +16,7 @@ import {FunctionComponent} from 'react';
 
 import {TableComponentsOrder} from '../Table.js';
 import {useTableContext} from '../TableContext.js';
+import {useIsInToolbar} from '../table-toolbar/TableToolbarContext.js';
 
 export type TablePredicateStylesNames = 'predicate' | 'predicateWrapper' | 'predicateLabel' | 'predicateSelect';
 
@@ -58,6 +60,32 @@ export const TablePredicate: FunctionComponent<TablePredicateProps> = factory<Ta
     };
 
     const stylesApiProps = {classNames, styles};
+    const isInToolbar = useIsInToolbar();
+
+    const content = (
+        <Group gap="xs" wrap="nowrap" {...getStyles('predicateWrapper', stylesApiProps)}>
+            {label ? <Text {...getStyles('predicateLabel', stylesApiProps)}>{label}:</Text> : null}
+            <Select
+                comboboxProps={{withinPortal: true, ...comboboxProps}}
+                value={store.state.predicates[id]}
+                onChange={handleChange}
+                data={data}
+                aria-label={label ?? id}
+                searchable={data.length > 7}
+                renderOption={renderOption}
+                scrollAreaProps={{type: 'always'}}
+                {...getStyles('predicateSelect', stylesApiProps)}
+            />
+        </Group>
+    );
+
+    if (isInToolbar) {
+        return (
+            <Box ref={ref} {...getStyles('predicate', {className, style, ...stylesApiProps})} {...others}>
+                {content}
+            </Box>
+        );
+    }
 
     return (
         <Grid.Col
@@ -67,20 +95,7 @@ export const TablePredicate: FunctionComponent<TablePredicateProps> = factory<Ta
             {...getStyles('predicate', {className, style, ...stylesApiProps})}
             {...others}
         >
-            <Group gap="xs" wrap="nowrap" {...getStyles('predicateWrapper', stylesApiProps)}>
-                {label ? <Text {...getStyles('predicateLabel', stylesApiProps)}>{label}:</Text> : null}
-                <Select
-                    comboboxProps={{withinPortal: true, ...comboboxProps}}
-                    value={store.state.predicates[id]}
-                    onChange={handleChange}
-                    data={data}
-                    aria-label={label ?? id}
-                    searchable={data.length > 7}
-                    renderOption={renderOption}
-                    scrollAreaProps={{type: 'always'}}
-                    {...getStyles('predicateSelect', stylesApiProps)}
-                />
-            </Group>
+            {content}
         </Grid.Col>
     );
 });

--- a/packages/mantine/src/components/Table/table-toolbar/TableToolbar.tsx
+++ b/packages/mantine/src/components/Table/table-toolbar/TableToolbar.tsx
@@ -1,0 +1,38 @@
+import {Box, BoxProps, CompoundStylesApiProps, factory, Factory, useProps} from '@mantine/core';
+import {ReactNode} from 'react';
+import {useTableContext} from '../TableContext.js';
+import {TableToolbarProvider} from './TableToolbarContext.js';
+
+export type TableToolbarStylesNames = 'toolbarRoot';
+
+export interface TableToolbarProps extends BoxProps, CompoundStylesApiProps<TableToolbarFactory> {
+    children?: ReactNode;
+}
+
+export type TableToolbarFactory = Factory<{
+    props: TableToolbarProps;
+    ref: HTMLDivElement;
+    stylesNames: TableToolbarStylesNames;
+    compound: true;
+}>;
+
+const defaultProps: Partial<TableToolbarProps> = {};
+
+export const TableToolbar = factory<TableToolbarFactory>((props, ref) => {
+    const {getStyles} = useTableContext();
+    const {children, classNames, className, styles, style, vars, ...others} = useProps(
+        'PlasmaTableToolbar',
+        defaultProps,
+        props,
+    );
+
+    const stylesApiProps = {classNames, styles};
+
+    return (
+        <Box ref={ref} {...getStyles('toolbarRoot', {className, style, ...stylesApiProps})} {...others}>
+            <TableToolbarProvider value={true}>{children}</TableToolbarProvider>
+        </Box>
+    );
+});
+
+TableToolbar.displayName = 'Table.Toolbar';

--- a/packages/mantine/src/components/Table/table-toolbar/TableToolbar.tsx
+++ b/packages/mantine/src/components/Table/table-toolbar/TableToolbar.tsx
@@ -18,7 +18,7 @@ export type TableToolbarFactory = Factory<{
 
 const defaultProps: Partial<TableToolbarProps> = {};
 
-export const TableToolbar = factory<TableToolbarFactory>((props, ref) => {
+export const TableToolbar = factory<TableToolbarFactory>(({ref, ...props}) => {
     const {getStyles} = useTableContext();
     const {children, classNames, className, styles, style, vars, ...others} = useProps(
         'PlasmaTableToolbar',

--- a/packages/mantine/src/components/Table/table-toolbar/TableToolbarContext.tsx
+++ b/packages/mantine/src/components/Table/table-toolbar/TableToolbarContext.tsx
@@ -1,0 +1,6 @@
+import {createContext, useContext} from 'react';
+
+const TableToolbarContext = createContext(false);
+
+export const TableToolbarProvider = TableToolbarContext.Provider;
+export const useIsInToolbar = () => useContext(TableToolbarContext);

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -401,6 +401,7 @@ export {
     type TableCellStylesNames,
 } from './components/Table/table-cell/TableCell.js';
 export {type TablePredicateProps} from './components/Table/table-predicate/TablePredicate.js';
+export {type TableToolbarProps} from './components/Table/table-toolbar/TableToolbar.js';
 export {Table, TableComponentsOrder, type PlasmaTableFactory} from './components/Table/Table.js';
 export {
     type TableAction,

--- a/packages/storybook/src/data-display/Table.stories.tsx
+++ b/packages/storybook/src/data-display/Table.stories.tsx
@@ -1,5 +1,6 @@
 import {
     Avatar,
+    Box,
     Center,
     createColumnHelper,
     DateRangePickerPreset,

--- a/packages/storybook/src/data-display/Table.stories.tsx
+++ b/packages/storybook/src/data-display/Table.stories.tsx
@@ -31,7 +31,7 @@ faker.setDefaultRefDate(SEEDED_DATE);
 type StoryArgs = TableProps<Person> & {
     withFilter: boolean;
     withPredicateFilter: boolean;
-    withHeader: boolean;
+    controlPlacement: 'header' | 'toolbar';
     withPagination: boolean;
     withSorting: boolean;
     withDateRangePicker: boolean;
@@ -100,7 +100,7 @@ export const Demo: Story = {
         loading: false,
         withFilter: false,
         withPredicateFilter: false,
-        withHeader: true,
+        controlPlacement: 'header',
         withPagination: false,
         withSorting: false,
         withDateRangePicker: false,
@@ -119,12 +119,16 @@ export const Demo: Story = {
             options: ['collapse', 'accordion'],
             defaultValue: 'collapse',
         },
+        controlPlacement: {
+            control: 'radio',
+            options: ['header', 'toolbar'],
+        },
     },
     render: ({
         loading,
         withFilter,
         withPredicateFilter,
-        withHeader,
+        controlPlacement,
         withPagination,
         withSorting,
         withDateRangePicker,
@@ -263,7 +267,33 @@ export const Demo: Story = {
                         : undefined
                 }
             >
-                {withHeader && (
+                {controlPlacement === 'toolbar' && (
+                    <Table.Toolbar renderRoot={(props) => <Group w="100%" mb="xl" {...props} />}>
+                        {withPredicateFilter && (
+                            <Table.Predicate
+                                id="age"
+                                label="Age group"
+                                data={[
+                                    {value: 'ANY', label: 'Any'},
+                                    {value: 'below20', label: 'Below 20'},
+                                    {value: 'between20to60', label: '20 to 60'},
+                                    {value: 'above60', label: 'Above 60'},
+                                ]}
+                            />
+                        )}
+                        {withDateRangePicker && (
+                            <Table.DateRangePicker
+                                startProps={{}}
+                                endProps={{}}
+                                rangeCalendarProps={{maxDate: dayjs().endOf('day').toDate()}}
+                                presets={datePickerPresets}
+                            />
+                        )}
+                        <Box flex={1} />
+                        {withFilter && <Table.Filter />}
+                    </Table.Toolbar>
+                )}
+                {controlPlacement === 'header' && (
                     <Table.Header>
                         {withFilter && <Table.Filter />}
                         {withDateRangePicker && (


### PR DESCRIPTION
### Proposed Changes

Adds a new `Table.Toolbar` sub-component that allows `Table.Filter`, `Table.Predicate`, and `Table.DateRangePicker` to be rendered outside of the `Table.Header` grid layout. This is opt-in and fully backward compatible. Existing usage with `Table.Header` is unchanged.

#### Motivation

`Table.Header` comes with some style and renders its children inside a `Grid`. Due to this Grid, the components we normaly see in the header (`Filter`, `Predicate`, `DateRangePicker`) are wrapped in a `Grid.Col`. In some implementation people had to duplicate a lot of logic to achieve a similar behaviour while matching UX mockups 

<img width="1199" height="211" alt="image" src="https://github.com/user-attachments/assets/dffd80b1-3c3f-43d3-8d01-0c0062711e4d" />


#### Usage

```tsx
<Table store={store} columns={columns} data={data}>
    <Table.Toolbar>
        <Table.Filter />
        <Table.DateRangePicker />
        <Table.Predicate id="status" data={[...]} label="Status" />
    </Table.Toolbar>
...
</Table>
```

Components inside `Table.Toolbar` skip the `Grid.Col` wrapper and render as plain flex items. The toolbar renders above the table layout. It can be customized via `renderRoot`, `className`, or standard Box props.

#### Open question

> The name `Toolbar` was chosen to distinguish it from `Header` (which has specific grid/actions/layout-control behaviour). Open to renaming if there's a better fit.

### Potential Breaking Changes

No breaking changes. Existing `Table.Header` usage is unaffected.