### PR TITLE
Place PR link at end of title in changelog entries

### DIFF
--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -1,7 +1,7 @@
 // Custom changelog generator for Plasma.
 // - Suppresses all changelog entries while .changeset/pre.json mode is "pre".
 // - Delegates dependency update lines to the default GitHub changelog generator.
-// - Simple entries: "- Summary [#PR](url)"
+// - Simple entries: "- Summary [#PR](url)" (PR link at the end of the first line/title)
 // - Rich entries (containing headings): "#### Title [#PR](url)\n\nBody..."
 //   Per the changeset template (see CONTRIBUTING.md), body headings start at a
 //   single "#". They are re-leveled relative to the h4 title so they always nest
@@ -83,8 +83,9 @@ async function getReleaseLine(changeset, _type, options) {
 
     // Simple entry — render as a list item.
     const restLines = rest.trim();
-    const summary = restLines ? `${firstLine}\n\n  ${restLines.split('\n').join('\n  ')}` : firstLine;
-    return `\n\n- ${summary}${prLink ? ` ${prLink}` : ''}`;
+    const title = firstLine + (prLink ? ` ${prLink}` : '');
+    const summary = restLines ? `${title}\n\n  ${restLines.split('\n').join('\n  ')}` : title;
+    return `\n\n- ${summary}`;
 }
 
 async function getDependencyReleaseLine(changesets, dependenciesUpdated, options) {


### PR DESCRIPTION
### Proposed Changes

Simple changelog entries now append the PR link to the end of the first line (the title) instead of after the whole entry body. This matches the behavior already used for rich entries (those containing headings), so the PR link placement is now consistent across both entry types.

Before:

```
- Fix the thing

  Extra detail line one
  Extra detail line two [#1234](url)
```

After:

```
- Fix the thing [#1234](url)

  Extra detail line one
  Extra detail line two
```

### Potential Breaking Changes

None. This only affects how changelog entries are rendered at release time.

### Acceptance Criteria

- [ ] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [x] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)

<sub>Note: no changeset added — this is a tooling-only change to the changelog generator and does not affect any published package. No unit tests exist for `.changeset/changelog.cjs`.</sub>