### PR TITLE
fix(ci): truncate branch name to 37 chars in Chromatic URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,8 @@ jobs:
               shell: bash
               run: |
                   BRANCH="${{ github.head_ref || github.ref_name }}"
-                  CLEAN_BRANCH=$(echo "$BRANCH" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+                  # Replace slashes with dashes, lowercase, and truncate to 37 chars (Chromatic's subdomain limit)
+                  CLEAN_BRANCH=$(echo "$BRANCH" | tr '/' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-37)
                   echo "url=https://${CLEAN_BRANCH}--69e1126f9e24a5e560359ac2.chromatic.com/" >> $GITHUB_OUTPUT
             - name: Add demo link as a comment on the PR
               uses: ./.github/actions/comment-on-pr


### PR DESCRIPTION
## Summary

Chromatic truncates branch names to 37 characters in their subdomain URLs. Our CI was computing the demo URL with the full (cleaned) branch name, causing broken demo links for branches exceeding 37 characters.

**Example:** PR #4489 branch `ADUI-11178/update-pagination-attributes` produces a 39-char slug (`adui-11178-update-pagination-attributes`), but Chromatic serves it at the 37-char truncated version (`adui-11178-update-pagination-attribut`).

## Changes

- Added `| cut -c1-37` to the branch name cleaning step in `.github/workflows/ci.yml`

## Testing

Verified locally that the truncation produces the correct URL for the example branch.

Resolves: [ADUI-11505](https://coveord.atlassian.net/browse/ADUI-11505)

[ADUI-11505]: https://coveord.atlassian.net/browse/ADUI-11505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ