### PR TITLE
Fix CodeEditor crash when hidden and shown again by React Activity

### DIFF
--- a/.changeset/happy-tigers-dream.md
+++ b/.changeset/happy-tigers-dream.md
@@ -4,7 +4,4 @@
 
 Fix `CodeEditor` crashing when hidden and shown again by React's `Activity`
 
-When a `CodeEditor` was placed inside a component that hides inactive content with React's `Activity`
-(such as `Tabs`, `Collapse`, or `Accordion` with `keepMountedMode="activity"`), switching away and back
-disposed the underlying Monaco editor and left it in a broken state. The editor now recreates itself when
-it is disposed while still mounted, so it keeps working across visibility changes.
+When a `CodeEditor` was placed inside a component that hides inactive content with React's `Activity` (such as `Tabs`, `Collapse`, or `Accordion` with `keepMountedMode="activity"`), switching away and back disposed the underlying Monaco editor and left it in a broken state. The editor now recreates itself when it is disposed while still mounted, so it keeps working across visibility changes.

--- a/.changeset/happy-tigers-dream.md
+++ b/.changeset/happy-tigers-dream.md
@@ -1,0 +1,10 @@
+---
+'@coveord/plasma-mantine': patch
+---
+
+Fix `CodeEditor` crashing when hidden and shown again by React's `Activity`
+
+When a `CodeEditor` was placed inside a component that hides inactive content with React's `Activity`
+(such as `Tabs`, `Collapse`, or `Accordion` with `keepMountedMode="activity"`), switching away and back
+disposed the underlying Monaco editor and left it in a broken state. The editor now recreates itself when
+it is disposed while still mounted, so it keeps working across visibility changes.

--- a/packages/mantine/__mocks__/@monaco-editor/react.tsx
+++ b/packages/mantine/__mocks__/@monaco-editor/react.tsx
@@ -4,6 +4,7 @@ import {type FunctionComponent, useEffect} from 'react';
 const editor: any = {
     onDidFocusEditorText: vi.fn(),
     onDidBlurEditorText: vi.fn(),
+    onDidDispose: vi.fn(() => ({dispose: vi.fn()})),
     focus: vi
         .fn()
         .mockImplementation(() =>

--- a/packages/mantine/src/__tests__/Utils.tsx
+++ b/packages/mantine/src/__tests__/Utils.tsx
@@ -1,12 +1,22 @@
+import {MantineProviderProps} from '@mantine/core';
 import {render, RenderOptions, RenderResult} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {FunctionComponent, PropsWithChildren, ReactElement} from 'react';
 
 import {Plasmantine} from '../theme/Plasmantine.js';
 
-const customRender = (ui: ReactElement, options?: Omit<RenderOptions, 'queries'>): RenderResult => {
+interface CustomRenderOptions extends Omit<RenderOptions, 'queries'> {
+    /**
+     * The Mantine environment passed to the `Plasmantine` provider.
+     * Defaults to `'test'`, which disables environment-specific behavior such as React's `<Activity>`.
+     * Set it to `'default'` when a test needs the real runtime behavior (e.g. Activity-based mounting).
+     */
+    env?: MantineProviderProps['env'];
+}
+
+const customRender = (ui: ReactElement, {env = 'test', ...options}: CustomRenderOptions = {}): RenderResult => {
     const TestWrapper: FunctionComponent<PropsWithChildren> = ({children}) => (
-        <Plasmantine withCssVariables={false} env="test">
+        <Plasmantine withCssVariables={false} env={env}>
             {children}
         </Plasmantine>
     );

--- a/packages/mantine/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/mantine/src/components/CodeEditor/CodeEditor.tsx
@@ -124,6 +124,12 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
     });
     const [parentHeight, ref] = useParentHeight();
     const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null);
+    // React 19's `<Activity>` (used by Mantine's Tabs/Collapse/Accordion to hide inactive content) destroys
+    // effects while preserving state. `@monaco-editor/react` disposes the editor in its mount-effect cleanup
+    // but keeps its internal "editor ready" flag, so when the content becomes visible again it never recreates
+    // the editor and ends up operating on a disposed instance, which crashes. We detect the disposal and bump
+    // this key to force a fresh `<Editor>` instance on the next render. The value is preserved via `_value`.
+    const [editorKey, setEditorKey] = useState(0);
 
     const loadLocalMonaco = async () => {
         const monacoInstance = await import('monaco-editor');
@@ -220,6 +226,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
             data-testid="editor-wrapper"
         >
             <Editor
+                key={editorKey}
                 onValidate={handleValidate}
                 defaultLanguage={language}
                 theme={editorTheme}
@@ -245,6 +252,12 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (props) => {
                         editorHandle.current = editor;
                     }
                     editor.onDidFocusEditorText(() => onFocus?.());
+                    editor.onDidDispose(() => {
+                        // If the editor is disposed while the component is still mounted (e.g. React's
+                        // `<Activity>` tore down the effects to hide the panel), force a fresh instance so we
+                        // never render against a disposed editor when the panel becomes visible again.
+                        setEditorKey((key) => key + 1);
+                    });
                     editor.onDidBlurEditorText(async () => {
                         // monaco editor has a timeout of 500ms populating errors, we want to ensure that checking errors happen after that
                         setTimeout(async () => {

--- a/packages/mantine/src/components/CodeEditor/__tests__/CodeEditor.activity.spec.tsx
+++ b/packages/mantine/src/components/CodeEditor/__tests__/CodeEditor.activity.spec.tsx
@@ -1,0 +1,112 @@
+import {Tabs} from '@mantine/core';
+import {render, screen, userEvent, waitFor} from '@test-utils';
+import {CodeEditor} from '../CodeEditor.js';
+
+// Use case: a CodeEditor inside Tabs. Switching to another tab and back used to crash the editor because
+// React's `<Activity>` (how Tabs hides inactive panels) disposes the Monaco editor and it was never recreated.
+//
+// To reproduce it we use the real `@monaco-editor/react` (not mocked) and only fake the Monaco engine via
+// `window.monaco`, which the real loader honors instead of loading the jsdom-incompatible engine. Rendering
+// with `env="default"` keeps `<Activity>` active (Mantine disables it when `env === 'test'`).
+vi.mock('monaco-editor');
+
+interface FakeEditor {
+    dispose: () => void;
+    onDidDispose: (cb: () => void) => {dispose: () => void};
+}
+
+const createFakeEditor = (): FakeEditor => {
+    const disposeListeners = new Set<() => void>();
+    const fakeModel = {
+        getFullModelRange: vi.fn(() => ({})),
+        dispose: vi.fn(),
+        uri: {path: ''},
+    };
+    return {
+        getModel: vi.fn(() => fakeModel),
+        getOption: vi.fn(() => false),
+        getValue: vi.fn(() => ''),
+        setValue: vi.fn(),
+        executeEdits: vi.fn(),
+        pushUndoStop: vi.fn(),
+        updateOptions: vi.fn(),
+        setModel: vi.fn(),
+        saveViewState: vi.fn(() => ({})),
+        restoreViewState: vi.fn(),
+        revealLine: vi.fn(),
+        focus: vi.fn(),
+        trigger: vi.fn(),
+        getAction: vi.fn(() => ({run: vi.fn(() => Promise.resolve())})),
+        onDidChangeModelContent: vi.fn(() => ({dispose: vi.fn()})),
+        onDidFocusEditorText: vi.fn(() => ({dispose: vi.fn()})),
+        onDidBlurEditorText: vi.fn(() => ({dispose: vi.fn()})),
+        onDidDispose: vi.fn((cb: () => void) => {
+            disposeListeners.add(cb);
+            return {dispose: () => disposeListeners.delete(cb)};
+        }),
+        dispose: vi.fn(() => {
+            disposeListeners.forEach((cb) => cb());
+        }),
+    } as unknown as FakeEditor;
+};
+
+const createMock = vi.fn(() => createFakeEditor());
+
+const fakeMonaco = {
+    Uri: {parse: (path: string) => ({path, toString: () => path})},
+    editor: {
+        create: createMock,
+        getModel: vi.fn(() => undefined),
+        createModel: vi.fn(() => ({getFullModelRange: vi.fn(() => ({})), dispose: vi.fn(), uri: {path: ''}})),
+        defineTheme: vi.fn(),
+        setTheme: vi.fn(),
+        setModelLanguage: vi.fn(),
+        onDidChangeMarkers: vi.fn(() => ({dispose: vi.fn()})),
+        getModelMarkers: vi.fn(() => []),
+        EditorOption: {readOnly: 'readOnly'},
+    },
+};
+
+describe('CodeEditor with React Activity', () => {
+    beforeEach(() => {
+        createMock.mockClear();
+        // `@monaco-editor/react`'s real loader resolves the Monaco instance from `window.monaco` when present,
+        // so it never hits the network or loads the real (jsdom-incompatible) engine.
+        (window as unknown as {monaco: typeof fakeMonaco}).monaco = fakeMonaco;
+    });
+
+    afterEach(() => {
+        delete (window as unknown as {monaco?: typeof fakeMonaco}).monaco;
+    });
+
+    it('recreates the editor after being hidden and shown again by Activity', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <Tabs defaultValue="editor" keepMountedMode="activity">
+                <Tabs.List>
+                    <Tabs.Tab value="editor">Editor</Tabs.Tab>
+                    <Tabs.Tab value="other">Other</Tabs.Tab>
+                </Tabs.List>
+                <Tabs.Panel value="editor">
+                    <CodeEditor monacoLoader="cdn" aria-label="code" />
+                </Tabs.Panel>
+                <Tabs.Panel value="other">Other content</Tabs.Panel>
+            </Tabs>,
+            {env: 'default'},
+        );
+
+        // The editor is shown and created once on the initially active tab.
+        expect(await screen.findByTestId('editor-wrapper')).toBeVisible();
+        await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
+
+        // Switch away (Activity hides the panel and disposes the editor) then back.
+        await user.click(screen.getByRole('tab', {name: 'Other'}));
+        await user.click(screen.getByRole('tab', {name: 'Editor'}));
+
+        // The editor is visible again and a fresh instance was created. Before the fix, coming back reused the
+        // disposed editor, which crashed, leaving no editor on the tab.
+        expect(await screen.findByTestId('editor-wrapper')).toBeVisible();
+        await waitFor(() => expect(createMock).toHaveBeenCalledTimes(2));
+    });
+});

--- a/packages/mantine/vitest.config.ts
+++ b/packages/mantine/vitest.config.ts
@@ -19,6 +19,14 @@ export default defineConfig({
         globals: true,
         environment: 'jsdom',
         setupFiles: './src/__tests__/VitestSetup.ts',
+        server: {
+            deps: {
+                // Inline the Monaco packages so Vitest transforms them with consistent ESM/CJS interop.
+                // Without this, `@monaco-editor/react`'s default import of `@monaco-editor/loader` resolves
+                // to a wrapped module and `loader.init` is undefined at runtime.
+                inline: [/@monaco-editor\//],
+            },
+        },
         alias: [
             {
                 find: /^monaco-editor$/,


### PR DESCRIPTION
### Proposed Changes

Following the Mantine 9 upgrade, placing a `CodeEditor` inside a container that hides inactive content with React 19's `<Activity>` (Tabs, Collapse, Accordion with `keepMountedMode="activity"`) would crash when switching away from and back to the panel.

Root cause: `<Activity mode="hidden">` tears down effects while preserving state. `@monaco-editor/react` disposes the underlying Monaco editor in its mount-effect cleanup but keeps its internal "editor ready" flag, so on re-show it never recreates the editor and operates on a disposed instance.

Changes:

- **`CodeEditor`**: subscribe to `editor.onDidDispose` and bump a `key` on the `<Editor>` so a fresh instance is created when the panel becomes visible again. The value is preserved via the controlled `_value` state.
- **Test util** (`src/__tests__/Utils.tsx`): added an optional `env` to the shared `render` helper (defaults to `'test'`) so tests can opt into the real runtime behavior where React `<Activity>` is active.
- **Regression test** (`CodeEditor.activity.spec.tsx`): exercises the real `@monaco-editor/react` mount/dispose lifecycle inside real Mantine `Tabs` with `env="default"`, faking only the Monaco engine via `window.monaco`. Asserts the editor is recreated after a hide/show cycle.
- **Vitest config**: inline the `@monaco-editor/*` packages so their default-import interop resolves correctly under Vitest.
- **Mock**: added `onDidDispose` to the `@monaco-editor/react` test mock.

The existing `Tabs` theme default (`keepMountedMode: 'display-none'`) is intentionally kept as a cheap belt-and-suspenders default; the `CodeEditor` fix covers every other Activity source.

> Note: a manual verification story (`CodeEditor` within `Tabs`) was implemented locally but intentionally not committed.

### Potential Breaking Changes

None. No public API changes.

### Acceptance Criteria

- [x] The proposed changes are covered by unit tests
- [x] The potential breaking changes are clearly identified
- [x] A changeset is added for releasable changes, following [CONTRIBUTING.md](https://github.com/coveo/plasma/blob/master/CONTRIBUTING.md#writing-changesets)
- [ ] [README.md](https://github.com/coveo/plasma/blob/master/README.md) is adjusted to reflect the proposed changes (if relevant)