### PR TITLE
fix(tabs): set keepMountedMode to display-none by default

### DIFF
--- a/.changeset/lucky-donkeys-run.md
+++ b/.changeset/lucky-donkeys-run.md
@@ -1,0 +1,7 @@
+---
+'@coveord/plasma-mantine': patch
+---
+
+Set `keepMountedMode: 'display-none'` as the default for Tabs in the Plasma theme.
+
+Mantine's default (`'activity'`) hides inactive panels using React's `Activity` component. This caused unexpected rendering issues in components that don't handle being suspended/hidden well, such as code editors: switching away from and back to a tab could leave the editor in a broken or stale state. Defaulting to `'display-none'` avoids this by hiding inactive panels with `display: none` styles instead, while still keeping their content mounted.

--- a/packages/mantine/src/theme/Theme.tsx
+++ b/packages/mantine/src/theme/Theme.tsx
@@ -535,6 +535,9 @@ export const plasmaTheme: MantineThemeOverride = createTheme({
             }),
         }),
         Tabs: Tabs.extend({
+            defaultProps: {
+                keepMountedMode: 'display-none',
+            },
             classNames: TabsClasses,
         }),
         Text: Text.extend({


### PR DESCRIPTION
## Summary

Sets `keepMountedMode: 'display-none'` as the default for Tabs in the Plasma theme.

## Problem

Mantine's default (`'activity'`) hides inactive tab panels using React's `Activity` component. This causes unexpected rendering issues in components that don't handle being suspended/hidden well, such as code editors — switching away from and back to a tab can leave the editor in a broken or stale state.

## Solution

Defaulting to `'display-none'` avoids this by hiding inactive panels with `display: none` styles instead, while still keeping their content mounted.