### PR TITLE
feat(table): hide pagination and perPage when rows fit in one page

### DIFF
--- a/.changeset/cool-wombats-repeat.md
+++ b/.changeset/cool-wombats-repeat.md
@@ -1,0 +1,5 @@
+---
+'@coveord/plasma-mantine': patch
+---
+
+**Table.Pagination** is now hidden when there is only one page or fewer. **Table.PerPage** is now hidden when the total number of rows is smaller than or equal to the smallest page size option.

--- a/packages/mantine/src/components/Table/__tests__/TablePagination.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/TablePagination.spec.tsx
@@ -140,6 +140,27 @@ describe('Table.Pagination', () => {
         expect(screen.getByTestId('table-footer')).toBeEmptyDOMElement();
     });
 
+    it('renders nothing when there is only one page', () => {
+        const data = [{name: 'fruit'}, {name: 'vegetable'}];
+        const Fixture = () => {
+            const store = useTable<RowData>({
+                initialState: {
+                    pagination: {perPage: 50},
+                    totalEntries: 2,
+                },
+            });
+            return (
+                <Table store={store} data={data} columns={columns}>
+                    <Table.Footer data-testid="table-footer">
+                        <Table.Pagination />
+                    </Table.Footer>
+                </Table>
+            );
+        };
+        render(<Fixture />);
+        expect(screen.getByTestId('table-footer')).toBeEmptyDOMElement();
+    });
+
     it('changes page when the current page is greater than the total number of pages', async () => {
         const user = userEvent.setup();
         const onChangePage = vi.fn();
@@ -178,7 +199,7 @@ describe('Table.Pagination', () => {
         expect(buttons[4]).toHaveAccessibleName('3');
         expect(buttons[5]).toHaveAccessibleName('next page');
 
-        // remove a page
+        // remove a page (totalEntries: 3 -> 2, pageCount: 3 -> 2)
         await user.click(screen.getByTestId('remove-page'));
 
         // The page is 2, but the index is 1
@@ -194,27 +215,13 @@ describe('Table.Pagination', () => {
 
         onChangePage.mockReset();
 
-        // remove a page
+        // remove a page (totalEntries: 2 -> 1, pageCount: 2 -> 1)
         await user.click(screen.getByTestId('remove-page'));
 
         // The page is 1, but the index is 0
         expect(onChangePage).toHaveBeenCalledExactlyOnceWith(0);
 
-        buttons = screen.getAllByRole('button');
-        expect(buttons).toHaveLength(4);
-        expect(buttons[0]).toHaveAccessibleName('change total pages');
-        expect(buttons[1]).toHaveAccessibleName('previous page');
-        expect(buttons[2]).toHaveAccessibleName('1');
-        expect(buttons[3]).toHaveAccessibleName('next page');
-
-        onChangePage.mockReset();
-
-        // remove a page
-        await user.click(screen.getByTestId('remove-page'));
-
-        // There is no more pages
-        expect(onChangePage).not.toHaveBeenCalled();
-
+        // Pagination hides when there is only one page
         buttons = screen.getAllByRole('button');
         expect(buttons).toHaveLength(1);
         expect(buttons[0]).toHaveAccessibleName('change total pages');

--- a/packages/mantine/src/components/Table/__tests__/TablePerPage.spec.tsx
+++ b/packages/mantine/src/components/Table/__tests__/TablePerPage.spec.tsx
@@ -13,7 +13,7 @@ describe('Table.PerPage', () => {
     it('displays the label', () => {
         const data = [{name: 'fruit'}, {name: 'vegetable'}];
         const Fixture = () => {
-            const store = useTable<RowData>();
+            const store = useTable<RowData>({initialState: {totalEntries: 30}});
             return (
                 <Table store={store} data={data} columns={columns}>
                     <Table.Footer>
@@ -28,9 +28,9 @@ describe('Table.PerPage', () => {
     });
 
     it('displays the values', () => {
-        const data = [{name: 'fruit'}, {name: 'vegetable'}];
+        const data = [{name: 'fruit'}, {name: 'vegetable'}, {name: 'grain'}];
         const Fixture = () => {
-            const store = useTable<RowData>({initialState: {pagination: {perPage: 2}}});
+            const store = useTable<RowData>({initialState: {pagination: {perPage: 2}, totalEntries: 3}});
             return (
                 <Table store={store} data={data} columns={columns}>
                     <Table.Footer>
@@ -56,7 +56,7 @@ describe('Table.PerPage', () => {
             const store = useTable<RowData>({
                 initialState: {
                     pagination: {page: 1, perPage: 50},
-                    totalEntries: 52,
+                    totalEntries: 150,
                 },
             });
             return (
@@ -121,6 +121,48 @@ describe('Table.PerPage', () => {
         };
         render(<Fixture />);
         expect(screen.getByTestId('table-footer')).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when total rows fit in the smallest page size', () => {
+        const data = [{name: 'fruit'}, {name: 'vegetable'}];
+        const Fixture = () => {
+            const store = useTable<RowData>({
+                initialState: {
+                    pagination: {perPage: 10},
+                    totalEntries: 5,
+                },
+            });
+            return (
+                <Table store={store} data={data} columns={columns}>
+                    <Table.Footer data-testid="table-footer">
+                        <Table.PerPage values={[10, 25, 50]} />
+                    </Table.Footer>
+                </Table>
+            );
+        };
+        render(<Fixture />);
+        expect(screen.getByTestId('table-footer')).toBeEmptyDOMElement();
+    });
+
+    it('renders when total rows exceed the smallest page size', () => {
+        const data = [{name: 'fruit'}, {name: 'vegetable'}];
+        const Fixture = () => {
+            const store = useTable<RowData>({
+                initialState: {
+                    pagination: {perPage: 50},
+                    totalEntries: 30,
+                },
+            });
+            return (
+                <Table store={store} data={data} columns={columns}>
+                    <Table.Footer>
+                        <Table.PerPage values={[25, 50, 100]} />
+                    </Table.Footer>
+                </Table>
+            );
+        };
+        render(<Fixture />);
+        expect(screen.getByText('Results per page')).toBeVisible();
     });
 
     describe('when url sync is activated', () => {

--- a/packages/mantine/src/components/Table/table-pagination/TablePagination.tsx
+++ b/packages/mantine/src/components/Table/table-pagination/TablePagination.tsx
@@ -22,6 +22,10 @@ export const TablePagination: FunctionComponent<TablePaginationProps> = ({onPage
         }
     }, [store.state.pagination.page, total]);
 
+    if (total <= 1) {
+        return null;
+    }
+
     return (
         <Pagination
             value={store.state.pagination.page + 1}

--- a/packages/mantine/src/components/Table/table-per-page/TablePerPage.tsx
+++ b/packages/mantine/src/components/Table/table-per-page/TablePerPage.tsx
@@ -17,7 +17,14 @@ export const TablePerPage: FunctionComponent<TablePerPageProps> & {DEFAULT_SIZE:
         store.setPagination({page: 0, perPage: parseInt(newPerPage, 10)});
     };
 
-    return table.getPageCount() > 0 ? (
+    const totalRows = table.getRowCount();
+    const smallestPageSize = Math.min(...values);
+
+    if (totalRows <= smallestPageSize) {
+        return null;
+    }
+
+    return (
         <Group gap="sm">
             <Text fw={500}>{label}</Text>
             <SegmentedControl
@@ -27,7 +34,7 @@ export const TablePerPage: FunctionComponent<TablePerPageProps> & {DEFAULT_SIZE:
                 size="sm"
             />
         </Group>
-    ) : null;
+    );
 };
 
 TablePerPage.displayName = 'Table.PerPage';


### PR DESCRIPTION
## Summary

Hide `Table.Pagination` and `Table.PerPage` when they are not useful:

- **Table.Pagination**: hidden when `pageCount <= 1` (all data fits on one page)
- **Table.PerPage**: hidden when total rows `<=` the smallest page size option (switching page sizes would never produce multiple pages)

## What was changed

| File | Change |
|------|--------|
| `TablePagination.tsx` | Return `null` when `table.getPageCount() <= 1` |
| `TablePerPage.tsx` | Return `null` when `table.getRowCount() <= Math.min(...values)` |
| `TablePagination.spec.tsx` | Added test for single-page hide; updated decreasing-pages test |
| `TablePerPage.spec.tsx` | Added tests for new hide condition; fixed existing tests |

## Testing

All 413 unit tests pass. Build compiles cleanly.

Resolves [ADUI-11487](https://coveord.atlassian.net/browse/ADUI-11487)

[ADUI-11487]: https://coveord.atlassian.net/browse/ADUI-11487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ