### PR TITLE
chore(chromatic): improve turbosnap detection by avoiding barrel files

### DIFF
--- a/packages/mantine/src/core.ts
+++ b/packages/mantine/src/core.ts
@@ -1,1 +1,8 @@
-export {createVarsResolver, getSize, type MantineSize, type MantineTheme} from '@mantine/core';
+export {
+    createTheme,
+    createVarsResolver,
+    useMantineColorScheme,
+    getSize,
+    type MantineSize,
+    type MantineTheme,
+} from '@mantine/core';

--- a/packages/storybook/.storybook/ThemedDocsContainer.tsx
+++ b/packages/storybook/.storybook/ThemedDocsContainer.tsx
@@ -1,4 +1,5 @@
-import {Plasmantine, useMantineColorScheme} from '@coveord/plasma-mantine';
+import {useMantineColorScheme} from '@coveord/plasma-mantine/core';
+import {Plasmantine} from '@coveord/plasma-mantine/plasmantine';
 import {DocsContainer, type DocsContainerProps} from '@storybook/addon-docs/blocks';
 import {type PropsWithChildren, useEffect, useMemo, useState} from 'react';
 import {GLOBALS_UPDATED} from 'storybook/internal/core-events';

--- a/packages/storybook/.storybook/decorators/withTheme.tsx
+++ b/packages/storybook/.storybook/decorators/withTheme.tsx
@@ -1,4 +1,6 @@
-import {createTheme, Notifications, Plasmantine} from '@coveord/plasma-mantine';
+import {createTheme} from '@coveord/plasma-mantine/core';
+import {Plasmantine} from '@coveord/plasma-mantine/plasmantine';
+import {Notifications} from '@coveord/plasma-mantine/notifications';
 import type {Decorator} from '@storybook/react-vite';
 
 type Theme = 'teal' | 'blue' | 'violet';


### PR DESCRIPTION
### Proposed Changes

I was looking at Chromatic TurboSnap feature and even if it's enabled it didn't seem to work. It seems to always detect a change in the preview.tsx file. I tried to help by switching the plasma imports to use scoped entry points

https://coveo.chromatic.com/docs/turbosnap/troubleshooting/#changedstorybookfiles

<img width="316" height="289" alt="image" src="https://github.com/user-attachments/assets/b57b38c7-5a9b-4d70-8603-0749fed9a0ef" />


### Potential Breaking Changes

None