### PR TITLE
feat(changesets): enforce a changeset template and clean up changelogs

### DIFF
--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -3,6 +3,10 @@
 // - Suppresses dependency update lines entirely.
 // - Simple entries: "- Summary [#PR](url)"
 // - Rich entries (containing headings): "#### Title [#PR](url)\n\nBody..."
+//   Per the changeset template (see CONTRIBUTING.md), body headings start at a
+//   single "#". They are re-leveled relative to the h4 title so they always nest
+//   correctly (shallowest body heading becomes h5). The re-leveling is relative,
+//   so it stays correct even if an author starts deeper than "#".
 
 const {readFileSync} = require('fs');
 const {join} = require('path');
@@ -18,11 +22,23 @@ function isPrerelease() {
 }
 
 /**
- * Bump all markdown headings in text by 2 levels (e.g. # → ###, ## → ####)
- * so they nest correctly under the #### entry title.
+ * Re-level the markdown headings in a rich entry's body so they always nest
+ * under the entry title, regardless of the heading depth the author used.
+ *
+ * The entry title is rendered as an h4 (one level below the `### Major/Minor/Patch
+ * Changes` section), so the body's shallowest heading is remapped to h5 and every
+ * deeper heading is shifted by the same amount to preserve relative nesting.
+ * Levels are clamped at h6 (the deepest markdown supports).
+ *
+ * @param {string} text - The entry body (may contain headings).
+ * @param {number} [baseLevel=5] - Target level for the shallowest heading.
  */
-function bumpHeadings(text) {
-    return text.replace(/^(#{1,6}) /gm, (_match, hashes) => `${'#'.repeat(Math.min(hashes.length + 2, 6))} `);
+function normalizeHeadings(text, baseLevel = 5) {
+    const levels = [...text.matchAll(/^(#{1,6}) /gm)].map(([, hashes]) => hashes.length);
+    if (levels.length === 0) return text;
+
+    const shift = baseLevel - Math.min(...levels);
+    return text.replace(/^(#{1,6}) /gm, (_match, hashes) => `${'#'.repeat(Math.min(hashes.length + shift, 6))} `);
 }
 
 /**
@@ -60,7 +76,7 @@ async function getReleaseLine(changeset, _type, options) {
     // Rich entry — contains headings in the body, render as a subsection.
     if (hasHeadings(rest)) {
         const title = firstLine + (prLink ? ` ${prLink}` : '');
-        const body = bumpHeadings(rest.trim());
+        const body = normalizeHeadings(rest.trim());
         return `\n\n#### ${title}\n\n${body}`;
     }
 

--- a/.changeset/common-baboons-say.md
+++ b/.changeset/common-baboons-say.md
@@ -4,14 +4,16 @@
 
 Upgrade to Mantine 9
 
-## Breaking changes
+All `@mantine/*` peer dependencies now require `^9.0.0`, and `react`/`react-dom` now require `>= 19.2.0 < 20.0.0`.
 
-### Peer dependencies
+# Migration
 
-- All `@mantine/*` peer dependencies now require `^9.0.0`
-- `react` and `react-dom` peer dependencies now require `>= 19.2.0 < 20.0.0`
+## Peer dependencies
 
-### ChildForm
+- Upgrade all `@mantine/*` packages to `^9.0.0`.
+- Upgrade `react` and `react-dom` to `>= 19.2.0 < 20.0.0`.
+
+## ChildForm
 
 The `in` prop is now `expanded` (inherited from Mantine's `Collapse` component):
 
@@ -20,12 +22,6 @@ The `in` prop is now `expanded` (inherited from Mantine's `Collapse` component):
 +<ChildForm expanded={true} title="Settings">
 ```
 
-## Internal changes
-
-- All `factory()` and `polymorphicFactory()` callbacks updated to receive `ref` via props instead of as a second argument (Mantine 9 dropped `forwardRef` internally).
-- `Collapse` usage in `Table` row layout updated from `in` to `expanded`.
-- `enhanceWithCollectionProps` type extraction updated to work with `@mantine/form` v9 exports.
-
-## Mantine 9 upstream changes
+## Upstream changes
 
 For the full list of Mantine 9 breaking changes (renamed props, hook changes, etc.), see the [Mantine 8.x → 9.x migration guide](https://mantine.dev/guides/8x-to-9x/).

--- a/.changeset/cool-wombats-repeat.md
+++ b/.changeset/cool-wombats-repeat.md
@@ -2,4 +2,6 @@
 '@coveord/plasma-mantine': patch
 ---
 
-**Table.Pagination** is now hidden when there is only one page or fewer. **Table.PerPage** is now hidden when the total number of rows is smaller than or equal to the smallest page size option.
+Hide `Table.Pagination` and `Table.PerPage` when there is nothing to paginate
+
+`Table.Pagination` is now hidden when there is only one page or fewer. `Table.PerPage` is now hidden when the total number of rows is smaller than or equal to the smallest page size option.

--- a/.changeset/cyan-worms-fry.md
+++ b/.changeset/cyan-worms-fry.md
@@ -2,4 +2,4 @@
 '@coveord/plasma-mantine': patch
 ---
 
-fix table header inner grid min height
+Fix table header inner grid min height

--- a/.changeset/lucky-donkeys-run.md
+++ b/.changeset/lucky-donkeys-run.md
@@ -2,6 +2,6 @@
 '@coveord/plasma-mantine': patch
 ---
 
-Set `keepMountedMode: 'display-none'` as the default for Tabs in the Plasma theme.
+Set `keepMountedMode: 'display-none'` as the default for Tabs in the Plasma theme
 
 Mantine's default (`'activity'`) hides inactive panels using React's `Activity` component. This caused unexpected rendering issues in components that don't handle being suspended/hidden well, such as code editors: switching away from and back to a tab could leave the editor in a broken or stale state. Defaulting to `'display-none'` avoids this by hiding inactive panels with `display: none` styles instead, while still keeping their content mounted.

--- a/.changeset/remove-info-status-token.md
+++ b/.changeset/remove-info-status-token.md
@@ -2,11 +2,11 @@
 '@coveord/plasma-mantine': major
 ---
 
-**BREAKING:** Remove the `info` variant from `StatusToken` and make `variant` required
+Remove the `info` variant from `StatusToken` and make `variant` required
 
 The `variant` prop no longer defaults to `info` — it is now required.
 
-### Migration
+# Migration
 
 1. **If you used the `info` variant**, replace it with the variant that best matches your intent (e.g., `waiting` or `disabled`).
 2. **If you relied on the default variant**, explicitly pass `variant="success"` to every `<StatusToken />` that did not already specify one.

--- a/.changeset/table-cell-component.md
+++ b/.changeset/table-cell-component.md
@@ -2,4 +2,6 @@
 '@coveord/plasma-mantine': minor
 ---
 
-**Table.Cell**: New component for controlling text overflow in table cells. Supports single-line ellipsis (default), multi-line clamping with `lineClamp`, word wrapping with `wrap`, and an expandable "Show more"/"Show less" toggle with `expandable`.
+Add `Table.Cell` for controlling text overflow in table cells
+
+Supports single-line ellipsis (default), multi-line clamping with `lineClamp`, word wrapping with `wrap`, and an expandable "Show more"/"Show less" toggle with `expandable`.

--- a/.changeset/thin-lions-fly.md
+++ b/.changeset/thin-lions-fly.md
@@ -2,4 +2,15 @@
 '@coveord/plasma-mantine': major
 ---
 
-Remove the `borderTop` prop on `Table.Header`. The table border is now handled automatically.
+Remove the `borderTop` prop on `Table.Header`
+
+The table border is now handled automatically, so the prop is no longer needed.
+
+# Migration
+
+Remove `borderTop` from any `Table.Header` usage:
+
+```diff
+- <Table.Header borderTop>
++ <Table.Header>
+```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,4 +10,5 @@
 
 - [ ] The proposed changes are covered by unit tests
 - [ ] The potential breaking changes are clearly identified
+- [ ] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
 - [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)

--- a/.github/skills/changesets-author/SKILL.md
+++ b/.github/skills/changesets-author/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: changesets-author
+description: Author Changesets files for the Plasma monorepo that conform to the project's changelog template. Use when adding or editing a `.changeset/*.md` file, when a PR changes a releasable package (`packages/*`), or when the user says "add a changeset", "write a changeset for…", "create a changeset", "document this change for release", or "fix the failing changeset validation". Covers frontmatter, bump selection, title rules, per-bump body requirements, and the `pnpm changeset:new` / `pnpm changeset:validate` commands.
+---
+
+Write `.changeset/*.md` files that pass `pnpm changeset:validate` (the same check CI runs) and render cleanly in each package's `CHANGELOG.md`. The full contributor-facing rules live in [CONTRIBUTING.md](../../../CONTRIBUTING.md#writing-changesets); see [references/template.md](references/template.md) for annotated per-bump examples.
+
+## Workflow
+
+### 1. Decide the bump
+
+- `major` — a breaking change (removed/renamed/behavior-changed public API).
+- `minor` — a new, backward-compatible capability.
+- `patch` — a bug fix or internal change with no API surface change.
+
+Identify every affected releasable package under `packages/*` (a change can bump several).
+
+### 2. Scaffold the file
+
+```bash
+pnpm changeset:new <bump>      # e.g. pnpm changeset:new major
+pnpm changeset:new -p @coveord/plasma-tokens -b minor
+```
+
+This writes `.changeset/<name>.md` pre-filled with the correct skeleton. Fill in the `TODO`s and remove the guiding comments. Add extra packages to the frontmatter if the change spans more than one.
+
+### 3. Apply the format rules
+
+**Frontmatter** — one line per package: `'<package>': <major|minor|patch>`.
+
+**Title (first line after the frontmatter)**
+
+- Single line, sentence case, **no trailing period**, ≤ 100 characters.
+- Consumer's perspective; describe _what_ changed, not the implementation.
+- Backtick component / prop / API names.
+- No `**BREAKING:**` prefix (the `major` bump already signals it) and no leading list marker.
+
+**Body**
+
+- Blank line after the title, then markdown.
+- Headings **start at a single `#`** — they are re-leveled automatically by `.changeset/changelog.cjs`.
+- Use ` ```diff ` blocks for before/after code.
+
+**Audience — write for external users**
+
+Changesets become the public `CHANGELOG.md`. Document only what a consumer of the package needs to know to understand or adopt the release.
+
+- Focus on the observable, external-facing impact: new/changed/removed API, behavior changes, and migration steps.
+- Omit internal changes that are transparent to users (refactors, internal type plumbing, private helper updates, test-only changes, build tweaks). Do **not** add an "Internal changes" section.
+- If an internal change is only worth noting because it _might_ surface for users, describe the user-facing symptom, not the implementation detail.
+
+**Per-bump body requirements**
+
+- `major`: body **required** and must contain a `# Migration` section with concrete steps.
+- `minor`: body **required** (what it does / how to use it).
+- `patch`: title only is acceptable.
+
+### 4. Validate
+
+```bash
+pnpm changeset:validate
+```
+
+Fix every reported issue before committing. Commit the `.changeset/*.md` file with your change.

--- a/.github/skills/changesets-author/SKILL.md
+++ b/.github/skills/changesets-author/SKILL.md
@@ -22,7 +22,7 @@ pnpm changeset:new <bump>      # e.g. pnpm changeset:new major
 pnpm changeset:new -p @coveord/plasma-tokens -b minor
 ```
 
-This writes `.changeset/<name>.md` pre-filled with the correct skeleton. Fill in the `TODO`s and remove the guiding comments. Add extra packages to the frontmatter if the change spans more than one.
+This writes `.changeset/<name>.md` pre-filled with the correct skeleton. Replace the `TODO` placeholders. Add extra packages to the frontmatter if the change spans more than one.
 
 ### 3. Apply the format rules
 

--- a/.github/skills/changesets-author/references/template.md
+++ b/.github/skills/changesets-author/references/template.md
@@ -1,0 +1,81 @@
+# Changeset templates (annotated)
+
+Annotated examples for each bump type. Rules enforced by `scripts/validateChangesets.js`.
+
+## Table of contents
+
+- [major](#major)
+- [minor](#minor)
+- [patch](#patch)
+- [Multiple packages](#multiple-packages)
+
+## major
+
+Breaking change — body required, must include a `# Migration` section.
+
+````markdown
+---
+'@coveord/plasma-mantine': major
+---
+
+Remove the `info` variant from `StatusToken` and make `variant` required
+
+The `variant` prop no longer defaults to `info` — it is now required.
+
+# Migration
+
+Pass a `variant` explicitly to every `StatusToken`:
+
+```diff
+- <StatusToken />
++ <StatusToken variant="success" />
+```
+````
+
+Notes:
+
+- No `**BREAKING:**` prefix — the `major` bump already groups this under "Major Changes".
+- `# Migration` uses a single `#`; it renders as `##### Migration` under the entry title.
+
+## minor
+
+New capability — body required.
+
+```markdown
+---
+'@coveord/plasma-mantine': minor
+---
+
+Add `Table.Cell` for controlling text overflow in table cells
+
+Supports single-line ellipsis (default), multi-line clamping with `lineClamp`, word wrapping with
+`wrap`, and an expandable "Show more" toggle with `expandable`.
+```
+
+## patch
+
+Bug fix — title only is acceptable.
+
+```markdown
+---
+'@coveord/plasma-mantine': patch
+---
+
+Fix table header inner grid min height
+```
+
+## Multiple packages
+
+One line per package in the frontmatter; the strongest bump determines the body requirement.
+
+```markdown
+---
+'@coveord/plasma-llms': minor
+'@coveord/plasma-mcp-server': minor
+---
+
+Add content guidelines to LLM documentation outputs and MCP server
+
+- Include content guideline files in `llms.txt` and `llms-full.txt`
+- Add `list_content_guidelines` and `get_content_guideline` MCP tools
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
                   OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS: true
             - name: Check format
               run: pnpm fmt:check
+            - name: Validate changesets
+              run: pnpm changeset:validate
     test:
         name: Test
         runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ This repo ships agent **skills** in `.github/skills/`. Use them when the task ma
 - **`plasma-component-docs`** — write/update the LLM component specs in `packages/llms/src/components/`. Use when adding a component, updating a spec after an API change, or auditing docs.
 - **`converting-md-to-storybook-mdx`** — **Step 1**: convert a component `.md` spec from `packages/llms/src/components/` into a Storybook `.mdx` page in `packages/storybook`.
 - **`storybook-component-guidelines`** — **Step 2**: rewrite the converted `.mdx` into clear, human-readable Storybook documentation. Runs after Step 1.
+- **`changesets-author`** — write or edit a changeset that follows the enforced template. Use when adding or editing a `.changeset/*.md` file. Scaffold with `pnpm changeset:new` and check with `pnpm changeset:validate`.
 
 There is also a public agent skill served at `https://plasma.coveo.com/plasma-skill.md` (source: `packages/llms/src/skill.md`) and an MCP server (`@coveord/plasma-mcp-server`) for looking up Plasma component APIs. When consulting component APIs, read the specs in `packages/llms/src/components/` or use the Plasma/Mantine MCP servers described in the [README](README.md).
 
@@ -100,7 +101,7 @@ When you change a component's public API:
 1. **Branch** off `master`. Name it `<jira-ticket-number>-short-one-liner-description` (e.g., `ADUI-1234-change-something`). If you don't know the Jira ticket number, ask the user for it; if there is no related Jira ticket, use just the one-liner description (e.g., `change-something`).
 2. Make changes following the conventions above.
 3. `pnpm test`, `pnpm lint`, and `pnpm fmt:check` must all pass.
-4. **Add a changeset** if you touched a releasable package: `pnpm changeset`, then commit the generated file in `.changeset/`. Releases are driven by Changesets, **not** inferred from commit messages.
+4. **Add a changeset** if you touched a releasable package. Load the `changesets-author` skill — it walks through bump selection, the changelog template, and the `pnpm changeset:new` / `pnpm changeset:validate` workflow. Commit the generated `.changeset/*.md` file with your change. CI runs `pnpm changeset:validate` and fails on non-conforming changesets. Releases are driven by Changesets, **not** inferred from commit messages.
 5. **Commit** with a concise, descriptive message. Mention the affected subject/package when it helps: `Add new Button variant`, `Fix primary color token value`.
 6. **Push** the branch and open a draft PR (`gh pr create --draft`); do not push to `master`. Fill in the PR template (`.github/pull_request_template.md`): proposed changes, potential breaking changes, and the acceptance-criteria checklist.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,7 @@ Run all tests from the root with `pnpm test`. From within `packages/{name}` you 
 - **`plasma-component-docs`** — write or update the per-component LLM specs in `packages/llms/src/components/`.
 - **`converting-md-to-storybook-mdx`** — Step 1: convert a component `.md` spec into a Storybook `.mdx` page.
 - **`storybook-component-guidelines`** — Step 2: rewrite the converted `.mdx` into human-readable documentation.
+- **`changesets-author`** — write or edit a changeset that follows the template documented below.
 
 A public agent skill is also served at [`https://plasma.coveo.com/plasma-skill.md`](https://plasma.coveo.com/plasma-skill.md), and the `@coveord/plasma-mcp-server` package exposes Plasma docs to AI agents (see the [README](README.md) for setup).
 
@@ -96,15 +97,114 @@ Write a concise commit message that describes what changed and, when helpful, me
 
 A pre-commit hook (Husky + lint-staged) automatically formats staged files with oxfmt and fixes SCSS with Stylelint. Don't skip hooks (`--no-verify`) unless asked.
 
-## Changesets
+## Writing changesets
 
-Releases are managed with [Changesets](https://github.com/changesets/changesets), **not** inferred from commit messages. If your PR changes a releasable package, run:
+Add a changeset whenever your PR changes a releasable package. The changeset becomes the entry in that
+package's `CHANGELOG.md` (and the Storybook changelog page), so it is written for **consumers** of the
+package.
+
+### Creating one
+
+Scaffold a pre-filled changeset from the template:
 
 ```bash
-pnpm changeset
+pnpm changeset:new           # patch (default)
+pnpm changeset:new minor
+pnpm changeset:new major
+pnpm changeset:new -p @coveord/plasma-tokens -b minor
 ```
 
-Answer the prompts to pick the affected packages and bump type, then commit the generated file in `.changeset/`. CI previews the version bumps your changesets would produce.
+Then edit the generated `.changeset/*.md` file: fill in the `TODO` placeholders, remove the guiding
+comments, and adjust the package(s) and bump in the frontmatter. You can also use the interactive
+`pnpm changeset` if you prefer.
+
+Validate your changeset before pushing (CI runs the same check):
+
+```bash
+pnpm changeset:validate
+```
+
+### Format
+
+A changeset is frontmatter (package + bump) followed by a title and an optional body:
+
+```markdown
+---
+'@coveord/plasma-mantine': minor
+---
+
+Title on the first line
+
+Optional body explaining the change.
+```
+
+**Title (first line)**
+
+- One line, sentence case, **no trailing period**.
+- Written from the consumer's perspective; describe _what changed_, not the implementation.
+- Wrap component / prop / API names in backticks.
+- Do **not** add a `**BREAKING:**` prefix — a `major` bump already marks breaking changes.
+- Keep it to **100 characters or fewer**. Put anything longer in the body.
+
+**Body**
+
+- Separate it from the title with a blank line.
+- Body headings start at a single `#` (they are re-leveled automatically in the changelog).
+- Use ` ```diff ` fenced blocks for before/after code.
+
+**Requirements by bump type**
+
+| Bump    | Body required? | Notes                                              |
+| ------- | -------------- | -------------------------------------------------- |
+| `major` | Yes            | Must include a `# Migration` section (with steps). |
+| `minor` | Yes            | Describe what the feature does and how to use it.  |
+| `patch` | No             | A title alone is fine; add a body for context.     |
+
+### Examples
+
+`major` — breaking change with migration steps:
+
+````markdown
+---
+'@coveord/plasma-mantine': major
+---
+
+Remove the `info` variant from `StatusToken` and make `variant` required
+
+The `variant` prop no longer defaults to `info` — it is now required.
+
+# Migration
+
+Pass a `variant` explicitly to every `StatusToken`:
+
+```diff
+- <StatusToken />
++ <StatusToken variant="success" />
+```
+````
+
+`minor` — new capability:
+
+```markdown
+---
+'@coveord/plasma-mantine': minor
+---
+
+Add `Table.Cell` for controlling text overflow in table cells
+
+Supports single-line ellipsis (default), multi-line clamping with `lineClamp`, word wrapping with
+`wrap`, and an expandable "Show more" toggle with `expandable`.
+```
+
+`patch` — small fix, title only:
+
+```markdown
+---
+'@coveord/plasma-mantine': patch
+---
+
+Fix table header inner grid min height
+```
 
 ## Opening a pull request
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for how to set up the repo, run the demo,
 
 > `@coveord/plasma-style` and `@coveord/plasma-react` are in maintenance mode and live on the [`v53` branch](https://github.com/coveo/plasma/tree/v53).
 
+See [CONTRIBUTING.md](CONTRIBUTING.md#writing-changesets) for the changeset format (title rules, per-bump requirements, and examples). You can scaffold a pre-filled changeset with `pnpm changeset:new` and check it with `pnpm changeset:validate`.
+
 ## License
 
 All packages under this repository are distributed under [Apache 2.0 license](LICENSE).

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "scripts": {
         "build": "turbo run build",
         "changeset": "changeset",
+        "changeset:new": "node scripts/newChangeset.js",
+        "changeset:validate": "node scripts/validateChangesets.js",
         "changeset:version": "changeset version",
         "clean": "pnpm --recursive --parallel run clean",
         "fmt": "oxfmt",

--- a/packages/figma/CHANGELOG.md
+++ b/packages/figma/CHANGELOG.md
@@ -1,16 +1,12 @@
 # @coveord/plasma-figma-code-connect
 
-## 60.0.2-next.2
-
-## 60.0.2-next.1
-
 ## 60.0.0
 
 ### Major Changes
 
 #### Plasma 60 — internal modernization overhaul [#4412](https://github.com/coveo/plasma/pull/4412)
 
-##### ⚡ Pure ESM Packages
+##### Pure ESM Packages
 
 All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are no longer included.
 
@@ -23,23 +19,23 @@ All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are n
 
 For more details on ESM migration, see [Pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
 
-##### 🛠️ TypeScript 7 (Preview)
+##### TypeScript 7 (Preview)
 
 The monorepo now uses the [TypeScript 7 preview](https://devblogs.microsoft.com/typescript/announcing-typescript-7-beta/) via `tsgo`. This is an internal toolchain change — **no action required from consumers**. Published type definitions remain compatible with TypeScript 5.x and above.
 
-##### 🔒 Strict TypeScript
+##### Strict TypeScript
 
 Strict type checking (`"strict": true`) is now enabled across the entire monorepo. This improves the reliability of exported types. In rare cases, you may notice more precise types (e.g., narrower unions, stricter nullability) in your IDE — but no intentional runtime behavior changes were introduced.
 
-##### 📦 Changesets for Versioning
+##### Changesets for Versioning
 
 Plasma now uses [Changesets](https://github.com/changesets/changesets) for versioning and changelog generation. This replaces the previous custom publishing workflow and makes version history clearer for contributors and consumers.
 
-##### 🗑️ Removed Legacy Website
+##### Removed Legacy Website
 
 The `packages/website` documentation site has been removed. All component documentation now lives in [Storybook](https://plasma.coveo.com).
 
-##### 🔧 Internal: Developer Tooling Overhaul
+##### Internal: Developer Tooling Overhaul
 
 These changes affect **contributors** to the Plasma monorepo, not consumers of the published packages.
 

--- a/packages/llms/CHANGELOG.md
+++ b/packages/llms/CHANGELOG.md
@@ -1,14 +1,12 @@
 # @coveord/plasma-llms
 
-## 60.1.0-next.0
-
 ## 60.0.0
 
 ### Major Changes
 
 #### Plasma 60 — internal modernization overhaul [#4412](https://github.com/coveo/plasma/pull/4412)
 
-##### ⚡ Pure ESM Packages
+##### Pure ESM Packages
 
 All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are no longer included.
 
@@ -21,23 +19,23 @@ All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are n
 
 For more details on ESM migration, see [Pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
 
-##### 🛠️ TypeScript 7 (Preview)
+##### TypeScript 7 (Preview)
 
 The monorepo now uses the [TypeScript 7 preview](https://devblogs.microsoft.com/typescript/announcing-typescript-7-beta/) via `tsgo`. This is an internal toolchain change — **no action required from consumers**. Published type definitions remain compatible with TypeScript 5.x and above.
 
-##### 🔒 Strict TypeScript
+##### Strict TypeScript
 
 Strict type checking (`"strict": true`) is now enabled across the entire monorepo. This improves the reliability of exported types. In rare cases, you may notice more precise types (e.g., narrower unions, stricter nullability) in your IDE — but no intentional runtime behavior changes were introduced.
 
-##### 📦 Changesets for Versioning
+##### Changesets for Versioning
 
 Plasma now uses [Changesets](https://github.com/changesets/changesets) for versioning and changelog generation. This replaces the previous custom publishing workflow and makes version history clearer for contributors and consumers.
 
-##### 🗑️ Removed Legacy Website
+##### Removed Legacy Website
 
 The `packages/website` documentation site has been removed. All component documentation now lives in [Storybook](https://plasma.coveo.com).
 
-##### 🔧 Internal: Developer Tooling Overhaul
+##### Internal: Developer Tooling Overhaul
 
 These changes affect **contributors** to the Plasma monorepo, not consumers of the published packages.
 

--- a/packages/mantine/CHANGELOG.md
+++ b/packages/mantine/CHANGELOG.md
@@ -1,41 +1,5 @@
 # @coveord/plasma-mantine
 
-## 61.0.0-next.2
-
-## 61.0.0-next.1
-
-## 61.0.0-next.0
-
-### Major Changes
-
-- [#4509](https://github.com/coveo/plasma/pull/4509) [`f98660d`](https://github.com/coveo/plasma/commit/f98660da12f7fb514465ec073c94a73e95f16893) Thanks [@GermainBergeron](https://github.com/GermainBergeron)! - Upgrade to Mantine 9
-
-  ## Breaking changes
-
-  ### Peer dependencies
-
-  - All `@mantine/*` peer dependencies now require `^9.0.0`
-  - `react` and `react-dom` peer dependencies now require `>= 19.2.0 < 20.0.0`
-
-  ### ChildForm
-
-  The `in` prop is now `expanded` (inherited from Mantine's `Collapse` component):
-
-  ```diff
-  -<ChildForm in={true} title="Settings">
-  +<ChildForm expanded={true} title="Settings">
-  ```
-
-  ## Internal changes
-
-  - All `factory()` and `polymorphicFactory()` callbacks updated to receive `ref` via props instead of as a second argument (Mantine 9 dropped `forwardRef` internally).
-  - `Collapse` usage in `Table` row layout updated from `in` to `expanded`.
-  - `enhanceWithCollectionProps` type extraction updated to work with `@mantine/form` v9 exports.
-
-  ## Mantine 9 upstream changes
-
-  For the full list of Mantine 9 breaking changes (renamed props, hook changes, etc.), see the [Mantine 8.x → 9.x migration guide](https://mantine.dev/guides/8x-to-9x/).
-
 ## 60.0.1
 
 ### Patch Changes
@@ -76,7 +40,7 @@ The URL parameter for items per page also changed from `pageSize` to `perPage`.
 
 #### Plasma 60 — internal modernization overhaul [#4412](https://github.com/coveo/plasma/pull/4412)
 
-##### ⚡ Pure ESM Packages
+##### Pure ESM Packages
 
 All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are no longer included.
 
@@ -89,23 +53,23 @@ All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are n
 
 For more details on ESM migration, see [Pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
 
-##### 🛠️ TypeScript 7 (Preview)
+##### TypeScript 7 (Preview)
 
 The monorepo now uses the [TypeScript 7 preview](https://devblogs.microsoft.com/typescript/announcing-typescript-7-beta/) via `tsgo`. This is an internal toolchain change — **no action required from consumers**. Published type definitions remain compatible with TypeScript 5.x and above.
 
-##### 🔒 Strict TypeScript
+##### Strict TypeScript
 
 Strict type checking (`"strict": true`) is now enabled across the entire monorepo. This improves the reliability of exported types. In rare cases, you may notice more precise types (e.g., narrower unions, stricter nullability) in your IDE — but no intentional runtime behavior changes were introduced.
 
-##### 📦 Changesets for Versioning
+##### Changesets for Versioning
 
 Plasma now uses [Changesets](https://github.com/changesets/changesets) for versioning and changelog generation. This replaces the previous custom publishing workflow and makes version history clearer for contributors and consumers.
 
-##### 🗑️ Removed Legacy Website
+##### Removed Legacy Website
 
 The `packages/website` documentation site has been removed. All component documentation now lives in [Storybook](https://plasma.coveo.com).
 
-##### 🔧 Internal: Developer Tooling Overhaul
+##### Internal: Developer Tooling Overhaul
 
 These changes affect **contributors** to the Plasma monorepo, not consumers of the published packages.
 

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,14 +1,12 @@
 # @coveord/plasma-mcp-server
 
-## 60.1.0-next.0
-
 ## 60.0.0
 
 ### Major Changes
 
 #### Plasma 60 — internal modernization overhaul [#4412](https://github.com/coveo/plasma/pull/4412)
 
-##### ⚡ Pure ESM Packages
+##### Pure ESM Packages
 
 All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are no longer included.
 
@@ -21,23 +19,23 @@ All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are n
 
 For more details on ESM migration, see [Pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
 
-##### 🛠️ TypeScript 7 (Preview)
+##### TypeScript 7 (Preview)
 
 The monorepo now uses the [TypeScript 7 preview](https://devblogs.microsoft.com/typescript/announcing-typescript-7-beta/) via `tsgo`. This is an internal toolchain change — **no action required from consumers**. Published type definitions remain compatible with TypeScript 5.x and above.
 
-##### 🔒 Strict TypeScript
+##### Strict TypeScript
 
 Strict type checking (`"strict": true`) is now enabled across the entire monorepo. This improves the reliability of exported types. In rare cases, you may notice more precise types (e.g., narrower unions, stricter nullability) in your IDE — but no intentional runtime behavior changes were introduced.
 
-##### 📦 Changesets for Versioning
+##### Changesets for Versioning
 
 Plasma now uses [Changesets](https://github.com/changesets/changesets) for versioning and changelog generation. This replaces the previous custom publishing workflow and makes version history clearer for contributors and consumers.
 
-##### 🗑️ Removed Legacy Website
+##### Removed Legacy Website
 
 The `packages/website` documentation site has been removed. All component documentation now lives in [Storybook](https://plasma.coveo.com).
 
-##### 🔧 Internal: Developer Tooling Overhaul
+##### Internal: Developer Tooling Overhaul
 
 These changes affect **contributors** to the Plasma monorepo, not consumers of the published packages.
 

--- a/packages/react-icons/CHANGELOG.md
+++ b/packages/react-icons/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Plasma 60 — internal modernization overhaul [#4412](https://github.com/coveo/plasma/pull/4412)
 
-##### ⚡ Pure ESM Packages
+##### Pure ESM Packages
 
 All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are no longer included.
 
@@ -19,23 +19,23 @@ All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are n
 
 For more details on ESM migration, see [Pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
 
-##### 🛠️ TypeScript 7 (Preview)
+##### TypeScript 7 (Preview)
 
 The monorepo now uses the [TypeScript 7 preview](https://devblogs.microsoft.com/typescript/announcing-typescript-7-beta/) via `tsgo`. This is an internal toolchain change — **no action required from consumers**. Published type definitions remain compatible with TypeScript 5.x and above.
 
-##### 🔒 Strict TypeScript
+##### Strict TypeScript
 
 Strict type checking (`"strict": true`) is now enabled across the entire monorepo. This improves the reliability of exported types. In rare cases, you may notice more precise types (e.g., narrower unions, stricter nullability) in your IDE — but no intentional runtime behavior changes were introduced.
 
-##### 📦 Changesets for Versioning
+##### Changesets for Versioning
 
 Plasma now uses [Changesets](https://github.com/changesets/changesets) for versioning and changelog generation. This replaces the previous custom publishing workflow and makes version history clearer for contributors and consumers.
 
-##### 🗑️ Removed Legacy Website
+##### Removed Legacy Website
 
 The `packages/website` documentation site has been removed. All component documentation now lives in [Storybook](https://plasma.coveo.com).
 
-##### 🔧 Internal: Developer Tooling Overhaul
+##### Internal: Developer Tooling Overhaul
 
 These changes affect **contributors** to the Plasma monorepo, not consumers of the published packages.
 

--- a/packages/storybook/.storybook/ThemedDocsContainer.tsx
+++ b/packages/storybook/.storybook/ThemedDocsContainer.tsx
@@ -1,4 +1,4 @@
-import {createTheme, useMantineColorScheme} from '@coveord/plasma-mantine/core';
+import {useMantineColorScheme} from '@coveord/plasma-mantine/core';
 import {Plasmantine} from '@coveord/plasma-mantine/plasmantine';
 import {DocsContainer, type DocsContainerProps} from '@storybook/addon-docs/blocks';
 import {type PropsWithChildren, useEffect, useMemo, useState} from 'react';

--- a/packages/storybook/.storybook/ThemedDocsContainer.tsx
+++ b/packages/storybook/.storybook/ThemedDocsContainer.tsx
@@ -1,10 +1,11 @@
-import {useMantineColorScheme} from '@coveord/plasma-mantine/core';
+import {createTheme, useMantineColorScheme} from '@coveord/plasma-mantine/core';
 import {Plasmantine} from '@coveord/plasma-mantine/plasmantine';
 import {DocsContainer, type DocsContainerProps} from '@storybook/addon-docs/blocks';
 import {type PropsWithChildren, useEffect, useMemo, useState} from 'react';
 import {GLOBALS_UPDATED} from 'storybook/internal/core-events';
 import {create} from 'storybook/theming';
 import {backgroundOptions, prefersDark} from './backgroundOptions.js';
+import {DocsTheme} from './styles/docsTheme.js';
 
 export const ThemedDocsContainer = ({children, context, ...props}: PropsWithChildren<DocsContainerProps>) => {
     const [isDark, setIsDark] = useState(() => {
@@ -37,7 +38,7 @@ export const ThemedDocsContainer = ({children, context, ...props}: PropsWithChil
 
     return (
         <DocsContainer {...props} context={context} theme={docsTheme}>
-            <Plasmantine defaultColorScheme={isDark ? 'dark' : 'light'}>
+            <Plasmantine defaultColorScheme={isDark ? 'dark' : 'light'} theme={DocsTheme}>
                 <SchemeWatcher isDark={isDark} />
                 <div className="sb-unstyled">{children}</div>
             </Plasmantine>

--- a/packages/storybook/.storybook/plasmaMarkdownOverrides.tsx
+++ b/packages/storybook/.storybook/plasmaMarkdownOverrides.tsx
@@ -98,14 +98,14 @@ export const plasmaDocsComponents: Record<string, ComponentType<any>> = {
     h4: (props) => <HeadingWithAnchor order={4} mt="md" mb="sm" {...props} />,
     h5: (props) => <HeadingWithAnchor order={5} mt="md" mb="sm" {...props} />,
     h6: (props) => <HeadingWithAnchor order={6} mt="md" mb="sm" {...props} />,
-    em: (props) => <Text span fs="italic" {...props} />,
+    em: (props) => <Text span inherit fs="italic" {...props} />,
     a: (props) => <Anchor {...props} />,
     hr: () => <Divider />,
     code: ({className, children, ...props}) => {
         if (typeof className === 'string' && className.startsWith('lang-')) {
             return <Source language={className.replace('lang-', '') as any} code={children} />;
         }
-        return <Code c="grape" className={className} children={children} {...props} />;
+        return <Code c="grape" fz="inherit" className={className} children={children} {...props} />;
     },
     ul: (props) => <List my="xs" {...props} />,
     ol: (props) => <List type="ordered" my="xs" {...props} />,

--- a/packages/storybook/.storybook/styles/docsTheme.ts
+++ b/packages/storybook/.storybook/styles/docsTheme.ts
@@ -1,0 +1,12 @@
+import {createTheme} from '@coveord/plasma-mantine';
+
+export const DocsTheme = createTheme({
+    lineHeights: {
+        xxs: '1.5',
+        xs: '1.5',
+        sm: '1.5',
+        md: '1.5',
+        lg: '1.5',
+        xl: '1.5',
+    },
+});

--- a/packages/storybook/CHANGELOG.md
+++ b/packages/storybook/CHANGELOG.md
@@ -1,16 +1,12 @@
 # @coveord/plasma-storybook
 
-## 60.0.2-next.2
-
-## 60.0.2-next.1
-
 ## 60.0.0
 
 ### Major Changes
 
 #### Plasma 60 — internal modernization overhaul [#4412](https://github.com/coveo/plasma/pull/4412)
 
-##### ⚡ Pure ESM Packages
+##### Pure ESM Packages
 
 All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are no longer included.
 
@@ -23,23 +19,23 @@ All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are n
 
 For more details on ESM migration, see [Pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
 
-##### 🛠️ TypeScript 7 (Preview)
+##### TypeScript 7 (Preview)
 
 The monorepo now uses the [TypeScript 7 preview](https://devblogs.microsoft.com/typescript/announcing-typescript-7-beta/) via `tsgo`. This is an internal toolchain change — **no action required from consumers**. Published type definitions remain compatible with TypeScript 5.x and above.
 
-##### 🔒 Strict TypeScript
+##### Strict TypeScript
 
 Strict type checking (`"strict": true`) is now enabled across the entire monorepo. This improves the reliability of exported types. In rare cases, you may notice more precise types (e.g., narrower unions, stricter nullability) in your IDE — but no intentional runtime behavior changes were introduced.
 
-##### 📦 Changesets for Versioning
+##### Changesets for Versioning
 
 Plasma now uses [Changesets](https://github.com/changesets/changesets) for versioning and changelog generation. This replaces the previous custom publishing workflow and makes version history clearer for contributors and consumers.
 
-##### 🗑️ Removed Legacy Website
+##### Removed Legacy Website
 
 The `packages/website` documentation site has been removed. All component documentation now lives in [Storybook](https://plasma.coveo.com).
 
-##### 🔧 Internal: Developer Tooling Overhaul
+##### Internal: Developer Tooling Overhaul
 
 These changes affect **contributors** to the Plasma monorepo, not consumers of the published packages.
 

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Plasma 60 — internal modernization overhaul [#4412](https://github.com/coveo/plasma/pull/4412)
 
-##### ⚡ Pure ESM Packages
+##### Pure ESM Packages
 
 All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are no longer included.
 
@@ -19,23 +19,23 @@ All Plasma packages are now shipped as **ESM only**. CommonJS (CJS) builds are n
 
 For more details on ESM migration, see [Pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
 
-##### 🛠️ TypeScript 7 (Preview)
+##### TypeScript 7 (Preview)
 
 The monorepo now uses the [TypeScript 7 preview](https://devblogs.microsoft.com/typescript/announcing-typescript-7-beta/) via `tsgo`. This is an internal toolchain change — **no action required from consumers**. Published type definitions remain compatible with TypeScript 5.x and above.
 
-##### 🔒 Strict TypeScript
+##### Strict TypeScript
 
 Strict type checking (`"strict": true`) is now enabled across the entire monorepo. This improves the reliability of exported types. In rare cases, you may notice more precise types (e.g., narrower unions, stricter nullability) in your IDE — but no intentional runtime behavior changes were introduced.
 
-##### 📦 Changesets for Versioning
+##### Changesets for Versioning
 
 Plasma now uses [Changesets](https://github.com/changesets/changesets) for versioning and changelog generation. This replaces the previous custom publishing workflow and makes version history clearer for contributors and consumers.
 
-##### 🗑️ Removed Legacy Website
+##### Removed Legacy Website
 
 The `packages/website` documentation site has been removed. All component documentation now lives in [Storybook](https://plasma.coveo.com).
 
-##### 🔧 Internal: Developer Tooling Overhaul
+##### Internal: Developer Tooling Overhaul
 
 These changes affect **contributors** to the Plasma monorepo, not consumers of the published packages.
 

--- a/scripts/newChangeset.js
+++ b/scripts/newChangeset.js
@@ -36,41 +36,39 @@ const parseArgs = (argv) => {
 /**
  * Build the changeset body skeleton for a given bump type. The template mirrors
  * the rules enforced by scripts/validateChangesets.js:
- * - Title on the first line (plain, no trailing period).
+ * - Title on the first line after the frontmatter (plain, no trailing period).
  * - Body headings start at a single `#`.
  * - `major` requires a body and a `# Migration` section; `minor` requires a body.
+ *
+ * The skeleton is kept comment-free: the validator treats the first non-empty
+ * line after the frontmatter as the title, so the title placeholder must come
+ * first. Guidance is folded into the `TODO` placeholders instead.
  */
 const buildTemplate = (packageName, bump) => {
     const frontmatter = `---\n'${packageName}': ${bump}\n---\n`;
 
     if (bump === 'major') {
         return `${frontmatter}
-<!-- Title: concise, sentence case, no trailing period, describe the change for consumers. -->
-TODO: describe the breaking change
+TODO: describe the breaking change (sentence case, no trailing period, consumer's view)
 
-<!-- Explain what changed and why. -->
-TODO: details
+TODO: explain what changed and why
 
 # Migration
 
-<!-- Steps consumers must take. Use \`\`\`diff for before/after code. -->
-TODO: migration steps
+TODO: migration steps consumers must take (use \`\`\`diff blocks for before/after code)
 `;
     }
 
     if (bump === 'minor') {
         return `${frontmatter}
-<!-- Title: concise, sentence case, no trailing period. -->
-TODO: describe the new capability
+TODO: describe the new capability (sentence case, no trailing period)
 
-<!-- Explain what it does and how to use it. -->
-TODO: details
+TODO: explain what it does and how to use it
 `;
     }
 
     return `${frontmatter}
-<!-- Title: concise, sentence case, no trailing period. -->
-TODO: describe the fix
+TODO: describe the fix (sentence case, no trailing period)
 `;
 };
 
@@ -94,7 +92,7 @@ const main = () => {
     writeFileSync(filePath, buildTemplate(packageName, bump));
 
     console.log(`Created .changeset/${name}.md (${bump}, ${packageName}).`);
-    console.log('Replace the TODO placeholders and remove the comments, then run `pnpm changeset:validate`.');
+    console.log('Replace the TODO placeholders, then run `pnpm changeset:validate`.');
 };
 
 main();

--- a/scripts/newChangeset.js
+++ b/scripts/newChangeset.js
@@ -1,0 +1,100 @@
+import {existsSync, mkdirSync, writeFileSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const CHANGESET_DIR = join(ROOT, '.changeset');
+
+const VALID_BUMPS = new Set(['major', 'minor', 'patch']);
+const DEFAULT_BUMP = 'patch';
+const DEFAULT_PACKAGE = '@coveord/plasma-mantine';
+
+// Word lists to build a Changesets-style, human-readable file name.
+const ADJECTIVES = ['brave', 'calm', 'clever', 'eager', 'fuzzy', 'gentle', 'happy', 'lucky', 'proud', 'swift'];
+const NOUNS = ['badgers', 'comets', 'donkeys', 'foxes', 'lions', 'otters', 'pandas', 'ravens', 'tigers', 'wolves'];
+const VERBS = ['bake', 'dance', 'dream', 'jump', 'race', 'shine', 'sing', 'travel', 'wander', 'wink'];
+
+const pick = (list) => list[Math.floor(Math.random() * list.length)];
+const generateName = () => `${pick(ADJECTIVES)}-${pick(NOUNS)}-${pick(VERBS)}`;
+
+const parseArgs = (argv) => {
+    const args = {bump: DEFAULT_BUMP, package: DEFAULT_PACKAGE};
+    for (let i = 0; i < argv.length; i += 1) {
+        const arg = argv[i];
+        if (arg === '--bump' || arg === '-b') {
+            args.bump = argv[(i += 1)];
+        } else if (arg === '--package' || arg === '-p') {
+            args.package = argv[(i += 1)];
+        } else if (VALID_BUMPS.has(arg)) {
+            // Allow the bump as a bare positional argument (e.g. `changeset:new major`).
+            args.bump = arg;
+        }
+    }
+    return args;
+};
+
+/**
+ * Build the changeset body skeleton for a given bump type. The template mirrors
+ * the rules enforced by scripts/validateChangesets.js:
+ * - Title on the first line (plain, no trailing period).
+ * - Body headings start at a single `#`.
+ * - `major` requires a body and a `# Migration` section; `minor` requires a body.
+ */
+const buildTemplate = (packageName, bump) => {
+    const frontmatter = `---\n'${packageName}': ${bump}\n---\n`;
+
+    if (bump === 'major') {
+        return `${frontmatter}
+<!-- Title: concise, sentence case, no trailing period, describe the change for consumers. -->
+TODO: describe the breaking change
+
+<!-- Explain what changed and why. -->
+TODO: details
+
+# Migration
+
+<!-- Steps consumers must take. Use \`\`\`diff for before/after code. -->
+TODO: migration steps
+`;
+    }
+
+    if (bump === 'minor') {
+        return `${frontmatter}
+<!-- Title: concise, sentence case, no trailing period. -->
+TODO: describe the new capability
+
+<!-- Explain what it does and how to use it. -->
+TODO: details
+`;
+    }
+
+    return `${frontmatter}
+<!-- Title: concise, sentence case, no trailing period. -->
+TODO: describe the fix
+`;
+};
+
+const main = () => {
+    const {bump, package: packageName} = parseArgs(process.argv.slice(2));
+
+    if (!VALID_BUMPS.has(bump)) {
+        console.error(`Invalid bump "${bump}". Expected one of: major, minor, patch.`);
+        process.exitCode = 1;
+        return;
+    }
+
+    mkdirSync(CHANGESET_DIR, {recursive: true});
+
+    let name = generateName();
+    while (existsSync(join(CHANGESET_DIR, `${name}.md`))) {
+        name = generateName();
+    }
+
+    const filePath = join(CHANGESET_DIR, `${name}.md`);
+    writeFileSync(filePath, buildTemplate(packageName, bump));
+
+    console.log(`Created .changeset/${name}.md (${bump}, ${packageName}).`);
+    console.log('Replace the TODO placeholders and remove the comments, then run `pnpm changeset:validate`.');
+};
+
+main();

--- a/scripts/validateChangesets.js
+++ b/scripts/validateChangesets.js
@@ -83,12 +83,23 @@ const validateChangeset = (name, content, knownPackages) => {
         }
     }
 
+    // The title is the first non-empty, non-comment line after the frontmatter.
+    // Track its index (rather than using `indexOf` on the trimmed title) so the
+    // body-after-title slice stays correct even when the title line has
+    // surrounding whitespace or is preceded by guiding HTML comments.
     const bodyLines = body.split('\n');
-    const title = bodyLines.find((line) => line.trim() !== '')?.trim() ?? '';
-    const bodyAfterTitle = bodyLines
-        .slice(bodyLines.indexOf(title) + 1)
-        .join('\n')
-        .trim();
+    const titleIndex = bodyLines.findIndex((line) => {
+        const trimmed = line.trim();
+        return trimmed !== '' && !trimmed.startsWith('<!--');
+    });
+    const title = titleIndex === -1 ? '' : bodyLines[titleIndex].trim();
+    const bodyAfterTitle =
+        titleIndex === -1
+            ? ''
+            : bodyLines
+                  .slice(titleIndex + 1)
+                  .join('\n')
+                  .trim();
 
     // Title rules.
     if (!title) {

--- a/scripts/validateChangesets.js
+++ b/scripts/validateChangesets.js
@@ -1,0 +1,177 @@
+import {readdirSync, readFileSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const CHANGESET_DIR = join(ROOT, '.changeset');
+const PACKAGES_DIR = join(ROOT, 'packages');
+
+// Files in .changeset/ that are not changesets and must be ignored.
+const NON_CHANGESET_FILES = new Set(['README.md', 'config.json', 'pre.json', 'changelog.cjs']);
+
+const VALID_BUMPS = new Set(['major', 'minor', 'patch']);
+const MAX_TITLE_LENGTH = 100;
+
+/**
+ * Discover the workspace package names so frontmatter can be validated against
+ * packages that actually exist.
+ */
+const getWorkspacePackageNames = () => {
+    const names = new Set();
+    for (const entry of readdirSync(PACKAGES_DIR, {withFileTypes: true})) {
+        if (!entry.isDirectory()) continue;
+        try {
+            const pkg = JSON.parse(readFileSync(join(PACKAGES_DIR, entry.name, 'package.json'), 'utf8'));
+            if (pkg.name) names.add(pkg.name);
+        } catch {
+            // No package.json in this directory — skip.
+        }
+    }
+    return names;
+};
+
+/**
+ * Split a changeset into its frontmatter block and body.
+ * Returns null when the frontmatter delimiters are missing or malformed.
+ */
+const parseChangeset = (content) => {
+    const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+    if (!match) return null;
+
+    const releases = [];
+    for (const rawLine of match[1].split('\n')) {
+        const line = rawLine.trim();
+        if (!line) continue;
+        const entry = line.match(/^["']?(@?[\w./-]+)["']?\s*:\s*(\w+)$/);
+        if (!entry) {
+            releases.push({raw: line, invalid: true});
+            continue;
+        }
+        releases.push({name: entry[1], bump: entry[2]});
+    }
+
+    return {releases, body: match[2].trim()};
+};
+
+/** Return the heading levels (number of leading `#`) found in the body. */
+const headingLevels = (body) => [...body.matchAll(/^(#{1,6}) /gm)].map(([, hashes]) => hashes.length);
+
+const validateChangeset = (name, content, knownPackages) => {
+    const errors = [];
+    const parsed = parseChangeset(content);
+
+    if (!parsed) {
+        return ['Missing or malformed frontmatter (expected a `---` delimited block).'];
+    }
+
+    const {releases, body} = parsed;
+
+    // Frontmatter: valid package names and bump types.
+    if (releases.length === 0) {
+        errors.push('Frontmatter declares no package bumps.');
+    }
+    for (const release of releases) {
+        if (release.invalid) {
+            errors.push(`Malformed frontmatter line: "${release.raw}" (expected "'<package>': <bump>").`);
+            continue;
+        }
+        if (!knownPackages.has(release.name)) {
+            errors.push(`Unknown package "${release.name}" (not a workspace package).`);
+        }
+        if (!VALID_BUMPS.has(release.bump)) {
+            errors.push(`Invalid bump "${release.bump}" for "${release.name}" (expected major, minor, or patch).`);
+        }
+    }
+
+    const bodyLines = body.split('\n');
+    const title = bodyLines.find((line) => line.trim() !== '')?.trim() ?? '';
+    const bodyAfterTitle = bodyLines
+        .slice(bodyLines.indexOf(title) + 1)
+        .join('\n')
+        .trim();
+
+    // Title rules.
+    if (!title) {
+        errors.push('Missing title (first line after the frontmatter).');
+    } else {
+        if (title.startsWith('#')) {
+            errors.push('Title must be plain text, not a markdown heading.');
+        }
+        if (title.startsWith('-') || title.startsWith('*')) {
+            errors.push('Title must not start with a list marker.');
+        }
+        if (title.endsWith('.')) {
+            errors.push('Title must not end with a period.');
+        }
+        if (/\*\*breaking:?\*\*/i.test(title)) {
+            errors.push('Do not prefix the title with **BREAKING:** — a `major` bump already marks breaking changes.');
+        }
+        if (title.length > MAX_TITLE_LENGTH) {
+            errors.push(`Title is ${title.length} characters; keep it to ${MAX_TITLE_LENGTH} or fewer.`);
+        }
+    }
+
+    // Body headings must start at a single `#`.
+    const levels = headingLevels(body);
+    if (levels.length > 0 && Math.min(...levels) !== 1) {
+        errors.push('Body headings must start at a single `#` (h1).');
+    }
+
+    // Per-bump body requirements (based on the strongest declared bump).
+    const bumps = new Set(releases.filter((r) => !r.invalid).map((r) => r.bump));
+    if (bumps.has('major')) {
+        if (!bodyAfterTitle) {
+            errors.push('A `major` changeset requires an explanatory body.');
+        }
+        if (!/^#\s+Migration\s*$/m.test(body)) {
+            errors.push('A `major` changeset must include a `# Migration` section.');
+        }
+    } else if (bumps.has('minor')) {
+        if (!bodyAfterTitle) {
+            errors.push('A `minor` changeset requires an explanatory body.');
+        }
+    }
+
+    return errors;
+};
+
+const main = () => {
+    const knownPackages = getWorkspacePackageNames();
+
+    let changesetFiles;
+    try {
+        changesetFiles = readdirSync(CHANGESET_DIR).filter(
+            (file) => file.endsWith('.md') && !NON_CHANGESET_FILES.has(file),
+        );
+    } catch {
+        console.log('No .changeset directory found — nothing to validate.');
+        return;
+    }
+
+    const failures = [];
+    for (const file of changesetFiles) {
+        const content = readFileSync(join(CHANGESET_DIR, file), 'utf8');
+        const errors = validateChangeset(file, content, knownPackages);
+        if (errors.length > 0) {
+            failures.push({file, errors});
+        }
+    }
+
+    if (failures.length === 0) {
+        console.log(`Validated ${changesetFiles.length} changeset file(s) — all conform to the template.`);
+        return;
+    }
+
+    console.error('Invalid changeset(s) found:\n');
+    for (const {file, errors} of failures) {
+        console.error(`  .changeset/${file}`);
+        for (const error of errors) {
+            console.error(`    - ${error}`);
+        }
+        console.error('');
+    }
+    console.error('See CONTRIBUTING.md ("Writing changesets") for the expected format.');
+    process.exitCode = 1;
+};
+
+main();


### PR DESCRIPTION
### Proposed Changes

Enforces a consistent changeset format and cleans up existing changelogs.

- Add `scripts/validateChangesets.js` + `pnpm changeset:validate`, wired into CI.
- Add `scripts/newChangeset.js` + `pnpm changeset:new` scaffolder that pre-fills the template.
- Add a `changesets-author` agent skill (`.github/skills/changesets-author/`) documenting the enforced template, including guidance to write changesets for external users and omit transparent internal changes.
- Document the changeset template in `CONTRIBUTING.md` (`## Writing changesets`: title/body rules, requirements-by-bump-type, examples).
- Re-level rich changelog entries relative to the h4 title in `.changeset/changelog.cjs`.
- Rewrite pending changesets and existing package changelogs to follow the template (dropping internal-only sections that are transparent to consumers).
- Reference the template from the PR template, `README.md`, and `AGENTS.md`; the `AGENTS.md` changeset step now points contributors to load the `changesets-author` skill rather than invoking the pnpm commands directly.

### Potential Breaking Changes

None for consumers. Internal-only: contributors must now follow the enforced changeset template — CI runs `pnpm changeset:validate` and fails on non-conforming changesets.

### Acceptance Criteria

- [ ] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)