### PR TITLE
docs(llms): UX guidance for A–B components

### DIFF
--- a/packages/llms/src/components/Accordion.md
+++ b/packages/llms/src/components/Accordion.md
@@ -1,7 +1,96 @@
 ---
 name: Accordion
-description: Collapsible content panels with an additional disabled control variant.
+description: Collapsible content group for progressively revealing related sections without leaving the current page.
 ---
+
+# Usage guidance
+
+## What problem does it solve?
+
+The `Accordion` lets users scan a set of related section headings and open the content they need without showing every detail at once.
+
+It is useful when content is secondary to the main task, grouped into clear sections, and worth keeping on the same page.
+
+## When to use it
+
+Use `Accordion` when:
+
+- related content can be organized into short, meaningful section labels
+- users benefit from scanning section headings before reading details
+- the content is useful in context but does not need to be visible all at once
+- one or many sections MAY be open depending on the task
+
+Use `multiple` when users commonly compare information across several sections or need more than one section open while working.
+
+## When not to use it
+
+Do not use `Accordion` when:
+
+- the content is required for completing the current task and should be visible without disclosure
+- the sections represent navigation destinations rather than expandable content
+- users need to compare large amounts of content side by side
+- there are only one or two very short details that could be shown inline
+- hiding the content would make errors, warnings, or required decisions easier to miss
+
+## Decision-making guidance
+
+- Use `Accordion` for progressive disclosure inside a page, not for moving between pages or major views.
+- Use `Tabs` when each section is a peer view and users choose one view at a time.
+- Use inline helper text or an `Alert` when the information is important enough to remain visible.
+- Use a table, list, or cards when users need to compare many items rather than open panels one by one.
+- Use `Accordion.ControlDisabled` when a section heading should appear in the accordion structure but should not be interactive.
+
+## Variants
+
+- Use `default` for the standard accordion treatment.
+- Use `contained` when the accordion needs a clearer boundary from surrounding page content.
+- Use `separated` when each item should read as an independent expandable section.
+- Use `filled` when the accordion needs stronger visual weight.
+
+## States
+
+Important states include:
+
+- collapsed
+- expanded
+- multiple expanded items, when `multiple` is enabled
+- disabled control, through `Accordion.ControlDisabled`
+
+## Interaction notes
+
+- Each section needs a unique, consistent identifier so the accordion can track which panels are open or closed.
+- Icons next to section labels can help users recognize content faster, but the label text must always be clear enough on its own.
+- A section heading can be made non-interactive — it appears in the accordion structure but cannot be expanded or collapsed.
+
+## Accessibility expectations
+
+- Each control MUST have clear text that describes the panel content.
+- Panel content SHOULD remain logically related to its control.
+- Interactive content inside panels MUST remain keyboard reachable when the panel is open.
+
+## Content guidance
+
+- Control labels SHOULD be short and specific.
+- Labels SHOULD describe the content inside the panel, not the action of expanding it.
+- Keep panel content focused on one section topic.
+- If every panel label needs a long sentence to be understandable, the content likely needs another structure.
+
+## Common anti-patterns
+
+- Using accordions as primary navigation.
+- Hiding required form fields or critical warnings inside collapsed panels.
+- Creating many vague sections such as "Details" or "More information."
+- Using an accordion to avoid designing a clearer content hierarchy.
+- Nesting accordions unless the relationship between levels is unmistakable.
+
+## What an AI agent should understand
+
+- `Accordion` is for progressive disclosure of related in-page content.
+- It is a poor choice when the content is required, critical, or needs direct comparison.
+- Use `Accordion.Item`, `Accordion.Control`, and `Accordion.Panel` together to compose each section.
+- `Accordion.ControlDisabled` is Plasma-specific and should be used for non-interactive controls inside an accordion structure.
+
+# API reference
 
 ## Props
 
@@ -9,14 +98,12 @@ _No additional props beyond the Mantine base component._
 
 ## Sub-components
 
-Plasma provides pre-configured sub-components as convenience wrappers. You SHOULD use these over setting props manually.
+Plasma exposes Mantine's compound accordion API and adds a disabled control convenience wrapper.
 
-- `Accordion.Control`
-- `Accordion.ControlDisabled`
-- `Accordion.Panel`
 - `Accordion.Item`
-
-`Accordion.ControlDisabled` renders a control with no chevron and disabled pointer events. You SHOULD use it for accordion items that are always expanded and cannot be collapsed by the user.
+- `Accordion.Control`
+- `Accordion.Panel`
+- `Accordion.ControlDisabled`
 
 ## Usage
 

--- a/packages/llms/src/components/Accordion.md
+++ b/packages/llms/src/components/Accordion.md
@@ -83,13 +83,6 @@ Important states include:
 - Using an accordion to avoid designing a clearer content hierarchy.
 - Nesting accordions unless the relationship between levels is unmistakable.
 
-## What an AI agent should understand
-
-- `Accordion` is for progressive disclosure of related in-page content.
-- It is a poor choice when the content is required, critical, or needs direct comparison.
-- Use `Accordion.Item`, `Accordion.Control`, and `Accordion.Panel` together to compose each section.
-- `Accordion.ControlDisabled` is Plasma-specific and should be used for non-interactive controls inside an accordion structure.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/ActionIcon.md
+++ b/packages/llms/src/components/ActionIcon.md
@@ -57,12 +57,6 @@ Do not use `ActionIcon` when:
 - Using destructive styling for non-destructive actions.
 - Placing many unlabeled icons together without enough distinction.
 
-## What an AI agent should understand
-
-- `ActionIcon` is for compact icon-only actions, not for primary page commands that need visible labels.
-- Choose semantic sub-components instead of manually setting visual variants.
-- Pair `disabled` with `disabledTooltip` when the reason is not obvious.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/ActionIcon.md
+++ b/packages/llms/src/components/ActionIcon.md
@@ -3,6 +3,68 @@ name: ActionIcon
 description: Icon-only button that can trigger actions and can show a disabled-state tooltip.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `ActionIcon` gives users a compact way to trigger an action when the action can be represented clearly by an icon.
+
+It is useful in dense interfaces where a full text button would add visual noise, such as tables, cards, toolbars, or repeated item actions.
+
+## When to use it
+
+Use `ActionIcon` when:
+
+- the action is short, familiar, and icon-recognizable
+- space is limited or the action appears in a repeated row or card
+- the action supplements nearby content rather than carrying the primary page task alone
+- disabled actions need a tooltip explaining why they are unavailable
+
+## When not to use it
+
+Do not use `ActionIcon` when:
+
+- the action is primary, high-stakes, or unfamiliar enough to need visible text
+- the icon would be ambiguous without a label
+- several adjacent icon-only actions would be hard to scan or distinguish
+- the user needs to compare choices by reading command names
+
+## Decision-making guidance
+
+- Use `Button` when the action label should remain visible.
+- Use `ActionIcon` for compact utility actions such as edit, remove, copy, open, or refresh.
+- Use destructive variants only for actions that can remove, delete, revoke, or otherwise negatively affect data.
+- Use lower-emphasis variants for repeated row actions so they do not compete with page-level actions.
+
+## Variants
+
+- Ignore Mantine's `variant` values (`filled`, `light`, `outline`, `subtle`, `default`); always select emphasis through the Plasma sub-components below.
+- Use `Primary` for the most important compact action in a local context.
+- Use `Secondary`, `Tertiary`, or `Quaternary` as emphasis decreases.
+- Use `DestructivePrimary` for the primary destructive action in a local context (e.g. the confirming delete in a toolbar or row).
+- Use `DestructiveSecondary`, `DestructiveTertiary`, or `DestructiveQuaternary` as the destructive action's emphasis decreases — e.g. `DestructiveQuaternary` for a low-emphasis remove in a repeated row.
+- Use `ActionIcon.Group` when related icon actions need to be visually grouped.
+
+## Accessibility expectations
+
+- Icon-only actions MUST provide an accessible name — set `aria-label` on the control (or on the icon).
+- Disabled icon actions SHOULD explain why they are unavailable with `disabledTooltip`.
+- The icon MUST NOT be the only source of meaning when the action is ambiguous.
+
+## Common anti-patterns
+
+- Replacing important text buttons with icon-only actions just to save space.
+- Using destructive styling for non-destructive actions.
+- Placing many unlabeled icons together without enough distinction.
+
+## What an AI agent should understand
+
+- `ActionIcon` is for compact icon-only actions, not for primary page commands that need visible labels.
+- Choose semantic sub-components instead of manually setting visual variants.
+- Pair `disabled` with `disabledTooltip` when the reason is not obvious.
+
+# API reference
+
 ## Props
 
 > Extends: `MantineActionIconProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.

--- a/packages/llms/src/components/Alert.md
+++ b/packages/llms/src/components/Alert.md
@@ -54,12 +54,6 @@ Do not use `Alert` when:
 - Using critical alerts for neutral information.
 - Putting long documentation inside an alert instead of linking to supporting content.
 
-## What an AI agent should understand
-
-- `Alert` is for persistent contextual messaging inside a layout.
-- It is not the right choice for transient notifications or optional hints.
-- Choose semantic sub-components according to message intent.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Alert.md
+++ b/packages/llms/src/components/Alert.md
@@ -3,6 +3,65 @@ name: Alert
 description: Alert callout for contextual information, advice, warnings, critical errors, and success states.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `Alert` makes contextual information visible in the page layout so users can notice, read, and act on it without relying on hover or transient feedback.
+
+## When to use it
+
+Use `Alert` when:
+
+- a message should remain visible until the user has had a chance to read it
+- the message affects the current page, form, or workflow
+- users need context, advice, warning, error, or success feedback near related content
+- the message is more important than helper text but does not require a modal interruption
+
+## When not to use it
+
+Do not use `Alert` when:
+
+- feedback is lightweight and transient; use `Notification`
+- information is optional clarification for one field; use helper text or `Input.LabelInfo`
+- the user must confirm a blocking decision; use `Prompt` or `Modal`
+- the message is only a compact status label; use `Badge` or `StatusToken`
+
+## Decision-making guidance
+
+- Use `Alert` over `Notification` when the message must remain visible in the page layout.
+- Use `Alert` over `Tooltip` when the information is important and should not depend on hover or focus.
+- Use `Prompt` for confirmation flows where the user must choose before continuing.
+
+## Variants
+
+- Ignore Mantine's `color`/`variant` props for choosing intent; select the message type through the Plasma sub-components below.
+- Use `Alert.Information` for neutral contextual information.
+- Use `Alert.Advice` for recommendations or next-best-action guidance.
+- Use `Alert.Warning` when users can proceed but should be careful.
+- Use `Alert.Critical` for errors, failures, or blocking issues.
+- Use `Alert.Success` for persistent success states that remain relevant in context.
+
+## Content guidance
+
+- Titles SHOULD be short and state the message purpose.
+- Body text SHOULD explain the impact or next step.
+- Critical alerts SHOULD make the consequence and recovery path clear.
+
+## Common anti-patterns
+
+- Stacking several alerts instead of grouping related messages.
+- Using critical alerts for neutral information.
+- Putting long documentation inside an alert instead of linking to supporting content.
+
+## What an AI agent should understand
+
+- `Alert` is for persistent contextual messaging inside a layout.
+- It is not the right choice for transient notifications or optional hints.
+- Choose semantic sub-components according to message intent.
+
+# API reference
+
 ## Props
 
 _No additional props beyond the Mantine base component._

--- a/packages/llms/src/components/Anchor.md
+++ b/packages/llms/src/components/Anchor.md
@@ -1,0 +1,99 @@
+---
+name: Anchor
+description: Inline text link that navigates the user to another page or section.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Anchor` lets users navigate to another page, section, or resource directly from within text — without breaking the reading flow or pulling attention away from the content with a button. A plain `<a>` tag would be unstyled and inconsistent; a `Button` would be too heavy for in-context navigation. `Anchor` is the right weight when the navigation action lives inside prose.
+
+## When to use it
+
+- Navigating to an external URL or a different route within the application.
+- Embedding a navigation action inline within a sentence or paragraph.
+- Providing secondary navigation options such as "Learn more" or "See all results" beside descriptive text.
+
+## When not to use it
+
+- When the action triggers a mutation, submission, or workflow step — use `Button` instead.
+- When the link stands alone as a primary call-to-action with enough prominence to warrant a button shape.
+- When breadcrumb-style navigation is needed — use `Breadcrumbs` with `Anchor` children rather than bare `Anchor` elements.
+
+## Decision-making guidance
+
+- Prefer `Anchor` over a plain `<a>` element so that Plasma theming, focus styles, and size tokens are applied consistently.
+- Open links in a new tab only when leaving the current context would interrupt the user's task.
+- Use `size="xs"` for compact contexts such as table cells or captions; use `size="sm"` (default) for body text.
+- Pass `inherit` when the anchor sits inside a `Text`, `Breadcrumbs`, or other typographic container so its font size inherits from the parent rather than resetting.
+
+## Variants
+
+Plasma exposes two size options:
+
+- `sm` (default) — standard body-text size.
+- `xs` — smaller, suited to dense UI areas.
+
+## Accessibility expectations
+
+- Link text MUST describe the destination or action, not just "click here" or "read more".
+- When opening a new tab, the link SHOULD signal this to screen-reader users, either through visible text or an `aria-label`.
+
+## Content guidance
+
+- Keep link labels short and descriptive.
+- Avoid punctuation at the end of a link label unless it is part of a sentence.
+
+## Common anti-patterns
+
+- Using `Anchor` to trigger an `onClick` action with no `href` — use `Button.Tertiary` or an `ActionIcon` instead.
+- Wrapping large blocks of content in an `Anchor`; links SHOULD target meaningful, concise labels.
+- Omitting `inherit` when placing an `Anchor` inside a typographic component, causing a size mismatch.
+
+## What an AI agent should understand
+
+- `Anchor` is a thin Plasma wrapper around Mantine's `Anchor`; all Mantine `AnchorProps` are available.
+- Use `inherit` when nesting inside `Text` or `Breadcrumbs` to avoid font-size conflicts.
+- For pure navigation links, `Anchor` is always preferable to a `Button` styled as a link.
+
+# API reference
+
+## Props
+
+> Extends: `AnchorProps` from `@mantine/core`. No additional Plasma-specific props beyond the Mantine base component.
+
+## Usage
+
+```tsx
+import {Anchor, Breadcrumbs} from '@coveord/plasma-mantine';
+
+// Standalone link
+function ExternalLink() {
+    return (
+        <Anchor href="https://plasma.coveo.com" target="_blank" rel="noopener noreferrer" size="sm">
+            Plasma Design System
+        </Anchor>
+    );
+}
+
+// Inside a Breadcrumbs trail — inherit parent font size
+import {Anchor, Breadcrumbs} from '@coveord/plasma-mantine';
+
+function BreadcrumbTrail() {
+    return (
+        <Breadcrumbs>
+            <Anchor href="/home" inherit>
+                Home
+            </Anchor>
+            <Anchor href="/catalog" inherit>
+                Catalog
+            </Anchor>
+        </Breadcrumbs>
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/Anchor.md
+++ b/packages/llms/src/components/Anchor.md
@@ -13,27 +13,27 @@ description: Inline text link that navigates the user to another page or section
 
 - Navigating to an external URL or a different route within the application.
 - Embedding a navigation action inline within a sentence or paragraph.
-- Providing secondary navigation options such as "Learn more" or "See all results" beside descriptive text.
+- Providing secondary navigation options such as "View documentation" or "See all results" beside descriptive text.
 
 ## When not to use it
 
 - When the action triggers a mutation, submission, or workflow step — use `Button` instead.
 - When the link stands alone as a primary call-to-action with enough prominence to warrant a button shape.
-- When breadcrumb-style navigation is needed — use `Breadcrumbs` with `Anchor` children rather than bare `Anchor` elements.
+- When breadcrumb-style navigation is needed — use `Header.Breadcrumbs` with `Header.BreadcrumbAnchor` rather than bare `Anchor` elements.
 
 ## Decision-making guidance
 
 - Prefer `Anchor` over a plain `<a>` element so that Plasma theming, focus styles, and size tokens are applied consistently.
 - Open links in a new tab only when leaving the current context would interrupt the user's task.
-- Use `size="xs"` for compact contexts such as table cells or captions; use `size="sm"` (default) for body text.
-- Pass `inherit` when the anchor sits inside a `Text`, `Breadcrumbs`, or other typographic container so its font size inherits from the parent rather than resetting.
+- Use `size="xs"` for compact contexts such as table cells or captions; use `size="sm"` for body text.
+- Pass `inherit` when the anchor sits inside a `Text` or other typographic container so its font size and font-weight inherit from the parent rather than resetting.
 
 ## Variants
 
-Plasma exposes two size options:
+`Anchor` is a straight re-export of Mantine's `Anchor`, so the full Mantine `size` scale (`xs`–`xl`) is available. In practice, prefer:
 
-- `sm` (default) — standard body-text size.
-- `xs` — smaller, suited to dense UI areas.
+- `sm` — standard body-text links.
+- `xs` — compact areas such as table cells or captions.
 
 ## Accessibility expectations
 
@@ -51,12 +51,6 @@ Plasma exposes two size options:
 - Wrapping large blocks of content in an `Anchor`; links SHOULD target meaningful, concise labels.
 - Omitting `inherit` when placing an `Anchor` inside a typographic component, causing a size mismatch.
 
-## What an AI agent should understand
-
-- `Anchor` is a thin Plasma wrapper around Mantine's `Anchor`; all Mantine `AnchorProps` are available.
-- Use `inherit` when nesting inside `Text` or `Breadcrumbs` to avoid font-size conflicts.
-- For pure navigation links, `Anchor` is always preferable to a `Button` styled as a link.
-
 # API reference
 
 ## Props
@@ -66,7 +60,7 @@ Plasma exposes two size options:
 ## Usage
 
 ```tsx
-import {Anchor, Breadcrumbs} from '@coveord/plasma-mantine';
+import {Alert, Anchor} from '@coveord/plasma-mantine';
 
 // Standalone link
 function ExternalLink() {
@@ -77,19 +71,16 @@ function ExternalLink() {
     );
 }
 
-// Inside a Breadcrumbs trail — inherit parent font size
-import {Anchor, Breadcrumbs} from '@coveord/plasma-mantine';
-
-function BreadcrumbTrail() {
+// Inside an Alert description — inherit the parent font size and weight
+function SomeAlert() {
     return (
-        <Breadcrumbs>
-            <Anchor href="/home" inherit>
-                Home
-            </Anchor>
-            <Anchor href="/catalog" inherit>
-                Catalog
-            </Anchor>
-        </Breadcrumbs>
+        <Alert.Information title="Alert title">
+            Read the{' '}
+            <Anchor inherit href="#details">
+                setup details
+            </Anchor>{' '}
+            before continuing.
+        </Alert.Information>
     );
 }
 ```

--- a/packages/llms/src/components/AppShell.md
+++ b/packages/llms/src/components/AppShell.md
@@ -3,6 +3,59 @@ name: AppShell
 description: Application layout shell with a scrollable main content area.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `AppShell` provides the structural frame for application pages, including persistent regions such as header, navigation, main content, aside, and footer.
+
+Plasma's `AppShell.Main` keeps main content scrolling independently so the shell structure remains stable.
+
+## When to use it
+
+Use `AppShell` when:
+
+- building a full application or product area layout
+- the page needs persistent navigation, header, footer, or aside regions
+- main content should scroll inside a stable shell
+- responsive shell behavior is needed around the main content
+
+## When not to use it
+
+Do not use `AppShell` when:
+
+- only a local panel, card, or form section needs layout
+- a modal or embedded preview needs its own smaller structure
+- the layout does not need persistent shell regions
+
+## Decision-making guidance
+
+- Use `AppShell` at the application or page-frame level.
+- Use `Header` for page-level title/action structure inside a shell.
+- Use regular layout primitives for local section layout.
+- Use `BrowserPreview` when the goal is to preview content inside simulated browser chrome, not structure the application.
+
+## Accessibility expectations
+
+- Shell regions SHOULD preserve a logical page structure.
+- Main content SHOULD remain reachable without trapping keyboard users in persistent regions.
+- Navigation and header areas SHOULD have clear landmarks or labels when appropriate.
+
+## Common anti-patterns
+
+- Nesting multiple application shells inside each other.
+- Using `AppShell` for a single card or local page section.
+- Making both shell and inner content compete for scrolling in a way that hides actions.
+
+## What an AI agent should understand
+
+- `AppShell` is for high-level application structure.
+- `AppShell.Main` provides Plasma's scrollable main content behavior.
+- Use `AppShell.Section` to group and space content within a region (e.g. a scrollable list between a fixed top and bottom section inside the navbar).
+- Use smaller layout components for local composition.
+
+# API reference
+
 ## Props
 
 _No additional props beyond the Mantine base component._

--- a/packages/llms/src/components/AppShell.md
+++ b/packages/llms/src/components/AppShell.md
@@ -47,13 +47,6 @@ Do not use `AppShell` when:
 - Using `AppShell` for a single card or local page section.
 - Making both shell and inner content compete for scrolling in a way that hides actions.
 
-## What an AI agent should understand
-
-- `AppShell` is for high-level application structure.
-- `AppShell.Main` provides Plasma's scrollable main content behavior.
-- Use `AppShell.Section` to group and space content within a region (e.g. a scrollable list between a fixed top and bottom section inside the navbar).
-- Use smaller layout components for local composition.
-
 # API reference
 
 ## Props

--- a/packages/llms/src/components/Badge.md
+++ b/packages/llms/src/components/Badge.md
@@ -3,6 +3,67 @@ name: Badge
 description: Status label that can display short text, counts, or metadata tags.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `Badge` gives users a compact text label for status, category, count, or metadata that needs to be visible near an object.
+
+## When to use it
+
+Use `Badge` when:
+
+- a short label adds scannable metadata to an item
+- a state or category should be visible but not interruptive
+- the value is textual and needs more context than an icon alone
+- a list, card, or header needs compact status information
+
+## When not to use it
+
+Do not use `Badge` when:
+
+- the message needs explanation or action; use `Alert` or inline text
+- only a small semantic marker is needed; use `StatusToken`
+- the value is interactive; use a button, chip, or link pattern
+- the label is too long to scan as metadata
+
+## Decision-making guidance
+
+- Use `Badge` for readable status or metadata text.
+- Use `StatusToken` when an icon-like status marker is enough or space is very constrained.
+- Use `Chip` when the pill is selectable.
+- Keep the default `small` size for dense lists and inline metadata; use `large` only when the badge must read as a standalone status indicator.
+
+## Variants
+
+- Ignore Mantine's `color`/`variant` props for choosing status; select meaning through the Plasma sub-components below.
+- Use `Badge.Primary` for the most prominent neutral label on an item.
+- Use `Badge.Secondary` for lower-emphasis neutral metadata.
+- Use `Badge.Success` for healthy, enabled, or completed states.
+- Use `Badge.Warning` for cautionary states.
+- Use `Badge.Critical` for error or failure states.
+- Use `Badge.Disabled` for unavailable or inactive states.
+
+## Content guidance
+
+- Badge text SHOULD be short, usually one to three words.
+- Use nouns or concise state labels rather than full sentences.
+- Keep wording consistent across badges in the same set.
+
+## Common anti-patterns
+
+- Using badges as buttons.
+- Writing long explanatory messages inside badges.
+- Using semantic colors inconsistently across similar statuses.
+
+## What an AI agent should understand
+
+- `Badge` is for compact visible text metadata.
+- It is not interactive and should not replace alerts or controls.
+- Choose semantic sub-components by status meaning.
+
+# API reference
+
 ## Props
 
 > Extends: `BadgeProps` (sub-components use `SemanticBadgeProps`, a restricted subset). Only Plasma-specific props are listed below; inherited props MUST be referenced in Mantine documentation.

--- a/packages/llms/src/components/Badge.md
+++ b/packages/llms/src/components/Badge.md
@@ -24,14 +24,13 @@ Do not use `Badge` when:
 
 - the message needs explanation or action; use `Alert` or inline text
 - only a small semantic marker is needed; use `StatusToken`
-- the value is interactive; use a button, chip, or link pattern
+- the value is interactive; use a button or link pattern
 - the label is too long to scan as metadata
 
 ## Decision-making guidance
 
 - Use `Badge` for readable status or metadata text.
 - Use `StatusToken` when an icon-like status marker is enough or space is very constrained.
-- Use `Chip` when the pill is selectable.
 - Keep the default `small` size for dense lists and inline metadata; use `large` only when the badge must read as a standalone status indicator.
 
 ## Variants
@@ -55,12 +54,6 @@ Do not use `Badge` when:
 - Using badges as buttons.
 - Writing long explanatory messages inside badges.
 - Using semantic colors inconsistently across similar statuses.
-
-## What an AI agent should understand
-
-- `Badge` is for compact visible text metadata.
-- It is not interactive and should not replace alerts or controls.
-- Choose semantic sub-components by status meaning.
 
 # API reference
 

--- a/packages/llms/src/components/Breadcrumbs.md
+++ b/packages/llms/src/components/Breadcrumbs.md
@@ -22,6 +22,7 @@ description: Horizontal trail of navigation links showing the user's position wi
 
 ## Decision-making guidance
 
+- In Plasma products, breadcrumbs are normally placed inside a page `Header` via `Header.Breadcrumbs` / `Header.BreadcrumbAnchor`; use standalone `Breadcrumbs` only outside a `Header` context.
 - When there are two ancestors, use two `Anchor` links.
 - When there are three or more ancestors, show up to three `Anchor` links — avoid going deeper as it becomes unreadable.
 - Do not include the current page in the trail — the page header already shows the current page name.
@@ -42,12 +43,6 @@ The separator between items is rendered automatically by the component. Do not p
 - Including the current page in the trail — the page header already communicates where the user is.
 - Nesting more than three levels; deeply nested breadcrumbs become unreadable and suggest that the information architecture needs rethinking.
 - Using plain `<a>` tags instead of `Anchor` children, which bypasses Plasma theming and focus styles.
-
-## What an AI agent should understand
-
-- `Breadcrumbs` is a thin Plasma wrapper around Mantine's `Breadcrumbs`. All `BreadcrumbsProps` are available.
-- Children are `Anchor` elements representing ancestor pages.
-- The level 1 pattern uses an `Anchor` containing a `Flex` with an `IconChevronLeft` icon alongside the parent label — this is a design convention, not a prop.
 
 # API reference
 

--- a/packages/llms/src/components/Breadcrumbs.md
+++ b/packages/llms/src/components/Breadcrumbs.md
@@ -1,0 +1,95 @@
+---
+name: Breadcrumbs
+description: Horizontal trail of navigation links showing the user's position within a page hierarchy.
+---
+
+# Usage guidance
+
+## What problem does it solve?
+
+`Breadcrumbs` shows users where they are within a multi-level information hierarchy and lets them navigate back to ancestor pages without using the browser back button.
+
+## When to use it
+
+- Pages that sit two or more levels deep in a navigation tree.
+- Drill-down workflows such as an item detail page reached from a list.
+- Contexts where the user may want to jump directly to a grandparent level rather than navigating step-by-step.
+
+## When not to use it
+
+- Flat, single-level applications where there is no meaningful hierarchy.
+- Inside modals or drawers where the user is expected to close rather than navigate away.
+
+## Decision-making guidance
+
+- When there are two ancestors, use two `Anchor` links.
+- When there are three or more ancestors, show up to three `Anchor` links — avoid going deeper as it becomes unreadable.
+- Do not include the current page in the trail — the page header already shows the current page name.
+- All items MUST be `Anchor` elements so they are keyboard-focusable and screen-reader navigable.
+- Pass `inherit` on each `Anchor` child so its font size matches the `Breadcrumbs` container styling.
+
+## Interaction notes
+
+The separator between items is rendered automatically by the component. Do not place separator characters manually between children.
+
+## Accessibility expectations
+
+- Consider wrapping the `Breadcrumbs` in a `<nav aria-label="Breadcrumb">` landmark when the page does not already have a dedicated navigation region for it.
+- Each ancestor link MUST have descriptive text that matches or summarises the target page title.
+
+## Common anti-patterns
+
+- Including the current page in the trail — the page header already communicates where the user is.
+- Nesting more than three levels; deeply nested breadcrumbs become unreadable and suggest that the information architecture needs rethinking.
+- Using plain `<a>` tags instead of `Anchor` children, which bypasses Plasma theming and focus styles.
+
+## What an AI agent should understand
+
+- `Breadcrumbs` is a thin Plasma wrapper around Mantine's `Breadcrumbs`. All `BreadcrumbsProps` are available.
+- Children are `Anchor` elements representing ancestor pages.
+- The level 1 pattern uses an `Anchor` containing a `Flex` with an `IconChevronLeft` icon alongside the parent label — this is a design convention, not a prop.
+
+# API reference
+
+## Props
+
+> Extends: `BreadcrumbsProps` from `@mantine/core`. No additional Plasma-specific props beyond the Mantine base component.
+
+## Usage
+
+```tsx
+import {Anchor, Breadcrumbs, Flex} from '@coveord/plasma-mantine';
+import {IconChevronLeft} from '@coveord/plasma-react-icons';
+
+// Level 1: single parent with back-arrow affordance
+function Level1() {
+    return (
+        <Breadcrumbs>
+            <Anchor href="/catalog" inherit>
+                <Flex align="center">
+                    <IconChevronLeft aria-label="arrow pointing back" size={16} />
+                    Catalog
+                </Flex>
+            </Anchor>
+        </Breadcrumbs>
+    );
+}
+
+// Level 2: two ancestors
+function Level2() {
+    return (
+        <Breadcrumbs>
+            <Anchor href="/home" inherit>
+                Home
+            </Anchor>
+            <Anchor href="/catalog" inherit>
+                Catalog
+            </Anchor>
+        </Breadcrumbs>
+    );
+}
+```
+
+---
+
+[Full Plasma documentation]({{BASE_URL}})

--- a/packages/llms/src/components/BrowserPreview.md
+++ b/packages/llms/src/components/BrowserPreview.md
@@ -3,6 +3,56 @@ name: BrowserPreview
 description: Renders a simulated browser chrome frame around preview content.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `BrowserPreview` frames content as a simulated browser view so users can evaluate how a rendered page, result, or experience will look in context.
+
+## When to use it
+
+Use `BrowserPreview` when:
+
+- users need to preview content as it will appear in a browser-like surface
+- the preview benefits from a title or header tooltip
+- the content is separate from the configuration controls around it
+- the interface needs to distinguish editable settings from preview output
+
+## When not to use it
+
+Do not use `BrowserPreview` when:
+
+- the content is the actual page, not a preview
+- the frame would add decoration without clarifying context
+- users need to interact with a full application shell
+- the preview content is too small or abstract to benefit from browser chrome
+
+## Decision-making guidance
+
+- Use `BrowserPreview` for preview surfaces inside configuration or authoring flows.
+- Use `AppShell` for real application layout.
+- Use `Card` or layout primitives for ordinary content grouping.
+
+## Interaction notes
+
+- Preview content MAY be interactive when that helps users validate behavior.
+- Header tooltips SHOULD clarify what is being previewed, not explain the whole feature.
+- Keep controls that modify the preview outside the preview frame when possible.
+
+## Common anti-patterns
+
+- Using browser chrome as decoration around normal content.
+- Putting unrelated controls inside the preview surface.
+- Treating a preview frame as the real navigational shell.
+
+## What an AI agent should understand
+
+- `BrowserPreview` is for simulated browser previews, not application layout.
+- Use it when users need to inspect rendered output in context.
+- Keep configuration controls separate from preview content.
+
+# API reference
+
 ## Props
 
 > Extends: `StackProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.

--- a/packages/llms/src/components/BrowserPreview.md
+++ b/packages/llms/src/components/BrowserPreview.md
@@ -25,7 +25,7 @@ Do not use `BrowserPreview` when:
 - the content is the actual page, not a preview
 - the frame would add decoration without clarifying context
 - users need to interact with a full application shell
-- the preview content is too small or abstract to benefit from browser chrome
+- the preview content is too small or abstract for the simulated browser frame to add meaningful context
 
 ## Decision-making guidance
 
@@ -44,12 +44,6 @@ Do not use `BrowserPreview` when:
 - Using browser chrome as decoration around normal content.
 - Putting unrelated controls inside the preview surface.
 - Treating a preview frame as the real navigational shell.
-
-## What an AI agent should understand
-
-- `BrowserPreview` is for simulated browser previews, not application layout.
-- Use it when users need to inspect rendered output in context.
-- Keep configuration controls separate from preview content.
 
 # API reference
 

--- a/packages/llms/src/components/Button.md
+++ b/packages/llms/src/components/Button.md
@@ -3,6 +3,76 @@ name: Button
 description: Action button that triggers tasks and provides async loading and disabled-tooltip feedback.
 ---
 
+# Usage guidance
+
+## What problem does it solve?
+
+The `Button` lets users intentionally trigger an action, submit a decision, or move a workflow forward.
+
+It provides clear visual hierarchy for actions and supports async loading and disabled-state explanations.
+
+## When to use it
+
+Use `Button` when:
+
+- the user triggers an explicit command
+- the action label should be visible
+- the action participates in a form, modal, footer, toolbar, or page-level command area
+- the interface needs a clear primary, secondary, tertiary, or destructive action
+
+## When not to use it
+
+Do not use `Button` when:
+
+- the action is compact and familiar enough to be icon-only; use `ActionIcon`
+- the control represents an immediate persistent setting; use a selection or boolean control
+- too many buttons would make the decision hierarchy unclear
+
+## Decision-making guidance
+
+- Use one primary button per decision area when possible.
+- Use `Button.Secondary` for important supporting actions such as cancel; use `Button.Tertiary` or `Button.Quaternary` for low-emphasis actions such as preview or back.
+- Use destructive variants only when the action can delete, revoke, archive, or otherwise negatively affect data.
+
+## Variants
+
+- Ignore Mantine's `variant` values (`filled`, `light`, `outline`, `subtle`, `default`); always select emphasis through the Plasma sub-components below.
+- Use `Button.Primary` for the main action.
+- Use `Button.Secondary` for important alternatives.
+- Use `Button.Tertiary` or `Button.Quaternary` for low-emphasis actions.
+- Use `Button.DestructivePrimary` for the primary destructive action in a decision area (e.g. the confirming delete in a dialog footer).
+- Use `Button.DestructiveSecondary`, `Button.DestructiveTertiary`, or `Button.DestructiveQuaternary` as the destructive action's emphasis decreases.
+
+## States
+
+Important states include:
+
+- normal
+- loading during async `onClick`
+- disabled with optional tooltip explanation
+- full width when the surrounding layout requires it
+
+## Accessibility expectations
+
+- Button text MUST describe the action that will happen.
+- Disabled buttons SHOULD explain the missing requirement when the reason is not visible nearby.
+- Destructive buttons SHOULD use wording that makes the consequence clear.
+
+## Common anti-patterns
+
+- Using multiple primary buttons in one decision area.
+- Using a button for navigation.
+- Disabling a button without explaining how the user can enable it.
+- Hiding destructive consequences behind vague labels such as "OK".
+
+## What an AI agent should understand
+
+- `Button` is for explicit user-triggered actions with visible labels.
+- Prefer semantic sub-components over manual variants.
+- Async `onClick` handlers can be used directly; the button shows loading while pending.
+
+# API reference
+
 ## Props
 
 > Extends: `ButtonProps`, `ButtonWithDisabledTooltipProps`. Only Plasma-specific props are listed below; refer to Mantine documentation for inherited props.

--- a/packages/llms/src/components/Button.md
+++ b/packages/llms/src/components/Button.md
@@ -65,12 +65,6 @@ Important states include:
 - Disabling a button without explaining how the user can enable it.
 - Hiding destructive consequences behind vague labels such as "OK".
 
-## What an AI agent should understand
-
-- `Button` is for explicit user-triggered actions with visible labels.
-- Prefer semantic sub-components over manual variants.
-- Async `onClick` handlers can be used directly; the button shows loading while pending.
-
 # API reference
 
 ## Props


### PR DESCRIPTION
## What

Carves the **A** and **B** component usage-guidance docs out of #4437 into a smaller, independently reviewable PR — the first of the planned splits of that larger PR. #4437 stays open as the tracking PR.

## Components in this slice

**A** — Accordion, ActionIcon, Alert, Anchor, AppShell
**B** — Badge, Breadcrumbs, BrowserPreview, Button

(`Anchor`, `Breadcrumbs` are new files; the rest are modifications.)

## What changed vs. a plain carve-out

These files also include a usage-guidance review pass (cross-checked against each component's Mantine `llms` doc and its own API reference):

- Explicit "ignore Mantine's variant/color model, use the Plasma sub-components" overrides where Plasma renames the variant model (ActionIcon, Alert, Badge, Button).
- Per-variant "when to use" coverage for destructive sub-components (ActionIcon, Button).
- Fixed an internal secondary/tertiary contradiction (Button).
- Removed unverified/incorrect claims (e.g. the `unstyled` accordion "variant", a false chevron-removal behavior, `Button.Group` guidance since it isn't in Figma/Storybook).

## Not included (belongs in later slices)

Global/shared parts of #4437 — the aggregate build files (`llms-full-txt.ts`, `llms-txt.ts`, `skill.md`, `tsconfig.json`) and `src/content/*` changes — are intentionally left out of this component-scoped slice.

## Follow-ups for the API-reference owner (out of scope here)

- **ActionIcon**: async-`onClick` auto-loading claim in the API reference is not real (confirmed).
- **Anchor** / **CloseButton**: API reference says "no additional Plasma props" but `size` is restricted — a real delta to note.
- **Button**: `Button.Group` listed in the API reference/sub-components but absent from Figma/Storybook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)