### PR TITLE
feat: add Storybook page for Chip component

### DIFF
--- a/packages/mantine/src/components/Badge/Badge.tsx
+++ b/packages/mantine/src/components/Badge/Badge.tsx
@@ -165,8 +165,8 @@ const BadgeDisabled = enhanceBadge(
     MantineBadge.withProps({
         variant: 'light',
         color: 'gray',
-        c: 'var(--coveo-color-text-disabled)',
-        bg: 'var(--coveo-color-bg-disabled)',
+        c: 'var(--mantine-color-disabled-color)',
+        bg: 'var(--mantine-color-disabled)',
     }),
     MantineBadge.withProps({
         variant: 'light',

--- a/packages/mantine/src/components/Chip/Chip.tsx
+++ b/packages/mantine/src/components/Chip/Chip.tsx
@@ -1,5 +1,5 @@
-import {ChipFactory, ChipGroup, factory, Chip as MantineChip} from '@mantine/core';
+import {Chip} from '@mantine/core';
 
-export const Chip = factory<ChipFactory>(({variant: _variant, ...props}, ref) => <MantineChip {...props} ref={ref} />);
+Chip.displayName = 'Chip';
 
-Chip.Group = ChipGroup;
+export {Chip, type ChipFactory, ChipGroup, factory} from '@mantine/core';

--- a/packages/mantine/src/styles/Chip.module.css
+++ b/packages/mantine/src/styles/Chip.module.css
@@ -4,10 +4,10 @@
     --chip-hover: var(--mantine-primary-color-filled-hover);
     --chip-radius: var(--mantine-radius-lg);
     --chip-size-xs: 24px;
-    --chip-icon-size-xs: 16px;
+    --chip-icon-size-xs: 12px;
     --chip-spacing-xs: var(--mantine-spacing-xs);
     --chip-padding-xs: 12px;
-    --chip-checked-padding-xs: var(--mantine-spacing-xs) 12px;
+    --chip-checked-padding-xs: 6px 12px;
     --chip-icon-size-sm: var(--mantine-spacing-sm);
     --chip-spacing-sm: var(--mantine-spacing-xs);
     --chip-padding-sm: var(--mantine-spacing-sm);

--- a/packages/mantine/src/styles/Chip.module.css
+++ b/packages/mantine/src/styles/Chip.module.css
@@ -3,8 +3,15 @@
     --chip-bg: var(--mantine-primary-color-light);
     --chip-hover: var(--mantine-primary-color-filled-hover);
     --chip-radius: var(--mantine-radius-lg);
-    --chip-padding: var(--mantine-spacing-sm);
-    --chip-spacing: var(--mantine-spacing-sm);
+    --chip-size-xs: 24px;
+    --chip-icon-size-xs: 16px;
+    --chip-spacing-xs: var(--mantine-spacing-xs);
+    --chip-padding-xs: 12px;
+    --chip-checked-padding-xs: var(--mantine-spacing-xs) 12px;
+    --chip-icon-size-sm: var(--mantine-spacing-sm);
+    --chip-spacing-sm: var(--mantine-spacing-xs);
+    --chip-padding-sm: var(--mantine-spacing-sm);
+    --chip-checked-padding-sm: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
 
     > .label {
         &:not([data-checked]) {
@@ -15,8 +22,8 @@
             @mixin hover {
                 &[data-disabled] {
                     border: none;
-                    color: var(--coveo-color-text-disabled);
-                    background-color: var(--coveo-color-bg-disabled);
+                    color: var(--mantine-color-disabled-color);
+                    background-color: var(--mantine-color-disabled);
                 }
 
                 background-color: var(--mantine-color-gray-light);
@@ -34,8 +41,8 @@
 
         &[data-disabled] {
             border: none;
-            color: var(--coveo-color-text-disabled);
-            background-color: var(--coveo-color-bg-disabled);
+            color: var(--mantine-color-disabled-color);
+            background-color: var(--mantine-color-disabled);
         }
     }
 }

--- a/packages/mantine/src/styles/NavLink.module.css
+++ b/packages/mantine/src/styles/NavLink.module.css
@@ -6,7 +6,7 @@
     }
 
     &:where([data-disabled]) {
-        color: var(--coveo-color-text-disabled);
+        color: var(--mantine-color-disabled-color);
     }
 }
 

--- a/packages/mantine/src/styles/Pagination.module.css
+++ b/packages/mantine/src/styles/Pagination.module.css
@@ -19,10 +19,10 @@
 
         &[data-disabled] {
             opacity: 1;
-            background-color: var(--coveo-color-bg-disabled);
+            background-color: var(--mantine-color-disabled);
 
             & + .icon {
-                color: var(--coveo-color-text-disabled);
+                color: var(--mantine-color-disabled-color);
             }
         }
     }

--- a/packages/mantine/src/styles/Slider.module.css
+++ b/packages/mantine/src/styles/Slider.module.css
@@ -13,7 +13,7 @@
 }
 
 .track[data-disabled] .markLabel {
-    color: var(--coveo-color-text-disabled);
+    color: var(--mantine-color-disabled-color);
 }
 
 .bar {

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -266,7 +266,7 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
         }),
         Chip: Chip.extend({
             defaultProps: {
-                icon: <IconCheck size={16} />,
+                icon: <IconCheck size="var(--chip-icon-size)" />,
             },
             classNames: ChipClasses,
         }),

--- a/packages/storybook/src/form/array/Chip.stories.tsx
+++ b/packages/storybook/src/form/array/Chip.stories.tsx
@@ -1,0 +1,32 @@
+import {Chip} from '@coveord/plasma-mantine/components/Chip';
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {useArgs} from 'storybook/internal/preview-api';
+
+const meta: Meta<typeof Chip> = {
+    title: '@components/form/array/Chip',
+    id: 'Chip',
+    component: Chip,
+    parameters: {
+        layout: 'centered',
+    },
+    args: {
+        children: 'Chip',
+        size: 'sm',
+        disabled: false,
+        checked: false,
+    },
+    argTypes: {
+        children: {control: 'text', description: 'Chip label'},
+        size: {control: 'select', options: ['xs', 'sm']},
+        disabled: {control: 'boolean'},
+    },
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Demo: Story = {
+    render: (props) => {
+        const [{checked}, updateArgs] = useArgs();
+        return <Chip {...props} checked={checked} onChange={(newValue) => updateArgs({checked: newValue})} />;
+    },
+};

--- a/packages/storybook/src/form/array/Chip.stories.tsx
+++ b/packages/storybook/src/form/array/Chip.stories.tsx
@@ -1,6 +1,6 @@
 import {Chip} from '@coveord/plasma-mantine/components/Chip';
 import type {Meta, StoryObj} from '@storybook/react-vite';
-import {useArgs} from 'storybook/internal/preview-api';
+import {useArgs} from 'storybook/preview-api';
 
 const meta: Meta<typeof Chip> = {
     title: '@components/form/array/Chip',


### PR DESCRIPTION
Adds a storybook story for the Chip component under form/array with controlled checked state via `useArgs`.

Also includes:
- Simplify Chip re-export to a plain re-export with displayName override
- Add `xs` size CSS variables for Chip
- Migrate disabled styles from `--coveo-color-*` to `--mantine-color-disabled*` tokens (Chip, Badge, NavLink, Pagination, Slider)
- Use dynamic `var(--chip-icon-size)` for the check icon default prop

[ADUI-11495](https://coveord.atlassian.net/browse/ADUI-11495)

[ADUI-11495]: https://coveord.atlassian.net/browse/ADUI-11495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ