### PR TITLE
fix table missing a border top when no header is present

### DIFF
--- a/.changeset/thin-lions-fly.md
+++ b/.changeset/thin-lions-fly.md
@@ -1,0 +1,5 @@
+---
+'@coveord/plasma-mantine': major
+---
+
+Remove the `borderTop` prop on `Table.Header`. The table border is now handled automatically.

--- a/packages/mantine/src/components/Table/Table.module.css
+++ b/packages/mantine/src/components/Table/Table.module.css
@@ -17,6 +17,15 @@
     transition-duration: var(--coveo-transition-duration);
     z-index: 1;
 
+    &::before {
+        content: '';
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: -1px;
+        border-top: 1px solid var(--mantine-color-default-border);
+    }
+
     &::after {
         content: '';
         position: absolute;
@@ -75,10 +84,6 @@
     padding: var(--mantine-spacing-sm) var(--mantine-spacing-xl);
     position: relative;
     min-height: 70px;
-
-    &:where([data-with-border-top]) {
-        border-top: 1px solid var(--mantine-color-default-border);
-    }
 }
 
 .headerGridInner {

--- a/packages/mantine/src/components/Table/table-header/TableHeader.tsx
+++ b/packages/mantine/src/components/Table/table-header/TableHeader.tsx
@@ -22,12 +22,6 @@ export interface TableHeaderProps
      * default true
      */
     showActions?: boolean;
-    /**
-     * Whether to show a border on top of the header
-     *
-     * default true
-     */
-    borderTop?: boolean;
 }
 
 export type TableHeaderFactory = Factory<{
@@ -41,7 +35,6 @@ const defaultProps = {
     unselectAllLabel: 'Unselect all',
     selectedCountLabel: (count) => `${count} selected`,
     showActions: true,
-    borderTop: true,
 } satisfies Partial<TableHeaderProps>;
 
 export const TableHeader = factory<TableHeaderFactory>((props) => {
@@ -50,7 +43,6 @@ export const TableHeader = factory<TableHeaderFactory>((props) => {
         showActions,
         unselectAllLabel,
         selectedCountLabel,
-        borderTop,
         children,
         classNames,
         className,
@@ -67,12 +59,7 @@ export const TableHeader = factory<TableHeaderFactory>((props) => {
     const gridStyles = getStyles('headerGrid', stylesApiProps);
 
     return (
-        <Box
-            ref={ref}
-            {...getStyles('headerRoot', {className, style, ...stylesApiProps})}
-            {...others}
-            mod={{'with-border-top': borderTop}}
-        >
+        <Box ref={ref} {...getStyles('headerRoot', {className, style, ...stylesApiProps})} {...others}>
             <Grid
                 justify="flex-start"
                 align="center"


### PR DESCRIPTION
### Proposed Changes

Before

<img width="1234" height="324" alt="image" src="https://github.com/user-attachments/assets/beb7d3ea-9ce4-4b0d-a65c-0db2dc5b6b58" />


After

<img width="1245" height="734" alt="image" src="https://github.com/user-attachments/assets/4fdf3753-2671-4ace-bcab-51518da57f42" />


Also I fixed a bug with the local setup where a .module.css files would not trigger an update to the storybook website.

### Potential Breaking Changes

<!-- List all changes that might be breaking to plasma's users if any. -->

### Acceptance Criteria

- [ ] The proposed changes are covered by unit tests
- [ ] The potential breaking changes are clearly identified
- [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)
