### PR TITLE
fix(ci): add missing id-token permission for npm provenance

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,6 +11,7 @@ env:
 
 permissions:
     pull-requests: write
+    id-token: write
     actions: read
     contents: write
     security-events: write


### PR DESCRIPTION
## Summary

The `id-token: write` permission was accidentally removed from `.github/workflows/cd.yml` in the Version 60 PR (#4412). This permission is required for GitHub Actions to generate OIDC tokens used by npm for provenance attestations. The `@coveord` npm org enforces provenance, so without it all publishes fail with E404.

## Changes

Adds `id-token: write` back to the CD workflow permissions block.

## Failed run

https://github.com/coveo/plasma/actions/runs/28967670330/job/8595489368

## Jira

[ADUI-11510](https://coveord.atlassian.net/browse/ADUI-11510)

[ADUI-11510]: https://coveord.atlassian.net/browse/ADUI-11510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ