### PR TITLE
chore: override oxfmt config for pnpm-workspace.yaml

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -10,5 +10,14 @@
         "**/dist",
         "CHANGELOG.md",
         "packages/react-icons/src/generated"
+    ],
+    "overrides": [
+        {
+            "files": ["pnpm-workspace.yaml"],
+            "options": {
+                "tabWidth": 2,
+                "singleQuote": true
+            }
+        }
     ]
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,22 +1,22 @@
 packages:
-    - 'packages/*'
+  - 'packages/*'
 allowBuilds:
-    aws-sdk: false
-    core-js-pure: false
-    esbuild: false
-    unrs-resolver: false
+  aws-sdk: false
+  core-js-pure: false
+  esbuild: false
+  unrs-resolver: false
 minimumReleaseAge: 10080 # 7 days in minutes
 minimumReleaseAgeExclude:
-    - '@mantine/*'
+  - '@mantine/*'
 peerDependencyRules:
-    ignoreMissing:
-        - react-native
+  ignoreMissing:
+    - react-native
 overrides:
-    '@babel/traverse': ^7.23.2
-    nwsapi: 2.2.24
+  '@babel/traverse': ^7.23.2
+  nwsapi: 2.2.24
 strictPeerDependencies: false
 saveExact: true
 autoInstallPeers: false
 patchedDependencies:
-    '@mantine/form@8.3.18': patches/@mantine__form@8.3.18.patch
-    '@monaco-editor/react@4.7.0': patches/@monaco-editor__react@4.7.0.patch
+  '@mantine/form@8.3.18': patches/@mantine__form@8.3.18.patch
+  '@monaco-editor/react@4.7.0': patches/@monaco-editor__react@4.7.0.patch


### PR DESCRIPTION
### Proposed Changes

Pretty much all renovate PRs are failing because of the formating of the `pnpm-workspace.yaml` file. I created an override for oxfmt so it matches the original format. All Renovate PRs should be green once merged

### Potential Breaking Changes

None

### Acceptance Criteria

- [ ] The proposed changes are covered by unit tests
- [ ] The potential breaking changes are clearly identified
- [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
