### PR TITLE
Publish mantine dist by declaring files field

### DIFF
--- a/.changeset/mantine-files-field.md
+++ b/.changeset/mantine-files-field.md
@@ -1,0 +1,7 @@
+---
+'@coveord/plasma-mantine': patch
+---
+
+Publish the `dist` folder by declaring it in the package `files` field
+
+Newer pnpm versions honor the repository `.gitignore` when packing, which excluded the gitignored `dist` folder from the published tarball and caused `publint` to fail during release. Declaring `files: ["dist"]` (matching the other Plasma packages) ensures the built output is included.

--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -18,6 +18,9 @@
         "url": "git+https://github.com/coveo/plasma.git",
         "directory": "packages/mantine"
     },
+    "files": [
+        "dist"
+    ],
     "type": "module",
     "sideEffects": true,
     "exports": {


### PR DESCRIPTION
### Proposed Changes

The `@coveord/plasma-mantine@61.0.0` publish failed in [CD run 30286170021](https://github.com/coveo/plasma/actions/runs/30286170021/job/90044384337) because its `prepublishOnly` hook (`publint`) exited with code 1.

Root cause: `packages/mantine/package.json` had no `files` field, and `**/dist` is gitignored. The recent pnpm bump `11.11.0 → 11.13.1` (#4517) made pnpm honor the repository `.gitignore` when packing, so `dist/` was excluded from the tarball entirely. `publint` correctly flagged that every export pointed at unpublished files and aborted the publish. This was not a false positive: a plain `pnpm pack` produced a tarball with 0 `dist` files.

mantine was the only publishable package missing `files: ["dist"]` (`llms`, `mcp-server`, `tokens`, and `react-icons` all declare it), which is why those packages published fine while mantine did not.

This PR adds `"files": ["dist"]` to the mantine package, matching the other packages. Verified locally: with the field present, `pnpm pack` includes the built output (1832 dist files) and `publint` reports "All good!".

> Note: the failed run left the release in a partial state (`plasma-llms` and `plasma-mcp-server` published at 60.1.0 and got git tags, mantine 61.0.0 did not). CD will need to be re-run after this merges to publish mantine, and the version state may need reconciling.

### Potential Breaking Changes

None.

### Acceptance Criteria

- [ ] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)