### PR TITLE
feat(llms,mcp-server): add content guidelines to llms.txt and MCP server

### DIFF
--- a/.changeset/content-guidelines-llms-mcp.md
+++ b/.changeset/content-guidelines-llms-mcp.md
@@ -1,0 +1,13 @@
+---
+'@coveord/plasma-llms': minor
+'@coveord/plasma-mcp-server': minor
+---
+
+Add content guidelines to LLM documentation outputs and MCP server
+
+- Include content guideline files (Voice, Writing Mechanics, Product Vocabulary, Target Audience) in `llms.txt` and `llms-full.txt`
+- Component docs have moved from `plasma.coveo.com/llms/<Component>.md` to `plasma.coveo.com/llms/components/<Component>.md`
+- Content guidelines are available at `plasma.coveo.com/llms/content/<Guideline>.md`
+- Add `list_content_guidelines` and `get_content_guideline` MCP tools
+- Extend `search_docs` to search across both components and content guidelines
+- Update `plasma-skill.md` to reference content guidelines

--- a/packages/llms/src/build.ts
+++ b/packages/llms/src/build.ts
@@ -6,14 +6,15 @@ import {generateLlmsFullTxt} from './llms-full-txt.ts';
 import {generateLlmsTxt} from './llms-txt.ts';
 
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
-const docsDir = path.resolve(currentDir, '../src/components');
 const distDir = path.resolve(currentDir, '../dist');
 
 /** Base URL where the generated files will be served (Storybook static deployment). */
 const BASE_URL = process.env.PLASMA_BASE_URL ?? 'https://plasma.coveo.com';
 
-export interface ComponentDoc {
-    /** Component name (filename without .md extension). */
+export interface DocEntry {
+    /** Filename without .md extension, used for URL paths. */
+    slug: string;
+    /** Display name (from frontmatter `name:` field, falls back to slug). */
     name: string;
     /** One-sentence description, sourced from YAML frontmatter `description:` field. */
     description: string;
@@ -21,59 +22,82 @@ export interface ComponentDoc {
     content: string;
 }
 
-const ensureDir = (dir: string) => {
-    fs.mkdirSync(dir, {recursive: true});
-};
-
 const UTF8_BOM = '\uFEFF';
 
+/** Returns the UTF-8 BOM prefix for text-based files (.md, .txt), empty string otherwise. */
+const bomPrefix = (filePath: string): string => (filePath.endsWith('.md') || filePath.endsWith('.txt') ? UTF8_BOM : '');
+
 const write = (filePath: string, content: string) => {
-    fs.writeFileSync(filePath, UTF8_BOM + content, 'utf-8');
-    const kb = (content.length / 1024).toFixed(1);
+    const interpolated = content.replaceAll('{{BASE_URL}}', BASE_URL);
+    fs.writeFileSync(filePath, bomPrefix(filePath) + interpolated, 'utf-8');
+    const kb = (interpolated.length / 1024).toFixed(1);
     console.log(`  ✓  ${path.relative(distDir, filePath)} (${kb} KB)`);
+};
+
+/**
+ * Reads all .md files from a source directory, parses YAML frontmatter,
+ * and returns a sorted array of DocEntry objects.
+ */
+const readDocs = (sourceDir: string): DocEntry[] =>
+    fs
+        .readdirSync(sourceDir)
+        .filter((f) => f.endsWith('.md'))
+        .sort()
+        .map((file) => {
+            const slug = path.basename(file, '.md');
+            const raw = fs.readFileSync(path.join(sourceDir, file), 'utf-8');
+            const {data, content} = matter(raw);
+            return {
+                slug,
+                name: (data.name as string) ?? slug,
+                description: (data.description as string) ?? '',
+                content,
+            };
+        });
+
+/**
+ * Writes a set of doc entries to an output directory:
+ * - One .md file per entry (frontmatter stripped, BASE_URL replaced)
+ * - An index.json manifest with slug, name, and description for each entry
+ */
+const writeDocs = (entries: DocEntry[], outDir: string) => {
+    fs.mkdirSync(outDir, {recursive: true});
+
+    for (const entry of entries) {
+        write(path.join(outDir, `${entry.slug}.md`), entry.content);
+    }
+
+    const index = entries.map(({slug, name, description}) => ({slug, name, description}));
+    write(path.join(outDir, 'index.json'), JSON.stringify(index, null, 2));
 };
 
 const main = () => {
     console.log('\n🚀 Generating Plasma LLM documentation…\n');
     console.log(`   Base URL: ${BASE_URL}\n`);
 
-    ensureDir(distDir);
-    ensureDir(path.join(distDir, 'llms'));
+    fs.mkdirSync(distDir, {recursive: true});
 
-    const docs: ComponentDoc[] = fs
-        .readdirSync(docsDir)
-        .filter((f) => f.endsWith('.md'))
-        .sort()
-        .map((file) => {
-            const name = path.basename(file, '.md');
-            const raw = fs.readFileSync(path.join(docsDir, file), 'utf-8');
-            const {data, content} = matter(raw);
-            return {name, description: (data.description as string) ?? '', content};
-        });
+    const components = readDocs(path.resolve(currentDir, '../src/components'));
+    const contentGuidelines = readDocs(path.resolve(currentDir, '../src/content'));
 
     console.log(`📄 Writing output files…\n`);
 
-    // Per-component .md files (frontmatter stripped — clean Markdown for LLM consumption)
-    for (const doc of docs) {
-        write(path.join(distDir, 'llms', `${doc.name}.md`), doc.content.replaceAll('{{BASE_URL}}', BASE_URL));
-    }
-
-    // descriptions.json — used by @coveord/plasma-mcp-server to populate list_components
-    const descriptions = Object.fromEntries(docs.map((d) => [d.name, d.description]));
-    fs.writeFileSync(path.join(distDir, 'descriptions.json'), JSON.stringify(descriptions, null, 2), 'utf-8');
-    console.log(`  ✓  descriptions.json`);
+    writeDocs(components, path.join(distDir, 'llms', 'components'));
+    writeDocs(contentGuidelines, path.join(distDir, 'llms', 'content'));
 
     // llms.txt index
-    write(path.join(distDir, 'llms.txt'), generateLlmsTxt(docs, BASE_URL));
+    write(path.join(distDir, 'llms.txt'), generateLlmsTxt(components, contentGuidelines, BASE_URL));
 
     // llms-full.txt
-    write(path.join(distDir, 'llms-full.txt'), generateLlmsFullTxt(docs));
+    write(path.join(distDir, 'llms-full.txt'), generateLlmsFullTxt(components, contentGuidelines));
 
     // Skill — read src/skill.md, replace {{BASE_URL}} placeholder
     const skillTemplate = fs.readFileSync(path.resolve(currentDir, '../src/skill.md'), 'utf-8');
-    write(path.join(distDir, 'plasma-skill.md'), skillTemplate.replaceAll('{{BASE_URL}}', BASE_URL));
+    write(path.join(distDir, 'plasma-skill.md'), skillTemplate);
 
-    console.log(`\n✅ Done! Generated docs for ${docs.length} components.\n`);
+    console.log(
+        `\n✅ Done! Generated docs for ${components.length} components and ${contentGuidelines.length} content guidelines.\n`,
+    );
 };
 
 main();

--- a/packages/llms/src/llms-full-txt.md
+++ b/packages/llms/src/llms-full-txt.md
@@ -21,3 +21,7 @@ function App() {
 ## Components
 
 {{COMPONENT_DOCS}}
+
+## Content Guidelines
+
+{{CONTENT_DOCS}}

--- a/packages/llms/src/llms-full-txt.ts
+++ b/packages/llms/src/llms-full-txt.ts
@@ -1,27 +1,31 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
-import type {ComponentDoc} from './build.ts';
+import type {DocEntry} from './build.ts';
 
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const template = fs.readFileSync(path.resolve(currentDir, '../src/llms-full-txt.md'), 'utf-8');
 
 const BOUNDARY = `\n\n${'─'.repeat(80)}\n\n`;
 
-/** Generates llms-full.txt — a single file concatenating all component documentation. */
-export const generateLlmsFullTxt = (docs: ComponentDoc[]): string => {
-    const componentDocs = docs
-        .map((doc) => {
-            const header = `### ${doc.name}\n\n${doc.description}`;
-            const body = doc.content
-                .replace(/^# .+\n/m, '')
-                .replace(/\n---\n\n\[Full Plasma documentation\]\([^)]+\)\s*$/m, '')
-                .replace(/\n{3,}/g, '\n\n')
-                .replace(/^(#{1,6} )/gm, '##$1')
-                .trim();
-            return `${header}\n\n${body}`;
-        })
-        .join(BOUNDARY);
-
-    return template.replace('{{COMPONENT_DOCS}}', componentDocs);
+/** Formats a single doc entry for inline inclusion in llms-full.txt. */
+const formatEntry = (entry: DocEntry): string => {
+    const header = `### ${entry.name}\n\n${entry.description}`;
+    const body = entry.content
+        // Remove the top-level heading (replaced by the ### header above)
+        .replace(/^# .+\n/m, '')
+        // Strip the trailing "Full Plasma documentation" link found in component docs
+        .replace(/\n---\n\n\[Full Plasma documentation\]\([^)]+\)\s*$/m, '')
+        // Collapse excessive blank lines into a single blank line
+        .replace(/\n{3,}/g, '\n\n')
+        // Shift all headings down two levels to nest under the ### entry header
+        .replace(/^(#{1,6} )/gm, '##$1')
+        .trim();
+    return `${header}\n\n${body}`;
 };
+
+/** Generates llms-full.txt — a single file concatenating all component and content guideline documentation. */
+export const generateLlmsFullTxt = (components: DocEntry[], contentGuidelines: DocEntry[]): string =>
+    template
+        .replace('{{COMPONENT_DOCS}}', components.map(formatEntry).join(BOUNDARY))
+        .replace('{{CONTENT_DOCS}}', contentGuidelines.map(formatEntry).join(BOUNDARY));

--- a/packages/llms/src/llms-txt.md
+++ b/packages/llms/src/llms-txt.md
@@ -13,6 +13,10 @@ For a single consolidated file with all component documentation, use:
 
 {{COMPONENT_LIST}}
 
+## Content Guidelines
+
+{{CONTENT_LIST}}
+
 ## Optional
 
 Plasma re-exports ~90 Mantine components unchanged. For components not listed above, refer to Mantine's documentation — but always import from `@coveord/plasma-mantine`, not from `@mantine/*` packages.

--- a/packages/llms/src/llms-txt.ts
+++ b/packages/llms/src/llms-txt.ts
@@ -1,19 +1,23 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
-import type {ComponentDoc} from './build.ts';
+import type {DocEntry} from './build.ts';
 
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const template = fs.readFileSync(path.resolve(currentDir, '../src/llms-txt.md'), 'utf-8');
 
 /** Generates the llms.txt index file following the llmstxt.org standard. */
-export const generateLlmsTxt = (components: ComponentDoc[], baseUrl: string): string => {
+export const generateLlmsTxt = (components: DocEntry[], contentGuidelines: DocEntry[], baseUrl: string): string => {
     const componentList = components
         .map(
             (c) =>
-                `- [${c.name}](${baseUrl}/llms/${c.name}.md): ${c.description || `${c.name} component from @coveord/plasma-mantine`}`,
+                `- [${c.name}](${baseUrl}/llms/components/${c.slug}.md): ${c.description || `${c.name} component from @coveord/plasma-mantine`}`,
         )
         .join('\n');
 
-    return template.replaceAll('{{BASE_URL}}', baseUrl).replace('{{COMPONENT_LIST}}', componentList);
+    const contentList = contentGuidelines
+        .map((g) => `- [${g.name}](${baseUrl}/llms/content/${g.slug}.md): ${g.description || g.name}`)
+        .join('\n');
+
+    return template.replace('{{COMPONENT_LIST}}', componentList).replace('{{CONTENT_LIST}}', contentList);
 };

--- a/packages/llms/src/skill.md
+++ b/packages/llms/src/skill.md
@@ -46,7 +46,7 @@ Fetch the component index to see what Plasma documents:
 Fetch specific component docs (props, sub-components, usage examples):
 
 ```
-{{BASE_URL}}/llms/ComponentName.md
+{{BASE_URL}}/llms/components/ComponentName.md
 ```
 
 Fetch full docs for all Plasma-wrapped components (props, sub-components, usage examples):
@@ -61,6 +61,19 @@ If a component isn't listed in the Plasma index, fetch Mantine's documentation:
 
 ```
 https://mantine.dev/llms.txt
+```
+
+## Content Guidelines
+
+Plasma provides content guidelines for writing UX copy in Coveo products. Always follow these when writing user-facing text (labels, errors, tooltips, descriptions, etc.).
+
+Fetch a specific content guideline:
+
+```
+{{BASE_URL}}/llms/content/Voice.md
+{{BASE_URL}}/llms/content/WritingMechanics.md
+{{BASE_URL}}/llms/content/ProductVocabulary.md
+{{BASE_URL}}/llms/content/TargetAudience.md
 ```
 
 ## Import invariant

--- a/packages/mcp-server/lib/build.ts
+++ b/packages/mcp-server/lib/build.ts
@@ -6,12 +6,32 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
-import type {ComponentData, LlmsData} from '../src/tools/types.ts';
+import type {ComponentData, ContentGuidelineData, LlmsData} from '../src/tools/types.ts';
 
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const llmsDistDir = path.resolve(currentDir, '../../llms/dist');
 const distDir = path.resolve(currentDir, '../dist');
 const dataFile = path.join(distDir, 'data.json');
+
+interface IndexEntry {
+    slug: string;
+    name: string;
+    description: string;
+}
+
+interface BundledDoc extends IndexEntry {
+    content: string;
+}
+
+/** Reads an index.json and loads the corresponding .md files from the same directory. */
+const readDocs = (dir: string): BundledDoc[] => {
+    const indexPath = path.join(dir, 'index.json');
+    const entries: IndexEntry[] = fs.existsSync(indexPath) ? JSON.parse(fs.readFileSync(indexPath, 'utf-8')) : [];
+    return entries.map((entry) => {
+        const content = fs.readFileSync(path.join(dir, `${entry.slug}.md`), 'utf-8');
+        return {...entry, content};
+    });
+};
 
 const main = () => {
     if (!fs.existsSync(llmsDistDir)) {
@@ -19,30 +39,22 @@ const main = () => {
         process.exit(1);
     }
 
-    const llmsDir = path.join(llmsDistDir, 'llms');
-    const descriptionsFile = path.join(llmsDistDir, 'descriptions.json');
-    const descriptions: Record<string, string> = fs.existsSync(descriptionsFile)
-        ? JSON.parse(fs.readFileSync(descriptionsFile, 'utf-8'))
-        : {};
-    const components: ComponentData[] = [];
-
-    for (const file of fs.readdirSync(llmsDir).filter((f) => f.endsWith('.md'))) {
-        const name = file.replace('.md', '');
-        const content = fs.readFileSync(path.join(llmsDir, file), 'utf-8');
-        const description = descriptions[name] ?? '';
-        components.push({name, description, content});
-    }
+    const components: ComponentData[] = readDocs(path.join(llmsDistDir, 'llms', 'components'));
+    const contentGuidelines: ContentGuidelineData[] = readDocs(path.join(llmsDistDir, 'llms', 'content'));
 
     const data: LlmsData = {
         index: fs.readFileSync(path.join(llmsDistDir, 'llms.txt'), 'utf-8'),
         full: fs.readFileSync(path.join(llmsDistDir, 'llms-full.txt'), 'utf-8'),
         skill: fs.readFileSync(path.join(llmsDistDir, 'plasma-skill.md'), 'utf-8'),
         components,
+        contentGuidelines,
     };
 
     fs.mkdirSync(distDir, {recursive: true});
     fs.writeFileSync(dataFile, JSON.stringify(data, null, 2), 'utf-8');
-    console.error(`✅ Bundled data for ${components.length} components → dist/data.json`);
+    console.error(
+        `✅ Bundled data for ${components.length} components and ${contentGuidelines.length} content guidelines → dist/data.json`,
+    );
 };
 
 main();

--- a/packages/mcp-server/src/__tests__/server.spec.ts
+++ b/packages/mcp-server/src/__tests__/server.spec.ts
@@ -1,7 +1,7 @@
 import type {McpServer} from 'tmcp';
 import {beforeEach, describe, expect, it} from 'vitest';
 import {createServer} from '../createServer.js';
-import {BUTTON, makeData} from '../tools/__tests__/fixtures.js';
+import {BUTTON, VOICE_GUIDELINE, makeData} from '../tools/__tests__/fixtures.js';
 
 // Minimal JSON-RPC helpers
 const req = (id: number, method: string, params: Record<string, unknown> = {}) => ({
@@ -45,7 +45,7 @@ describe('plasma-mcp-server integration', () => {
     });
 
     describe('tools/list', () => {
-        it('registers all four tools', async () => {
+        it('registers all six tools', async () => {
             const response = await server.receive(req(1, 'tools/list'));
             const tools = (response as {result: {tools: Array<{name: string}>}}).result.tools;
             const names = tools.map((t) => t.name);
@@ -53,7 +53,9 @@ describe('plasma-mcp-server integration', () => {
             expect(names).toContain('get_component_doc');
             expect(names).toContain('get_component_props');
             expect(names).toContain('search_docs');
-            expect(tools).toHaveLength(4);
+            expect(names).toContain('list_content_guidelines');
+            expect(names).toContain('get_content_guideline');
+            expect(tools).toHaveLength(6);
         });
 
         it('includes inputSchema for tools that require arguments', async () => {
@@ -161,37 +163,17 @@ describe('plasma-mcp-server integration', () => {
             const response = await server.receive(
                 req(1, 'tools/call', {name: 'search_docs', arguments: {query: 'button'}}),
             );
-            expect(firstText(response)).toMatchInlineSnapshot(`
-              "# Search Results for "button"
-
-              Found 1 component(s):
-
-              ## Button
-
-              A clickable button component
-
-              # Button
-
-              Use the Button to trigger actions.
-
-              ## Props
-
-              | Prop | Type | Default |
-              |------|------|---------|
-              | variant | string | 'filled' |
-              | disabled | boolean | false |
-
-              ## Usage
-
-              Import from \`@coveord/plasma-mantine\`."
-            `);
+            const text = firstText(response);
+            expect(text).toContain('# Search Results for "button"');
+            expect(text).toContain('## Button');
+            expect(text).toContain('A clickable button component');
         });
 
         it('returns a no-results message when nothing matches', async () => {
             const response = await server.receive(
                 req(1, 'tools/call', {name: 'search_docs', arguments: {query: 'xyznonexistent'}}),
             );
-            expect(firstText(response)).toMatchInlineSnapshot(`"No components found matching "xyznonexistent"."`);
+            expect(firstText(response)).toMatchInlineSnapshot(`"No results found matching "xyznonexistent"."`);
         });
 
         it('returns a schema validation error when query argument is missing', async () => {
@@ -209,28 +191,78 @@ describe('plasma-mcp-server integration', () => {
             expect(buttonIdx).toBeLessThan(modalIdx === -1 ? Infinity : modalIdx);
         });
 
+        it('searches across both components and content guidelines', async () => {
+            // "capitalization" only appears in the WritingMechanics guideline
+            const response = await server.receive(
+                req(1, 'tools/call', {name: 'search_docs', arguments: {query: 'capitalization'}}),
+            );
+            const text = firstText(response);
+            expect(text).toContain('Content Guidelines — Writing Mechanics');
+            expect(text).toContain('(Content Guideline)');
+        });
+
         it('searches across both BUTTON and MODAL fixture components', async () => {
             // "overlay" only appears in MODAL
             const response = await server.receive(
                 req(1, 'tools/call', {name: 'search_docs', arguments: {query: 'overlay'}}),
             );
-            expect(firstText(response)).toMatchInlineSnapshot(`
-              "# Search Results for "overlay"
+            const text = firstText(response);
+            expect(text).toContain('## Modal');
+            expect(text).toContain('A dialog overlay component');
+        });
+    });
 
-              Found 1 component(s):
+    describe('list_content_guidelines tool', () => {
+        it('returns a markdown list of all content guidelines', async () => {
+            const response = await server.receive(
+                req(1, 'tools/call', {name: 'list_content_guidelines', arguments: {}}),
+            );
+            const text = firstText(response);
+            expect(text).toContain('# Plasma Content Guidelines');
+            expect(text).toContain('**Content Guidelines — Voice**');
+            expect(text).toContain('**Content Guidelines — Writing Mechanics**');
+        });
+    });
 
-              ## Modal
+    describe('get_content_guideline tool', () => {
+        it('returns full guideline content for a known guideline by slug', async () => {
+            const response = await server.receive(
+                req(1, 'tools/call', {name: 'get_content_guideline', arguments: {guideline: 'Voice'}}),
+            );
+            expect(isError(response)).toBe(false);
+            expect(firstText(response)).toBe(VOICE_GUIDELINE.content);
+        });
 
-              A dialog overlay component
+        it('is case-insensitive', async () => {
+            const response = await server.receive(
+                req(1, 'tools/call', {name: 'get_content_guideline', arguments: {guideline: 'voice'}}),
+            );
+            expect(firstText(response)).toBe(VOICE_GUIDELINE.content);
+        });
 
-              # Modal
+        it('allows lookup by full name', async () => {
+            const response = await server.receive(
+                req(1, 'tools/call', {
+                    name: 'get_content_guideline',
+                    arguments: {guideline: 'Content Guidelines — Voice'},
+                }),
+            );
+            expect(firstText(response)).toBe(VOICE_GUIDELINE.content);
+        });
 
-              Use the Modal to display overlay dialogs.
+        it('returns an error result for an unknown guideline', async () => {
+            const response = await server.receive(
+                req(1, 'tools/call', {name: 'get_content_guideline', arguments: {guideline: 'Nonexistent'}}),
+            );
+            expect(isError(response)).toBe(true);
+            expect(firstText(response)).toMatchInlineSnapshot(
+                `"Content guideline "Nonexistent" not found. Use list_content_guidelines to see available guidelines."`,
+            );
+        });
 
-              ## Usage
-
-              Import from \`@coveord/plasma-mantine\`."
-            `);
+        it('returns a schema validation error when guideline argument is missing', async () => {
+            const response = await server.receive(req(1, 'tools/call', {name: 'get_content_guideline', arguments: {}}));
+            expect(isError(response)).toBe(true);
         });
     });
 });

--- a/packages/mcp-server/src/createServer.ts
+++ b/packages/mcp-server/src/createServer.ts
@@ -8,10 +8,21 @@ import {listComponents} from './tools/listComponents.js';
 import {getComponentDoc} from './tools/getComponentDoc.js';
 import {getComponentProps} from './tools/getComponentProps.js';
 import {searchDocs} from './tools/searchDocs.js';
+import {listContentGuidelines} from './tools/listContentGuidelines.js';
+import {buildGuidelineMap, getContentGuideline} from './tools/getContentGuideline.js';
 import type {LlmsData} from './tools/types.js';
 
 const componentSchema = v.object({
     component: v.pipe(v.string(), v.description('The component name (e.g., "Button", "Modal", "Alert")')),
+});
+
+const guidelineSchema = v.object({
+    guideline: v.pipe(
+        v.string(),
+        v.description(
+            'The content guideline name or slug (e.g., "Voice", "WritingMechanics", "ProductVocabulary", "TargetAudience")',
+        ),
+    ),
 });
 
 const querySchema = v.object({
@@ -23,6 +34,7 @@ const querySchema = v.object({
 
 export const createServer = (data: LlmsData): McpServer => {
     const componentMap = buildComponentMap(data);
+    const guidelineMap = buildGuidelineMap(data.contentGuidelines);
 
     const adapter = new ValibotJsonSchemaAdapter();
     const server = new McpServer(
@@ -81,6 +93,30 @@ export const createServer = (data: LlmsData): McpServer => {
             schema: querySchema,
         },
         async ({query}) => tool.text(searchDocs(data, query)),
+    );
+
+    server.tool(
+        {
+            name: 'list_content_guidelines',
+            description:
+                'List all available Plasma content guidelines (voice, writing mechanics, vocabulary, audience)',
+        },
+        async () => tool.text(listContentGuidelines(data)),
+    );
+
+    server.tool(
+        {
+            name: 'get_content_guideline',
+            description: 'Get full documentation for a specific Plasma content guideline',
+            schema: guidelineSchema,
+        },
+        async ({guideline}) => {
+            const result = getContentGuideline(guidelineMap, guideline);
+            if (result.isError) {
+                return {content: [{type: 'text' as const, text: result.text}], isError: true};
+            }
+            return tool.text(result.text);
+        },
     );
 
     return server;

--- a/packages/mcp-server/src/tools/__tests__/fixtures.ts
+++ b/packages/mcp-server/src/tools/__tests__/fixtures.ts
@@ -1,4 +1,4 @@
-import type {ComponentData, LlmsData} from '../types.js';
+import type {ComponentData, ContentGuidelineData, LlmsData} from '../types.js';
 
 export const BUTTON: ComponentData = {
     name: 'Button',
@@ -18,9 +18,27 @@ export const ALERT: ComponentData = {
     content: `# Alert\n\nUse the Alert to display feedback messages.\n\n## Props\n\n| Prop | Type |\n|------|------|\n| color | string |\n\n## Usage\n\nImport from \`@coveord/plasma-mantine\`.`,
 };
 
-export const makeData = (components: ComponentData[] = [BUTTON, MODAL, ALERT]): LlmsData => ({
+export const VOICE_GUIDELINE: ContentGuidelineData = {
+    name: 'Content Guidelines — Voice',
+    slug: 'Voice',
+    description: "Coveo's required voice qualities (clear, human, helpful) and how to apply tone by context.",
+    content: `## Voice of Coveo\n\nVoice is fixed. Every piece of UX copy must be **clear**, **human**, and **helpful**.\n\n### Clear\n\nUse plain words. Be as short as possible.\n\n### Human\n\nSpeak directly to the user.\n\n### Helpful\n\nExplain what the user can do, not what the system did.`,
+};
+
+export const WRITING_MECHANICS_GUIDELINE: ContentGuidelineData = {
+    name: 'Content Guidelines — Writing Mechanics',
+    slug: 'WritingMechanics',
+    description: 'Required rules for grammar, punctuation, capitalization, structure, and length in Coveo UX copy.',
+    content: `## Capitalization\n\nUse sentence case for all UI text.\n\n## Punctuation\n\nAdd a period after full sentences. Do not add a period after fragments.`,
+};
+
+export const makeData = (
+    components: ComponentData[] = [BUTTON, MODAL, ALERT],
+    contentGuidelines: ContentGuidelineData[] = [VOICE_GUIDELINE, WRITING_MECHANICS_GUIDELINE],
+): LlmsData => ({
     index: 'index content',
     full: 'full content',
     skill: 'skill content',
     components,
+    contentGuidelines,
 });

--- a/packages/mcp-server/src/tools/__tests__/getContentGuideline.spec.ts
+++ b/packages/mcp-server/src/tools/__tests__/getContentGuideline.spec.ts
@@ -1,0 +1,62 @@
+import {describe, expect, it} from 'vitest';
+import {buildGuidelineMap, getContentGuideline} from '../getContentGuideline.js';
+import {VOICE_GUIDELINE, WRITING_MECHANICS_GUIDELINE} from './fixtures.js';
+
+describe('getContentGuideline', () => {
+    const guidelineMap = buildGuidelineMap([VOICE_GUIDELINE, WRITING_MECHANICS_GUIDELINE]);
+
+    it('returns the content for a known guideline by slug', () => {
+        const result = getContentGuideline(guidelineMap, 'Voice');
+        expect(result.isError).toBeFalsy();
+        expect(result.text).toMatchInlineSnapshot(`
+          "## Voice of Coveo
+
+          Voice is fixed. Every piece of UX copy must be **clear**, **human**, and **helpful**.
+
+          ### Clear
+
+          Use plain words. Be as short as possible.
+
+          ### Human
+
+          Speak directly to the user.
+
+          ### Helpful
+
+          Explain what the user can do, not what the system did."
+        `);
+    });
+
+    it('returns the content for a known guideline by full name', () => {
+        const result = getContentGuideline(guidelineMap, 'Content Guidelines — Voice');
+        expect(result.isError).toBeFalsy();
+        expect(result.text).toBe(VOICE_GUIDELINE.content);
+    });
+
+    it('is case-insensitive', () => {
+        expect(getContentGuideline(guidelineMap, 'voice').text).toBe(VOICE_GUIDELINE.content);
+        expect(getContentGuideline(guidelineMap, 'VOICE').text).toBe(VOICE_GUIDELINE.content);
+    });
+
+    it('finds WritingMechanics by slug', () => {
+        const result = getContentGuideline(guidelineMap, 'WritingMechanics');
+        expect(result.isError).toBeFalsy();
+        expect(result.text).toMatchInlineSnapshot(`
+          "## Capitalization
+
+          Use sentence case for all UI text.
+
+          ## Punctuation
+
+          Add a period after full sentences. Do not add a period after fragments."
+        `);
+    });
+
+    it('returns an error for an unknown guideline', () => {
+        const result = getContentGuideline(guidelineMap, 'Nonexistent');
+        expect(result.isError).toBe(true);
+        expect(result.text).toMatchInlineSnapshot(
+            `"Content guideline "Nonexistent" not found. Use list_content_guidelines to see available guidelines."`,
+        );
+    });
+});

--- a/packages/mcp-server/src/tools/__tests__/listContentGuidelines.spec.ts
+++ b/packages/mcp-server/src/tools/__tests__/listContentGuidelines.spec.ts
@@ -1,0 +1,26 @@
+import {describe, expect, it} from 'vitest';
+import {listContentGuidelines} from '../listContentGuidelines.js';
+import {makeData} from './fixtures.js';
+
+describe('listContentGuidelines', () => {
+    it('returns a formatted markdown list', () => {
+        expect(listContentGuidelines(makeData())).toMatchInlineSnapshot(`
+          "# Plasma Content Guidelines
+
+          Guidelines for writing UX copy in Coveo products.
+
+          - **Content Guidelines — Voice**: Coveo's required voice qualities (clear, human, helpful) and how to apply tone by context.
+          - **Content Guidelines — Writing Mechanics**: Required rules for grammar, punctuation, capitalization, structure, and length in Coveo UX copy."
+        `);
+    });
+
+    it('handles empty content guidelines', () => {
+        expect(listContentGuidelines(makeData(undefined, []))).toMatchInlineSnapshot(`
+          "# Plasma Content Guidelines
+
+          Guidelines for writing UX copy in Coveo products.
+
+          "
+        `);
+    });
+});

--- a/packages/mcp-server/src/tools/__tests__/searchDocs.spec.ts
+++ b/packages/mcp-server/src/tools/__tests__/searchDocs.spec.ts
@@ -5,7 +5,7 @@ import {makeData} from './fixtures.js';
 describe('searchDocs', () => {
     it('returns a no-results message when nothing matches', () => {
         expect(searchDocs(makeData(), 'xyznonexistent')).toMatchInlineSnapshot(
-            `"No components found matching "xyznonexistent"."`,
+            `"No results found matching "xyznonexistent"."`,
         );
     });
 
@@ -13,7 +13,7 @@ describe('searchDocs', () => {
         expect(searchDocs(makeData(), 'button')).toMatchInlineSnapshot(`
           "# Search Results for "button"
 
-          Found 1 component(s):
+          Found 1 result(s):
 
           ## Button
 
@@ -36,7 +36,7 @@ describe('searchDocs', () => {
         `);
     });
 
-    it('ranks components by relevance (more matches first)', () => {
+    it('ranks results by relevance (more matches first)', () => {
         const result = searchDocs(makeData(), 'button');
         const buttonIndex = result.indexOf('## Button');
         const modalIndex = result.indexOf('## Modal');
@@ -46,7 +46,6 @@ describe('searchDocs', () => {
     it('is case-insensitive in matching', () => {
         const lower = searchDocs(makeData(), 'button');
         const upper = searchDocs(makeData(), 'BUTTON');
-        // Both queries should find the same component regardless of casing
         expect(lower).toContain('## Button');
         expect(upper).toContain('## Button');
     });
@@ -57,7 +56,7 @@ describe('searchDocs', () => {
             description: 'common description text',
             content: `# Comp${i}\n\ncommon description text`,
         }));
-        const result = searchDocs(makeData(manyComponents), 'common');
+        const result = searchDocs(makeData(manyComponents, []), 'common');
         const matches = result.match(/^## Comp\d/gm);
         expect(matches).not.toBeNull();
         expect(matches!.length).toBeLessThanOrEqual(5);
@@ -67,7 +66,7 @@ describe('searchDocs', () => {
         expect(searchDocs(makeData(), 'button clickable')).toMatchInlineSnapshot(`
           "# Search Results for "button clickable"
 
-          Found 1 component(s):
+          Found 1 result(s):
 
           ## Button
 
@@ -94,7 +93,7 @@ describe('searchDocs', () => {
         expect(searchDocs(makeData(), 'dialog')).toMatchInlineSnapshot(`
           "# Search Results for "dialog"
 
-          Found 1 component(s):
+          Found 1 result(s):
 
           ## Modal
 
@@ -107,6 +106,54 @@ describe('searchDocs', () => {
           ## Usage
 
           Import from \`@coveord/plasma-mantine\`."
+        `);
+    });
+
+    it('searches content guidelines as well', () => {
+        expect(searchDocs(makeData(), 'capitalization')).toMatchInlineSnapshot(`
+          "# Search Results for "capitalization"
+
+          Found 1 result(s):
+
+          ## Content Guidelines — Writing Mechanics (Content Guideline)
+
+          Required rules for grammar, punctuation, capitalization, structure, and length in Coveo UX copy.
+
+          ## Capitalization
+
+          Use sentence case for all UI text.
+
+          ## Punctuation
+
+          Add a period after full sentences. Do not add a period after fragments."
+        `);
+    });
+
+    it('labels content guideline results with (Content Guideline)', () => {
+        expect(searchDocs(makeData(), 'voice')).toMatchInlineSnapshot(`
+          "# Search Results for "voice"
+
+          Found 1 result(s):
+
+          ## Content Guidelines — Voice (Content Guideline)
+
+          Coveo's required voice qualities (clear, human, helpful) and how to apply tone by context.
+
+          ## Voice of Coveo
+
+          Voice is fixed. Every piece of UX copy must be **clear**, **human**, and **helpful**.
+
+          ### Clear
+
+          Use plain words. Be as short as possible.
+
+          ### Human
+
+          Speak directly to the user.
+
+          ### Helpful
+
+          Explain what the user can do, not what the system did."
         `);
     });
 });

--- a/packages/mcp-server/src/tools/getContentGuideline.ts
+++ b/packages/mcp-server/src/tools/getContentGuideline.ts
@@ -1,0 +1,21 @@
+import type {ContentGuidelineData, ToolResult} from './types.js';
+
+export const buildGuidelineMap = (guidelines: ContentGuidelineData[]): Map<string, ContentGuidelineData> => {
+    const map = new Map<string, ContentGuidelineData>();
+    for (const g of guidelines) {
+        map.set(g.name.toLowerCase(), g);
+        map.set(g.slug.toLowerCase(), g);
+    }
+    return map;
+};
+
+export const getContentGuideline = (guidelineMap: Map<string, ContentGuidelineData>, guideline: string): ToolResult => {
+    const match = guidelineMap.get(guideline.toLowerCase());
+    if (!match) {
+        return {
+            text: `Content guideline "${guideline}" not found. Use list_content_guidelines to see available guidelines.`,
+            isError: true,
+        };
+    }
+    return {text: match.content};
+};

--- a/packages/mcp-server/src/tools/listContentGuidelines.ts
+++ b/packages/mcp-server/src/tools/listContentGuidelines.ts
@@ -1,0 +1,8 @@
+import type {LlmsData} from './types.js';
+
+export const listContentGuidelines = (data: LlmsData): string => {
+    const list = data.contentGuidelines
+        .map((g) => `- **${g.name}**: ${g.description || 'Plasma content guideline'}`)
+        .join('\n');
+    return `# Plasma Content Guidelines\n\nGuidelines for writing UX copy in Coveo products.\n\n${list}`;
+};

--- a/packages/mcp-server/src/tools/searchDocs.ts
+++ b/packages/mcp-server/src/tools/searchDocs.ts
@@ -1,29 +1,42 @@
 import type {LlmsData} from './types.js';
 
-export const searchDocs = (data: LlmsData, query: string): string => {
-    const lowerQuery = query.toLowerCase();
-    const terms = lowerQuery.split(/\s+/).filter(Boolean);
+type ResultKind = 'component' | 'content_guideline';
 
-    const results = data.components
-        .map((c) => {
-            const haystack = (c.name + ' ' + c.description + ' ' + c.content).toLowerCase();
-            const score = terms.reduce((acc: number, term: string) => {
-                const count = (haystack.match(new RegExp(term, 'g')) ?? []).length;
-                return acc + count;
-            }, 0);
-            return {component: c, score};
-        })
-        .filter(({score}) => score > 0)
+interface SearchResult {
+    name: string;
+    description: string;
+    content: string;
+    score: number;
+    kind: ResultKind;
+}
+
+export const searchDocs = (data: LlmsData, query: string): string => {
+    const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+
+    const escapeRegex = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    const score = (text: string): number =>
+        terms.reduce((acc, term) => acc + (text.match(new RegExp(escapeRegex(term), 'g')) ?? []).length, 0);
+
+    const results: SearchResult[] = [
+        ...data.components.map((c) => ({...c, kind: 'component' as const})),
+        ...(data.contentGuidelines ?? []).map((g) => ({...g, kind: 'content_guideline' as const})),
+    ]
+        .map((item) => ({...item, score: score(`${item.name} ${item.description} ${item.content}`.toLowerCase())}))
+        .filter((item) => item.score > 0)
         .sort((a, b) => b.score - a.score)
         .slice(0, 5);
 
     if (results.length === 0) {
-        return `No components found matching "${query}".`;
+        return `No results found matching "${query}".`;
     }
 
     const output = results
-        .map(({component}) => `## ${component.name}\n\n${component.description}\n\n${component.content}`)
+        .map(({name, description, content, kind}) => {
+            const kindLabel = kind === 'content_guideline' ? ' (Content Guideline)' : '';
+            return `## ${name}${kindLabel}\n\n${description}\n\n${content}`;
+        })
         .join('\n\n---\n\n');
 
-    return `# Search Results for "${query}"\n\nFound ${results.length} component(s):\n\n${output}`;
+    return `# Search Results for "${query}"\n\nFound ${results.length} result(s):\n\n${output}`;
 };

--- a/packages/mcp-server/src/tools/types.ts
+++ b/packages/mcp-server/src/tools/types.ts
@@ -4,11 +4,19 @@ export interface ComponentData {
     content: string;
 }
 
+export interface ContentGuidelineData {
+    name: string;
+    slug: string;
+    description: string;
+    content: string;
+}
+
 export interface LlmsData {
     index: string;
     full: string;
     skill: string;
     components: ComponentData[];
+    contentGuidelines: ContentGuidelineData[];
 }
 
 export interface ToolError {


### PR DESCRIPTION
## Summary

Includes the `packages/llms/src/content/*.md` files (Voice, Writing Mechanics, Product Vocabulary, Target Audience) in the generated `llms.txt` and `llms-full.txt` outputs, and exposes them through two new MCP server tools.

## Changes

### `@coveord/plasma-llms`
- Build script reads `src/content/*.md` alongside `src/components/*.md` using shared `readDocs`/`writeDocs` helpers
- Outputs to `dist/llms/components/` and `dist/llms/content/` with an `index.json` manifest in each (same `[{ slug, name, description }]` shape)
- `llms.txt` gets a new **Content Guidelines** section with links to each guideline
- `llms-full.txt` gets a new **Content Guidelines** section with inlined content
- `plasma-skill.md` references content guidelines so agents know to follow them

### `@coveord/plasma-mcp-server`
- New `list_content_guidelines` tool — lists all available content guidelines with descriptions
- New `get_content_guideline` tool — retrieves a specific guideline by name or slug (case-insensitive)
- `search_docs` now searches across both components and content guidelines, labeling guideline results with `(Content Guideline)`
- Build script uses shared `readDocs` helper for both components and content

### Dist structure

```
dist/
├── llms/
│   ├── components/
│   │   ├── index.json
│   │   ├── Button.md
│   │   └── ...
│   └── content/
│       ├── index.json
│       ├── Voice.md
│       └── ...
├── llms.txt
├── llms-full.txt
└── plasma-skill.md
```

## Testing
- All 52 unit tests pass (including new tests with inline snapshots)
- Both packages build successfully