### PR TITLE
chore: enable pre-commit hook for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,4 +29,7 @@
         enabled: true,
         extends: ['schedule:weekly'],
     },
+    'pre-commit': {
+        enabled: true,
+    },
 }

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,10 @@
+- id: oxfmt
+  name: oxfmt
+  description: 'Formatter for the JavaScript Oxidation Compiler'
+  entry: oxfmt
+  language: node
+  'types_or': [javascript, jsx, ts, tsx]
+  args: []
+  require_serial: false
+  additional_dependencies: ['oxfmt@0.57.0']
+  minimum_pre_commit_version: '2.9.2'


### PR DESCRIPTION
### Proposed Changes

Enabled the oxfmt pre-commit hook for renovate. This should help with the failing PRs

https://docs.renovatebot.com/modules/manager/pre-commit/

### Potential Breaking Changes

None

### Acceptance Criteria

- [ ] The proposed changes are covered by unit tests
- [ ] The potential breaking changes are clearly identified
- [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
