### PR TITLE
fix(cd): use changesets/action to create git tags and GitHub releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,9 +79,12 @@ jobs:
                   git push deploy HEAD:next
             - name: Publish prereleases
               if: github.ref_name == 'next'
-              run: |
-                  pnpm release:pre:publish:next
-                  git push deploy --follow-tags
+              uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
+              with:
+                  publish: pnpm release:pre:publish:next
+                  createGithubReleases: false
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Copy LLM files into Storybook output
               run: cp -r ./packages/llms/dist/. ./packages/storybook/storybook-static/
             - name: Deploy Storybook to Chromatic

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,9 +46,12 @@ jobs:
               uses: ./.github/actions/test
             - name: Publish stable releases
               if: github.ref_name == 'master'
-              run: |
-                  pnpm release:publish
-                  git push --follow-tags
+              uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
+              with:
+                  publish: pnpm release:publish
+                  createGithubReleases: true
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Configure git for prerelease commits
               if: github.ref_name == 'next'
               uses: ./.github/actions/configure-git-ssh


### PR DESCRIPTION
## Summary

The CD workflow publishes to npm successfully but fails to create git tags or GitHub releases.

**Root cause:** `git push --follow-tags` only pushes tags alongside new commits. Since version bumps are already merged via the Release PR, there are no new commits — so tags are stranded on the CI runner.

**Fix:** Replace the raw shell publish step with `changesets/action` using the `publish` input. This action uses the GitHub API to create tags and GitHub Releases for each newly published package.

## What was tested

- Verified via CI logs that `git push --follow-tags` reported "Everything up-to-date" on the v60.0.0 release
- Confirmed no `60.0.0` tags exist on the remote despite successful npm publish

Fixes [ADUI-11511](https://coveord.atlassian.net/browse/ADUI-11511)

[ADUI-11511]: https://coveord.atlassian.net/browse/ADUI-11511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ