### PR TITLE
Stop versioning private packages to avoid empty changelog sections

### DIFF
--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -1,6 +1,6 @@
 // Custom changelog generator for Plasma.
 // - Suppresses all changelog entries while .changeset/pre.json mode is "pre".
-// - Suppresses dependency update lines entirely.
+// - Delegates dependency update lines to the default GitHub changelog generator.
 // - Simple entries: "- Summary [#PR](url)"
 // - Rich entries (containing headings): "#### Title [#PR](url)\n\nBody..."
 //   Per the changeset template (see CONTRIBUTING.md), body headings start at a
@@ -10,6 +10,7 @@
 
 const {readFileSync} = require('fs');
 const {join} = require('path');
+const {default: defaultChangelog} = require('@changesets/changelog-github');
 
 function isPrerelease() {
     try {
@@ -86,8 +87,9 @@ async function getReleaseLine(changeset, _type, options) {
     return `\n\n- ${summary}${prLink ? ` ${prLink}` : ''}`;
 }
 
-async function getDependencyReleaseLine() {
-    return '';
+async function getDependencyReleaseLine(changesets, dependenciesUpdated, options) {
+    if (isPrerelease()) return '';
+    return defaultChangelog.getDependencyReleaseLine(changesets, dependenciesUpdated, options);
 }
 
 module.exports = {getReleaseLine, getDependencyReleaseLine};

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,7 +14,7 @@
     "updateInternalDependencies": "patch",
     "bumpVersionsWithWorkspaceProtocolOnly": true,
     "privatePackages": {
-        "version": true,
+        "version": false,
         "tag": false
     }
 }


### PR DESCRIPTION
### Proposed Changes

Private packages (`@coveord/plasma-figma-code-connect`, `@coveord/plasma-storybook`) were being versioned via `privatePackages.version: true`, so any internal dependency bump (e.g. `plasma-mantine`) bumped them too. Combined with `changelog.cjs` suppressing dependency-update lines, this produced empty changelog sections (see [this review comment](https://github.com/coveo/plasma/pull/4519#discussion_r3658299696)):

```
## 60.0.2

```

This PR:

- Sets `privatePackages.version` to `false` in `.changeset/config.json` so private packages are no longer versioned. Since they are never published to npm, their version numbers are internal-only.
- Restores dependency-update lines in `.changeset/changelog.cjs` by delegating `getDependencyReleaseLine` to `@changesets/changelog-github`'s default implementation (still suppressed during prerelease mode). With private packages out of the picture, the only remaining dependency-only bumps are on public packages (e.g. `plasma-mantine` when `plasma-tokens`/`plasma-react-icons` change), where showing the update is useful.

Verified by running `pnpm changeset:version` locally: private packages are no longer bumped, and a public dependency bump now renders an `Updated dependencies:` block instead of an empty section.

### Potential Breaking Changes

None for consumers. Private packages will stop tracking the monorepo's shared version and freeze at their current version — internal only, not published.

### Acceptance Criteria

- [ ] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets) — n/a, tooling-only change to `.changeset/` config
- [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant) — n/a