### PR TITLE
feat(mantine)!: rename pagination state from pageIndex/pageSize to page/perPage

### DIFF
--- a/.changeset/rename-pagination-attributes.md
+++ b/.changeset/rename-pagination-attributes.md
@@ -1,0 +1,30 @@
+---
+'@coveord/plasma-mantine': major
+'@coveord/plasma-llms': patch
+---
+
+**BREAKING:** Renamed pagination state attributes to match Coveo API standards for pagination (RFC 0002).
+
+- `pageIndex` → `page` (zero-based page index)
+- `pageSize` → `perPage` (number of items per page)
+
+This affects `PaginationState`, `TableState.pagination`, and all components that read/write pagination state (`Table.Pagination`, `Table.PerPage`, `Table.Filter`, `Table.Predicate`, `Table.DateRangePicker`).
+
+The URL parameter for items per page also changed from `pageSize` to `perPage`.
+
+### Migration
+
+```diff
+ const store = useTable({
+   initialState: {
+-    pagination: {pageIndex: 0, pageSize: 25},
++    pagination: {page: 0, perPage: 25},
+   },
+ });
+
+-store.state.pagination.pageIndex
++store.state.pagination.page
+
+-store.state.pagination.pageSize
++store.state.pagination.perPage
+```

--- a/packages/llms/src/components/Table.md
+++ b/packages/llms/src/components/Table.md
@@ -74,7 +74,7 @@ export function Example() {
     const store = useTable<TData>({
         initialState: {
             totalEntries: data.length,
-            pagination: {pageIndex: 0, pageSize: 10},
+            pagination: {page: 0, perPage: 10},
         },
     });
 

--- a/packages/mantine/src/components/Table/Table.tsx
+++ b/packages/mantine/src/components/Table/Table.tsx
@@ -4,6 +4,7 @@ import {
     ColumnDef,
     defaultColumnSizing,
     getCoreRowModel,
+    type PaginationState as TanStackPaginationState,
     Row,
     RowSelectionState,
     useReactTable,
@@ -134,14 +135,20 @@ export const Table = <T,>(props: TableProps<T> & {ref?: ForwardedRef<HTMLDivElem
         state: {
             globalFilter: store.state.globalFilter,
             sorting: store.state.sorting,
-            pagination: store.state.pagination,
+            pagination: {pageIndex: store.state.pagination.page, pageSize: store.state.pagination.perPage},
             columnVisibility: store.state.columnVisibility,
             expanded: store.state.expanded,
         },
         onGlobalFilterChange: store.setGlobalFilter,
         onExpandedChange: store.setExpanded,
         onSortingChange: store.setSorting,
-        onPaginationChange: store.setPagination,
+        onPaginationChange: (updater) => {
+            store.setPagination((prev) => {
+                const tanstackPrev: TanStackPaginationState = {pageIndex: prev.page, pageSize: prev.perPage};
+                const next = updater instanceof Function ? updater(tanstackPrev) : updater;
+                return {page: next.pageIndex, perPage: next.pageSize};
+            });
+        },
         onColumnVisibilityChange: store.setColumnVisibility,
         columns: store.multiRowSelectionEnabled ? [TableSelectableColumn as ColumnDef<T>].concat(columns) : columns,
         getCoreRowModel: getCoreRowModel(),

--- a/packages/mantine/src/components/Table/__tests__/TableFilter.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/TableFilter.spec.tsx
@@ -35,7 +35,7 @@ describe('Table.Filter', () => {
     it('goes back to the first page when changing the filter', async () => {
         const user = userEvent.setup({advanceTimers: vi.advanceTimersByTime});
         const Fixture = () => {
-            const store = useTable<RowData>({initialState: {pagination: {pageIndex: 1}, totalEntries: 52}});
+            const store = useTable<RowData>({initialState: {pagination: {page: 1}, totalEntries: 52}});
             return (
                 <Table store={store} data={[{name: 'fruit'}, {name: 'vegetable'}]} columns={columns}>
                     <Table.Header>

--- a/packages/mantine/src/components/Table/__tests__/TablePagination.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/TablePagination.spec.tsx
@@ -18,12 +18,12 @@ describe('Table.Pagination', () => {
         }
     });
 
-    it('calculates the number of pages based on the pageSize and the total number of entries', () => {
+    it('calculates the number of pages based on the perPage and the total number of entries', () => {
         const data = [{name: 'fruit'}, {name: 'vegetable'}];
         const Fixture = () => {
             const store = useTable<RowData>({
                 initialState: {
-                    pagination: {pageSize: 1},
+                    pagination: {perPage: 1},
                     totalEntries: 3,
                 },
             });
@@ -56,7 +56,7 @@ describe('Table.Pagination', () => {
             {name: 'dairy'},
         ];
         const Fixture = () => {
-            const store = useTable<RowData>({initialState: {pagination: {pageSize: 3}}});
+            const store = useTable<RowData>({initialState: {pagination: {perPage: 3}}});
 
             return (
                 <Table
@@ -104,7 +104,7 @@ describe('Table.Pagination', () => {
         const onChangePage = vi.fn();
         const data = [{name: 'fruit'}, {name: 'vegetable'}];
         const Fixture = () => {
-            const store = useTable<RowData>({initialState: {pagination: {pageSize: 1}}});
+            const store = useTable<RowData>({initialState: {pagination: {perPage: 1}}});
             return (
                 <Table store={store} data={data} columns={columns}>
                     <Table.Footer>
@@ -147,7 +147,7 @@ describe('Table.Pagination', () => {
         const Fixture = () => {
             const store = useTable<RowData>({
                 initialState: {
-                    pagination: {pageSize: 1, pageIndex: 2},
+                    pagination: {perPage: 1, page: 2},
                     totalEntries: 3,
                 },
             });
@@ -231,7 +231,7 @@ describe('Table.Pagination', () => {
             const Fixture = () => {
                 const store = useTable<RowData>({
                     initialState: {
-                        pagination: {pageSize: 1, pageIndex: 0},
+                        pagination: {perPage: 1, page: 0},
                         totalEntries: 3,
                     },
                     syncWithUrl: true,
@@ -255,7 +255,7 @@ describe('Table.Pagination', () => {
             const Fixture = () => {
                 const store = useTable<RowData>({
                     initialState: {
-                        pagination: {pageSize: 1, pageIndex: 0},
+                        pagination: {perPage: 1, page: 0},
                         totalEntries: 3,
                     },
                     syncWithUrl: true,

--- a/packages/mantine/src/components/Table/__tests__/TablePerPage.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/TablePerPage.spec.tsx
@@ -30,7 +30,7 @@ describe('Table.PerPage', () => {
     it('displays the values', () => {
         const data = [{name: 'fruit'}, {name: 'vegetable'}];
         const Fixture = () => {
-            const store = useTable<RowData>({initialState: {pagination: {pageSize: 2}}});
+            const store = useTable<RowData>({initialState: {pagination: {perPage: 2}}});
             return (
                 <Table store={store} data={data} columns={columns}>
                     <Table.Footer>
@@ -55,7 +55,7 @@ describe('Table.PerPage', () => {
         const Fixture = () => {
             const store = useTable<RowData>({
                 initialState: {
-                    pagination: {pageIndex: 1, pageSize: 50},
+                    pagination: {page: 1, perPage: 50},
                     totalEntries: 52,
                 },
             });
@@ -83,7 +83,7 @@ describe('Table.PerPage', () => {
         const Fixture = () => {
             const store = useTable<RowData>({
                 initialState: {
-                    pagination: {pageIndex: 1, pageSize: 50},
+                    pagination: {page: 1, perPage: 50},
                     totalEntries: 52,
                 },
             });
@@ -128,13 +128,13 @@ describe('Table.PerPage', () => {
             window.history.replaceState(null, '', '/');
         });
 
-        it('sets the current page size in the url using the parameter "pageSize"', async () => {
+        it('sets the current page size in the url using the parameter "perPage"', async () => {
             const data = [{name: 'fruit'}, {name: 'vegetable'}];
             const user = userEvent.setup();
             const Fixture = () => {
                 const store = useTable<RowData>({
                     initialState: {
-                        pagination: {pageIndex: 0, pageSize: 50},
+                        pagination: {page: 0, perPage: 50},
                         totalEntries: 52,
                     },
                     syncWithUrl: true,
@@ -150,16 +150,16 @@ describe('Table.PerPage', () => {
             };
             render(<Fixture />);
             await user.click(screen.getByRole('radio', {name: '100'}));
-            expect(window.location.search).toBe('?pageSize=100');
+            expect(window.location.search).toBe('?perPage=100');
         });
 
-        it('determines the initial pageSize from the url', async () => {
-            window.history.replaceState(null, '', '?pageSize=100');
+        it('determines the initial perPage from the url', async () => {
+            window.history.replaceState(null, '', '?perPage=100');
             const data = [{name: 'fruit'}, {name: 'vegetable'}];
             const Fixture = () => {
                 const store = useTable<RowData>({
                     initialState: {
-                        pagination: {pageIndex: 0, pageSize: 50},
+                        pagination: {page: 0, perPage: 50},
                         totalEntries: 52,
                     },
                     syncWithUrl: true,

--- a/packages/mantine/src/components/Table/__tests__/TablePredicate.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/TablePredicate.spec.tsx
@@ -19,7 +19,7 @@ describe('Table.Predicate', () => {
         const user = userEvent.setup();
         const data = [{name: 'fruit'}, {name: 'vegetable'}];
         const Fixture = () => {
-            const store = useTable<RowData>({initialState: {pagination: {pageIndex: 1}, totalEntries: 52}});
+            const store = useTable<RowData>({initialState: {pagination: {page: 1}, totalEntries: 52}});
             return (
                 <Table store={store} data={data} columns={columns}>
                     <Table.Header>

--- a/packages/mantine/src/components/Table/table-date-range-picker/TableDateRangePicker.tsx
+++ b/packages/mantine/src/components/Table/table-date-range-picker/TableDateRangePicker.tsx
@@ -55,7 +55,7 @@ export const TableDateRangePicker = factory<TableDateRangePickerFactory>((props,
 
     const onChange = (dates: DatesRangeValue<DateStringValue | null>) => {
         store.setDateRange(dates);
-        store.setPagination({pageIndex: 0, pageSize: store.state.pagination.pageSize});
+        store.setPagination({page: 0, perPage: store.state.pagination.perPage});
     };
 
     const stylesApiProps = {classNames, styles};

--- a/packages/mantine/src/components/Table/table-filter/TableFilter.tsx
+++ b/packages/mantine/src/components/Table/table-filter/TableFilter.tsx
@@ -45,7 +45,7 @@ export const TableFilter = factory<TableFilterFactory>((props, ref) => {
 
     useDidUpdate(() => {
         store.setGlobalFilter(debounced);
-        store.setPagination({pageIndex: 0, pageSize: store.state.pagination.pageSize});
+        store.setPagination({page: 0, perPage: store.state.pagination.perPage});
 
         return cancel;
     }, [debounced]);

--- a/packages/mantine/src/components/Table/table-pagination/TablePagination.tsx
+++ b/packages/mantine/src/components/Table/table-pagination/TablePagination.tsx
@@ -10,21 +10,21 @@ export const TablePagination: FunctionComponent<TablePaginationProps> = ({onPage
 
     const updatePage = (newPage: number) => {
         onPageChange?.(newPage - 1);
-        store.setPagination((prev) => ({...prev, pageIndex: newPage - 1}));
+        store.setPagination((prev) => ({...prev, page: newPage - 1}));
         containerRef.current?.scrollIntoView({behavior: 'smooth'});
     };
 
     const total = table.getPageCount();
 
     useDidUpdate(() => {
-        if (store.state.pagination.pageIndex + 1 > total && total > 0) {
+        if (store.state.pagination.page + 1 > total && total > 0) {
             updatePage(total);
         }
-    }, [store.state.pagination.pageIndex, total]);
+    }, [store.state.pagination.page, total]);
 
     return (
         <Pagination
-            value={store.state.pagination.pageIndex + 1}
+            value={store.state.pagination.page + 1}
             onChange={updatePage}
             total={total}
             boundaries={1}

--- a/packages/mantine/src/components/Table/table-pagination/TablePagination.types.ts
+++ b/packages/mantine/src/components/Table/table-pagination/TablePagination.types.ts
@@ -2,7 +2,7 @@ export interface TablePaginationProps {
     /**
      * The callback if the current page is changed.
      *
-     * @param pageIndex The index of the updated page.
+     * @param page The zero-based index of the updated page.
      */
-    onPageChange?: (pageIndex: number) => void;
+    onPageChange?: (page: number) => void;
 }

--- a/packages/mantine/src/components/Table/table-per-page/TablePerPage.tsx
+++ b/packages/mantine/src/components/Table/table-per-page/TablePerPage.tsx
@@ -14,14 +14,14 @@ export const TablePerPage: FunctionComponent<TablePerPageProps> & {DEFAULT_SIZE:
 
     const updatePerPage = (newPerPage: string) => {
         onPerPageChange?.(Number(newPerPage));
-        store.setPagination({pageIndex: 0, pageSize: parseInt(newPerPage, 10)});
+        store.setPagination({page: 0, perPage: parseInt(newPerPage, 10)});
     };
 
     return table.getPageCount() > 0 ? (
         <Group gap="sm">
             <Text fw={500}>{label}</Text>
             <SegmentedControl
-                value={store.state.pagination.pageSize.toString() ?? choices[1] ?? choices[0]}
+                value={store.state.pagination.perPage.toString() ?? choices[1] ?? choices[0]}
                 onChange={updatePerPage}
                 data={choices}
                 size="sm"

--- a/packages/mantine/src/components/Table/table-predicate/TablePredicate.tsx
+++ b/packages/mantine/src/components/Table/table-predicate/TablePredicate.tsx
@@ -65,7 +65,7 @@ export const TablePredicate: FunctionComponent<TablePredicateProps> = factory<Ta
 
     const handleChange = (newValue: string | null) => {
         store.setPredicates((prev) => ({...prev, [id]: newValue ?? ''}));
-        store.setPagination((prev) => ({...prev, pageIndex: 0}));
+        store.setPagination((prev) => ({...prev, page: 0}));
     };
 
     const stylesApiProps = {classNames, styles};

--- a/packages/mantine/src/components/Table/use-table.ts
+++ b/packages/mantine/src/components/Table/use-table.ts
@@ -1,6 +1,6 @@
 import type {DatesRangeValue, DateStringValue} from '@mantine/dates';
 import {useDidUpdate} from '@mantine/hooks';
-import {type ExpandedState, type PaginationState, type SortingState} from '@tanstack/table-core';
+import {type ExpandedState, type SortingState} from '@tanstack/table-core';
 import defaultsDeep from 'lodash.defaultsdeep';
 import {Dispatch, SetStateAction, useCallback, useMemo, useState} from 'react';
 import {useUrlSyncedState, UseUrlSyncedStateOptions} from '../../hooks/use-url-synced-state.js';
@@ -11,11 +11,22 @@ type DeepPartial<T> = {
     [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
 
+export interface PaginationState {
+    /**
+     * Zero-based page index.
+     */
+    page: number;
+    /**
+     * Number of items per page.
+     */
+    perPage: number;
+}
+
 export interface TableState<TData = unknown> {
     /**
      * Current pagination state
      *
-     * @default { pageIndex: 0, pageSize: 50 }
+     * @default { page: 0, perPage: 50 }
      */
     pagination: PaginationState;
     /**
@@ -215,8 +226,8 @@ const defaultOptions: UseTableOptions = {
 
 const defaultState: Partial<TableState> = {
     pagination: {
-        pageIndex: 0,
-        pageSize: 50,
+        page: 0,
+        perPage: 50,
     },
     totalEntries: null,
     sorting: [],
@@ -233,18 +244,18 @@ const serialization = <K extends keyof TableState>(
 ) => Object.freeze(input);
 
 const PAGINATION_SERIALIZATION = serialization<'pagination'>({
-    serializer: ({pageIndex, pageSize}) => [
-        ['page', (pageIndex + 1).toString()],
-        ['pageSize', pageSize.toString()],
+    serializer: ({page, perPage}) => [
+        ['page', (page + 1).toString()],
+        ['perPage', perPage.toString()],
     ],
     deserializer: (params, initialState) => {
         const page = params.get('page');
-        const pageSize = params.get('pageSize');
+        const perPage = params.get('perPage');
 
         return defaultsDeep(
             {
-                pageIndex: page ? Math.max(1, parseInt(page, 10)) - 1 : undefined,
-                pageSize: pageSize ? parseInt(pageSize, 10) : undefined,
+                page: page ? Math.max(1, parseInt(page, 10)) - 1 : undefined,
+                perPage: perPage ? parseInt(perPage, 10) : undefined,
             },
             initialState,
         );

--- a/packages/mantine/src/index.ts
+++ b/packages/mantine/src/index.ts
@@ -401,7 +401,13 @@ export {
     type TableProps,
 } from './components/Table/Table.types.js';
 export {useTableContext} from './components/Table/TableContext.js';
-export {useTable, type TableState, type TableStore, type UseTableOptions} from './components/Table/use-table.js';
+export {
+    useTable,
+    type PaginationState,
+    type TableState,
+    type TableStore,
+    type UseTableOptions,
+} from './components/Table/use-table.js';
 export {useUrlSyncedState, type SearchParamEntry, type UseUrlSyncedStateOptions} from './hooks/use-url-synced-state.js';
 
 // Table of Contents

--- a/packages/storybook/src/data-display/Table.stories.tsx
+++ b/packages/storybook/src/data-display/Table.stories.tsx
@@ -227,7 +227,7 @@ export const Demo: Story = {
         const table = useTable<Person>({
             initialState: {
                 totalEntries: data.length,
-                pagination: withPagination ? {pageSize: 5} : undefined,
+                pagination: withPagination ? {perPage: 5} : undefined,
                 dateRange: withDateRangePicker ? [previousWeek, today] : undefined,
                 predicates: withPredicateFilter ? {age: 'ANY'} : undefined,
             },

--- a/packages/storybook/src/foundation/iconography/Iconography.stories.tsx
+++ b/packages/storybook/src/foundation/iconography/Iconography.stories.tsx
@@ -89,7 +89,7 @@ const variantFilter = (icon: IconSet, predicates: Record<string, string>) => {
 
 const PlasmaIconsTable = () => {
     const table = useTable<IconSet>({
-        initialState: {totalEntries: plasmaIconsList.length, pagination: {pageSize: 10}, predicates: {variant: '24px'}},
+        initialState: {totalEntries: plasmaIconsList.length, pagination: {perPage: 10}, predicates: {variant: '24px'}},
         enableRowSelection: false,
     });
 
@@ -169,7 +169,7 @@ const tablerColumns = [
 
 const TablerIconsTable = () => {
     const table = useTable<TablerIconRow>({
-        initialState: {totalEntries: tablerIconRows.length, pagination: {pageSize: 10}},
+        initialState: {totalEntries: tablerIconRows.length, pagination: {perPage: 10}},
         enableRowSelection: false,
     });
     return (


### PR DESCRIPTION
## Summary

Renames pagination state attributes to match [Coveo API standards for offset pagination](https://github.com/coveo/api-standards/blob/main/accepted/0002-offset-pagination.md#paginated-api-call---request):

- `pageIndex` → `page` (zero-based page index)
- `pageSize` → `perPage` (number of items per page)

## Changes

- Defined a Plasma-owned `PaginationState` interface (`{page, perPage}`) that overrides the TanStack re-export
- Added a mapping layer in `Table.tsx` to bridge between Plasma's `{page, perPage}` and TanStack's internal `{pageIndex, pageSize}`
- Updated all sub-components: `Table.Pagination`, `Table.PerPage`, `Table.Filter`, `Table.Predicate`, `Table.DateRangePicker`
- URL parameter renamed from `pageSize` to `perPage`
- Updated tests, LLMs docs, and storybook stories

## Breaking Changes

| Before | After |
|--------|-------|
| `pagination: {pageIndex: 0, pageSize: 25}` | `pagination: {page: 0, perPage: 25}` |
| `store.state.pagination.pageIndex` | `store.state.pagination.page` |
| `store.state.pagination.pageSize` | `store.state.pagination.perPage` |
| URL: `?pageSize=100` | URL: `?perPage=100` |

## Testing

- Build passes (`pnpm build --filter @coveord/plasma-mantine`)
- All 391 tests pass (`pnpm test --filter @coveord/plasma-mantine`)

Resolves [ADUI-11178](https://coveord.atlassian.net/browse/ADUI-11178)

[ADUI-11178]: https://coveord.atlassian.net/browse/ADUI-11178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ