### PR TITLE
fix(mantine): declare plasma-mantine as having side effects

### DIFF
--- a/.changeset/witty-weeks-deny.md
+++ b/.changeset/witty-weeks-deny.md
@@ -1,0 +1,5 @@
+---
+'@coveord/plasma-mantine': patch
+---
+
+Fixed CSS cascade ordering in production builds by setting sideEffects to true

--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -19,9 +19,7 @@
         "directory": "packages/mantine"
     },
     "type": "module",
-    "sideEffects": [
-        "./dist/theme/Plasmantine.js"
-    ],
+    "sideEffects": true,
     "exports": {
         ".": {
             "import": "./dist/index.js"


### PR DESCRIPTION
### Proposed Changes

Set `sideEffects: true` in `@coveord/plasma-mantine` to fix CSS cascade ordering issues in production builds.

#### Problem

In v60, `plasma-mantine` was published with `"sideEffects": ["./dist/theme/Plasmantine.js"]`. This tells bundlers (Vite/Rolldown) that all other modules in the package are side-effect-free and can be freely reordered or tree-shaken during production builds.

The issue is that `Theme.js` (imported by `Plasmantine.js`) imports ~30 CSS module files (`../styles/Button.module.css`, `../styles/NavLink.module.css`, etc.). When the bundler considers `Theme.js` side-effect-free, it gains freedom to reorder how CSS is extracted into chunks — resulting in **different CSS cascade ordering between dev and production**.

**In dev mode**: CSS `<style>` tags are injected in module-evaluation order. Plasma's theme CSS loads first (through `Plasmantine` → `Theme.js`), then consumer app CSS modules load after. Consumer styles correctly override plasma defaults via source order.

**In production builds**: Rolldown reorders CSS chunk extraction. Consumer app CSS (e.g., a `TopBar.module.css`) ends up **before** plasma's theme CSS in the DOM, reversing the intended cascade. Styles that should be overridden by the app are now overriding plasma's styles instead.

#### Why `sideEffects: true`

- `"*.css"` in `sideEffects` alone is not sufficient — the problem is chunk-level CSS ordering, not CSS being dropped. The bundler still reorders chunks when the JS modules importing CSS are marked side-effect-free.
- `sideEffects: true` preserves the original module evaluation order during bundling, ensuring plasma's CSS always appears before consumer CSS.
- The tree-shaking cost is negligible: `Plasmantine` already imports `Theme.js` which references all component style overrides, so nothing was effectively being tree-shaken in practice.
- CSS code-splitting is preserved (unlike `cssCodeSplit: false` which would merge all CSS into one file).

#### Related Vite/Rolldown issues

- [vitejs/vite#3924](https://github.com/vitejs/vite/issues/3924) — CSS injection order wrong with dynamic imports and CSS modules
- [vitejs/vite#21903](https://github.com/vitejs/vite/issues/21903) — CSS cascade order differs between dev and production
- [vitejs/vite#22301](https://github.com/vitejs/vite/issues/22301) — CSS bundle order is incorrect (Vite 8/Rolldown)

### Potential Breaking Changes

None. This change only affects how bundlers handle the package during tree-shaking. Runtime behavior is unchanged. Bundle size impact is negligible since the theme module already pulled in all CSS.

### Acceptance Criteria

- [x] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
