### PR TITLE
fix(mantine): add missing .js extensions in relative imports

### DIFF
--- a/packages/mantine/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/packages/mantine/src/components/DateRangePicker/DateRangePicker.tsx
@@ -13,9 +13,9 @@ import {
 import {DatesRangeValue, DateStringValue} from '@mantine/dates';
 import {useUncontrolled} from '@mantine/hooks';
 import dayjs from 'dayjs';
-import {useUrlSyncedState, UseUrlSyncedStateOptions} from '../../hooks/use-url-synced-state';
+import {useUrlSyncedState, UseUrlSyncedStateOptions} from '../../hooks/use-url-synced-state.js';
 import classes from './DateRange.module.css';
-import {DateRangePickerInlineCalendar, DateRangePickerInlineCalendarProps} from './DateRangePickerInlineCalendar';
+import {DateRangePickerInlineCalendar, DateRangePickerInlineCalendarProps} from './DateRangePickerInlineCalendar.js';
 
 const serialization = (input: Pick<UseUrlSyncedStateOptions<DatesRangeValue<string>>, 'serializer' | 'deserializer'>) =>
     Object.freeze(input);

--- a/packages/mantine/src/components/DateRangePicker/EditableDateRangePicker.tsx
+++ b/packages/mantine/src/components/DateRangePicker/EditableDateRangePicker.tsx
@@ -52,4 +52,4 @@ export const EditableDateRangePicker = ({
         </>
     );
 };
-export type {DateRangePickerPreset} from './DateRangePickerPresetSelect';
+export type {DateRangePickerPreset} from './DateRangePickerPresetSelect.js';

--- a/packages/mantine/src/components/RadioCard/RadioCard.tsx
+++ b/packages/mantine/src/components/RadioCard/RadioCard.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mantine/core';
 import {ReactNode} from 'react';
 import classes from '../../styles/RadioCard.module.css';
-import {Input} from '../Input/Input';
+import {Input} from '../Input/Input.js';
 
 export type RadioCardStylesNames = MantineRadioCardStylesNames | 'container' | 'indicator' | 'title' | 'description';
 export type RadioCardFactory = Factory<{

--- a/packages/mantine/src/components/Table/table-columns-selector/TableColumnsSelector.tsx
+++ b/packages/mantine/src/components/Table/table-columns-selector/TableColumnsSelector.tsx
@@ -1,7 +1,7 @@
 import {IconSettings} from '@coveord/plasma-react-icons';
 import {Checkbox, Divider, Popover, ScrollArea, Stack, Text, Tooltip} from '@mantine/core';
 import {flexRender, Header, Table} from '@tanstack/react-table';
-import {ActionIcon} from '../../ActionIcon/ActionIcon';
+import {ActionIcon} from '../../ActionIcon/ActionIcon.js';
 
 export interface TableColumnsSelectorOptions {
     /**


### PR DESCRIPTION
## Summary

Adds `.js` extensions to extensionless relative imports that surface in `.d.ts` declarations, breaking consumers using `nodenext` module resolution.

## Problem

The published `@coveord/plasma-mantine` has `.d.ts` files with extensionless relative imports in the `DateRangePicker` component. This breaks consumers (e.g. admin-ui) that use strict ESM module resolution (`moduleResolution: "nodenext"`).

admin-ui currently patches this: `@coveord__plasma-mantine@59.7.0.patch`

## Changes

- `DateRangePicker.tsx`: `./DateRangePickerInlineCalendar` → `./DateRangePickerInlineCalendar.js`, `../../hooks/use-url-synced-state` → `../../hooks/use-url-synced-state.js`
- `EditableDateRangePicker.tsx`: `./DateRangePickerPresetSelect` → `./DateRangePickerPresetSelect.js`
- `RadioCard.tsx`: `../Input/Input` → `../Input/Input.js`
- `TableColumnsSelector.tsx`: `../../ActionIcon/ActionIcon` → `../../ActionIcon/ActionIcon.js`

## Verification

- Build produces correct `.d.ts` output with `.js` extensions
- All 391 tests pass

ADUI-11496