### PR TITLE
feat(BrowserPreview): update BrowserPreview style and story

### DIFF
--- a/packages/mantine/src/components/BrowserPreview/BrowserPreview.tsx
+++ b/packages/mantine/src/components/BrowserPreview/BrowserPreview.tsx
@@ -26,29 +26,24 @@ export const BrowserPreview = ({
     <Stack className={cx(BrowserPreviewClasses.root, className)} gap={0} maw={544} mih={0} {...others}>
         <Group
             className={BrowserPreviewClasses.header}
-            justify="space-between"
             p="sm"
             bg="var(--mantine-color-default-hover)"
             wrap="nowrap"
+            gap="xxs"
         >
-            <Group gap="xs" wrap="nowrap">
-                <Text c="dimmed" fz="md" lh="18px">
-                    Preview
-                </Text>
-                {!!headerTooltip && (
-                    <Tooltip label={headerTooltip} position="right" maw={400}>
-                        <InfoToken.Information className={BrowserPreviewClasses.infoIcon} />
-                    </Tooltip>
-                )}
-            </Group>
-            {title && (
-                <Text lineClamp={1} c="dimmed" fz="md" lh="18px">
-                    {title}
-                </Text>
+            <Text lineClamp={1} size="md">
+                {title || 'Preview'}
+            </Text>
+            {!!headerTooltip && (
+                <Tooltip label={headerTooltip} position="right">
+                    <InfoToken.Question className={BrowserPreviewClasses.infoIcon} />
+                </Tooltip>
             )}
         </Group>
-        <Flex className={BrowserPreviewClasses.content} p="lg" direction="column">
+        <Flex className={BrowserPreviewClasses.content} p="sm" direction="column" bg="var(--mantine-color-body)">
             {children}
         </Flex>
     </Stack>
 );
+
+BrowserPreview.displayName = 'BrowserPreview';

--- a/packages/mantine/src/components/BrowserPreview/__tests__/BrowserPreview.spec.tsx
+++ b/packages/mantine/src/components/BrowserPreview/__tests__/BrowserPreview.spec.tsx
@@ -6,7 +6,7 @@ describe('BrowserPreview', () => {
     it('shows no tooltip when none specified', async () => {
         render(<BrowserPreview />);
 
-        expect(screen.queryByRole('img', {name: /information/i})).not.toBeInTheDocument();
+        expect(screen.queryByRole('img', {name: /question/i})).not.toBeInTheDocument();
     });
 
     it('renders the specified text as the header tooltip content', async () => {
@@ -15,8 +15,8 @@ describe('BrowserPreview', () => {
 
         render(<BrowserPreview headerTooltip={headerTooltip} />);
 
-        await waitFor(() => screen.findByRole('img', {name: /information/i}));
-        await user.hover(screen.getByRole('img', {name: /information/i}));
+        await waitFor(() => screen.findByRole('img', {name: /question/i}));
+        await user.hover(screen.getByRole('img', {name: /question/i}));
 
         await waitFor(() => expect(screen.getByText(headerTooltip)).toBeVisible());
     });

--- a/packages/storybook/src/layout/BrowserPreview.stories.tsx
+++ b/packages/storybook/src/layout/BrowserPreview.stories.tsx
@@ -1,17 +1,21 @@
 import type {StoryObj, Meta} from '@storybook/react-vite';
 import {BrowserPreview} from '@coveord/plasma-mantine/components/BrowserPreview';
-import {faker} from '@faker-js/faker';
-import {useState} from 'react';
-import {Flex, Pagination, Stack, Text, Title} from '@coveord/plasma-mantine';
+import {Center} from '@coveord/plasma-mantine/components/Center';
 
-interface Product {
-    name: string;
-    department: string;
-    price: string;
-}
-
-const numberOfItems = 40;
-const pageSize = 5;
+const Placeholder = () => (
+    <Center
+        c="var(--mantine-color-blue-text)"
+        bg="var(--mantine-color-blue-light)"
+        fw="var(--coveo-fw-bold)"
+        bd="2px dashed var(--mantine-color-blue-filled)"
+        bdrs="sm"
+        mih={224}
+        miw={400}
+    >
+        Children
+    </Center>
+);
+Placeholder.displayName = 'Placeholder';
 
 const meta: Meta<typeof BrowserPreview> = {
     title: '@components/layout/BrowserPreview',
@@ -20,87 +24,23 @@ const meta: Meta<typeof BrowserPreview> = {
     parameters: {
         layout: 'centered',
     },
-    tags: ['autodocs'],
+    tags: ['!autodocs'],
+    argTypes: {
+        title: {control: 'text'},
+        headerTooltip: {control: 'text'},
+    },
 };
 export default meta;
 type Story = StoryObj<typeof BrowserPreview>;
 
-export const Default: Story = {
-    render: () => {
-        const makeData = (len: number): Product[] =>
-            Array(len)
-                .fill(0)
-                .map(() => ({
-                    name: faker.commerce.productName(),
-                    department: faker.commerce.department(),
-                    price: faker.commerce.price(),
-                }));
-        const [page, setPage] = useState(1);
-        const data = makeData(numberOfItems).reduce<Product[][]>((all, one, i) => {
-            const ch = Math.floor(i / pageSize);
-            all[ch] = [...(all[ch] ?? []), one];
-            return all;
-        }, []);
-        const numberOfPages = Math.ceil(numberOfItems / pageSize);
-        const currentPageData = data[page - 1] ?? [];
-        return (
-            <BrowserPreview>
-                <Stack flex={1}>
-                    <Stack gap="xl" pb="sm">
-                        {currentPageData.map((product) => (
-                            <Stack key={`${product.name}-${product.department}-${product.price}`} gap={0}>
-                                <Text size="md" fw={400}>
-                                    {product.name}
-                                </Text>
-                                <Text size="xs" c="dimmed" span>
-                                    <Text size="xs" fw={500} span>
-                                        Dept:{' '}
-                                    </Text>
-                                    {product.department}
-                                </Text>
-                                <Text size="xs" c="dimmed" span>
-                                    <Text size="xs" fw={500} span>
-                                        Price:{' '}
-                                    </Text>
-                                    {product.price}$
-                                </Text>
-                            </Stack>
-                        ))}
-                    </Stack>
-                    <Flex align="flex-end" justify="center" flex={1}>
-                        <Pagination value={page} total={numberOfPages} onChange={setPage} />
-                    </Flex>
-                </Stack>
-            </BrowserPreview>
-        );
+export const Demo: Story = {
+    args: {
+        title: 'Preview Title',
+        headerTooltip: 'Tooltip',
     },
-};
-
-export const BrowserPreviewOverflow: Story = {
-    render: () => {
-        const content = faker.lorem.paragraphs(20);
-        return (
-            <BrowserPreview>
-                <Stack gap="xs">
-                    <Title order={3}>Hello World !</Title>
-                    <Text>{content}</Text>
-                </Stack>
-            </BrowserPreview>
-        );
-    },
-};
-
-export const BrowserPreviewWithTitleAndDescription: Story = {
-    render: () => {
-        const title = faker.lorem.sentence(20);
-        const content = faker.lorem.paragraph(10);
-        return (
-            <BrowserPreview title={title} headerTooltip="This is a custom tooltip message.">
-                <Stack gap="xs">
-                    <Title order={3}>Hello World !</Title>
-                    <Text>{content}</Text>
-                </Stack>
-            </BrowserPreview>
-        );
-    },
+    render: (args) => (
+        <BrowserPreview {...args}>
+            <Placeholder />
+        </BrowserPreview>
+    ),
 };


### PR DESCRIPTION
### Proposed Changes

Update the BrowserPreview component to the recommended specs. Also simplified the story for it.

Before

<img width="293" height="179" alt="image" src="https://github.com/user-attachments/assets/57053568-8e2c-4fb8-89d8-e3c1833e90ac" />
<img width="481" height="633" alt="image" src="https://github.com/user-attachments/assets/f7ce4439-2403-408e-8526-08ad7a83583e" />

After

<img width="304" height="87" alt="image" src="https://github.com/user-attachments/assets/4ecd4182-377a-4bef-be12-05e8c21a64e2" />
<img width="493" height="382" alt="image" src="https://github.com/user-attachments/assets/7e1db2a8-adb1-4727-a648-8480cac40598" />
<img width="493" height="369" alt="image" src="https://github.com/user-attachments/assets/04edc06e-97cc-438f-a6a2-57cf1fada696" />



### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

-   [ ] The proposed changes are covered by unit tests
-   [ ] The potential breaking changes are clearly identified
-   [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
